### PR TITLE
fix(search): 搜索提交软导航——消除整页刷新闪烁

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,6 +6,7 @@ import { AppSidebar } from "../components/app-sidebar";
 import { RequestTrackButton } from "../components/request-track-button";
 import { DemoSessionLibrary } from "../components/demo-session-library";
 import { RememberQuery } from "../components/search-memory";
+import { SearchForm } from "../components/search-form";
 import { SeasonRequestMenu } from "../components/season-request-menu";
 import { getSearchView } from "../lib/search-page";
 import {
@@ -94,17 +95,7 @@ async function HomeSurface({
                 <h1>搜索</h1>
                 <p>找到目标后发起获取，后台会处理资源判断、转存和验证。</p>
               </div>
-              <form className="search-form" action={basePath} role="search">
-                <input type="hidden" name="tab" value="search" />
-                <label className="search-box search-box-large">
-                  <Search size={18} aria-hidden />
-                  <input name="q" aria-label="搜索媒体" placeholder="片名 / 剧名" defaultValue={query} />
-                </label>
-                <button className="primary-button" type="submit">
-                  <Search size={16} aria-hidden />
-                  搜索
-                </button>
-              </form>
+              <SearchForm basePath={basePath} defaultQuery={query} />
             </div>
             {driveCount >= 2 ? (
               <p className="panel-note" style={{ marginTop: -4, marginBottom: 4 }}>

--- a/apps/web/components/search-form.tsx
+++ b/apps/web/components/search-form.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+/**
+ * The search box. Submitting used to be a NATIVE `<form action>` GET — which is a
+ * full document navigation (Next only intercepts <Link>/router.push), so the whole
+ * page reloaded and the shell + header visibly flashed. Here onSubmit does a CLIENT
+ * soft navigation instead: the prerendered static shell (sidebar + this header)
+ * persists and only the results Suspense hole re-fetches — no full-page flash.
+ *
+ * `action`/hidden `tab` are kept so it still works as a plain GET if JS is off.
+ */
+export function SearchForm({
+  basePath = "/",
+  defaultQuery = "",
+}: {
+  basePath?: string;
+  defaultQuery?: string;
+}) {
+  const router = useRouter();
+  return (
+    <form
+      className="search-form"
+      role="search"
+      action={basePath}
+      onSubmit={(event) => {
+        event.preventDefault();
+        const value = String(new FormData(event.currentTarget).get("q") ?? "");
+        router.push(`${basePath}?tab=search&q=${encodeURIComponent(value)}`);
+      }}
+    >
+      <input type="hidden" name="tab" value="search" />
+      <label className="search-box search-box-large">
+        <Search size={18} aria-hidden />
+        <input name="q" aria-label="搜索媒体" placeholder="片名 / 剧名" defaultValue={defaultQuery} />
+      </label>
+      <button className="primary-button" type="submit">
+        <Search size={16} aria-hidden />
+        搜索
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
backlog ①。

**根因**:搜索框是原生 `<form action={basePath}>` GET —— 这是**整文档导航**(Next 只拦截 `<Link>`/`router.push`,不拦原生表单),每次搜索都整页重载,壳 + 头部 + 结果全闪。

**修复**:`SearchForm` 客户端组件,`onSubmit` `preventDefault` + `router.push` 软导航。PPR 的静态壳(侧栏 + 搜索头)跨导航保留,只有 results 的 Suspense 洞重取 —— 无整页闪。保留 `action` + hidden `tab` 作为**无 JS 回退**(渐进增强)。

**真验**(本地真 dev):搜索 "matrix" 提交后 `window.__navflag` 存活(证明是软导航、非整文档重载)、URL→`?tab=search&q=matrix`、结果更新为「黑客帝国」、搜索头与侧栏不闪;媒体库 tab 仍正常(12 卡)。web tsc / lint / vitest / 无 DB build 全绿。

**关于 backlog ②(loading 骨架)**:经评估已被现有架构覆盖 —— PPR 提供即时静态壳 + 各页内 Suspense 骨架(SearchResultsSkeleton / LibrarySurfaceSkeleton / skeleton-hub-*),且搜索现已软导航;再加路由级 loading.tsx 冗余且会引入侧栏骨架闪。故不另加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)