### PR TITLE
fix(web): #6 搜索候选卡"获取中"药丸也链到活动页(补 #24 漏的主路径)

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -290,10 +290,17 @@ function CandidateCard({
           </div>
           <div className="candidate-actions">
             {acquiring ? (
-              <span className="hub-badge tone-green" title="后台正在获取">
+              // #6: the persistent post-获取 pill links to the live 活动 page so the
+              // real progress is one click away (the gap the author flagged: "真实情况
+              // 要去活动里看"). storageId scopes it with ?w (mirrors globalNavHref).
+              <Link
+                className="hub-badge tone-green"
+                href={storageId ? `/activity?w=${encodeURIComponent(storageId)}` : "/activity"}
+                title="后台正在获取——点查看进度（活动）"
+              >
                 <LoaderCircle size={12} className="spin" aria-hidden />
                 获取中
-              </span>
+              </Link>
             ) : null}
             {!acquiring && isTv && untrackedSeasons.length > 0 ? (
               <SeasonRequestMenu


### PR DESCRIPTION
## 背景

[#24](https://github.com/fancydirty/mediary-scout/pull/24) 把 `RequestedBadge`("已请求")做成了活动页链接。但**部署后 agent-browser live 验证**(真点获取)暴露了主路径漏网:

点获取后,服务端一旦报告该标题 `acquiring`,`page.tsx` 的候选卡会用它**自己的内联 `<span>获取中</span>`**(line 292)整块替换掉 `RequestTrackButton`。这个"获取中"药丸才是用户点完获取后看到的**持久反馈**,而它没有链接——正是作者 #6 抱怨的"真实情况要去活动里看"。

## 改动

把候选卡的 acquiring "获取中" `<span>` 包成指向 **/活动(`?w` 盘 scope)** 的 `<Link>`。`page.tsx` 是 server 组件、已 import `next/link`,href 内联(镜像 `globalNavHref`,不碰 workflow barrel——避免 #24 第二个 commit 踩过的 pg-进-client-bundle 坑)。

至此搜索获取反馈两态都一键直达真实进度:排队 `已请求`(RequestedBadge)+ 处理中 `获取中`(候选卡)。

## 验证
- web tsc + `build:web` + lint 全绿。
- **live**(合并部署后):点获取→候选卡"获取中"是指向 /activity?w= 的链接→点它进活动页。结果回填。

> VBC 教训:#24 单测/build 绿但漏了主路径药丸,live 才暴露——前端状态也必须 live 看。

🤖 Generated with [Claude Code](https://claude.com/claude-code)