### PR TITLE
fix(agent): #4 真因2 — sandbox.finish() 过滤掉了 provider-ahead 标记

### DIFF
--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -427,7 +427,12 @@ export class TaskSandbox {
   async finish(): Promise<{ coverageMet: boolean; obtained: string[]; missing: string[] }> {
     return {
       coverageMet: this.isCoverageMet(),
-      obtained: this.need.filter((token) => this.obtainedCodes.has(token)),
+      // ALL the agent's marks — not just need∩marked. A coherent full pack often
+      // delivers episodes BEYOND the aired cursor (the need); those provider-ahead
+      // marks must survive finish() so syncSeasonNeed can record them as
+      // provider-ahead (frontend 超前). Filtering to `need` here silently dropped
+      // them — the live #4 bug (quark 超市: agent marked 12, only E01 persisted).
+      obtained: [...this.obtainedCodes],
       missing: this.missingNeed(),
     };
   }

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -434,9 +434,22 @@ export class TaskSandbox {
     // syntactically valid episode code — a malformed agent mark must NOT flow into
     // syncSeasonNeed's episodePartsFromCode (which throws), crashing the run.
     const needSet = new Set(this.need);
+    const parse = (code: string): [number, number] | null => {
+      const m = /^S(\d{2,})E(\d{2,})$/.exec(code);
+      return m ? [Number(m[1]), Number(m[2])] : null;
+    };
     const obtained = [...this.obtainedCodes]
-      .filter((code) => needSet.has(code) || /^S\d{2,}E\d{2,}$/.test(code))
-      .sort();
+      .filter((code) => needSet.has(code) || parse(code) !== null)
+      // Order by (season, episode) NUMERICALLY — a lexical sort misorders ≥100
+      // (S01E100 < S01E99). Non-episode tokens (e.g. the movie "MOVIE") sort last.
+      .sort((a, b) => {
+        const pa = parse(a);
+        const pb = parse(b);
+        if (pa && pb) return pa[0] - pb[0] || pa[1] - pb[1];
+        if (pa) return -1;
+        if (pb) return 1;
+        return a < b ? -1 : a > b ? 1 : 0;
+      });
     return {
       coverageMet: this.isCoverageMet(),
       obtained,

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -425,14 +425,21 @@ export class TaskSandbox {
   /** The agent declares it is done. Returns the honest coverage picture from the
    *  obtained marks — the workflow decides what to persist. */
   async finish(): Promise<{ coverageMet: boolean; obtained: string[]; missing: string[] }> {
+    // Report the agent's marks beyond just need∩marked — a coherent full pack
+    // often delivers episodes BEYOND the aired cursor (the need), and those
+    // provider-ahead marks must survive finish() so syncSeasonNeed records them as
+    // provider-ahead (frontend 超前). Filtering to `need` silently dropped them —
+    // the live #4 bug (quark 超市: agent marked 12, only E01 persisted).
+    // Guard: keep only an in-need token (e.g. the movie "MOVIE" sentinel) or a
+    // syntactically valid episode code — a malformed agent mark must NOT flow into
+    // syncSeasonNeed's episodePartsFromCode (which throws), crashing the run.
+    const needSet = new Set(this.need);
+    const obtained = [...this.obtainedCodes]
+      .filter((code) => needSet.has(code) || /^S\d{2,}E\d{2,}$/.test(code))
+      .sort();
     return {
       coverageMet: this.isCoverageMet(),
-      // ALL the agent's marks — not just need∩marked. A coherent full pack often
-      // delivers episodes BEYOND the aired cursor (the need); those provider-ahead
-      // marks must survive finish() so syncSeasonNeed can record them as
-      // provider-ahead (frontend 超前). Filtering to `need` here silently dropped
-      // them — the live #4 bug (quark 超市: agent marked 12, only E01 persisted).
-      obtained: [...this.obtainedCodes],
+      obtained,
       missing: this.missingNeed(),
     };
   }

--- a/packages/workflow/tests/v2-sandbox-mark.test.ts
+++ b/packages/workflow/tests/v2-sandbox-mark.test.ts
@@ -58,6 +58,17 @@ describe("TaskSandbox — markObtained (agent's final declaration; NO mechanical
     expect(summary.obtained).toEqual(["S01E01", "S01E02"]); // garbage dropped, sorted
   });
 
+  it("orders obtained codes NUMERICALLY, not lexically (≥100 episodes — Copilot #29)", async () => {
+    // Long-running shows (One Piece etc.) cross E99. A lexical sort would put
+    // S01E100 before S01E99; finish() must order by (season, episode) numerically.
+    const sandbox = await sandboxWithNeed(["S01E99"]);
+
+    await sandbox.markObtained({ codes: ["S01E100", "S01E09", "S01E99", "S01E10"] });
+
+    const summary = await sandbox.finish();
+    expect(summary.obtained).toEqual(["S01E09", "S01E10", "S01E99", "S01E100"]);
+  });
+
   it("does NOT re-read 115 to verify presence — the mark is the agent's call", async () => {
     // The system no longer mechanically re-reads the target dir to confirm a
     // backing file exists. move/flatten already force-reread and handed the

--- a/packages/workflow/tests/v2-sandbox-mark.test.ts
+++ b/packages/workflow/tests/v2-sandbox-mark.test.ts
@@ -29,6 +29,23 @@ describe("TaskSandbox — markObtained (agent's final declaration; NO mechanical
     expect(summary.missing).toEqual(["S01E02"]);
   });
 
+  it("surfaces provider-ahead marks BEYOND the need — a full pack delivered past the aired cursor (#4)", async () => {
+    // The live #4 bug: need = just the aired episode (S01E01, TMDB aired=1); the
+    // agent transferred a coherent full-season pack and (correctly, post skill fix)
+    // markObtained all 12. finish() must surface ALL the agent's marks — not just
+    // need∩marked — or E02–E12 are silently dropped here, before syncSeasonNeed can
+    // record them as provider-ahead (frontend "超前"). This is exactly where the
+    // quark 超市 run lost E02–E12 despite marking them.
+    const sandbox = await sandboxWithNeed(["S01E01"]);
+    const all = Array.from({ length: 12 }, (_, i) => `S01E${String(i + 1).padStart(2, "0")}`);
+
+    await sandbox.markObtained({ codes: all });
+
+    const summary = await sandbox.finish();
+    expect(summary.obtained).toEqual(all); // ALL 12, not just the aired need
+    expect(summary.coverageMet).toBe(true);
+  });
+
   it("does NOT re-read 115 to verify presence — the mark is the agent's call", async () => {
     // The system no longer mechanically re-reads the target dir to confirm a
     // backing file exists. move/flatten already force-reread and handed the

--- a/packages/workflow/tests/v2-sandbox-mark.test.ts
+++ b/packages/workflow/tests/v2-sandbox-mark.test.ts
@@ -46,6 +46,18 @@ describe("TaskSandbox — markObtained (agent's final declaration; NO mechanical
     expect(summary.coverageMet).toBe(true);
   });
 
+  it("drops a malformed mark so it never reaches syncSeasonNeed's strict parser (Copilot #29)", async () => {
+    // finish() feeds syncSeasonNeed → episodePartsFromCode, which THROWS on a
+    // non-SxxExx token. A stray/garbage agent mark must be filtered out here, not
+    // crash the whole run. Valid episode codes (incl. provider-ahead) still pass.
+    const sandbox = await sandboxWithNeed(["S01E01"]);
+
+    await sandbox.markObtained({ codes: ["S01E01", "garbage", "S01E02"] });
+
+    const summary = await sandbox.finish();
+    expect(summary.obtained).toEqual(["S01E01", "S01E02"]); // garbage dropped, sorted
+  });
+
   it("does NOT re-read 115 to verify presence — the mark is the agent's call", async () => {
     // The system no longer mechanically re-reads the target dir to confirm a
     // backing file exists. move/flatten already force-reread and handed the


### PR DESCRIPTION
## LIVE 取证链(承接 #27)

[#27](https://github.com/fancydirty/mediary-scout/pull/27) 修了 skill.ts 让 agent **愿意标** 全集包的超出集。部署后夸克盘真跑超市(run `d66a7f05`,清空目录后):

- agent `markObtained ["S01E01"…"S01E12"]`(全 12,✅ #27 起效)。
- 但 DB `episode_states`:**E01 obtained=true,E02-12 obtained=false**(airStatus=unaired)。

逐层取证(sandbox→workflow-v2→sync-need→bridge):
- `bridgeV2WorkflowToResult` 早已正确把 provider-ahead 落成 `obtained=true + metadataStatus=provider_ahead`。
- `syncSeasonNeed` 正确按 aired 切 `obtained`(aired) / `providerAhead`(超出)。
- **真因在 `sandbox.finish()`(sandbox.ts L430)**:`obtained: need.filter(c => obtainedCodes.has(c))` 只报 **need∩已标记**。超市 `need=[S01E01]`(aired=1),于是 agent 标的 E02-12 在 finish() 这层就被丢弃 → 下游 providerAhead 永远空。

## 改动
`finish()` 返回 `[...obtainedCodes]`(agent 的全部诚实标记),由下游 `syncSeasonNeed` 按 aired 切分。**sync-need 核心模型/前端/bridge 都不动**(守作者红线);只是不再在 finish() 这层提前丢弃。

## 验证
- TDD:`v2-sandbox-mark` 新增"need=E01、agent 标记全 12 → finish().obtained 报全 12"(先红后绿)。780 测试 + build:workflow + lint 绿。
- **live(合并部署后)**:重跑夸克超市 → 期望 DB `E01 obtained` + `E02-12 obtained=true/provider_ahead` + 前端显示「超前」。结果回填。

> #4 需要三处协同:#23 系统提示词 + #27 skill 手册(让 agent 标全集)+ 本 PR finish() 不丢标记(让标记落库)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)