### PR TITLE
fix(agent): 搜索关键词必须含片名——拦截「2026 电影」类垃圾搜索

### DIFF
--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -96,6 +96,9 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
       ? {}
       : { targetMovieDirectoryId: request.targetMovieDirectoryId }),
     need,
+    // The agent's search keywords must reference the title — reject genre/year-only
+    // fallbacks ("2026 电影") at the tool boundary so they never burn a search.
+    titleTerms: [request.target.title, ...request.target.aliases],
     ...(request.searchBudget === undefined ? {} : { searchBudget: request.searchBudget }),
   });
 

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -1,6 +1,7 @@
 import {
   MAX_DISTINCT_PLANNING_SEARCHES,
   decideSearchGate,
+  keywordReferencesTitle,
   normalizeSearchKeyword,
 } from "../planning-search-gate.js";
 import type { ResourceProviderV2, ResourceSnapshotV2 } from "./fake-provider.js";
@@ -35,6 +36,10 @@ export interface TaskSandboxOptions {
    *  has a markObtained-confirmed entry. Drives the §3 "no more side effects once
    *  satisfied" gate. The need is just "what's still missing"; sync computes it. */
   need?: string[];
+  /** Title + aliases + original title. A search keyword that references NONE of
+   *  these is rejected at the tool boundary (the agent's "2026 电影" genre/year
+   *  fallback only returns noise). Empty/omitted → no title check (fail open). */
+  titleTerms?: string[];
 }
 
 export interface SearchToolResult {
@@ -63,6 +68,7 @@ export class TaskSandbox {
   /** A movie task's one target directory (movies have no seasons). */
   private readonly movieDir: string | undefined;
   private readonly need: readonly string[];
+  private readonly titleTerms: readonly string[];
   private readonly seenKeywords = new Set<string>();
   private readonly snapshotByKeyword = new Map<string, ResourceSnapshotV2>();
   private readonly observedSnapshots = new Map<string, ResourceSnapshotV2>();
@@ -78,6 +84,7 @@ export class TaskSandbox {
     );
     this.movieDir = options.targetMovieDirectoryId;
     this.need = options.need ?? [];
+    this.titleTerms = options.titleTerms ?? [];
   }
 
   /** Every scoped target directory (all seasons + the movie) — the union used for
@@ -111,6 +118,15 @@ export class TaskSandbox {
    *  searches are capped by the budget. Every observed snapshot is recorded so a
    *  later transferCandidate can be bound to a snapshot seen in THIS task. */
   async searchResources(keyword: string): Promise<SearchToolResult> {
+    // Hard guard: a keyword that names no title term is a genre/year-only
+    // fallback ("2026 电影") — it can only return noise. Reject it BEFORE the
+    // budget/provider so it costs nothing and the agent must re-keyword with the
+    // real title. (asEvidence turns this throw into the {error} the agent reads.)
+    if (!keywordReferencesTitle(keyword, this.titleTerms)) {
+      throw new Error(
+        `搜索关键词必须包含片名(片名/原名/别名)。"${keyword}" 不含片名,只会返回噪音,已拒绝。请用包含片名的关键词(可附加年份/原名/4K/全集 等),不要用纯类型或纯年份(如 "电影"、"2026 电影")。`,
+      );
+    }
     const normalized = normalizeSearchKeyword(keyword);
     const decision = decideSearchGate({
       normalizedKeyword: normalized,

--- a/packages/workflow/src/acquisition-v2/skill.ts
+++ b/packages/workflow/src/acquisition-v2/skill.ts
@@ -28,7 +28,7 @@ Before any transferCandidate / moveToSeason / deleteFiles / markObtained, lay ou
 If you cannot state (1) and (2), you may not proceed.
 
 ## Decide the covering set, THEN transfer it — do NOT grope one at a time
-- searchResources is a DECISION point: search (re-keyword if the first was weak — add the year, the original title, "全集"/"complete") until your gathered candidates can cover the WHOLE need, then STOP searching. Once you can cover the need, more searching is pure waste.
+- searchResources is a DECISION point: search (re-keyword if the first was weak — add the year, the original title, "全集"/"complete") until your gathered candidates can cover the WHOLE need, then STOP searching. Once you can cover the need, more searching is pure waste. EVERY keyword MUST contain the title or an alias — never a bare genre/year fallback like "电影 2026" or "2026 电影": those name no title, only return noise, and the tool REJECTS them. If the title finds nothing after honest re-keywording, that is no-coverage — report it, do not flail at generic keywords.
 - Choosing WHICH candidates to transfer is the DECISION; transferring them is EXECUTION. Once you have decided the covering set, transfer those candidates one after another (each is its own transferCandidate call — that is simply how the tool works) WITHOUT searching again in between. NEVER transfer-one → search-again → transfer-one: that is the over-search that hammers 115's call budget.
 - After the transfers land, inspectStaging is a DECISION point again: read the TRUE files, then move / dedup / mark.
 

--- a/packages/workflow/src/planning-search-gate.ts
+++ b/packages/workflow/src/planning-search-gate.ts
@@ -31,6 +31,30 @@ export function normalizeSearchKeyword(keyword: string): string {
   return keyword.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
+/** Normalize for title-substring matching: lowercase + drop whitespace and the
+ *  common separators that differ between a title and a search keyword, so
+ *  "Citizen Vigilante 2026" contains "citizen vigilante" and "公民义警 电影"
+ *  contains "公民义警". */
+function normalizeForTitleMatch(value: string): string {
+  return value.toLowerCase().replace(/[\s·:：\-_.,，、。]/g, "");
+}
+
+/**
+ * A search keyword MUST reference the title — it has to contain the title, its
+ * original title, or an alias (after normalization). Blocks the agent's
+ * desperate genre/year-only fallbacks ("2026 电影", "电影") that can never find a
+ * specific film and only return noise. Fails OPEN when no usable title terms are
+ * known (tests / unscoped sandboxes) so it never wrongly blocks a real search.
+ */
+export function keywordReferencesTitle(keyword: string, titleTerms: readonly string[]): boolean {
+  const terms = titleTerms.map(normalizeForTitleMatch).filter((term) => term.length > 0);
+  if (terms.length === 0) {
+    return true;
+  }
+  const normalizedKeyword = normalizeForTitleMatch(keyword);
+  return terms.some((term) => normalizedKeyword.includes(term));
+}
+
 export function decideSearchGate(args: {
   normalizedKeyword: string;
   seenKeywords: ReadonlySet<string>;

--- a/packages/workflow/tests/keyword-references-title.test.ts
+++ b/packages/workflow/tests/keyword-references-title.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { keywordReferencesTitle } from "../src/planning-search-gate.js";
+
+describe("keywordReferencesTitle", () => {
+  const terms = ["公民义警", "Citizen Vigilante"];
+
+  it("accepts keywords containing the title or an alias", () => {
+    for (const k of [
+      "公民义警",
+      "公民义警 2026",
+      "公民义警 电影",
+      "Citizen Vigilante",
+      "Citizen Vigilante 2026",
+    ]) {
+      expect(keywordReferencesTitle(k, terms), k).toBe(true);
+    }
+  });
+
+  it("rejects genre-only / year-only / genre+year keywords (the '2026 电影' garbage)", () => {
+    for (const k of ["电影", "2026", "2026 电影", "电影 2026"]) {
+      expect(keywordReferencesTitle(k, terms), k).toBe(false);
+    }
+  });
+
+  it("matches across case / spacing / punctuation", () => {
+    expect(keywordReferencesTitle("超人 2025 4K", ["超人", "Superman"])).toBe(true);
+    expect(keywordReferencesTitle("SUPERMAN.2025", ["超人", "Superman"])).toBe(true);
+  });
+
+  it("fails open when no usable title terms are known", () => {
+    expect(keywordReferencesTitle("anything", [])).toBe(true);
+    expect(keywordReferencesTitle("anything", ["", "  "])).toBe(true);
+  });
+});

--- a/packages/workflow/tests/v2-orchestrator.test.ts
+++ b/packages/workflow/tests/v2-orchestrator.test.ts
@@ -26,7 +26,8 @@ function searchThenReportModel() {
   return new MockLanguageModelV3({
     doGenerate: async () => {
       i += 1;
-      if (i === 1) return tool("searchResources", { keyword: "nothing here" });
+      // Keyword must reference the title (the new title-guard); "Show" is the target.
+      if (i === 1) return tool("searchResources", { keyword: "Show" });
       if (i === 2) return tool("reportNoCoverage", { reason: "no candidates" });
       return { content: [{ type: "text" as const, text: "done" }], finishReason: { unified: "stop" as const, raw: "stop" as const }, usage: USAGE, warnings: [] };
     },
@@ -56,7 +57,7 @@ describe("runAcquisitionV2 — composition root wiring real adapters + sandbox +
 
     // The need came from the missing episodes; nothing landed → honestly unmet.
     expect(result.coverage.missing).toEqual(["S01E01", "S01E02"]);
-    expect(searched).toEqual(["nothing here"]); // the real provider was driven through the adapter
+    expect(searched).toEqual(["Show"]); // the real provider was driven through the adapter
     // The persistable trace is assembled from the adapters: one (empty) snapshot
     // observed, no transfers, so no decisions.
     expect(result.outcome.resourceSnapshots.map((s) => s.id)).toEqual(["snap_empty"]);

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -54,4 +54,22 @@ describe("TaskSandbox — searchResources (system-budgeted, dedup, snapshot-boun
     expect(sandbox.hasObservedSnapshot(result.snapshot!.id)).toBe(true);
     expect(sandbox.hasObservedSnapshot("never-observed")).toBe(false);
   });
+
+  it("rejects a keyword that does not reference the title (no provider hit, no budget spent)", async () => {
+    let calls = 0;
+    const sandbox = new TaskSandbox({
+      provider: { async search(keyword) { calls += 1; return { id: `s_${keyword}`, keyword, candidates: [] }; } },
+      searchBudget: 8,
+      titleTerms: ["公民义警", "Citizen Vigilante"],
+    });
+
+    // The "2026 电影" garbage fallback: genre+year, no title → refused before the provider.
+    await expect(sandbox.searchResources("2026 电影")).rejects.toThrow(/片名/);
+    expect(calls).toBe(0);
+
+    // A title-bearing keyword still works, and the rejected one consumed no budget.
+    const ok = await sandbox.searchResources("公民义警 2026");
+    expect(ok.snapshot).toBeDefined();
+    expect(calls).toBe(1);
+  });
 });


### PR DESCRIPTION
## 事故(用户经 CF tunnel 实测发现)
获取「公民义警 (Citizen Vigilante) 2026」找不到资源后,agent 退化成搜 **`2026 电影`**(纯类型+年份 → 69 个随机 2026 电影 = 纯噪音)。日志实证关键词序列:`公民义警` → `Citizen Vigilante` → `Citizen Vigilante 2026` → `公民义警 2025`(还搞错年份)→ `公民义警 电影` → **`2026 电影`** → `公民义警2026`。`no_coverage` 结论本身是对的(该片确实没资源),只有这个垃圾关键词是槽点。

## 根因
agent 自由生成搜索关键词,标题搜空后机械退化到通用词。违反项目自己的「禁机械 fallback」原则。

## 修复(硬校验器,agent 不可绕过)
- `keywordReferencesTitle`(planning-search-gate):关键词归一化后必须包含片名/原名/别名;否则拒绝。无 title term 时 fail-open。
- `TaskSandbox.searchResources`:不含片名的关键词 **throw**(`asEvidence` → `{error}`,agent 读后改),拦在预算/provider **之前** —— 垃圾关键词不耗搜索预算、不打 provider。orchestrator 传 `titleTerms=[title,...aliases]`。
- skill 提示词补一句:禁纯类型/年份关键词,搜空即如实 no-coverage。

## 不改的部分
超人 2025 落 2.9GB —— 用户判定:`超人` 在 115/磁力的返回噪音极大(111 个「超人」匹配几乎全是奥特曼/一拳超人/超人前传/超人总动员),agent 能从噪音里选对那个唯一的真·Superman 2025 已经不错;2.9GB 可能是该新片在网盘上的天花板。故不动选择逻辑/不加体积警示。

## 验证
新增 `keyword-references-title` + sandbox-search 拒绝用例;`vitest` 739 passed、双 tsc、lint 0、无 DB build 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)