### PR TITLE
feat(acquisition): 115 预算 240 软警告 + 300 硬停(作者拍板)

### DIFF
--- a/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
@@ -25,6 +25,41 @@ export const STEP_50_REMINDER =
   "这次没来得及拿的集不要紧——只要没被 markObtained,下次每日巡检会自动发现并补齐。" +
   "请稳妥收尾,绝不要为赶进度草率丢弃还能拿到的资源。";
 
+/** 115 API-call SOFT-warning threshold. The HARD limit (where the guard actually
+ *  throws Pan115RiskControlError) is 300 — see createProtectedStorage115Executor.
+ *  At the soft mark we nudge the agent to wrap up (same idea as the step cap),
+ *  leaving headroom so its own markObtained/discardStaging (which cost a few 115
+ *  calls) still fit under 300 instead of being cut off mid-cleanup. */
+export const BUDGET_SOFT_REMIND_AT = 240;
+
+/** Calm wrap-up nudge for the 115 call budget — mirrors STEP_50_REMINDER's tone. */
+export const BUDGET_REMINDER =
+  "【网盘调用提醒】本次任务的 115 接口调用已接近软上限(约 240,硬上限 300)。这是正常的收尾信号,不是失败。请:" +
+  "① 不要再发起新的 searchResources / transferCandidate;" +
+  "② 对确实落盘的 markObtained、把已转存好的用 moveToSeason 归位;" +
+  "③ discardStaging 打扫战场;④ finish。" +
+  "这次没来得及拿的集不要紧——只要没被 markObtained,下次每日巡检会自动补齐。" +
+  "请立刻稳妥收尾:到 300 次会被硬性中断,别把调用预算耗在还没收尾上。";
+
+/** The step-cap reminder as a pure nudge (text or null) — within the last
+ *  `within` steps before the cap. Composable with other nudges in prepareStep. */
+export function stepReflectionNudge(
+  stepNumber: number,
+  maxSteps: number,
+  within: number = REMIND_WITHIN_STEPS,
+): string | null {
+  return stepNumber >= maxSteps - within ? STEP_50_REMINDER : null;
+}
+
+/** The 115 call-budget reminder as a pure nudge (text or null) — at/after the soft
+ *  threshold. `spent` undefined (storage without apiCallCount, e.g. fakes) → null. */
+export function budgetReflectionNudge(
+  spent: number | undefined,
+  softAt: number = BUDGET_SOFT_REMIND_AT,
+): string | null {
+  return typeof spent === "number" && spent >= softAt ? BUDGET_REMINDER : null;
+}
+
 // Minimal structural view of an AI-SDK StepResult — only the fields we read.
 interface StepLike {
   toolCalls?: ReadonlyArray<{ toolName: string; input: unknown }>;
@@ -58,9 +93,27 @@ export function reflectionSystemOverride(input: {
   baseSystem: string;
   remindWithinSteps?: number;
 }): string | undefined {
-  const within = input.remindWithinSteps ?? REMIND_WITHIN_STEPS;
-  if (input.stepNumber >= input.maxSteps - within) {
-    return `${input.baseSystem}\n\n${STEP_50_REMINDER}`;
-  }
-  return undefined;
+  const nudge = stepReflectionNudge(input.stepNumber, input.maxSteps, input.remindWithinSteps);
+  return nudge ? `${input.baseSystem}\n\n${nudge}` : undefined;
+}
+
+/**
+ * Compose the applicable wrap-up nudges (step-cap AND/OR 115 budget) onto the base
+ * system for one step. Returns the overridden system text, or undefined when no
+ * nudge applies. Both can fire at once (near the step cap AND over budget) — then
+ * both are appended. Pure → unit-testable; prepareStep just calls this.
+ */
+export function prepareStepSystemOverride(input: {
+  stepNumber: number;
+  maxSteps: number;
+  baseSystem: string;
+  apiCallsSpent?: number;
+  remindWithinSteps?: number;
+  budgetSoftAt?: number;
+}): string | undefined {
+  const nudges = [
+    stepReflectionNudge(input.stepNumber, input.maxSteps, input.remindWithinSteps),
+    budgetReflectionNudge(input.apiCallsSpent, input.budgetSoftAt),
+  ].filter((nudge): nudge is string => nudge !== null);
+  return nudges.length > 0 ? [input.baseSystem, ...nudges].join("\n\n") : undefined;
 }

--- a/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
@@ -21,7 +21,7 @@ export const STEP_50_REMINDER =
   "【进度提醒】本次任务已接近步数预算(约剩 10 步)。这是正常的收尾信号,不是失败。请:" +
   "① 不要再发起任何新的搜索或转存(searchResources / transferCandidate / transferUntilLanded 都不要);" +
   "② 把已转存好的归位(TV/动漫用 moveToSeason 入季;电影用 flattenMovie 收进影片目录)、对确实落盘的 markObtained;" +
-  "③ 打扫战场:TV/动漫用 discardStaging 清空 staging;电影已 flattenMovie 就地清理,不要再 discardStaging;④ finish。" +
+  "③ 打扫战场:TV/动漫用 discardStaging 清空 staging;电影没有独立 staging——由 flattenMovie(见②)负责就地清掉包装目录,不要用 discardStaging;④ finish。" +
   "这次没来得及拿的集不要紧——只要没被 markObtained,下次每日巡检会自动发现并补齐。" +
   "请稳妥收尾,绝不要为赶进度草率丢弃还能拿到的资源。";
 

--- a/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
@@ -46,7 +46,7 @@ export function budgetSoftThreshold(hardBudget: number): number {
  *  No hardcoded numbers: the threshold is configurable, so the text stays generic. */
 export const BUDGET_REMINDER =
   "【网盘调用提醒】本次任务的 115 接口调用已接近预算上限。这是正常的收尾信号,不是失败。请:" +
-  "① 不要再发起新的 searchResources / transferCandidate;" +
+  "① 不要再发起任何新的搜索或转存(searchResources / transferCandidate / transferUntilLanded 都不要);" +
   "② 对确实落盘的 markObtained、把已转存好的用 moveToSeason 归位;" +
   "③ discardStaging 打扫战场;④ finish。" +
   "这次没来得及拿的集不要紧——只要没被 markObtained,下次每日巡检会自动补齐。" +

--- a/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
@@ -47,8 +47,8 @@ export function budgetSoftThreshold(hardBudget: number): number {
 export const BUDGET_REMINDER =
   "【网盘调用提醒】本次任务的 115 接口调用已接近预算上限。这是正常的收尾信号,不是失败。请:" +
   "① 不要再发起任何新的搜索或转存(searchResources / transferCandidate / transferUntilLanded 都不要);" +
-  "② 对确实落盘的 markObtained、把已转存好的用 moveToSeason 归位;" +
-  "③ discardStaging 打扫战场;④ finish。" +
+  "② 对确实落盘的 markObtained、把已转存好的归位(TV/动漫用 moveToSeason 入季;电影用 flattenMovie 收进影片目录);" +
+  "③ 打扫战场:TV/动漫用 discardStaging 清空 staging;电影已落影片目录、flattenMovie 已就地清理,不要再 discardStaging;④ finish。" +
   "这次没来得及拿的集不要紧——只要没被 markObtained,下次每日巡检会自动补齐。" +
   "请立刻稳妥收尾:调用一旦到硬上限会被强制中断,别把预算耗在还没收尾上。";
 

--- a/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
@@ -25,21 +25,32 @@ export const STEP_50_REMINDER =
   "这次没来得及拿的集不要紧——只要没被 markObtained,下次每日巡检会自动发现并补齐。" +
   "请稳妥收尾,绝不要为赶进度草率丢弃还能拿到的资源。";
 
-/** 115 API-call SOFT-warning threshold. The HARD limit (where the guard actually
- *  throws Pan115RiskControlError) is 300 — see createProtectedStorage115Executor.
- *  At the soft mark we nudge the agent to wrap up (same idea as the step cap),
- *  leaving headroom so its own markObtained/discardStaging (which cost a few 115
- *  calls) still fit under 300 instead of being cut off mid-cleanup. */
+/** Default SOFT-warning threshold, used only as a fallback when the hard budget is
+ *  unknown (storage without apiCallBudget). In production the threshold is DERIVED
+ *  from the configured hard limit via budgetSoftThreshold so the two never drift
+ *  (default hard 300 → soft 240, matching the拍板 design). */
 export const BUDGET_SOFT_REMIND_AT = 240;
 
-/** Calm wrap-up nudge for the 115 call budget — mirrors STEP_50_REMINDER's tone. */
+/** Headroom (in 115 calls) reserved between the SOFT warning and the HARD limit, so
+ *  the agent's own wrap-up (markObtained / discardStaging — themselves a few 115
+ *  calls) still fits before the hard stop. Default hard 300 − 60 = soft 240. */
+export const BUDGET_SOFT_HEADROOM = 60;
+
+/** Derive the SOFT-warning threshold from the configured HARD budget so they stay
+ *  consistent even when MEDIA_TRACK_115_MAX_API_CALLS overrides the limit. */
+export function budgetSoftThreshold(hardBudget: number): number {
+  return Math.max(1, hardBudget - BUDGET_SOFT_HEADROOM);
+}
+
+/** Calm wrap-up nudge for the 115 call budget — mirrors STEP_50_REMINDER's tone.
+ *  No hardcoded numbers: the threshold is configurable, so the text stays generic. */
 export const BUDGET_REMINDER =
-  "【网盘调用提醒】本次任务的 115 接口调用已接近软上限(约 240,硬上限 300)。这是正常的收尾信号,不是失败。请:" +
+  "【网盘调用提醒】本次任务的 115 接口调用已接近预算上限。这是正常的收尾信号,不是失败。请:" +
   "① 不要再发起新的 searchResources / transferCandidate;" +
   "② 对确实落盘的 markObtained、把已转存好的用 moveToSeason 归位;" +
   "③ discardStaging 打扫战场;④ finish。" +
   "这次没来得及拿的集不要紧——只要没被 markObtained,下次每日巡检会自动补齐。" +
-  "请立刻稳妥收尾:到 300 次会被硬性中断,别把调用预算耗在还没收尾上。";
+  "请立刻稳妥收尾:调用一旦到硬上限会被强制中断,别把预算耗在还没收尾上。";
 
 /** The step-cap reminder as a pure nudge (text or null) — within the last
  *  `within` steps before the cap. Composable with other nudges in prepareStep. */

--- a/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
@@ -19,9 +19,9 @@ export const REMIND_WITHIN_STEPS = 10;
 /** Calm wrap-up nudge (R3: must NOT scare the agent into dropping still-gettable episodes). */
 export const STEP_50_REMINDER =
   "【进度提醒】本次任务已接近步数预算(约剩 10 步)。这是正常的收尾信号,不是失败。请:" +
-  "① 不要再发起新的 searchResources / transferCandidate;" +
-  "② 把已转存好的用 moveToSeason 归位、对确实落盘的 markObtained;" +
-  "③ discardStaging 清理本次 staging;④ finish。" +
+  "① 不要再发起任何新的搜索或转存(searchResources / transferCandidate / transferUntilLanded 都不要);" +
+  "② 把已转存好的归位(TV/动漫用 moveToSeason 入季;电影用 flattenMovie 收进影片目录)、对确实落盘的 markObtained;" +
+  "③ 打扫战场:TV/动漫用 discardStaging 清空 staging;电影已 flattenMovie 就地清理,不要再 discardStaging;④ finish。" +
   "这次没来得及拿的集不要紧——只要没被 markObtained,下次每日巡检会自动发现并补齐。" +
   "请稳妥收尾,绝不要为赶进度草率丢弃还能拿到的资源。";
 

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -204,9 +204,12 @@ export interface AcquisitionAgentRequest {
    *  + raw name/args). Best-effort; absent in tests/headless. */
   onProgress?: (event: AgentToolEvent) => void;
   /** Cumulative 115 API calls so far (real 115 only). Lets prepareStep inject the
-   *  budget soft-warning at BUDGET_SOFT_REMIND_AT, the same way it injects the
-   *  step-cap wind-down. Absent (fakes/sim) → no budget nudge. */
+   *  budget soft-warning, the same way it injects the step-cap wind-down. Absent
+   *  (fakes/sim) → no budget nudge. */
   apiCallCount?: () => number | undefined;
+  /** SOFT-warning threshold, derived from the configured HARD budget upstream
+   *  (budgetSoftThreshold). Absent → falls back to BUDGET_SOFT_REMIND_AT. */
+  budgetSoftAt?: number;
 }
 
 export interface AcquisitionAgentResult {
@@ -251,6 +254,7 @@ export async function runAcquisitionAgent(
         maxSteps,
         baseSystem: request.system,
         ...(typeof spent === "number" ? { apiCallsSpent: spent } : {}),
+        ...(typeof request.budgetSoftAt === "number" ? { budgetSoftAt: request.budgetSoftAt } : {}),
       });
       return system ? { system } : undefined;
     },

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -5,7 +5,7 @@ import { readSkillSection } from "./skill.js";
 import {
   DEFAULT_MAX_STEPS,
   buildRepetitionStop,
-  reflectionSystemOverride,
+  prepareStepSystemOverride,
 } from "./agent-loop-guards.js";
 import { interpretTool, type AgentToolEvent } from "./activity.js";
 
@@ -203,6 +203,10 @@ export interface AcquisitionAgentRequest {
   /** Per-tool-call live progress for the activity page (cleaned activity + phase
    *  + raw name/args). Best-effort; absent in tests/headless. */
   onProgress?: (event: AgentToolEvent) => void;
+  /** Cumulative 115 API calls so far (real 115 only). Lets prepareStep inject the
+   *  budget soft-warning at BUDGET_SOFT_REMIND_AT, the same way it injects the
+   *  step-cap wind-down. Absent (fakes/sim) → no budget nudge. */
+  apiCallCount?: () => number | undefined;
 }
 
 export interface AcquisitionAgentResult {
@@ -241,7 +245,13 @@ export async function runAcquisitionAgent(
     // Last ~10 steps before the cap: inject a calm "wrap up + clean staging" nudge
     // so a step-capped run doesn't leave the 一人之下-style half-done mess.
     prepareStep: ({ stepNumber }) => {
-      const system = reflectionSystemOverride({ stepNumber, maxSteps, baseSystem: request.system });
+      const spent = request.apiCallCount?.();
+      const system = prepareStepSystemOverride({
+        stepNumber,
+        maxSteps,
+        baseSystem: request.system,
+        ...(typeof spent === "number" ? { apiCallsSpent: spent } : {}),
+      });
       return system ? { system } : undefined;
     },
   });

--- a/packages/workflow/src/acquisition-v2/landed-size.ts
+++ b/packages/workflow/src/acquisition-v2/landed-size.ts
@@ -11,7 +11,7 @@ export interface LandedSize {
  * claimed quality tag.
  *
  * Returns undefined on ANY read failure — most importantly the per-run 115 call
- * budget (240) being exhausted on a heavy run (`Pan115RiskControlError`): the
+ * budget being exhausted on a heavy run (`Pan115RiskControlError`): the
  * size is a notification nicety read AFTER the acquisition already succeeded, so
  * it must never throw and fail an otherwise-good run. Also undefined when no
  * videos are found (omit the line rather than report 0 bytes).

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -111,6 +111,9 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
     ...(request.qualityGuidance === undefined ? {} : { qualityGuidance: request.qualityGuidance }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
     ...(request.onProgress ? { onProgress: request.onProgress } : {}),
+    // Real 115 exposes its cumulative call count → drives the budget soft-warning
+    // (240) in the agent loop; fakes/sim omit apiCallCount → no nudge.
+    ...(request.executor.apiCallCount ? { apiCallCount: () => request.executor.apiCallCount!() } : {}),
   };
 
   const result =

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -7,6 +7,7 @@ import { CandidateRegistry } from "./candidate-registry.js";
 import type { DeadLinkStore } from "./dead-links.js";
 import { RealResourceProviderV2 } from "./real-provider-adapter.js";
 import { RealStorageV2 } from "./real-storage-adapter.js";
+import { budgetSoftThreshold } from "./agent-loop-guards.js";
 import { TaskSandbox } from "./sandbox.js";
 import {
   needForMovie,
@@ -112,8 +113,13 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
     ...(request.onProgress ? { onProgress: request.onProgress } : {}),
     // Real 115 exposes its cumulative call count → drives the budget soft-warning
-    // (240) in the agent loop; fakes/sim omit apiCallCount → no nudge.
+    // in the agent loop; fakes/sim omit apiCallCount → no nudge.
     ...(request.executor.apiCallCount ? { apiCallCount: () => request.executor.apiCallCount!() } : {}),
+    // Soft threshold derived from the configured HARD budget so they stay consistent
+    // even when MEDIA_TRACK_115_MAX_API_CALLS overrides the limit.
+    ...(request.executor.apiCallBudget
+      ? { budgetSoftAt: budgetSoftThreshold(request.executor.apiCallBudget()) }
+      : {}),
   };
 
   const result =

--- a/packages/workflow/src/acquisition-v2/task-agents.ts
+++ b/packages/workflow/src/acquisition-v2/task-agents.ts
@@ -187,6 +187,8 @@ export interface RunTvAnimeRequest extends TaskAgentPromptOptions {
   target: TvAnimeTarget;
   maxSteps?: number;
   onProgress?: (event: AgentToolEvent) => void;
+  /** Cumulative 115 API calls so far — drives the budget soft-warning (240). */
+  apiCallCount?: () => number | undefined;
 }
 
 export interface RunMovieRequest extends TaskAgentPromptOptions {
@@ -195,10 +197,12 @@ export interface RunMovieRequest extends TaskAgentPromptOptions {
   target: MovieTarget;
   maxSteps?: number;
   onProgress?: (event: AgentToolEvent) => void;
+  /** Cumulative 115 API calls so far — drives the budget soft-warning (240). */
+  apiCallCount?: () => number | undefined;
 }
 
 export async function runTvAnimeTaskAgent(request: RunTvAnimeRequest): Promise<AcquisitionAgentResult> {
-  const { sandbox, model, target, maxSteps, onProgress, ...promptOptions } = request;
+  const { sandbox, model, target, maxSteps, onProgress, apiCallCount, ...promptOptions } = request;
   const seasonsLabel =
     target.seasons.length === 1 ? `season ${target.seasons[0]}` : `seasons ${target.seasons.join(", ")}`;
   const prompt = `Acquire the missing episodes for "${target.title}"${target.aliases.length ? ` (aliases: ${target.aliases.join(", ")})` : ""}, ${seasonsLabel}.
@@ -212,11 +216,12 @@ If one pack covers multiple seasons, distribute its files in ONE plan with a mov
     ...(promptOptions.storageProvider === undefined ? {} : { storageProvider: promptOptions.storageProvider }),
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(onProgress ? { onProgress } : {}),
+    ...(apiCallCount ? { apiCallCount } : {}),
   });
 }
 
 export async function runMovieTaskAgent(request: RunMovieRequest): Promise<AcquisitionAgentResult> {
-  const { sandbox, model, target, maxSteps, onProgress, ...promptOptions } = request;
+  const { sandbox, model, target, maxSteps, onProgress, apiCallCount, ...promptOptions } = request;
   const prompt = `Acquire the movie "${target.title}" (${target.year})${target.aliases.length ? ` (aliases: ${target.aliases.join(", ")})` : ""}.
 This is the coverage need: the single MOVIE token. Cross-check title AND year so you do not grab a remake or same-IP different film.
 Find the one correct film, transfer it, keep the directory clean, mark it present, then finish.`;
@@ -229,5 +234,6 @@ Find the one correct film, transfer it, keep the directory clean, mark it presen
     ...(promptOptions.storageProvider === undefined ? {} : { storageProvider: promptOptions.storageProvider }),
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(onProgress ? { onProgress } : {}),
+    ...(apiCallCount ? { apiCallCount } : {}),
   });
 }

--- a/packages/workflow/src/acquisition-v2/task-agents.ts
+++ b/packages/workflow/src/acquisition-v2/task-agents.ts
@@ -187,8 +187,10 @@ export interface RunTvAnimeRequest extends TaskAgentPromptOptions {
   target: TvAnimeTarget;
   maxSteps?: number;
   onProgress?: (event: AgentToolEvent) => void;
-  /** Cumulative 115 API calls so far — drives the budget soft-warning (240). */
+  /** Cumulative 115 API calls so far — drives the budget soft-warning. */
   apiCallCount?: () => number | undefined;
+  /** SOFT-warning threshold derived from the configured hard budget. */
+  budgetSoftAt?: number;
 }
 
 export interface RunMovieRequest extends TaskAgentPromptOptions {
@@ -197,12 +199,14 @@ export interface RunMovieRequest extends TaskAgentPromptOptions {
   target: MovieTarget;
   maxSteps?: number;
   onProgress?: (event: AgentToolEvent) => void;
-  /** Cumulative 115 API calls so far — drives the budget soft-warning (240). */
+  /** Cumulative 115 API calls so far — drives the budget soft-warning. */
   apiCallCount?: () => number | undefined;
+  /** SOFT-warning threshold derived from the configured hard budget. */
+  budgetSoftAt?: number;
 }
 
 export async function runTvAnimeTaskAgent(request: RunTvAnimeRequest): Promise<AcquisitionAgentResult> {
-  const { sandbox, model, target, maxSteps, onProgress, apiCallCount, ...promptOptions } = request;
+  const { sandbox, model, target, maxSteps, onProgress, apiCallCount, budgetSoftAt, ...promptOptions } = request;
   const seasonsLabel =
     target.seasons.length === 1 ? `season ${target.seasons[0]}` : `seasons ${target.seasons.join(", ")}`;
   const prompt = `Acquire the missing episodes for "${target.title}"${target.aliases.length ? ` (aliases: ${target.aliases.join(", ")})` : ""}, ${seasonsLabel}.
@@ -217,11 +221,12 @@ If one pack covers multiple seasons, distribute its files in ONE plan with a mov
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(onProgress ? { onProgress } : {}),
     ...(apiCallCount ? { apiCallCount } : {}),
+    ...(budgetSoftAt === undefined ? {} : { budgetSoftAt }),
   });
 }
 
 export async function runMovieTaskAgent(request: RunMovieRequest): Promise<AcquisitionAgentResult> {
-  const { sandbox, model, target, maxSteps, onProgress, apiCallCount, ...promptOptions } = request;
+  const { sandbox, model, target, maxSteps, onProgress, apiCallCount, budgetSoftAt, ...promptOptions } = request;
   const prompt = `Acquire the movie "${target.title}" (${target.year})${target.aliases.length ? ` (aliases: ${target.aliases.join(", ")})` : ""}.
 This is the coverage need: the single MOVIE token. Cross-check title AND year so you do not grab a remake or same-IP different film.
 Find the one correct film, transfer it, keep the directory clean, mark it present, then finish.`;
@@ -235,5 +240,6 @@ Find the one correct film, transfer it, keep the directory clean, mark it presen
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(onProgress ? { onProgress } : {}),
     ...(apiCallCount ? { apiCallCount } : {}),
+    ...(budgetSoftAt === undefined ? {} : { budgetSoftAt }),
   });
 }

