### PR TITLE
feat(robustness): 启动期配置校验 + compose 配置回归测试

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -8,6 +8,12 @@ export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== "nodejs") {
     return;
   }
+  // Fail fast + loud on a runtime misconfig (e.g. MEDIA_TRACK_AGENT_ADAPTER=real)
+  // instead of booting a worker that can never drain the queue. Throwing here
+  // aborts startup with a clear reason.
+  const { validateRuntimeConfig } = await import("@media-track/workflow");
+  validateRuntimeConfig(process.env);
+
   console.log("[instrumentation] register() — running startup migrations + worker");
   const { runStartupMigrations } = await import("./lib/workflow-runtime");
   await runStartupMigrations();

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "@types/react-dom": "^19.2.3",
         "playwright": "^1.60.0",
         "typescript": "^5.9.0",
-        "vitest": "^4.0.0"
+        "vitest": "^4.0.0",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -2849,6 +2850,22 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@types/react-dom": "^19.2.3",
     "playwright": "^1.60.0",
     "typescript": "^5.9.0",
-    "vitest": "^4.0.0"
+    "vitest": "^4.0.0",
+    "yaml": "^2.9.0"
   },
   "dependencies": {
     "@ai-sdk/openai-compatible": "^2.0.48",

--- a/packages/workflow/src/runtime-policy.ts
+++ b/packages/workflow/src/runtime-policy.ts
@@ -4,6 +4,26 @@ export interface WorkflowRuntimeEnv extends Record<string, string | undefined> {
   MEDIA_TRACK_AGENT_ADAPTER?: string;
 }
 
+/** The only valid agent adapters. `real` (a past compose typo) is NOT one — it
+ *  passes silently then the worker can never drain the queue. */
+export const VALID_AGENT_ADAPTERS = ["vercel-ai", "fake"] as const;
+
+/**
+ * Boot-time + config-time runtime validation. Fail FAST and LOUD on a misconfig
+ * (e.g. MEDIA_TRACK_AGENT_ADAPTER=real) instead of silently never draining the
+ * queue. Used by instrumentation.register() at startup AND by a test that parses
+ * docker-compose.yml — so a bad value can never ship undetected again.
+ */
+export function validateRuntimeConfig(env: WorkflowRuntimeEnv): void {
+  const agent = env.MEDIA_TRACK_AGENT_ADAPTER;
+  if (agent !== undefined && agent !== "" && !VALID_AGENT_ADAPTERS.includes(agent as never)) {
+    throw new Error(
+      `MEDIA_TRACK_AGENT_ADAPTER_INVALID: "${agent}" — must be one of ${VALID_AGENT_ADAPTERS.join(", ")}.`,
+    );
+  }
+  assertWorkflowAgentAdapterPolicy(env);
+}
+
 export function assertWorkflowAgentAdapterPolicy(env: WorkflowRuntimeEnv): void {
   const usesLiveProvider = env.MEDIA_TRACK_WORKFLOW_ADAPTER === "pansou";
   const usesLiveStorage = env.MEDIA_TRACK_STORAGE_ADAPTER === "115";

--- a/packages/workflow/tests/runtime-config.test.ts
+++ b/packages/workflow/tests/runtime-config.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse } from "yaml";
+import { validateRuntimeConfig } from "../src/runtime-policy.js";
+
+describe("validateRuntimeConfig", () => {
+  it("accepts the live trio (pansou + 115 + vercel-ai)", () => {
+    expect(() =>
+      validateRuntimeConfig({
+        MEDIA_TRACK_WORKFLOW_ADAPTER: "pansou",
+        MEDIA_TRACK_STORAGE_ADAPTER: "115",
+        MEDIA_TRACK_AGENT_ADAPTER: "vercel-ai",
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an invalid agent adapter value like 'real'", () => {
+    expect(() => validateRuntimeConfig({ MEDIA_TRACK_AGENT_ADAPTER: "real" })).toThrow(
+      /MEDIA_TRACK_AGENT_ADAPTER_INVALID/,
+    );
+  });
+
+  it("rejects live workflow/storage without the vercel-ai agent", () => {
+    expect(() =>
+      validateRuntimeConfig({
+        MEDIA_TRACK_WORKFLOW_ADAPTER: "pansou",
+        MEDIA_TRACK_STORAGE_ADAPTER: "115",
+        MEDIA_TRACK_AGENT_ADAPTER: "fake",
+      }),
+    ).toThrow(/MEDIA_TRACK_AGENT_ADAPTER_REQUIRED_FOR_LIVE_WORKFLOW/);
+  });
+
+  it("accepts the fake agent adapter (no live provider/storage)", () => {
+    expect(() => validateRuntimeConfig({ MEDIA_TRACK_AGENT_ADAPTER: "fake" })).not.toThrow();
+  });
+
+  it("accepts an unset agent adapter", () => {
+    expect(() => validateRuntimeConfig({})).not.toThrow();
+  });
+});
+
+describe("docker-compose.yml web service config", () => {
+  it("ships a valid runtime config (regression guard for the AGENT_ADAPTER=real outage)", () => {
+    const composePath = resolve(process.cwd(), "docker-compose.yml");
+    const compose = parse(readFileSync(composePath, "utf8")) as {
+      services: { web: { environment: Record<string, string> } };
+    };
+    const webEnv = compose.services.web.environment;
+    expect(webEnv).toBeTruthy();
+    expect(webEnv.MEDIA_TRACK_AGENT_ADAPTER).toBeDefined();
+    expect(() => validateRuntimeConfig(webEnv)).not.toThrow();
+  });
+});


### PR DESCRIPTION
backlog 健壮性①+② 合并(共用一个 validator)。

- **`validateRuntimeConfig(env)`**(runtime-policy.ts):校验 `MEDIA_TRACK_AGENT_ADAPTER` 枚举(`vercel-ai`/`fake`,挡住曾导致停机的 `real`)+ 既有 live 三件套策略(pansou/115 必须配 vercel-ai)。
- **启动即校验**:`instrumentation.register()` 启动时跑 `validateRuntimeConfig(process.env)`,非法配置**启动即崩 + 清晰原因**,而非静默 boot 成一个永远 drain 不动队列的 worker。
- **compose 配置回归测试**:解析仓库 `docker-compose.yml` 的 web env,断言 `validateRuntimeConfig` 通过 —— `AGENT_ADAPTER=real` 那类错误 CI 当场红(那次停机的守门)。
- `yaml` 加为 devDependency(仅测试解析 compose)。

验证:`vitest` 648 passed(新增 runtime-config.test 6 例)、双 tsc、无 DB build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)