### PR TITLE
feat(web): #6 "已请求"药丸链到活动页(投产获取反馈一键直达真实进度)

### DIFF
--- a/apps/web/components/request-state.tsx
+++ b/apps/web/components/request-state.tsx
@@ -17,33 +17,25 @@ export function isLockedResult(result: RequestTrackingActionResult | null): bool
 }
 
 /** The standalone "已请求" pill shown after a request is queued (spinner — it is
- *  NOT done, only accepted). Shared by the badge-style acquire controls.
- *  When `activityHref` is given the pill becomes a link to the live 活动 page —
- *  so the real, persistent progress is one click away instead of a manual nav
- *  (the 投产 acquisition-feedback gap the author flagged: "真实情况要去活动里看"). */
+ *  NOT done, only accepted). Shared by the badge-style acquire controls. It links
+ *  to the live 活动 page so the real, persistent progress is one click away instead
+ *  of a manual nav (the 投产 feedback gap the author flagged: "真实情况要去活动里看").
+ *  The href is built inline (mirrors workflow's globalNavHref) — NOT imported from
+ *  the @media-track/workflow barrel, which would drag pg/postgres into this client
+ *  bundle and break the Next build. */
 export function RequestedBadge({
   title,
-  activityHref,
+  storageId,
 }: {
   title?: string | undefined;
-  activityHref?: string | undefined;
+  /** Active drive — scopes the 活动 link with ?w so leaving keeps the drive. */
+  storageId?: string | undefined;
 }) {
-  const inner = (
-    <>
+  const href = storageId ? `/activity?w=${encodeURIComponent(storageId)}` : "/activity";
+  return (
+    <Link className="hub-badge tone-green" href={href} title={title ?? "查看获取进度（活动）"}>
       <LoaderCircle size={12} className="spin" aria-hidden />
       已请求
-    </>
-  );
-  if (activityHref) {
-    return (
-      <Link className="hub-badge tone-green" href={activityHref} title={title ?? "查看获取进度（活动）"}>
-        {inner}
-      </Link>
-    );
-  }
-  return (
-    <span className="hub-badge tone-green" title={title}>
-      {inner}
-    </span>
+    </Link>
   );
 }

--- a/apps/web/components/request-state.tsx
+++ b/apps/web/components/request-state.tsx
@@ -1,4 +1,5 @@
 import { LoaderCircle } from "lucide-react";
+import Link from "next/link";
 import type { RequestTrackingActionResult } from "../app/actions";
 
 /**
@@ -16,12 +17,33 @@ export function isLockedResult(result: RequestTrackingActionResult | null): bool
 }
 
 /** The standalone "已请求" pill shown after a request is queued (spinner — it is
- *  NOT done, only accepted). Shared by the badge-style acquire controls. */
-export function RequestedBadge({ title }: { title?: string | undefined }) {
-  return (
-    <span className="hub-badge tone-green" title={title}>
+ *  NOT done, only accepted). Shared by the badge-style acquire controls.
+ *  When `activityHref` is given the pill becomes a link to the live 活动 page —
+ *  so the real, persistent progress is one click away instead of a manual nav
+ *  (the 投产 acquisition-feedback gap the author flagged: "真实情况要去活动里看"). */
+export function RequestedBadge({
+  title,
+  activityHref,
+}: {
+  title?: string | undefined;
+  activityHref?: string | undefined;
+}) {
+  const inner = (
+    <>
       <LoaderCircle size={12} className="spin" aria-hidden />
       已请求
+    </>
+  );
+  if (activityHref) {
+    return (
+      <Link className="hub-badge tone-green" href={activityHref} title={title ?? "查看获取进度（活动）"}>
+        {inner}
+      </Link>
+    );
+  }
+  return (
+    <span className="hub-badge tone-green" title={title}>
+      {inner}
     </span>
   );
 }

--- a/apps/web/components/request-track-button.tsx
+++ b/apps/web/components/request-track-button.tsx
@@ -4,7 +4,7 @@ import { CalendarClock, Check, LoaderCircle, Plus } from "lucide-react";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { requestTrackingAction, type RequestTrackingActionResult } from "../app/actions";
-import type { SearchActionState } from "@media-track/workflow";
+import { type SearchActionState, globalNavHref } from "@media-track/workflow";
 import { RequestedBadge } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
@@ -83,7 +83,7 @@ export function RequestTrackButton({
   }
 
   if (inProgress) {
-    return <RequestedBadge title={result?.message} />;
+    return <RequestedBadge title={result?.message} activityHref={globalNavHref("/activity", storageId)} />;
   }
 
   if (reserved) {

--- a/apps/web/components/request-track-button.tsx
+++ b/apps/web/components/request-track-button.tsx
@@ -4,7 +4,7 @@ import { CalendarClock, Check, LoaderCircle, Plus } from "lucide-react";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { requestTrackingAction, type RequestTrackingActionResult } from "../app/actions";
-import { type SearchActionState, globalNavHref } from "@media-track/workflow";
+import type { SearchActionState } from "@media-track/workflow";
 import { RequestedBadge } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
@@ -83,7 +83,7 @@ export function RequestTrackButton({
   }
 
   if (inProgress) {
-    return <RequestedBadge title={result?.message} activityHref={globalNavHref("/activity", storageId)} />;
+    return <RequestedBadge title={result?.message} storageId={storageId} />;
   }
 
   if (reserved) {

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -8,7 +8,6 @@ import {
   requestSeasonAction,
   type RequestTrackingActionResult,
 } from "../app/actions";
-import { globalNavHref } from "@media-track/workflow";
 import { isLockedResult, RequestedBadge } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
@@ -70,7 +69,7 @@ export function SeasonRequestMenu({
   }
 
   if (isLockedResult(result)) {
-    return <RequestedBadge title={result?.message} activityHref={globalNavHref("/activity", storageId)} />;
+    return <RequestedBadge title={result?.message} storageId={storageId} />;
   }
 
   const submit = () => {

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -8,6 +8,7 @@ import {
   requestSeasonAction,
   type RequestTrackingActionResult,
 } from "../app/actions";
+import { globalNavHref } from "@media-track/workflow";
 import { isLockedResult, RequestedBadge } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
@@ -69,7 +70,7 @@ export function SeasonRequestMenu({
   }
 
   if (isLockedResult(result)) {
-    return <RequestedBadge title={result?.message} />;
+    return <RequestedBadge title={result?.message} activityHref={globalNavHref("/activity", storageId)} />;
   }
 
   const submit = () => {


### PR DESCRIPTION
## 背景(作者 #6)

作者:投产点获取后只有个"已请求"小药丸在转,**真实进度要手动去活动页看**;demo 有点击位的优雅动画但**纯客户端、切页就没**(假的)。作者评价"各有优劣"。

## 改动(不抄 demo 假动画,而是让真实反馈更易达)

`RequestedBadge`("已请求"药丸)现在**渲染为指向 /活动 的链接**——点药丸即跳到真实、持久的 ticker,省掉手动导航。`storageId`(可选)用来给链接加 `?w=` 盘 scope(离开工作区仍保留盘);两个调用方(request-track-button / season-request-menu)都持有它。

设计说明(回应 review):**RequestedBadge 一律是链接**,因为它只在真实的"进行中"状态出现(demo 走 DemoAcquirePlayback,不用本组件),"已请求→活动进度"对所有调用方都成立,没有"想要个不可点的已请求"的场景。href 逻辑内联在组件里(镜像 workflow 的 globalNavHref),**不从 @media-track/workflow barrel import 值**——否则会把 pg/postgres 拖进 client bundle 炸掉 next build(本 PR 第二个 commit 修的就是这个:web tsc 不报、`build:web` 才报)。

## 验证
- **本地 `npm run build:web` 通过**(CI 同款检查)+ web tsc + root tsc + 全量 vitest(778)+ lint 全绿。
- 前端 UX(仓库无 jsdom 组件测试基建)走 **live 验证**:合并部署后点获取→"已请求"是指向 /activity?w= 的链接→点它进活动页。结果回填。

🤖 Generated with [Claude Code](https://claude.com/claude-code)