### PR TITLE
chore: 处理 Copilot 对 PR#14/#16 的有效 review 意见

### DIFF
--- a/apps/web/lib/demo-workflow.test.ts
+++ b/apps/web/lib/demo-workflow.test.ts
@@ -41,8 +41,12 @@ describe("seedDemoWorkflowRepository (rich demo library)", () => {
   it("seeds report-bearing notifications inside the 7-day window (通知 page isn't empty/filtered)", async () => {
     const repo = new InMemoryWorkflowRepository();
     await seedDemoWorkflowRepository(repo);
-    // Mirror the notifications page's 7-day cutoff: demo notifs must be recent
-    // enough to survive it (fixed past dates would be filtered → empty page).
+    // Mirrors NOTIFICATION_WINDOW_DAYS (=7) / notificationWindowSince() in
+    // workflow-runtime.ts. Kept as a literal on purpose: that module is Next
+    // server-only (next/headers, pg) and shouldn't be imported into a workflow
+    // unit test. The real invariant being guarded is "demo notifs are recent
+    // (now-relative), not fixed past dates" — seed max is 52h, far inside 7d, so
+    // this stays correct unless the window is cut below ~2 days (implausible).
     const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
     const recent = await repo.listNotifications({ accountId: "acct_default", since });
     expect(recent.length).toBeGreaterThan(0);

--- a/apps/web/lib/demo-workflow.ts
+++ b/apps/web/lib/demo-workflow.ts
@@ -200,7 +200,7 @@ const NOTIFS: Record<
 > = {
   37165: { kind: "package_initialized", status: "acquired", seasonLabel: null, lines: [], fileCount: 1, totalBytes: 10_200_000_000, hoursAgo: 2 },
   842675: { kind: "package_initialized", status: "acquired", seasonLabel: null, lines: [], fileCount: 1, totalBytes: 38_400_000_000, hoursAgo: 6 },
-  87108: { kind: "tracking_completed", status: "partial", seasonLabel: "第 1 季", lines: ["已获取 3/5 集 · 2 集缺失，等待每日巡检补齐"], realMissing: ["S01E04", "S01E05"], hoursAgo: 28 },
+  87108: { kind: "tracking_initialized", status: "partial", seasonLabel: "第 1 季", lines: ["已获取 3/5 集 · 2 集缺失，等待每日巡检补齐"], realMissing: ["S01E04", "S01E05"], hoursAgo: 28 },
   120089: { kind: "no_coverage", status: "no_coverage", seasonLabel: "第 2 季", lines: ["本次巡检暂未找到合适资源，明日继续尝试"], hoursAgo: 52 },
 };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
     # Lets the connector resolve the Docker host, so a tunnel Public Hostname of
     # type SSH can point at the host's sshd (host.docker.internal:22) — enabling
     # SSH-over-tunnel from anywhere without opening a port. Harmless if unused.
+    # ⚠️ A bare SSH Public Hostname is reachable by anyone who knows it — gate it
+    # with Cloudflare Access, or accept key-only auth (no password auth on sshd).
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:


### PR DESCRIPTION
检查了最近 PR(#14/#15/#16)的 Copilot review。**#15 干净**;#14/#16 各 2 条,均为 nit(非 bug),修了其中有价值的:

- **#14 demo-workflow.ts**:demo 通知把 `kind=tracking_completed`(🎉)配 `status=partial`(有缺集)→ 卡片自相矛盾。改 `kind=tracking_initialized`(下载图标),与「部分入库」一致。
- **#16 docker-compose.yml**:给 cloudflared SSH-over-tunnel 注释补安全提示(裸 SSH Public Hostname 谁知道都够得到 → 挂 Access 或只认密钥)。公共仓库该提醒。
- **#14 test:47**:把 7 天字面量与 `notificationWindowSince()`/`NOTIFICATION_WINDOW_DAYS` 的耦合在注释里写清楚(故意用字面量:该模块 Next server-only,不该 import 进 workflow 单测),消除「静默漂移」。

**跳过**(已说明):#16「PR 描述引用的 spec 不在仓库」——`docs/superpowers/` 是有意 gitignore,且是已合并 PR 描述,改不了。

验证:vitest 742 过 + apps/web tsc + lint + `docker compose config -q` 全绿。纯仓库质量,不影响实例运行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)