### PR TITLE
fix(acquisition): 非主网盘(夸克)获取丢 storageId 致 run 误投主盘——类型层根除

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -158,7 +158,10 @@ export async function requestTrackingAction(input?: {
 
 export async function requestSeriesAction(input: {
   candidateId: string;
-  storageId?: string;
+  // Tree model: the active workspace drive — REQUIRED (value may be undefined =
+  // primary) so a non-primary acquisition can't silently mis-route. See note on
+  // requestSeasonAction.
+  storageId: string | undefined;
 }): Promise<RequestTrackingActionResult> {
   assertNotDemo();
   const request = await queueCandidateSeries(input.candidateId, input.storageId);
@@ -214,7 +217,12 @@ export async function importForeignWorkAction(input: {
 export async function requestSeasonAction(input: {
   tmdbId: number;
   seasonNumber: number;
-  storageId?: string;
+  // Tree model: the active workspace drive — acquisition lands HERE, not the
+  // primary. REQUIRED (value may be undefined = primary) so every call site must
+  // consciously thread the workspace; an omitted storageId silently mis-routes a
+  // non-primary (e.g. quark) acquisition to the primary drive and the run never
+  // shows on the workspace the user is looking at.
+  storageId: string | undefined;
 }): Promise<RequestTrackingActionResult> {
   assertNotDemo();
   const { queueSeasonTracking } = await import("../lib/title-hub");
@@ -235,7 +243,10 @@ export async function requestSeasonAction(input: {
 
 export async function requestRemainingAction(input: {
   tmdbId: number;
-  storageId?: string;
+  // Tree model: the active workspace drive — REQUIRED (value may be undefined =
+  // primary) so a non-primary acquisition can't silently mis-route. See note on
+  // requestSeasonAction.
+  storageId: string | undefined;
 }): Promise<RequestTrackingActionResult> {
   assertNotDemo();
   const { queueRemainingSeasons } = await import("../lib/title-hub");

--- a/apps/web/app/show/[tmdbId]/page.tsx
+++ b/apps/web/app/show/[tmdbId]/page.tsx
@@ -121,7 +121,11 @@ async function ShowContent({
       activeStorageId={workspace.activeStorageId}
     >
       {view ? (
-        view.kind === "movie" ? <MovieHub view={view} /> : <TvHub view={view} />
+        view.kind === "movie" ? (
+          <MovieHub view={view} />
+        ) : (
+          <TvHub view={view} storageId={workspace.activeStorageId} />
+        )
       ) : (
         <div className="quiet-state">
           <TriangleAlert size={24} aria-hidden />
@@ -133,7 +137,7 @@ async function ShowContent({
   );
 }
 
-function TvHub({ view }: { view: TitleHubView }) {
+function TvHub({ view, storageId }: { view: TitleHubView; storageId: string | undefined }) {
   const badge = aggregateBadge[view.aggregate];
   return (
     <AcquisitionLockProvider>
@@ -186,6 +190,7 @@ function TvHub({ view }: { view: TitleHubView }) {
             {view.untrackedSeasonNumbers.length > 0 && view.seasons.length > 1 ? (
               <RequestRemainingButton
                 tmdbId={view.tmdbId}
+                storageId={storageId}
                 titleAcquiring={view.acquiring}
                 label={
                   view.aggregate === "untracked"
@@ -218,6 +223,7 @@ function TvHub({ view }: { view: TitleHubView }) {
               key={season.seasonNumber}
               season={season}
               tmdbId={view.tmdbId}
+              storageId={storageId}
               acquiring={view.acquiring}
               demoEntry={{
                 tmdbId: view.tmdbId,
@@ -324,11 +330,14 @@ function HubSkeleton() {
 function SeasonRow({
   season,
   tmdbId,
+  storageId,
   acquiring,
   demoEntry,
 }: {
   season: TitleHubSeason;
   tmdbId: number;
+  /** Tree model: the active workspace drive — acquisition lands HERE. */
+  storageId: string | undefined;
   acquiring: boolean;
   demoEntry?: DemoAcquisitionEntry | undefined;
 }) {
@@ -372,6 +381,7 @@ function SeasonRow({
         <RequestSeasonButton
           tmdbId={tmdbId}
           seasonNumber={season.seasonNumber}
+          storageId={storageId}
           titleAcquiring={acquiring}
           demoEntry={demoEntry}
         />

--- a/apps/web/components/request-series-button.tsx
+++ b/apps/web/components/request-series-button.tsx
@@ -11,9 +11,13 @@ import { useDemoAcquiredTmdbIds } from "../lib/use-demo-session";
 
 export function RequestSeriesButton({
   candidateId,
+  storageId,
   demoEntry,
 }: {
   candidateId: string;
+  /** Tree model: the active workspace drive — acquisition lands HERE. REQUIRED
+   *  (value may be undefined = primary) so the workspace is always threaded. */
+  storageId: string | undefined;
   /** Demo only: recorded to the session library when the scripted playback ends. */
   demoEntry?: DemoAcquisitionEntry | undefined;
 }) {
@@ -50,7 +54,7 @@ export function RequestSeriesButton({
           return;
         }
         startTransition(async () => {
-          setResult(await requestSeriesAction({ candidateId }));
+          setResult(await requestSeriesAction({ candidateId, storageId }));
         });
       }}
     >

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -38,8 +38,9 @@ export function SeasonRequestMenu({
   totalSeasonCount: number;
   /** Pill label for the all-remaining scope. */
   allLabel?: string;
-  /** Tree model: the active workspace drive — acquisition lands HERE. */
-  storageId?: string | undefined;
+  /** Tree model: the active workspace drive — acquisition lands HERE. REQUIRED
+   *  (value may be undefined = primary) so the workspace is always threaded. */
+  storageId: string | undefined;
   /** Demo only: recorded to the session library when the scripted playback ends. */
   demoEntry?: DemoAcquisitionEntry | undefined;
 }) {
@@ -80,8 +81,8 @@ export function SeasonRequestMenu({
       setOpen(false);
       setResult(
         selected === "all"
-          ? await requestRemainingAction({ tmdbId, ...(storageId ? { storageId } : {}) })
-          : await requestSeasonAction({ tmdbId, seasonNumber: selected, ...(storageId ? { storageId } : {}) }),
+          ? await requestRemainingAction({ tmdbId, storageId })
+          : await requestSeasonAction({ tmdbId, seasonNumber: selected, storageId }),
       );
       // Re-fetch so the queued run mounts the AcquiringPoller; once it finishes,
       // the acquired season leaves untrackedSeasons and this menu unmounts.
@@ -106,7 +107,7 @@ export function SeasonRequestMenu({
             return;
           }
           startTransition(async () => {
-            setResult(await requestSeasonAction({ tmdbId, seasonNumber: onlySeason }));
+            setResult(await requestSeasonAction({ tmdbId, seasonNumber: onlySeason, storageId }));
             router.refresh();
           });
         }}

--- a/apps/web/components/title-action-buttons.tsx
+++ b/apps/web/components/title-action-buttons.tsx
@@ -18,11 +18,15 @@ import { useDemoAcquiredTmdbIds } from "../lib/use-demo-session";
 export function RequestSeasonButton({
   tmdbId,
   seasonNumber,
+  storageId,
   titleAcquiring = false,
   demoEntry,
 }: {
   tmdbId: number;
   seasonNumber: number;
+  /** Tree model: the active workspace drive — acquisition lands HERE. REQUIRED
+   *  (value may be undefined = primary) so the workspace is always threaded. */
+  storageId: string | undefined;
   /** Server truth: this title already has an acquisition run in flight. */
   titleAcquiring?: boolean;
   /** Demo only: recorded to the session library when the scripted playback ends. */
@@ -69,7 +73,7 @@ export function RequestSeasonButton({
         }
         lock?.lock(scope);
         startTransition(async () => {
-          setResult(await requestSeasonAction({ tmdbId, seasonNumber }));
+          setResult(await requestSeasonAction({ tmdbId, seasonNumber, storageId }));
           router.refresh();
         });
       }}
@@ -89,11 +93,15 @@ export function RequestSeasonButton({
 export function RequestRemainingButton({
   tmdbId,
   label,
+  storageId,
   titleAcquiring = false,
   demoEntry,
 }: {
   tmdbId: number;
   label: string;
+  /** Tree model: the active workspace drive — acquisition lands HERE. REQUIRED
+   *  (value may be undefined = primary) so the workspace is always threaded. */
+  storageId: string | undefined;
   /** Server truth: this title already has an acquisition run in flight. */
   titleAcquiring?: boolean;
   /** Demo only: recorded to the session library when the scripted playback ends. */
@@ -138,7 +146,7 @@ export function RequestRemainingButton({
         }
         lock?.lock(scope);
         startTransition(async () => {
-          setResult(await requestRemainingAction({ tmdbId }));
+          setResult(await requestRemainingAction({ tmdbId, storageId }));
           router.refresh();
         });
       }}


### PR DESCRIPTION
## 症状
在夸克 workspace 点剧集「获取」,**媒体库/活动什么都不出现**;切走再回来按钮又变回「获取」而非「请求中」。(用户报「超级大问题」)

## 根因(证据先行)
- 单季剧的「获取」按钮 `season-request-menu.tsx:109` 内部调 `requestSeasonAction` 时**漏传 `storageId`** → `getActiveWorkspaceScope(undefined)` 回退到账号**主盘(115)**而非当前夸克 workspace。
- DB 实测:用户点的是单季 C-drama,误投主盘后该剧在 115 已 `completed`(episode_states 齐全)→ `reserveWorkflowRun` 命中 `already_has_episode_state` → **一个 run 都没建** → 夸克页面看不到任何东西、按钮回落「获取」。即便是 115 没有的剧,run 也会落到主盘、夸克页面同样看不见。

## 同类缺陷(共 6 处 call site)
都是「客户端没把当前 workspace 的 `storageId` 透到 server action」:
- `season-request-menu.tsx`(单季 / 多季 / 剩余)
- `title-action-buttons.tsx` `RequestSeasonButton` / `RequestRemainingButton`(**连 prop 都没有**)
- `request-series-button.tsx`

## 修法:硬规则转类型校验器
- `requestSeasonAction` / `requestRemainingAction` / `requestSeriesAction` 的 `storageId` 从 `storageId?`(可选)改为 **`storageId: string | undefined`(必填,值可为 undefined=主盘,但 key 必须显式传)**。→ 任何 call site 漏传直接 **tsc 报错**,CI 拦住,正是会复发的那一类 bug。
- 修复全部 6 处 call site;show 页把 `workspace.activeStorageId` 经 `TvHub→SeasonRow` 透到两个按钮。

## 验证
- 先把 action 改必填 → `tsc -p apps/web/tsconfig.json` **RED 精确点亮 6 处**(含 `season-request-menu.tsx:109` 这个真凶)→ 改完 call site **GREEN**(红→绿即回归守门)。
- `apps/web tsc` + `build:workflow` + `lint` + `build:web`(prod,含 PPR)全绿。
- 真·端到端(夸克盘点获取 → run 落夸克盘、夸克页面可见)待部署后实例上验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)