### PR TITLE
fix(docker): 自部署镜像漏拷 public/ 致切换器品牌图标 404

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,9 @@ ENV HOSTNAME=0.0.0.0
 # Standalone traces from the monorepo root → server entry at apps/web/server.js.
 COPY --from=builder /app/apps/web/.next/standalone ./
 COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+# `output: standalone` does NOT bundle public/ — copy it explicitly, else every
+# public asset (e.g. /brands/<provider>.svg for the workspace switcher icons) 404s
+# and BrandMark falls back to a bare dot (demo on Vercel serves public/ natively).
+COPY --from=builder /app/apps/web/public ./apps/web/public
 EXPOSE 3000
 CMD ["node", "apps/web/server.js"]


### PR DESCRIPTION
## 现象(投产实例 192.168.100.1:3300)
网盘切换器右上角不显示品牌图标(115 蓝块 / 夸克 Q),只剩一个小绿点;切页时偶尔变成破图占位符。**demo(Vercel)正常**。

## 根因
Next `output: standalone` **不打包 `public/`**。Dockerfile 的 runner 阶段只 `COPY` 了 `.next/standalone` + `.next/static`,**没拷 `apps/web/public`** → 实例上 `/brands/<provider>.svg` 全部 404 → `BrandMark` 的 `<img onError>` 回退到 `ws-dot`(回退前浏览器先闪一下破图占位符)。Vercel 原生伺服 `public/`,所以 demo 没事。

## 修复
runner 阶段加:
```
COPY --from=builder /app/apps/web/public ./apps/web/public
```

## 验证(本地模拟 Docker runner,无需 Docker / 无需实例)
用 `.next/standalone` 直接起 standalone server:
- 旧布局(只 standalone+static,无 public):`/brands/pan115.svg` → **404**(复现),`/` → 200。
- 拷入 `public/` 后:`/brands/pan115.svg` + `/brands/quark.svg` → **200 (image/svg+xml)**。
- 旁证:demo 侧 `curl /brands/*.svg` → 200,说明资源本身没问题、纯实例伺服缺失。

⚠️ 合并后**生产实例需回家在内网 `git pull && docker compose up -d --build web`** 重建镜像才生效(CI 不构建 Docker 镜像;我离家时 ssh 不通)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)