### PR TITLE
fix: 处理 Copilot 对 PR#4-#7 的有效 review 反馈

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1146,8 +1146,11 @@ p {
     z-index: 50;
     background: var(--bg-surface);
     border-top: 1px solid var(--border);
-    /* Honour the iPhone home-indicator safe area. */
-    padding: 6px 4px calc(6px + env(safe-area-inset-bottom));
+    /* Honour the safe area on all sides (home indicator + landscape notch). The
+       `, 0px` fallback is required — env() with no fallback invalidates the WHOLE
+       padding declaration on browsers without env() support. */
+    padding: 6px calc(4px + env(safe-area-inset-right, 0px))
+      calc(6px + env(safe-area-inset-bottom, 0px)) calc(4px + env(safe-area-inset-left, 0px));
   }
 
   .nav-list {
@@ -1201,7 +1204,7 @@ p {
   .main {
     /* Bottom padding clears the fixed bottom tab bar (~56px + safe area) so the
        last content isn't hidden behind it. */
-    padding: 20px 16px calc(72px + env(safe-area-inset-bottom));
+    padding: 20px 16px calc(72px + env(safe-area-inset-bottom, 0px));
   }
 
   .title-stage {

--- a/apps/web/components/search-form.tsx
+++ b/apps/web/components/search-form.tsx
@@ -34,7 +34,16 @@ export function SearchForm({
       <input type="hidden" name="tab" value="search" />
       <label className="search-box search-box-large">
         <Search size={18} aria-hidden />
-        <input name="q" aria-label="搜索媒体" placeholder="片名 / 剧名" defaultValue={defaultQuery} />
+        {/* key forces a remount when the URL query changes (back/forward, or a
+            restored remembered query) so the uncontrolled input reflects it,
+            while staying uncontrolled (no re-render churn) during typing. */}
+        <input
+          key={defaultQuery}
+          name="q"
+          aria-label="搜索媒体"
+          placeholder="片名 / 剧名"
+          defaultValue={defaultQuery}
+        />
       </label>
       <button className="primary-button" type="submit">
         <Search size={16} aria-hidden />

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint . --max-warnings 0"
   },
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.13.0"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.9",

--- a/packages/workflow/src/runtime-policy.ts
+++ b/packages/workflow/src/runtime-policy.ts
@@ -7,6 +7,7 @@ export interface WorkflowRuntimeEnv extends Record<string, string | undefined> {
 /** The only valid agent adapters. `real` (a past compose typo) is NOT one — it
  *  passes silently then the worker can never drain the queue. */
 export const VALID_AGENT_ADAPTERS = ["vercel-ai", "fake"] as const;
+const VALID_AGENT_ADAPTER_SET: ReadonlySet<string> = new Set(VALID_AGENT_ADAPTERS);
 
 /**
  * Boot-time + config-time runtime validation. Fail FAST and LOUD on a misconfig
@@ -16,7 +17,7 @@ export const VALID_AGENT_ADAPTERS = ["vercel-ai", "fake"] as const;
  */
 export function validateRuntimeConfig(env: WorkflowRuntimeEnv): void {
   const agent = env.MEDIA_TRACK_AGENT_ADAPTER;
-  if (agent !== undefined && agent !== "" && !VALID_AGENT_ADAPTERS.includes(agent as never)) {
+  if (agent !== undefined && agent !== "" && !VALID_AGENT_ADAPTER_SET.has(agent)) {
     throw new Error(
       `MEDIA_TRACK_AGENT_ADAPTER_INVALID: "${agent}" — must be one of ${VALID_AGENT_ADAPTERS.join(", ")}.`,
     );

--- a/packages/workflow/tests/runtime-config.test.ts
+++ b/packages/workflow/tests/runtime-config.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
-import { validateRuntimeConfig } from "../src/runtime-policy.js";
+import { validateRuntimeConfig } from "../src/index.js";
 
 describe("validateRuntimeConfig", () => {
   it("accepts the live trio (pansou + 115 + vercel-ai)", () => {
@@ -41,8 +42,10 @@ describe("validateRuntimeConfig", () => {
 });
 
 describe("docker-compose.yml web service config", () => {
-  it("ships a valid runtime config (regression guard for the AGENT_ADAPTER=real outage)", () => {
-    const composePath = resolve(process.cwd(), "docker-compose.yml");
+  it("ships a valid runtime config (regression guard for the MEDIA_TRACK_AGENT_ADAPTER=real outage)", () => {
+    // Resolve relative to THIS test file so it works regardless of the vitest
+    // working directory (process.cwd() would require running from the repo root).
+    const composePath = resolve(dirname(fileURLToPath(import.meta.url)), "../../../docker-compose.yml");
     const compose = parse(readFileSync(composePath, "utf8")) as {
       services: { web: { environment: Record<string, string> } };
     };


### PR DESCRIPTION
合并多个 PR 快速合入后才异步出现的 Copilot review 反馈,逐条**回读代码核实有效**后修复:

| 来源 | 反馈 | 修复 |
| --- | --- | --- |
| #4 | `env(safe-area-inset-*)` 无回退 → 不支持 env() 的浏览器整条 padding 失效、横屏不顾左右刘海 | `, 0px` 回退 + 底栏补 left/right inset |
| #5 | `includes(agent as never)` 不安全转换 | 改 `Set.has` |
| #5 | 测试用 `process.cwd()` 依赖在仓库根运行 | 改相对 test 文件路径 |
| #5 | 从内部模块 `runtime-policy.js` 导入、措辞 | 改公共入口 `../src/index.js`、措辞修正 |
| #6 | `engines.node >=22.12` 与 eslint@10 的 `^22.13` 不符 → 22.12.x 装失败 | bump `>=22.13.0` |
| #7 | 搜索 `<input>` uncontrolled,后退/恢复记忆查询时留旧值 | `key={defaultQuery}` 触发刷新 |

真验:`vitest` 734、`lint` 0、双 tsc、无 DB build 全绿;浏览器真验 #7(后退恢复 batman 不留 matrix)、#4(padding 6/4/72px 有效未失效)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)