--- a/packages/workflow/src/acquisition-v2/workflow-v2.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2.ts
@@ -144,7 +144,7 @@ export async function runAcquisitionV2Workflow(
 
   // Best-effort real landed size for the notification (true per-episode bytes,
   // not a claimed quality). Reads AFTER the acquisition succeeded; on the heavy
-  // run where the 240-call budget is spent this returns undefined rather than
+  // run where the 115 call budget is spent this returns undefined rather than
   // throwing, so the size is simply omitted — never failing a good run.
   const landed = await readLandedSize(
     request.executor,

--- a/packages/workflow/src/pan115-storage-factory.ts
+++ b/packages/workflow/src/pan115-storage-factory.ts
@@ -74,7 +74,9 @@ export function createBootstrapPan115CookieStorageExecutor(options: {
     writeScopeDirectoryIds: [],
     apiGuardOptions: {
       minDelayMs: Number.isFinite(minDelayMs) && minDelayMs > 0 ? minDelayMs : 1_200,
-      maxCallsPerOperation: Number.isFinite(maxCalls) && maxCalls > 0 ? maxCalls : 240,
+      // HARD limit (default 300, env-overridable) — kept in sync with
+      // createProtectedStorage115Executor; the agent's SOFT warning is derived from it.
+      maxCallsPerOperation: Number.isFinite(maxCalls) && maxCalls > 0 ? maxCalls : 300,
       maxListItemsPerResponse: 1_000,
     },
   });

--- a/packages/workflow/src/ports.ts
+++ b/packages/workflow/src/ports.ts
@@ -53,8 +53,9 @@ export interface StorageExecutor {
   listChildDirectories(directoryId: string): Promise<Array<{ id: string; name: string }>>;
   /** Move files (by provider file id) into a target directory inside the write scope. */
   moveFiles(input: { fileIds: string[]; targetDirectoryId: string }): Promise<{ moved: string[] }>;
-  /** Cumulative 115 API calls made so far — observability only. Optional: only the
-   *  real 115 executor implements it; fakes/sims omit it. */
+  /** Cumulative 115 API calls made so far — feeds the per-step trace AND the agent
+   *  loop's budget soft-warning. Optional: only the real 115 executor implements it;
+   *  fakes/sims omit it. */
   apiCallCount?(): number;
   /** The configured HARD 115 call budget — lets the agent loop derive its SOFT
    *  warning threshold from the real limit. Optional (real 115 executor only). */

--- a/packages/workflow/src/ports.ts
+++ b/packages/workflow/src/ports.ts
@@ -56,4 +56,7 @@ export interface StorageExecutor {
   /** Cumulative 115 API calls made so far — observability only. Optional: only the
    *  real 115 executor implements it; fakes/sims omit it. */
   apiCallCount?(): number;
+  /** The configured HARD 115 call budget — lets the agent loop derive its SOFT
+   *  warning threshold from the real limit. Optional (real 115 executor only). */
+  apiCallBudget?(): number;
 }

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -931,9 +931,11 @@ export function createProtectedStorage115Executor(
     // recursive post-transfer verification listings.
     executorOptions.apiGuardOptions = {
       minDelayMs: positiveIntFromEnv(env["MEDIA_TRACK_115_MIN_DELAY_MS"]) ?? 1_200,
-      // HARD limit (throws Pan115RiskControlError). The agent gets a SOFT wrap-up
-      // warning earlier at BUDGET_SOFT_REMIND_AT(=240) via the agent loop, leaving
-      // headroom so its own markObtained/discardStaging cleanup still fits under 300.
+      // HARD limit (throws Pan115RiskControlError) — default 300, configurable here.
+      // The agent gets a SOFT wrap-up warning earlier, at budgetSoftThreshold(this)
+      // (= this minus a fixed headroom) via the agent loop, so its own markObtained/
+      // discardStaging cleanup still fits before the hard stop. Override-safe: the
+      // soft threshold is derived from this value, never hardcoded.
       maxCallsPerOperation: positiveIntFromEnv(env["MEDIA_TRACK_115_MAX_API_CALLS"]) ?? 300,
       maxListItemsPerResponse: 1000,
       ...options.apiGuardOptions,

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -193,6 +193,13 @@ export class Pan115ApiGuard {
     return this.callCount;
   }
 
+  /** The HARD call budget (throws once callCount reaches it). Surfaced so the agent
+   *  loop can derive its SOFT-warning threshold from the actually-configured limit
+   *  instead of hardcoding a number. */
+  callBudget(): number {
+    return this.maxCallsPerOperation;
+  }
+
   async run<T>(operation: Pan115Operation, call: () => Promise<T>): Promise<T> {
     this.assertCircuitClosed(operation);
     await this.applyDelay(operation);
@@ -344,6 +351,12 @@ export class Storage115Executor implements StorageExecutor {
   /** Cumulative 115 API calls so far (observability — surfaced into the agent trace). */
   apiCallCount(): number {
     return this.apiGuard.callsSpent();
+  }
+
+  /** The configured HARD call budget — the agent loop derives its SOFT-warning
+   *  threshold from this so the two stay consistent when the limit is overridden. */
+  apiCallBudget(): number {
+    return this.apiGuard.callBudget();
   }
 
   async createDirectory(input: { name: string; parentId: string }): Promise<string> {

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -932,8 +932,9 @@ export function createProtectedStorage115Executor(
     executorOptions.apiGuardOptions = {
       minDelayMs: positiveIntFromEnv(env["MEDIA_TRACK_115_MIN_DELAY_MS"]) ?? 1_200,
       // HARD limit (throws Pan115RiskControlError) — default 300, configurable here.
-      // The agent gets a SOFT wrap-up warning earlier, at budgetSoftThreshold(this)
-      // (= this minus a fixed headroom) via the agent loop, so its own markObtained/
+      // The agent gets a SOFT wrap-up warning earlier, at
+      // budgetSoftThreshold(maxCallsPerOperation) (= that value minus a fixed
+      // headroom) via the agent loop, so its own markObtained/
       // discardStaging cleanup still fits before the hard stop. Override-safe: the
       // soft threshold is derived from this value, never hardcoded.
       maxCallsPerOperation: positiveIntFromEnv(env["MEDIA_TRACK_115_MAX_API_CALLS"]) ?? 300,

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -918,7 +918,10 @@ export function createProtectedStorage115Executor(
     // recursive post-transfer verification listings.
     executorOptions.apiGuardOptions = {
       minDelayMs: positiveIntFromEnv(env["MEDIA_TRACK_115_MIN_DELAY_MS"]) ?? 1_200,
-      maxCallsPerOperation: positiveIntFromEnv(env["MEDIA_TRACK_115_MAX_API_CALLS"]) ?? 240,
+      // HARD limit (throws Pan115RiskControlError). The agent gets a SOFT wrap-up
+      // warning earlier at BUDGET_SOFT_REMIND_AT(=240) via the agent loop, leaving
+      // headroom so its own markObtained/discardStaging cleanup still fits under 300.
+      maxCallsPerOperation: positiveIntFromEnv(env["MEDIA_TRACK_115_MAX_API_CALLS"]) ?? 300,
       maxListItemsPerResponse: 1000,
       ...options.apiGuardOptions,
     };

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -349,7 +349,8 @@ export class Storage115Executor implements StorageExecutor {
     this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   }
 
-  /** Cumulative 115 API calls so far (observability — surfaced into the agent trace). */
+  /** Cumulative 115 API calls so far — surfaced into the agent trace AND used to
+   *  drive the agent loop's budget soft-warning. */
   apiCallCount(): number {
     return this.apiGuard.callsSpent();
   }

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -193,9 +193,10 @@ export class Pan115ApiGuard {
     return this.callCount;
   }
 
-  /** The HARD call budget (throws once callCount reaches it). Surfaced so the agent
-   *  loop can derive its SOFT-warning threshold from the actually-configured limit
-   *  instead of hardcoding a number. */
+  /** The HARD call budget: checked BEFORE each call, the guard refuses (throws
+   *  Pan115RiskControlError) the next call once callCount has reached this value.
+   *  Surfaced so the agent loop can derive its SOFT-warning threshold from the
+   *  actually-configured limit instead of hardcoding a number. */
   callBudget(): number {
     return this.maxCallsPerOperation;
   }

--- a/packages/workflow/tests/agent-loop-guards.test.ts
+++ b/packages/workflow/tests/agent-loop-guards.test.ts
@@ -64,7 +64,8 @@ describe("reflectionSystemOverride", () => {
   it("reminder is calm, not scary — frames a normal wrap-up + next-patrol safety net", () => {
     // R3 in the spec: must not panic the agent into dropping still-gettable episodes.
     expect(STEP_50_REMINDER).toContain("巡检"); // remaining caught next patrol
-    expect(STEP_50_REMINDER).toContain("discardStaging");
+    expect(STEP_50_REMINDER).toContain("discardStaging"); // TV/anime cleanup
+    expect(STEP_50_REMINDER).toContain("flattenMovie"); // movie cleanup (not discardStaging)
     expect(STEP_50_REMINDER).toMatch(/不是失败|正常|稳/); // reassuring framing
   });
 });

--- a/packages/workflow/tests/agent-loop-guards.test.ts
+++ b/packages/workflow/tests/agent-loop-guards.test.ts
@@ -5,6 +5,8 @@ import {
   BUDGET_SOFT_REMIND_AT,
   BUDGET_REMINDER,
   budgetReflectionNudge,
+  budgetSoftThreshold,
+  BUDGET_SOFT_HEADROOM,
   stepReflectionNudge,
   prepareStepSystemOverride,
   buildRepetitionStop,
@@ -94,6 +96,18 @@ describe("budgetReflectionNudge (115 call-budget soft warning)", () => {
     expect(BUDGET_REMINDER).toContain("markObtained");
     expect(BUDGET_REMINDER).toContain("discardStaging");
     expect(BUDGET_REMINDER).toMatch(/不是失败|正常|巡检/);
+  });
+});
+
+describe("budgetSoftThreshold (derive soft from configured hard)", () => {
+  it("default hard 300 → soft 240 (作者拍板)", () => {
+    expect(budgetSoftThreshold(300)).toBe(240);
+  });
+  it("tracks an overridden hard limit (stays headroom below it)", () => {
+    expect(budgetSoftThreshold(500)).toBe(500 - BUDGET_SOFT_HEADROOM);
+  });
+  it("clamps to ≥1 for a tiny budget (never negative)", () => {
+    expect(budgetSoftThreshold(10)).toBe(1);
   });
 });
 

--- a/packages/workflow/tests/agent-loop-guards.test.ts
+++ b/packages/workflow/tests/agent-loop-guards.test.ts
@@ -92,10 +92,17 @@ describe("budgetReflectionNudge (115 call-budget soft warning)", () => {
     expect(BUDGET_SOFT_REMIND_AT).toBe(240);
   });
 
-  it("reminder is a calm wrap-up: markObtained + discardStaging + next-patrol safety net", () => {
+  it("reminder is a calm wrap-up: markObtained + next-patrol safety net", () => {
     expect(BUDGET_REMINDER).toContain("markObtained");
-    expect(BUDGET_REMINDER).toContain("discardStaging");
     expect(BUDGET_REMINDER).toMatch(/不是失败|正常|巡检/);
+  });
+
+  it("cleanup step is movie-aware: TV uses discardStaging, movie uses flattenMovie (not discardStaging)", () => {
+    // Injected for both TV and movie runs — must not tell a movie to discardStaging
+    // (movies have no separate staging; that path is wrong/harmful). Copilot PR#22.
+    expect(BUDGET_REMINDER).toContain("discardStaging"); // still the TV/anime path
+    expect(BUDGET_REMINDER).toContain("flattenMovie"); // movie path explicitly covered
+    expect(BUDGET_REMINDER).toMatch(/电影.*不要再?\s*discardStaging|电影.*flattenMovie/);
   });
 });
 

--- a/packages/workflow/tests/agent-loop-guards.test.ts
+++ b/packages/workflow/tests/agent-loop-guards.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_MAX_STEPS,
   STEP_50_REMINDER,
+  BUDGET_SOFT_REMIND_AT,
+  BUDGET_REMINDER,
+  budgetReflectionNudge,
+  stepReflectionNudge,
+  prepareStepSystemOverride,
   buildRepetitionStop,
   reflectionSystemOverride,
   toStepSignature,
@@ -59,6 +64,60 @@ describe("reflectionSystemOverride", () => {
     expect(STEP_50_REMINDER).toContain("巡检"); // remaining caught next patrol
     expect(STEP_50_REMINDER).toContain("discardStaging");
     expect(STEP_50_REMINDER).toMatch(/不是失败|正常|稳/); // reassuring framing
+  });
+});
+
+describe("stepReflectionNudge", () => {
+  it("returns the step reminder within the window, null before", () => {
+    expect(stepReflectionNudge(50, 60)).toBe(STEP_50_REMINDER);
+    expect(stepReflectionNudge(59, 60)).toBe(STEP_50_REMINDER);
+    expect(stepReflectionNudge(49, 60)).toBeNull();
+  });
+});
+
+describe("budgetReflectionNudge (115 call-budget soft warning)", () => {
+  it("fires at/after the soft threshold (240), not before", () => {
+    expect(budgetReflectionNudge(239)).toBeNull();
+    expect(budgetReflectionNudge(240)).toBe(BUDGET_REMINDER);
+    expect(budgetReflectionNudge(299)).toBe(BUDGET_REMINDER);
+  });
+
+  it("no nudge when spent is unknown (fakes/sim without apiCallCount)", () => {
+    expect(budgetReflectionNudge(undefined)).toBeNull();
+  });
+
+  it("soft threshold is 240 (hard limit 300 is the guard's throw)", () => {
+    expect(BUDGET_SOFT_REMIND_AT).toBe(240);
+  });
+
+  it("reminder is a calm wrap-up: markObtained + discardStaging + next-patrol safety net", () => {
+    expect(BUDGET_REMINDER).toContain("markObtained");
+    expect(BUDGET_REMINDER).toContain("discardStaging");
+    expect(BUDGET_REMINDER).toMatch(/不是失败|正常|巡检/);
+  });
+});
+
+describe("prepareStepSystemOverride (composes step-cap + budget nudges)", () => {
+  const base = "BASE SYSTEM";
+  it("budget only: over 240 calls, far from step cap → budget nudge, no step nudge", () => {
+    const s = prepareStepSystemOverride({ stepNumber: 5, maxSteps: 60, baseSystem: base, apiCallsSpent: 250 })!;
+    expect(s).toContain(BUDGET_REMINDER);
+    expect(s).not.toContain(STEP_50_REMINDER);
+    expect(s).toContain(base);
+  });
+  it("step only: near cap, under budget → step nudge, no budget nudge", () => {
+    const s = prepareStepSystemOverride({ stepNumber: 55, maxSteps: 60, baseSystem: base, apiCallsSpent: 10 })!;
+    expect(s).toContain(STEP_50_REMINDER);
+    expect(s).not.toContain(BUDGET_REMINDER);
+  });
+  it("both: near cap AND over budget → both nudges appended", () => {
+    const s = prepareStepSystemOverride({ stepNumber: 55, maxSteps: 60, baseSystem: base, apiCallsSpent: 260 })!;
+    expect(s).toContain(STEP_50_REMINDER);
+    expect(s).toContain(BUDGET_REMINDER);
+  });
+  it("neither → undefined (no override)", () => {
+    expect(prepareStepSystemOverride({ stepNumber: 5, maxSteps: 60, baseSystem: base, apiCallsSpent: 10 })).toBeUndefined();
+    expect(prepareStepSystemOverride({ stepNumber: 5, maxSteps: 60, baseSystem: base })).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## 设计(作者拍板)

「115 次数超 240 跟步数一样发软警告(该标记标记、该清理清理、打扫战场),硬极限改 300。」把单一硬 throw 拆成两段,镜像 agent-loop 的 step-cap reflection。

## 改动(纯加法 + 一个默认值)

- **硬上限 240 → 300**:`createProtectedStorage115Executor` 默认 `maxCallsPerOperation`(env 仍可覆盖)。撞 300 才 `Pan115RiskControlError`。
- **软阈值 240 + 收尾 nudge**:`agent-loop-guards` 加 `BUDGET_SOFT_REMIND_AT=240` / `BUDGET_REMINDER` / 纯函数 `budgetReflectionNudge` + `stepReflectionNudge` + `prepareStepSystemOverride`(组合 step-cap 与 budget 两个 nudge,两者可同时触发)。`reflectionSystemOverride` 改薄包装,原测试不变。
- **穿线**:`agent-loop` 暴露 `apiCallCount?` 选项,`prepareStep` 用组合器读它;`task-agents`(tv/movie)透传;`orchestrator` 用 `executor.apiCallCount()` 注入。fake/sim 无 apiCallCount → 不触发(可选链)。

留 240→300 的余量,是给 agent 自己的 markObtained/discardStaging 收尾(也要几次 115 调用)留空间——别在收尾时被硬切(正是莉可丽丝撞 240 硬死、绕过收尾的教训)。

## 护栏对齐
软警告靠注入 agent 提示(智能收尾),非机械中断;不动 sync-need/选片/前端。

## 验证
- TDD 单测:`budgetReflectionNudge`(239→null / 240,299→文案 / undefined→null)、`stepReflectionNudge`、`prepareStepSystemOverride`(budget-only / step-only / both / neither)。硬 throw 机制已有测试(`maxCallsPerOperation:2`)。三处 tsc + 全量 vitest(772)+ lint 全绿。
- ⏳ **live**:软警告/硬停只有重资源 run(莉可丽丝 BDRip)够得到 ≥240 调用 → live 验证搭载在 **#1 莉可丽丝复现**(下一项):agent_steps 的 apiCalls 爬过 240→该步注入软警告→agent 收尾而非撞死,300 才硬停。

🤖 Generated with [Claude Code](https://claude.com/claude-code)