### PR TITLE
fix(web): 客户端类型走窄子路径,杜绝 pg 漏进浏览器 bundle(治 CI flake)

### DIFF
--- a/apps/web/components/request-track-button.tsx
+++ b/apps/web/components/request-track-button.tsx
@@ -4,7 +4,12 @@ import { CalendarClock, Check, LoaderCircle, Plus } from "lucide-react";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { requestTrackingAction, type RequestTrackingActionResult } from "../app/actions";
-import type { SearchActionState } from "@media-track/workflow";
+// Import the type from the narrow subpath, NOT the root barrel: the barrel
+// `export *`s ./postgres.js (pg), and Turbopack intermittently fails to erase a
+// type-only barrel import, dragging pg into THIS client bundle → "pg in Client
+// Component Browser" build failures. The /search-view subpath pulls only pg-free
+// leaf modules (domain, workflow-scope), so the type can never carry pg in.
+import type { SearchActionState } from "@media-track/workflow/search-view";
 import { RequestedBadge } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -12,6 +12,10 @@
     "./scope": {
       "types": "./dist/workflow-scope.d.ts",
       "default": "./dist/workflow-scope.js"
+    },
+    "./search-view": {
+      "types": "./dist/search-view.d.ts",
+      "default": "./dist/search-view.js"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## 背景(作者发现的两次 CI 红)

`#6` 分支 2026-06-22 20:20 两次 `build:web` 失败(runs 27981361316/27981366191):
```
Turbopack build failed with 7 errors:
  ./node_modules/pg/... [Client Component Browser]
   ← packages/workflow/dist/postgres.js
   ← apps/web/app/page.tsx
```
main 一直 build 绿(同代码),只在该分支偶发两次 → Turbopack 构建非确定性,**会复发**。

## 真因
`@media-track/workflow` 是 barrel(`index.ts` `export * from "./postgres.js"`,含 `pg`)。唯一从 barrel 取类型的**客户端**组件 `request-track-button.tsx` 用 `import type { SearchActionState } from "@media-track/workflow"`。`import type` 本应被擦除,但 Turbopack 对 `export *` barrel 的类型擦除**偶发失效** → 顺着 barrel 把 `pg`(node 内置 fs/net)拖进 client bundle → 构建炸。

## 改动(根除唯一的 client→barrel 边)
- `packages/workflow/package.json`:加 `./search-view` 子路径导出。
- `request-track-button.tsx`:改从 `@media-track/workflow/search-view` 取 `SearchActionState`。该模块只依赖 pg-free 叶子(`domain` / `workflow-scope`),`pg` 再不可达 client——无论 Turbopack 是否擦除类型都安全。

这是全仓库**唯一**的客户端 barrel 导入(已 grep 全部 `"use client"` 文件确认),去掉即根治。

## 验证
- `build:workflow` + 根 `typecheck` + `apps/web tsc` + `build:web` 全绿。
- `rg` 确认生产 `.next/static` 客户端 chunk **无** `pg-connection-string`/`connection-parameters`(pg 已不在浏览器 bundle)。
- 782 vitest 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)