### PR TITLE
fix(observability): 已完成 run 的 agent_steps 在 finalize 时被误删

### DIFF
--- a/packages/workflow/src/postgres.ts
+++ b/packages/workflow/src/postgres.ts
@@ -1235,7 +1235,11 @@ export class PostgresWorkflowRepository implements WorkflowRepository {
     await client.query("DELETE FROM notifications WHERE workflow_run_id = $1", [workflowRunId]);
     await client.query("DELETE FROM transfer_attempts WHERE workflow_run_id = $1", [workflowRunId]);
     await client.query("DELETE FROM agent_decisions WHERE workflow_run_id = $1", [workflowRunId]);
-    await client.query("DELETE FROM agent_steps WHERE workflow_run_id = $1", [workflowRunId]);
+    // NOTE: do NOT delete agent_steps here. This runs on every saveWorkflowRunSnapshot
+    // (re-persist) to clear children the snapshot RE-INSERTS. agent_steps are written
+    // incrementally by the trace sink and are NOT in the snapshot, so deleting them here
+    // would wipe a completed run's trace at finalize. Cross-attempt clearing is handled
+    // by clearAgentSteps (sink start); true teardown is in cancel/untrack.
     await client.query("DELETE FROM resource_snapshots WHERE workflow_run_id = $1", [workflowRunId]);
     // Scope to THIS drive's episodes — never wipe another drive's episodes for the same season.
     await client.query(

--- a/packages/workflow/tests/agent-steps.pg.test.ts
+++ b/packages/workflow/tests/agent-steps.pg.test.ts
@@ -49,6 +49,20 @@ async function seedRun(
   });
 }
 
+async function cleanupRun(
+  pool: pg.Pool,
+  opts: { runId: string; tmdb: number; storage: string },
+): Promise<void> {
+  // Drive-scoped: tracked_seasons / episode_states are keyed by (…, connected_storage_id),
+  // so delete only THIS drive's rows — never another drive's for the same season.
+  const seasonId = `tmdb_tv_${opts.tmdb}_s1`;
+  await pool.query("DELETE FROM agent_steps WHERE workflow_run_id = $1", [opts.runId]);
+  await pool.query("DELETE FROM episode_states WHERE tracked_season_id = $1 AND connected_storage_id = $2", [seasonId, opts.storage]);
+  await pool.query("DELETE FROM workflow_runs WHERE id = $1", [opts.runId]);
+  await pool.query("DELETE FROM tracked_seasons WHERE id = $1 AND connected_storage_id = $2", [seasonId, opts.storage]);
+  await pool.query("DELETE FROM media_titles WHERE id = $1", [`tmdb_tv_${opts.tmdb}`]);
+}
+
 const URL = process.env.MEDIA_TRACK_POSTGRES_URL;
 const d = URL ? describe : describe.skip;
 
@@ -98,11 +112,7 @@ d("Postgres agent steps", () => {
       expect(await repo.listAgentSteps(runId, { accountId: "acct_other", connectedStorageId: null })).toEqual([]); // wrong account
       expect(await repo.listAgentSteps(runId, { accountId: "acct_obs_a", connectedStorageId: "cs_other" })).toEqual([]); // wrong drive
     } finally {
-      await pool.query("DELETE FROM agent_steps WHERE workflow_run_id = $1", [runId]);
-      await pool.query("DELETE FROM episode_states WHERE tracked_season_id = $1", [`tmdb_tv_${tmdb}_s1`]);
-      await pool.query("DELETE FROM workflow_runs WHERE id = $1", [runId]);
-      await pool.query("DELETE FROM tracked_seasons WHERE id = $1", [`tmdb_tv_${tmdb}_s1`]);
-      await pool.query("DELETE FROM media_titles WHERE id = $1", [`tmdb_tv_${tmdb}`]);
+      await cleanupRun(pool, { runId, tmdb, storage: "cs_obs_x" });
       await pool.end();
     }
   });
@@ -123,11 +133,7 @@ d("Postgres agent steps", () => {
       await seedRun(repo, { runId, account: "acct_obs_b", storage: "cs_obs_y", tmdb });
       expect((await repo.listAgentSteps(runId)).map((s) => s.ordinal)).toEqual([0, 1]);
     } finally {
-      await pool.query("DELETE FROM agent_steps WHERE workflow_run_id = $1", [runId]);
-      await pool.query("DELETE FROM episode_states WHERE tracked_season_id = $1", [`tmdb_tv_${tmdb}_s1`]);
-      await pool.query("DELETE FROM workflow_runs WHERE id = $1", [runId]);
-      await pool.query("DELETE FROM tracked_seasons WHERE id = $1", [`tmdb_tv_${tmdb}_s1`]);
-      await pool.query("DELETE FROM media_titles WHERE id = $1", [`tmdb_tv_${tmdb}`]);
+      await cleanupRun(pool, { runId, tmdb, storage: "cs_obs_y" });
       await pool.end();
     }
   });

