### PR TITLE
feat(self-host): cloudflared host-gateway — 为 SSH-over-tunnel 备路

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,11 @@ services:
     command: tunnel --no-autoupdate run
     environment:
       TUNNEL_TOKEN: ${TUNNEL_TOKEN:-}
+    # Lets the connector resolve the Docker host, so a tunnel Public Hostname of
+    # type SSH can point at the host's sshd (host.docker.internal:22) — enabling
+    # SSH-over-tunnel from anywhere without opening a port. Harmless if unused.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - web
     restart: unless-stopped


### PR DESCRIPTION
为「外网 SSH 到软路由」备路:给 compose 的 `cloudflared` 加 `extra_hosts: host.docker.internal:host-gateway`,让连接器能连到宿主的 sshd。

配合在 CF 隧道加一条 **Type=SSH** 的 Public Hostname(`ssh.dirtyfancy.sbs → host.docker.internal:22`)+ CF Access(邮箱 + service token),即可从任意网络(含纯 IPv4 WiFi)SSH 到软路由、**不开任何端口**。这条解决了 WireGuard 的「客户端也需公网 IPv6」限制(CF 两端出站到双栈边缘)。

- 仅当 ingress 直接指 `192.168.100.1:22` 不通时才需要此回退路径;无害,未用即闲置。
- `docker compose config -q` 通过。
- CF dashboard 三步 + Mac cloudflared 配置见 spec `docs/superpowers/specs/2026-06-22-ssh-over-cloudflare-tunnel-design.md`。
- ⚠️ 生效需作者在 CF dashboard 配 public hostname/Access/service token;走回退路径时实例需 `git pull` 重建一次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)