### PR TITLE
fix(notifications): 移动端状态药丸不换行 + 修 demo 通知被7天窗口清空

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1426,6 +1426,10 @@ p {
   font-weight: 700;
   padding: 2px 9px;
   border-radius: var(--radius-pill);
+  /* Never let the pill compress + wrap its label (e.g. 暂无资源 → 暂无/资源) on a
+     narrow head row; the title (min-width:0 + ellipsis) absorbs the squeeze instead. */
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .feed-status-pill.tone-green { color: var(--accent); background: rgba(30, 215, 96, 0.12); }
@@ -1501,6 +1505,7 @@ p {
   font-size: 12px;
   color: var(--text-muted);
   white-space: nowrap;
+  flex-shrink: 0;
 }
 
 /* Library — all tracked titles grid */

--- a/apps/web/lib/demo-workflow.test.ts
+++ b/apps/web/lib/demo-workflow.test.ts
@@ -38,6 +38,18 @@ describe("seedDemoWorkflowRepository (rich demo library)", () => {
     }
   });
 
+  it("seeds report-bearing notifications inside the 7-day window (通知 page isn't empty/filtered)", async () => {
+    const repo = new InMemoryWorkflowRepository();
+    await seedDemoWorkflowRepository(repo);
+    // Mirror the notifications page's 7-day cutoff: demo notifs must be recent
+    // enough to survive it (fixed past dates would be filtered → empty page).
+    const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+    const recent = await repo.listNotifications({ accountId: "acct_default", since });
+    expect(recent.length).toBeGreaterThan(0);
+    // Rich L2 cards: report-bearing (status pill + poster), not legacy plain rows.
+    expect(recent.some((n) => n.report != null)).toBe(true);
+  });
+
   it("covers reserved / partial / tracking states", async () => {
     const { all } = await seededStates();
     // reserved: a movie with a future release date (复仇者联盟5, 2026-12-16)

--- a/apps/web/lib/demo-workflow.ts
+++ b/apps/web/lib/demo-workflow.ts
@@ -4,10 +4,15 @@ import {
   InMemoryWorkflowRepository,
   type EpisodeState,
   type MediaTitle,
+  type NotificationReportStatus,
   type TrackedSeason,
   type WorkflowRepository,
   type WorkflowRun,
 } from "@media-track/workflow";
+
+/** Demo notification timestamps are relative to now so they always fall inside
+ *  the 通知 page's 7-day window (fixed past dates would be filtered out → empty). */
+const recentIso = (hoursAgo: number): string => new Date(Date.now() - hoursAgo * 3_600_000).toISOString();
 
 const DEMO_ACCOUNT = "acct_default";
 const DEMO_DRIVE_115 = "cs_demo_115";
@@ -176,12 +181,27 @@ const CURATED: Curated[] = [
   { kind: "series", drive: "quark", type: "anime", tmdbId: 209867, title: "葬送的芙莉莲", year: 2023, posterPath: "/1TtrtRIwXz5BB0gXEl8zgBypl9c.jpg", backdropPath: "/rBOnrVlck7BIlGeWVlzYiZeg4l2.jpg", totalEpisodes: 28, latestAired: 20, obtainedCount: 20, status: "active" },
 ];
 
-// A few notifications so the 通知 page isn't empty (keyed by tmdbId).
-const NOTIFS: Record<number, { kind: string; title: string; body: string; createdAt: string }> = {
-  37165: { kind: "movie_obtained", title: "楚门的世界 (1998) · 已入库", body: "已转存到 115 网盘并完成验证。", createdAt: "2026-06-12T08:00:00.000Z" },
-  842675: { kind: "movie_obtained", title: "流浪地球2 (2023) · 已入库", body: "已转存到 115 网盘并完成验证。", createdAt: "2026-06-12T09:10:00.000Z" },
-  87108: { kind: "tracking_initialized", title: "切尔诺贝利 第 1 季 · 已获取 5 集", body: "目标目录已验证到 5 个视频文件。", createdAt: "2026-06-11T00:02:00.000Z" },
-  120089: { kind: "tracking_initialized", title: "间谍过家家 · 已获取 8 集", body: "已获取至第 8 集，剩余将由每日巡检自动补齐。", createdAt: "2026-06-13T12:00:00.000Z" },
+// A few notifications so the 通知 page isn't empty (keyed by tmdbId). Report-bearing
+// so they render as rich poster + status-pill cards (the redesign's L2 card), with
+// recent timestamps + a spread of statuses (incl. the longer 4-char 暂无资源 pill).
+const NOTIFS: Record<
+  number,
+  {
+    kind: string;
+    status: NotificationReportStatus;
+    seasonLabel: string | null;
+    lines: string[];
+    newlyObtained?: string[];
+    realMissing?: string[];
+    fileCount?: number;
+    totalBytes?: number;
+    hoursAgo: number;
+  }
+> = {
+  37165: { kind: "package_initialized", status: "acquired", seasonLabel: null, lines: [], fileCount: 1, totalBytes: 10_200_000_000, hoursAgo: 2 },
+  842675: { kind: "package_initialized", status: "acquired", seasonLabel: null, lines: [], fileCount: 1, totalBytes: 38_400_000_000, hoursAgo: 6 },
+  87108: { kind: "tracking_completed", status: "partial", seasonLabel: "第 1 季", lines: ["已获取 3/5 集 · 2 集缺失，等待每日巡检补齐"], realMissing: ["S01E04", "S01E05"], hoursAgo: 28 },
+  120089: { kind: "no_coverage", status: "no_coverage", seasonLabel: "第 2 季", lines: ["本次巡检暂未找到合适资源，明日继续尝试"], hoursAgo: 52 },
 };
 
 export async function seedDemoWorkflowRepository(repository: WorkflowRepository): Promise<void> {
@@ -252,7 +272,30 @@ export async function seedDemoWorkflowRepository(repository: WorkflowRepository)
       decisions: [],
       transferAttempts: [],
       notifications: notif
-        ? [{ id: `demo_notif_${item.tmdbId}`, workflowRunId: run.id, kind: notif.kind, title: notif.title, body: notif.body, createdAt: notif.createdAt }]
+        ? [
+            {
+              id: `demo_notif_${item.tmdbId}`,
+              workflowRunId: run.id,
+              kind: notif.kind,
+              title: `${fixture.title.title}${notif.seasonLabel ? ` ${notif.seasonLabel}` : ""}`,
+              body: notif.lines[0] ?? "",
+              createdAt: recentIso(notif.hoursAgo),
+              report: {
+                titleName: fixture.title.title,
+                seasonLabel: notif.seasonLabel,
+                status: notif.status,
+                lines: notif.lines,
+                newlyObtained: notif.newlyObtained ?? [],
+                realMissing: notif.realMissing ?? [],
+                posterPath: fixture.title.posterPath ?? null,
+                tmdbId: item.tmdbId,
+                mediaType: fixture.title.type,
+                year: fixture.title.year,
+                ...(notif.fileCount !== undefined ? { fileCount: notif.fileCount } : {}),
+                ...(notif.totalBytes !== undefined ? { totalBytes: notif.totalBytes } : {}),
+              },
+            },
+          ]
         : [],
     });
   }


### PR DESCRIPTION
## ① 药丸换行(用户报告,真机移动端已确认)
窄屏(尤其 `has-poster` 卡)下 `.feed-status-pill` 是可压缩的 flex 子项,CJK 标签逐字换行:**已入库 → 已入/库**、**暂无资源 → 暂无/资源**。
- 修:`.feed-status-pill` 加 `white-space:nowrap` + `flex-shrink:0`(标题 `min-width:0`+省略号去吸收挤压);`.feed-time` 补 `flex-shrink:0`。
- 390px agent-browser 实测:**修前药丸高 37px(两行)→ 修后 21px(一行)**,标题正常省略。

## ② demo 通知页空(我在 #13 引入的回归)
demo 通知用固定日期 2026-06-11~13;今日 06-22,被 #13 新增的 7 天窗口**全部过滤 → demo 通知页空白**。
- 修:demo 通知升级为 **report-bearing 富卡**(海报 + 状态药丸,即重设计的 L2 卡)+ 时间戳相对 `now`(`recentIso`)+ 多样状态(含 4 字「暂无资源」用于复现换行)。
- 新增回归测试:demo 通知必须在 7 天窗口内且 report-bearing。

## 验证
749 测(+1 回归)+ apps/web tsc + lint + build:web 全绿;390px 真机修前/修后截图与药丸高度测量对比。合并后:demo(Vercel)自动重部署可验;生产实例(media.dirtyfancy.sbs)走 git pull + 重建吃到 CSS 修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)