--- a/packages/workflow/tests/agent-steps.pg.test.ts
+++ b/packages/workflow/tests/agent-steps.pg.test.ts
@@ -107,6 +107,31 @@ d("Postgres agent steps", () => {
     }
   });
 
+  it("agent_steps survive a terminal re-persist (saveWorkflowRunSnapshot must NOT wipe the trace)", async () => {
+    const pool = new pg.Pool({ connectionString: URL });
+    const repo = new PostgresWorkflowRepository(pool);
+    const tmdb = 810000 + (Date.now() % 90000);
+    const runId = `run_persist_${tmdb}`;
+    try {
+      await seedRun(repo, { runId, account: "acct_obs_b", storage: "cs_obs_y", tmdb });
+      await repo.appendAgentStep(runId, step(0, "searchResources"));
+      await repo.appendAgentStep(runId, step(1, "markObtained"));
+      expect((await repo.listAgentSteps(runId)).length).toBe(2);
+      // The worker finalizes a completed run by re-persisting its snapshot. That path
+      // (replaceWorkflowRunSnapshot → deleteWorkflowRunChildren) must NOT delete the
+      // incrementally-written trace — the snapshot doesn't carry agent_steps to re-insert.
+      await seedRun(repo, { runId, account: "acct_obs_b", storage: "cs_obs_y", tmdb });
+      expect((await repo.listAgentSteps(runId)).map((s) => s.ordinal)).toEqual([0, 1]);
+    } finally {
+      await pool.query("DELETE FROM agent_steps WHERE workflow_run_id = $1", [runId]);
+      await pool.query("DELETE FROM episode_states WHERE tracked_season_id = $1", [`tmdb_tv_${tmdb}_s1`]);
+      await pool.query("DELETE FROM workflow_runs WHERE id = $1", [runId]);
+      await pool.query("DELETE FROM tracked_seasons WHERE id = $1", [`tmdb_tv_${tmdb}_s1`]);
+      await pool.query("DELETE FROM media_titles WHERE id = $1", [`tmdb_tv_${tmdb}`]);
+      await pool.end();
+    }
+  });
+
   it("clearAgentSteps drops a prior attempt so a retry (same run id) re-traces from 0", async () => {
     const pool = new pg.Pool({ connectionString: URL });
     const repo = new PostgresWorkflowRepository(pool);


### PR DESCRIPTION
## 根因(live 终态验出)

PR #19 的 live 验证暴露一个真 bug:在 115 盘真获取超市(run \`678fb06f\`),**running 时** agent_steps 正常(ordinal 0..9),但 run 完成后 **psql 查到 0 行**——轨迹在 finalize 时被删了。

链路:run 完成 → \`saveWorkflowRunSnapshot\` → \`replaceWorkflowRunSnapshot\` → \`deleteWorkflowRunChildren\`,其中我在 #19 给它加了 \`DELETE FROM agent_steps\`。但 \`deleteWorkflowRunChildren\` 的语义是"删掉快照会 RE-INSERT 的子表";agent_steps 是 trace sink **增量写**的、**不在快照里**,所以删了就没人重插 → 已完成 run 的轨迹永久丢失(只 running 时可见,正好骗过了边跑边查的 live 验证)。

**Postgres 专属**:InMemory 的 \`saveWorkflowRunSnapshot\` 根本不碰 agentSteps,所以单测/InMemory 集成测试没抓到——又一次 InMemory/PG 行为分叉。

## 修复

\`deleteWorkflowRunChildren\` 不再删 \`agent_steps\`(加注释说明为什么)。跨重试的轨迹清理由 sink 启动时的 \`clearAgentSteps\` 负责(#19 已有);真正的拆除(cancel/untrack)仍删 agent_steps。

## 验证

- 新增真 Postgres 回归:seed run → appendAgentStep → **再次 saveWorkflowRunSnapshot(模拟 finalize)** → listAgentSteps 仍返回完整轨迹。先 red(0 行)后 green。
- 4 个真 PG 测试 + 三处 tsc + build:workflow + 全量 vitest(760)+ lint 全绿。
- ⏳ 合并部署后 live 终态复验(超市再获取→run 完成后 psql agent_steps 仍在)回填。

🤖 Generated with [Claude Code](https://claude.com/claude-code)