### PR TITLE
fix(failure-recovery): 回应 Copilot review——重排保留剧集桶 + 重试按钮 spinner 复位

### DIFF
--- a/apps/web/components/activity-feed.tsx
+++ b/apps/web/components/activity-feed.tsx
@@ -232,6 +232,9 @@ function RetryButton({ runId, title }: { runId: string; title: string }) {
       // The next poll reconciles: the run re-appears in 排队中/获取中.
     } catch {
       window.alert("重试失败，请稍后再试。");
+    } finally {
+      // Always release the spinner — a "not_retriable" (or any non-error) response
+      // must not leave the button stuck busy until a full page refresh.
       setBusy(false);
     }
   };

--- a/packages/workflow/src/worker.ts
+++ b/packages/workflow/src/worker.ts
@@ -204,16 +204,24 @@ export async function handleWorkflowRunFailure(input: {
     trigger: "user",
     report,
   };
+  // saveWorkflowRunSnapshot DELETES the season's episode bucket then re-inserts
+  // only what we pass. The two branches need OPPOSITE handling:
+  //  - auto-requeue: the run is going BACK to queued (still in flight) → preserve
+  //    the claimed snapshot's children, else a TV/series run loses its reserved
+  //    episode bucket mid-retry (Copilot review #1).
+  //  - terminal failure: a failed Type 2 init intentionally clears its initial
+  //    episode state so a fresh, never-acquired season doesn't linger as tracked
+  //    (see worker.test "clears initial episode state when the agent model dies").
   await repository.saveWorkflowRunSnapshot({
     accountId: claimed.accountId,
     connectedStorageId: claimed.connectedStorageId,
     title: claimed.title,
     season: claimed.season,
     workflowRun,
-    episodes: [],
-    resourceSnapshots: [],
-    decisions: [],
-    transferAttempts: [],
+    episodes: willRetry ? claimed.episodes : [],
+    resourceSnapshots: willRetry ? claimed.resourceSnapshots : [],
+    decisions: willRetry ? claimed.decisions : [],
+    transferAttempts: willRetry ? claimed.transferAttempts : [],
     notifications: [notification],
   });
   return {

--- a/packages/workflow/tests/handle-workflow-failure.test.ts
+++ b/packages/workflow/tests/handle-workflow-failure.test.ts
@@ -85,6 +85,32 @@ describe("handleWorkflowRunFailure", () => {
     expect(saved.notifications[0]?.report?.status).toBe("failed");
   });
 
+  it("preserves the claimed snapshot's episode bucket across auto-requeue (does NOT wipe it)", async () => {
+    const save = vi.fn(async (_input: PersistWorkflowRunSnapshotInput) => {});
+    const episodes = [
+      {
+        trackedSeasonId: "tmdb_movie_1_movie",
+        episodeCode: "S01E01",
+        airDate: null,
+        airStatus: "aired" as const,
+        obtained: false,
+      },
+    ];
+    const claimed = { ...snapshot(), episodes } as PersistedWorkflowRunSnapshot;
+    await handleWorkflowRunFailure({
+      claimed,
+      error: new Error("read ECONNRESET"),
+      repository: { saveWorkflowRunSnapshot: save },
+      now,
+    });
+    const saved = save.mock.calls[0]![0];
+    // Bug (Copilot): saving with episodes:[] deletes the season's reserved bucket
+    // (replaceWorkflowRunSnapshot wipes by season then re-inserts) — losing tracked
+    // state on a run that is going BACK to queued. Must round-trip claimed.episodes.
+    expect(saved.episodes).toHaveLength(1);
+    expect(saved.episodes[0]?.episodeCode).toBe("S01E01");
+  });
+
   it("terminally fails a NON-transient error immediately (count=0)", async () => {
     const save = vi.fn(async (_input: PersistWorkflowRunSnapshotInput) => {});
     const out = await handleWorkflowRunFailure({


### PR DESCRIPTION
回应 [#1](https://github.com/fancydirty/mediary-scout/pull/1) 的 Copilot review 两处真 bug:

1. **worker.ts** — `handleWorkflowRunFailure` 自动重排时以 `episodes:[]` 落库,而 `replaceWorkflowRunSnapshot` 按季删除剧集后只重插传入的,导致**在飞(回 queued)的 TV/系列 run 的预留剧集桶被抹掉**,activity 的 missingCount 归零。修:**重排分支保留 `claimed` 的 episodes/resourceSnapshots/decisions/transferAttempts**;**终态失败分支仍清空**(保留既有「失败的 Type2 init 清初始剧集态」语义,worker.test 钉死)。
2. **activity-feed.tsx** — `RetryButton` 只在 `catch` 复位 `busy`,`{status:"not_retriable"}` 等非异常响应会让 spinner 永久卡死。修:`finally` 必复位。

新增测试:auto-requeue 保留剧集桶。验证:`vitest` 728 passed、双 tsc、无 DB build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)