### PR TITLE
feat(web): demo 进行中态跨页联动 (#3b)

### DIFF
--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -19,6 +19,7 @@ import {
 import type { NotificationEvent, NotificationReportStatus } from "@media-track/workflow";
 import { landedSize } from "@media-track/workflow";
 import { NotificationsSeenMarker } from "../../components/notifications-seen-marker";
+import { DemoSessionNotifications } from "../../components/demo-session-notifications";
 import { AppSidebar } from "../../components/app-sidebar";
 import {
   ensureDemoSeeded,
@@ -94,6 +95,7 @@ async function NotificationsSurface({ searchParams }: { searchParams: Promise<{ 
             <p>每天的资源获取与追踪日报</p>
           </div>
         </div>
+        <DemoSessionNotifications />
         <Suspense fallback={<FeedSkeleton />}>
           <NotificationFeed connectedStorageId={workspace.connectedStorageId} />
         </Suspense>

--- a/apps/web/components/activity-feed.tsx
+++ b/apps/web/components/activity-feed.tsx
@@ -6,8 +6,8 @@ import { CheckCircle2, ChevronDown, ChevronRight, Clock3, Loader2, RotateCcw, Tr
 import { showHref } from "@media-track/workflow/scope";
 import type { ActivityActiveRun, ActivityCompletedItem, ActivityView } from "../lib/activity-view";
 import { isDemoModeClient } from "../lib/demo-mode";
-import { demoCompletedItems } from "../lib/demo-session";
-import { useDemoAcquisitions } from "../lib/use-demo-session";
+import { demoCompletedItems, demoInProgressActivityItems } from "../lib/demo-session";
+import { useDemoAcquisitions, useDemoInProgress } from "../lib/use-demo-session";
 
 const POLL_MS = 2600;
 const POSTER = "https://image.tmdb.org/t/p/w185";
@@ -50,19 +50,29 @@ export function ActivityFeed({ storageId }: { storageId?: string | undefined }) 
   // Only show completions for runs THIS session watched go active → done.
   const completed = view.recentCompleted.filter((item) => seenActive.current.has(item.workflowRunId));
   // Demo: acquisitions are client-only (no DB run) → surface this session's
-  // acquired titles as completed items so the activity page reflects them.
+  // acquired titles as completed items, and in-progress playbacks as live 获取中
+  // rows, so the activity page reflects them like production.
   const demoAcq = useDemoAcquisitions();
-  const demoDone = isDemoModeClient() ? demoCompletedItems(demoAcq) : [];
+  const isDemo = isDemoModeClient();
+  const demoDone = isDemo ? demoCompletedItems(demoAcq) : [];
+  const demoActive = demoInProgressActivityItems(useDemoInProgress());
   const allCompleted = [...demoDone, ...completed];
 
   return (
     <div className="activity">
       <section className="act-section">
         <div className="act-section-head act-section-head-static">获取中</div>
-        {running.length === 0 ? (
+        {running.length === 0 && demoActive.length === 0 ? (
           <p className="act-empty">当前没有正在处理的任务。</p>
         ) : (
-          running.map((run) => <RunningRow run={run} storageId={storageId} key={run.runId} />)
+          <>
+            {demoActive.map((item) => (
+              <DemoRunningRow item={item} key={item.id} />
+            ))}
+            {running.map((run) => (
+              <RunningRow run={run} storageId={storageId} key={run.runId} />
+            ))}
+          </>
         )}
       </section>
 
@@ -159,6 +169,31 @@ function Ticker({ text }: { text: string }) {
           {line.text}
         </div>
       ))}
+    </div>
+  );
+}
+
+type DemoActivityItem = ReturnType<typeof demoInProgressActivityItems>[number];
+
+/** Demo-only 获取中 row: clock-driven progress, no DB run (not a link). Mirrors
+ *  RunningRow's poster + progress bar + step layout. */
+function DemoRunningRow({ item }: { item: DemoActivityItem }) {
+  const percent = Math.max(3, Math.min(100, item.progress));
+  return (
+    <div className="act-row act-row-active">
+      {poster(item.posterPath, item.title, "info")}
+      <div className="act-row-body">
+        <div className="act-row-head">
+          <strong>{item.title}</strong>
+        </div>
+        <div className="act-bar">
+          <div className="act-bar-fill" style={{ width: `${percent}%` }} />
+        </div>
+        <div className="act-ticker-row">
+          <Loader2 size={14} className="act-spin" aria-hidden />
+          <Ticker text={item.step} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/demo-acquire-playback.tsx
+++ b/apps/web/components/demo-acquire-playback.tsx
@@ -18,7 +18,12 @@ import {
 export function DemoAcquirePlayback({ entry }: { entry?: DemoAcquisitionEntry | undefined }) {
   const [elapsed, setElapsed] = useState(0);
   const recorded = useRef(false);
+  // Keyed on entry.tmdbId so a new acquisition (entry change) resets the timer +
+  // the recorded guard and re-announces in-progress, instead of staying stuck on
+  // the previous title's playback.
   useEffect(() => {
+    recorded.current = false;
+    setElapsed(0);
     // Announce this acquisition as in-progress so OTHER pages (media library,
     // activity) show a real-time 获取中 card/row, clock-driven from startedAt —
     // not just this local progress bar. Completion promotion is handled by
@@ -43,7 +48,7 @@ export function DemoAcquirePlayback({ entry }: { entry?: DemoAcquisitionEntry | 
       }
     }, 400);
     return () => clearInterval(id);
-  }, []);
+  }, [entry?.tmdbId]);
 
   const state = playbackStateAt(elapsed);
   const done = state.progress >= 100;

--- a/apps/web/components/demo-acquire-playback.tsx
+++ b/apps/web/components/demo-acquire-playback.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, LoaderCircle } from "lucide-react";
 import { playbackStateAt, DEMO_PLAYBACK_TOTAL_MS } from "../lib/demo-playback-timeline";
-import { recordDemoAcquisition, type DemoAcquisitionEntry } from "../lib/demo-session";
+import {
+  clearDemoInProgress,
+  recordDemoAcquisition,
+  startDemoInProgress,
+  type DemoAcquisitionEntry,
+} from "../lib/demo-session";
 
 /**
  * Read-only demo: a scripted, client-only playback of an agent acquisition. Drives
@@ -14,6 +19,21 @@ export function DemoAcquirePlayback({ entry }: { entry?: DemoAcquisitionEntry | 
   const [elapsed, setElapsed] = useState(0);
   const recorded = useRef(false);
   useEffect(() => {
+    // Announce this acquisition as in-progress so OTHER pages (media library,
+    // activity) show a real-time 获取中 card/row, clock-driven from startedAt —
+    // not just this local progress bar. Completion promotion is handled by
+    // useDemoInProgress's tick when navigated away, or by the done-record below
+    // when this component stays mounted (both dedup by tmdbId → safe either way).
+    if (entry) {
+      startDemoInProgress({
+        tmdbId: entry.tmdbId,
+        title: entry.title,
+        year: entry.year,
+        type: entry.type,
+        posterPath: entry.posterPath,
+        startedAt: Date.now(),
+      });
+    }
     const start = Date.now();
     const id = setInterval(() => {
       const t = Date.now() - start;
@@ -32,6 +52,7 @@ export function DemoAcquirePlayback({ entry }: { entry?: DemoAcquisitionEntry | 
     if (done && entry && !recorded.current) {
       recorded.current = true;
       recordDemoAcquisition(entry);
+      clearDemoInProgress(entry.tmdbId);
     }
   }, [done, entry]);
 

--- a/apps/web/components/demo-session-library.tsx
+++ b/apps/web/components/demo-session-library.tsx
@@ -1,29 +1,69 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { Check, LoaderCircle } from "lucide-react";
 import { isDemoModeClient } from "../lib/demo-mode";
-import { useDemoAcquisitions } from "../lib/use-demo-session";
+import { demoInProgressLibraryCards } from "../lib/demo-session";
+import { useDemoAcquisitions, useDemoInProgress } from "../lib/use-demo-session";
 
 /**
- * Read-only demo: a top "本次演示获取" section showing the titles the visitor
- * "acquired" this session (client-only sessionStorage — no DB, no server render).
- * Mounted in the library's static shell (NOT inside the streaming Suspense) so it
- * actually hydrates. Renders nothing outside demo or when empty.
+ * Read-only demo: top sections reflecting THIS session's activity (client-only
+ * sessionStorage — no DB, no server render). Mounted in the library's static
+ * shell (NOT inside the streaming Suspense) so it actually hydrates. Shows
+ * in-progress "获取中" placeholder cards (clock-driven, mirroring production's
+ * InProgressCard) above the completed "本次演示获取" wall. Renders nothing outside
+ * demo or when both are empty.
  */
 export function DemoSessionLibrary() {
   const entries = useDemoAcquisitions();
+  const acquiring = demoInProgressLibraryCards(useDemoInProgress());
 
-  if (!isDemoModeClient() || entries.length === 0) {
+  if (!isDemoModeClient() || (entries.length === 0 && acquiring.length === 0)) {
     return null;
   }
 
   return (
-    <div className="category-section" aria-label="本次演示获取">
-      <div className="category-header is-static">
-        <h2>本次演示获取 {entries.length}</h2>
-      </div>
-      <div className="poster-row">
-        {entries.map((e) => (
+    <>
+      {acquiring.length > 0 ? (
+        <div className="category-section" aria-label="获取中">
+          <div className="category-header is-static">
+            <h2>获取中 {acquiring.length}</h2>
+          </div>
+          <div className="poster-row">
+            {acquiring.map((e) => (
+              <div
+                className="wall-card is-loading"
+                aria-disabled
+                key={`ip_${e.type}_${e.tmdbId}`}
+                title="获取中，完成后可进入"
+              >
+                <span className="wall-poster">
+                  {e.posterPath ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={`https://image.tmdb.org/t/p/w342${e.posterPath}`} alt="" loading="lazy" />
+                  ) : (
+                    <span className="poster-fallback">{e.title.slice(0, 4)}</span>
+                  )}
+                  <span className="wall-loading-overlay">
+                    <LoaderCircle size={20} className="spin" aria-hidden />
+                    <span>获取中</span>
+                  </span>
+                </span>
+                <span className="wall-copy">
+                  <strong>{e.title}</strong>
+                  <span>{e.year} · 正在获取</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {entries.length > 0 ? (
+        <div className="category-section" aria-label="本次演示获取">
+          <div className="category-header is-static">
+            <h2>本次演示获取 {entries.length}</h2>
+          </div>
+          <div className="poster-row">
+            {entries.map((e) => (
           <div className="wall-card" key={`${e.type}_${e.tmdbId}`} title="本次演示获取（仅本次浏览）">
             <span className="wall-poster">
               {e.posterPath ? (
@@ -44,7 +84,9 @@ export function DemoSessionLibrary() {
             </span>
           </div>
         ))}
-      </div>
-    </div>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/apps/web/components/demo-session-library.tsx
+++ b/apps/web/components/demo-session-library.tsx
@@ -14,10 +14,20 @@ import { useDemoAcquisitions, useDemoInProgress } from "../lib/use-demo-session"
  * demo or when both are empty.
  */
 export function DemoSessionLibrary() {
+  // Guard at the COMPONENT boundary, before any demo hooks: isDemoModeClient() is a
+  // build-time constant, so in real builds the inner (hook-using) body never mounts
+  // → zero hook/effect/render cost. (Conditional component, NOT conditional hook.)
+  if (!isDemoModeClient()) {
+    return null;
+  }
+  return <DemoSessionLibraryInner />;
+}
+
+function DemoSessionLibraryInner() {
   const entries = useDemoAcquisitions();
   const acquiring = demoInProgressLibraryCards(useDemoInProgress());
 
-  if (!isDemoModeClient() || (entries.length === 0 && acquiring.length === 0)) {
+  if (entries.length === 0 && acquiring.length === 0) {
     return null;
   }
 

--- a/apps/web/components/demo-session-notifications.tsx
+++ b/apps/web/components/demo-session-notifications.tsx
@@ -16,9 +16,19 @@ const TMDB_FEED_POSTER = "https://image.tmdb.org/t/p/w154";
  * outside demo or when empty.
  */
 export function DemoSessionNotifications() {
+  // Guard at the COMPONENT boundary, before any demo hooks: isDemoModeClient() is a
+  // build-time constant, so in real builds the inner (hook-using) body never mounts
+  // → zero hook/effect/render cost. (Conditional component, NOT conditional hook.)
+  if (!isDemoModeClient()) {
+    return null;
+  }
+  return <DemoSessionNotificationsInner />;
+}
+
+function DemoSessionNotificationsInner() {
   const items = demoSessionNotifications(useDemoAcquisitions());
 
-  if (!isDemoModeClient() || items.length === 0) {
+  if (items.length === 0) {
     return null;
   }
 

--- a/apps/web/components/demo-session-notifications.tsx
+++ b/apps/web/components/demo-session-notifications.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { CheckCircle2, PartyPopper } from "lucide-react";
+import { isDemoModeClient } from "../lib/demo-mode";
+import { demoSessionNotifications } from "../lib/demo-session";
+import { useDemoAcquisitions } from "../lib/use-demo-session";
+
+const TMDB_FEED_POSTER = "https://image.tmdb.org/t/p/w154";
+
+/**
+ * Read-only demo: this session's acquisitions surfaced as 通知-feed cards (no DB
+ * notification exists). Mounted in the notifications page's static shell (NOT
+ * inside the streaming Suspense) so it hydrates AND so its `data-created-at`
+ * cards are seen by NotificationsSeenMarker — which marks them NEW and advances
+ * the last-seen watermark, exactly like real notifications. Renders nothing
+ * outside demo or when empty.
+ */
+export function DemoSessionNotifications() {
+  const items = demoSessionNotifications(useDemoAcquisitions());
+
+  if (!isDemoModeClient() || items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="feed" aria-label="本次演示通知">
+      <section className="feed-day">
+        <header className="feed-day-header">
+          <span className="feed-day-label">本次浏览</span>
+          <span className="feed-day-summary">{items.length} 项演示获取</span>
+        </header>
+        <div className="feed-cards">
+          {items.map((item) => {
+            const posterUrl = item.posterPath ? `${TMDB_FEED_POSTER}${item.posterPath}` : null;
+            const heading = item.year ? `${item.title} (${item.year})` : item.title;
+            return (
+              <article
+                className={`feed-card${posterUrl ? " has-poster" : ""}`}
+                data-created-at={item.createdAt}
+                key={item.id}
+              >
+                {posterUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img className="feed-poster" src={posterUrl} alt="" loading="lazy" />
+                ) : null}
+                <div className="feed-card-body">
+                  <div className="feed-card-head">
+                    <span className="feed-icon tone-green">
+                      <PartyPopper size={15} aria-hidden />
+                    </span>
+                    <strong className="feed-card-title">{heading}</strong>
+                    <span className="feed-status-pill tone-green">
+                      <CheckCircle2 size={11} aria-hidden />
+                      已入库
+                    </span>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/apps/web/components/notifications-nav-badge.tsx
+++ b/apps/web/components/notifications-nav-badge.tsx
@@ -1,12 +1,18 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { isDemoModeClient } from "../lib/demo-mode";
+import { DEMO_ACQUIRED_EVENT, demoSessionNotifications, listDemoAcquisitions } from "../lib/demo-session";
 import { getLastSeen } from "../lib/notifications-seen";
 
 /** Unread count on the 通知 nav: notifications newer than this browser's last-seen
- *  watermark. Clears when the 通知 page is opened (which advances the watermark). */
+ *  watermark. Clears when the 通知 page is opened (which advances the watermark).
+ *  In demo mode, this session's acquisitions are client-only (no DB row), so they
+ *  are counted too — by the same last-seen diff (their cards carry data-created-at,
+ *  so opening 通知 advances the watermark past them and clears the badge). */
 export function NotificationsNavBadge({ storageId }: { storageId?: string | undefined }) {
   const [count, setCount] = useState(0);
+  const [demoUnread, setDemoUnread] = useState(0);
 
   useEffect(() => {
     let alive = true;
@@ -33,8 +39,29 @@ export function NotificationsNavBadge({ storageId }: { storageId?: string | unde
     };
   }, [storageId]);
 
-  if (count === 0) {
+  useEffect(() => {
+    if (!isDemoModeClient()) {
+      return;
+    }
+    const recompute = () => {
+      const lastSeen = getLastSeen();
+      const unread = demoSessionNotifications(listDemoAcquisitions()).filter(
+        (n) => n.createdAt > lastSeen,
+      ).length;
+      setDemoUnread(unread);
+    };
+    recompute();
+    const id = window.setInterval(recompute, 2000);
+    window.addEventListener(DEMO_ACQUIRED_EVENT, recompute);
+    return () => {
+      window.clearInterval(id);
+      window.removeEventListener(DEMO_ACQUIRED_EVENT, recompute);
+    };
+  }, []);
+
+  const total = count + demoUnread;
+  if (total === 0) {
     return null;
   }
-  return <span className="nav-badge nav-badge-alert">{count}</span>;
+  return <span className="nav-badge nav-badge-alert">{total}</span>;
 }

--- a/apps/web/lib/demo-session.test.ts
+++ b/apps/web/lib/demo-session.test.ts
@@ -215,4 +215,34 @@ describe("demoSessionNotifications", () => {
     expect(n).toHaveLength(1);
     expect(typeof n[0]!.createdAt).toBe("string");
   });
+
+  it("tolerates corrupted acquiredAt (NaN/string) without throwing", () => {
+    const corrupted = [
+      { tmdbId: 1, title: "A", year: 2026, type: "movie", posterPath: null, acquiredAt: NaN },
+      { tmdbId: 2, title: "B", year: 2026, type: "tv", posterPath: null, acquiredAt: "oops" },
+    ] as unknown as DemoAcquisitionEntry[];
+    let out!: ReturnType<typeof demoSessionNotifications>;
+    expect(() => {
+      out = demoSessionNotifications(corrupted);
+    }).not.toThrow();
+    expect(out).toHaveLength(2);
+    for (const n of out) {
+      // createdAt must be a real ISO string (fallback), never "Invalid Date".
+      expect(new Date(n.createdAt).toISOString()).toBe(n.createdAt);
+    }
+  });
+});
+
+describe("recordDemoAcquisition acquiredAt stability", () => {
+  it("preserves the first acquiredAt across a second (no-arg) record of the same tmdbId", () => {
+    const s = fakeStorage();
+    recordDemoAcquisition({ tmdbId: 5, title: "A", year: 2026, type: "movie", posterPath: null, acquiredAt: 1000 }, s);
+    // Second promotion (e.g. hook tick) for the same title, no acquiredAt → must
+    // NOT re-stamp, or the 通知 NEW/unread diff would jump forward and the badge
+    // would wrongly reappear after the user already saw it.
+    recordDemoAcquisition({ tmdbId: 5, title: "A", year: 2026, type: "movie", posterPath: null }, s);
+    const list = listDemoAcquisitions(s);
+    expect(list).toHaveLength(1);
+    expect(list[0]!.acquiredAt).toBe(1000);
+  });
 });

--- a/apps/web/lib/demo-session.test.ts
+++ b/apps/web/lib/demo-session.test.ts
@@ -129,6 +129,16 @@ describe("demo in-progress overlay", () => {
     ).toEqual([7]);
   });
 
+  it("rejects non-finite startedAt (corruption guard → never stuck 获取中)", () => {
+    const raw = JSON.stringify([
+      { tmdbId: 1, title: "A", year: 2026, type: "tv", posterPath: null, startedAt: "x" },
+      { tmdbId: 7, title: "B", year: 2026, type: "tv", posterPath: null, startedAt: 5 },
+    ]);
+    expect(
+      listDemoInProgress(fakeStorage({ "mediary-demo-inprogress": raw })).map((e) => e.tmdbId),
+    ).toEqual([7]);
+  });
+
   it("caps at 20 (newest first) — no unbounded growth", () => {
     const s = fakeStorage();
     for (let i = 1; i <= 25; i++) startDemoInProgress(ip(i, i), s);
@@ -244,5 +254,16 @@ describe("recordDemoAcquisition acquiredAt stability", () => {
     const list = listDemoAcquisitions(s);
     expect(list).toHaveLength(1);
     expect(list[0]!.acquiredAt).toBe(1000);
+  });
+
+  it("does NOT preserve a corrupted existing acquiredAt — re-stamps a finite value", () => {
+    const raw = JSON.stringify([
+      { tmdbId: 5, title: "A", year: 2026, type: "movie", posterPath: null, acquiredAt: "bad" },
+    ]);
+    const s = fakeStorage({ "mediary-demo-acquired": raw });
+    recordDemoAcquisition({ tmdbId: 5, title: "A", year: 2026, type: "movie", posterPath: null }, s);
+    const list = listDemoAcquisitions(s);
+    expect(list).toHaveLength(1);
+    expect(Number.isFinite(list[0]!.acquiredAt)).toBe(true);
   });
 });

--- a/apps/web/lib/demo-session.test.ts
+++ b/apps/web/lib/demo-session.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { listDemoAcquisitions, recordDemoAcquisition, demoCompletedItems, type DemoAcquisitionEntry } from "./demo-session";
+import {
+  listDemoAcquisitions,
+  recordDemoAcquisition,
+  demoCompletedItems,
+  type DemoAcquisitionEntry,
+  startDemoInProgress,
+  listDemoInProgress,
+  clearDemoInProgress,
+  demoInProgressView,
+  demoInProgressLibraryCards,
+  demoInProgressActivityItems,
+  demoSessionNotifications,
+  type DemoInProgressEntry,
+  type DemoInProgressActive,
+} from "./demo-session";
+import { DEMO_PLAYBACK_TOTAL_MS } from "./demo-playback-timeline";
 
 function fakeStorage(initial: Record<string, string> = {}) {
   const map = new Map(Object.entries(initial));
@@ -76,5 +91,120 @@ describe("demoCompletedItems", () => {
     expect(it0.seasonLabel).toBeNull();
     expect(it0.sizeText).toBeNull();
     expect(typeof it0.createdAt).toBe("string");
+  });
+});
+
+describe("demo in-progress overlay", () => {
+  const ip = (tmdbId: number, startedAt: number): DemoInProgressEntry => ({
+    tmdbId,
+    title: `T${tmdbId}`,
+    year: 2026,
+    type: "tv",
+    posterPath: "/p.jpg",
+    startedAt,
+  });
+
+  it("records, lists, dedups by tmdbId (replace, front), clears", () => {
+    const s = fakeStorage();
+    startDemoInProgress(ip(1, 1000), s);
+    startDemoInProgress(ip(2, 1500), s);
+    startDemoInProgress({ ...ip(1, 2000) }, s); // same tmdbId → replace, move front
+    const list = listDemoInProgress(s);
+    expect(list.map((e) => e.tmdbId)).toEqual([1, 2]);
+    expect(list[0]!.startedAt).toBe(2000);
+    clearDemoInProgress(1, s);
+    expect(listDemoInProgress(s).map((e) => e.tmdbId)).toEqual([2]);
+  });
+
+  it("null storage (SSR) → empty list, no throw", () => {
+    expect(listDemoInProgress(null)).toEqual([]);
+    expect(() => startDemoInProgress(ip(1, 0), null)).not.toThrow();
+    expect(() => clearDemoInProgress(1, null)).not.toThrow();
+  });
+
+  it("drops wrong-shape entries", () => {
+    const bad = JSON.stringify([{ tmdbId: "x", startedAt: 1 }, ip(7, 0)]);
+    expect(
+      listDemoInProgress(fakeStorage({ "mediary-demo-inprogress": bad })).map((e) => e.tmdbId),
+    ).toEqual([7]);
+  });
+});
+
+describe("demoInProgressView", () => {
+  const base = { tmdbId: 1, title: "A", year: 2026, type: "tv" as const, posterPath: null };
+
+  it("splits active vs done by the clock", () => {
+    const started = { ...base, startedAt: 0 };
+    const mid = demoInProgressView([started], Math.floor(DEMO_PLAYBACK_TOTAL_MS / 2));
+    expect(mid.done).toEqual([]);
+    expect(mid.active).toHaveLength(1);
+    expect(mid.active[0]!.progress).toBeGreaterThan(0);
+    expect(mid.active[0]!.progress).toBeLessThanOrEqual(100);
+    expect(typeof mid.active[0]!.step).toBe("string");
+    expect(mid.active[0]!.step.length).toBeGreaterThan(0);
+
+    const after = demoInProgressView([started], DEMO_PLAYBACK_TOTAL_MS + 10);
+    expect(after.active).toEqual([]);
+    expect(after.done).toEqual([started]);
+  });
+
+  it("clamps negative elapsed (clock skew) to the first step, never crashes", () => {
+    const future = { ...base, startedAt: 100 };
+    const view = demoInProgressView([future], 0); // now < startedAt
+    expect(view.active).toHaveLength(1);
+    expect(view.active[0]!.progress).toBeGreaterThan(0);
+  });
+});
+
+describe("demo in-progress view mappers", () => {
+  const active: DemoInProgressActive[] = [
+    {
+      tmdbId: 7,
+      title: "X",
+      year: 2026,
+      type: "anime",
+      posterPath: "/p.jpg",
+      startedAt: 0,
+      progress: 40,
+      step: "转存到网盘…",
+    },
+  ];
+
+  it("maps active entries to library 获取中 cards", () => {
+    expect(demoInProgressLibraryCards(active)).toEqual([
+      { tmdbId: 7, title: "X", year: 2026, type: "anime", posterPath: "/p.jpg", acquiring: true },
+    ]);
+  });
+
+  it("maps active entries to activity 获取中 items with progress", () => {
+    const items = demoInProgressActivityItems(active);
+    expect(items[0]!.id).toBe("demo-inprogress-7");
+    expect(items[0]!.title).toBe("X");
+    expect(items[0]!.progress).toBe(40);
+    expect(items[0]!.step).toBe("转存到网盘…");
+    expect(items[0]!.posterPath).toBe("/p.jpg");
+  });
+});
+
+describe("demoSessionNotifications", () => {
+  it("maps completed demo acquisitions to session notification cards (newest first by acquiredAt)", () => {
+    const n = demoSessionNotifications([
+      { tmdbId: 7, title: "X", year: 2026, type: "movie", posterPath: "/p.jpg", acquiredAt: 2000 },
+      { tmdbId: 8, title: "Y", year: 2025, type: "tv", posterPath: null, acquiredAt: 3000 },
+    ]);
+    expect(n).toHaveLength(2);
+    expect(n[0]!.tmdbId).toBe(8); // newest acquiredAt first
+    expect(n[0]!.kind).toBe("acquired");
+    expect(n[0]!.id).toBe("demo-notif-8");
+    expect(n[1]!.title).toBe("X");
+    // createdAt is an ISO string derived from acquiredAt so the seen-marker can diff it.
+    expect(typeof n[0]!.createdAt).toBe("string");
+    expect(new Date(n[0]!.createdAt).toISOString()).toBe(n[0]!.createdAt);
+  });
+
+  it("entries without acquiredAt still render (stable fallback createdAt)", () => {
+    const n = demoSessionNotifications([{ tmdbId: 9, title: "Z", year: 2024, type: "movie", posterPath: null }]);
+    expect(n).toHaveLength(1);
+    expect(typeof n[0]!.createdAt).toBe("string");
   });
 });

--- a/apps/web/lib/demo-session.test.ts
+++ b/apps/web/lib/demo-session.test.ts
@@ -128,6 +128,14 @@ describe("demo in-progress overlay", () => {
       listDemoInProgress(fakeStorage({ "mediary-demo-inprogress": bad })).map((e) => e.tmdbId),
     ).toEqual([7]);
   });
+
+  it("caps at 20 (newest first) — no unbounded growth", () => {
+    const s = fakeStorage();
+    for (let i = 1; i <= 25; i++) startDemoInProgress(ip(i, i), s);
+    const list = listDemoInProgress(s);
+    expect(list).toHaveLength(20);
+    expect(list[0]!.tmdbId).toBe(25);
+  });
 });
 
 describe("demoInProgressView", () => {

--- a/apps/web/lib/demo-session.ts
+++ b/apps/web/lib/demo-session.ts
@@ -1,4 +1,5 @@
 import type { ActivityCompletedItem } from "./activity-view";
+import { playbackStateAt, DEMO_PLAYBACK_TOTAL_MS } from "./demo-playback-timeline";
 
 export interface DemoAcquisitionEntry {
   tmdbId: number;
@@ -6,6 +7,10 @@ export interface DemoAcquisitionEntry {
   year: number;
   type: "movie" | "tv" | "anime";
   posterPath: string | null;
+  /** Wall-clock ms when this acquisition completed. Optional for back-compat /
+   *  direct construction; recordDemoAcquisition stamps it so the 通知 NEW badge
+   *  can diff it against the last-seen watermark. */
+  acquiredAt?: number;
 }
 
 const KEY = "mediary-demo-acquired";
@@ -70,7 +75,11 @@ export function recordDemoAcquisition(
   if (!storage) {
     return [];
   }
-  const next = [entry, ...listDemoAcquisitions(storage).filter((e) => e.tmdbId !== entry.tmdbId)].slice(0, MAX);
+  const stamped: DemoAcquisitionEntry = {
+    ...entry,
+    acquiredAt: entry.acquiredAt ?? (typeof Date !== "undefined" ? Date.now() : 0),
+  };
+  const next = [stamped, ...listDemoAcquisitions(storage).filter((e) => e.tmdbId !== entry.tmdbId)].slice(0, MAX);
   try {
     storage.setItem(KEY, JSON.stringify(next));
     if (typeof window !== "undefined") {
@@ -98,4 +107,213 @@ export function demoCompletedItems(entries: DemoAcquisitionEntry[]): ActivityCom
     sizeText: null,
     createdAt: "2026-06-12T08:00:00.000Z",
   }));
+}
+
+// ── In-progress overlay (demo only) ───────────────────────────────────────────
+// Mirrors the completed-acquisition layer, for acquisitions still PLAYING. An
+// entry only stores `startedAt`; the live progress is derived from the clock
+// (`now - startedAt` via playbackStateAt), so ANY page that mounts a tick shows
+// the real-time 获取中 state without depending on the playback component staying
+// mounted — the cross-page parity #3b is about. When the clock passes the total,
+// the entry is "done" and gets promoted to the completed layer (+ a notification).
+
+export interface DemoInProgressEntry {
+  tmdbId: number;
+  title: string;
+  year: number;
+  type: "movie" | "tv" | "anime";
+  posterPath: string | null;
+  /** Wall-clock ms when the acquisition playback started. */
+  startedAt: number;
+}
+
+/** An in-progress entry with its clock-derived progress + step label. */
+export interface DemoInProgressActive extends DemoInProgressEntry {
+  /** 0–100 progress bar value at `now`. */
+  progress: number;
+  /** Human step label at `now` (e.g. "转存到网盘…"). */
+  step: string;
+}
+
+const INPROGRESS_KEY = "mediary-demo-inprogress";
+
+/** Fired on the window whenever the in-progress set changes, so every mounted
+ *  surface (library, activity) re-reads and re-ticks. */
+export const DEMO_INPROGRESS_EVENT = "mediary-demo-inprogress";
+
+function isInProgressEntry(value: unknown): value is DemoInProgressEntry {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const e = value as Record<string, unknown>;
+  return (
+    typeof e.tmdbId === "number" &&
+    typeof e.title === "string" &&
+    typeof e.year === "number" &&
+    (e.type === "movie" || e.type === "tv" || e.type === "anime") &&
+    (e.posterPath === null || typeof e.posterPath === "string") &&
+    typeof e.startedAt === "number"
+  );
+}
+
+export function listDemoInProgress(
+  storage: StorageLike | null = defaultStorage(),
+): DemoInProgressEntry[] {
+  if (!storage) {
+    return [];
+  }
+  try {
+    const raw = storage.getItem(INPROGRESS_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(isInProgressEntry);
+  } catch {
+    return [];
+  }
+}
+
+function fireInProgress(): void {
+  if (typeof window !== "undefined") {
+    try {
+      window.dispatchEvent(new Event(DEMO_INPROGRESS_EVENT));
+    } catch {
+      // no DOM event support — non-fatal
+    }
+  }
+}
+
+export function startDemoInProgress(
+  entry: DemoInProgressEntry,
+  storage: StorageLike | null = defaultStorage(),
+): void {
+  if (!storage) {
+    return;
+  }
+  const next = [entry, ...listDemoInProgress(storage).filter((e) => e.tmdbId !== entry.tmdbId)];
+  try {
+    storage.setItem(INPROGRESS_KEY, JSON.stringify(next));
+    fireInProgress();
+  } catch {
+    // storage full / unavailable — best-effort, demo only
+  }
+}
+
+export function clearDemoInProgress(
+  tmdbId: number,
+  storage: StorageLike | null = defaultStorage(),
+): void {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(
+      INPROGRESS_KEY,
+      JSON.stringify(listDemoInProgress(storage).filter((e) => e.tmdbId !== tmdbId)),
+    );
+    fireInProgress();
+  } catch {
+    // best-effort, demo only
+  }
+}
+
+/** Split the in-progress entries into still-active (with clock-derived progress)
+ *  and done (clock passed the playback total). Pure — drives the tick. */
+export function demoInProgressView(
+  entries: DemoInProgressEntry[],
+  now: number,
+): { active: DemoInProgressActive[]; done: DemoInProgressEntry[] } {
+  const active: DemoInProgressActive[] = [];
+  const done: DemoInProgressEntry[] = [];
+  for (const e of entries) {
+    const elapsed = now - e.startedAt;
+    if (elapsed >= DEMO_PLAYBACK_TOTAL_MS) {
+      done.push(e);
+      continue;
+    }
+    const state = playbackStateAt(Math.max(0, elapsed));
+    active.push({ ...e, progress: state.progress, step: state.label });
+  }
+  return { active, done };
+}
+
+/** Map active in-progress entries to media-library "获取中" placeholder cards. */
+export function demoInProgressLibraryCards(active: DemoInProgressActive[]): Array<{
+  tmdbId: number;
+  title: string;
+  year: number;
+  type: "movie" | "tv" | "anime";
+  posterPath: string | null;
+  acquiring: true;
+}> {
+  return active.map((e) => ({
+    tmdbId: e.tmdbId,
+    title: e.title,
+    year: e.year,
+    type: e.type,
+    posterPath: e.posterPath,
+    acquiring: true as const,
+  }));
+}
+
+/** Map active in-progress entries to activity-page "获取中" rows (with progress). */
+export function demoInProgressActivityItems(active: DemoInProgressActive[]): Array<{
+  id: string;
+  tmdbId: number;
+  title: string;
+  year: number;
+  type: "movie" | "tv" | "anime";
+  posterPath: string | null;
+  progress: number;
+  step: string;
+}> {
+  return active.map((e) => ({
+    id: `demo-inprogress-${e.tmdbId}`,
+    tmdbId: e.tmdbId,
+    title: e.title,
+    year: e.year,
+    type: e.type,
+    posterPath: e.posterPath,
+    progress: e.progress,
+    step: e.step,
+  }));
+}
+
+/** One demo session notification card (completion). */
+export interface DemoSessionNotification {
+  id: string;
+  tmdbId: number;
+  title: string;
+  year: number;
+  type: "movie" | "tv" | "anime";
+  posterPath: string | null;
+  kind: "acquired";
+  /** ISO string derived from acquiredAt so the 通知 seen-marker can diff it. */
+  createdAt: string;
+}
+
+/** Fixed fallback for entries lacking acquiredAt (legacy / direct construction). */
+const DEMO_NOTIF_FALLBACK_AT = "2026-06-12T08:00:00.000Z";
+
+/** Map completed demo acquisitions to 通知-feed session cards, newest first. */
+export function demoSessionNotifications(
+  completed: DemoAcquisitionEntry[],
+): DemoSessionNotification[] {
+  return [...completed]
+    .sort((a, b) => (b.acquiredAt ?? 0) - (a.acquiredAt ?? 0))
+    .map((e) => ({
+      id: `demo-notif-${e.tmdbId}`,
+      tmdbId: e.tmdbId,
+      title: e.title,
+      year: e.year,
+      type: e.type,
+      posterPath: e.posterPath,
+      kind: "acquired" as const,
+      createdAt:
+        e.acquiredAt != null ? new Date(e.acquiredAt).toISOString() : DEMO_NOTIF_FALLBACK_AT,
+    }));
 }

--- a/apps/web/lib/demo-session.ts
+++ b/apps/web/lib/demo-session.ts
@@ -178,11 +178,21 @@ export function listDemoInProgress(
 }
 
 function fireInProgress(): void {
+  // Dispatched ASYNCHRONOUSLY: useDemoInProgress both listens to this event AND
+  // calls clearDemoInProgress() (→ fireInProgress) inside its tick when promoting
+  // done items. A synchronous dispatch would re-enter tick() mid-loop (nested
+  // recursion). Deferring to a macrotask lets the current call stack unwind first.
   if (typeof window !== "undefined") {
     try {
-      window.dispatchEvent(new Event(DEMO_INPROGRESS_EVENT));
+      window.setTimeout(() => {
+        try {
+          window.dispatchEvent(new Event(DEMO_INPROGRESS_EVENT));
+        } catch {
+          // no DOM event support — non-fatal
+        }
+      }, 0);
     } catch {
-      // no DOM event support — non-fatal
+      // no timer support — non-fatal
     }
   }
 }
@@ -194,7 +204,12 @@ export function startDemoInProgress(
   if (!storage) {
     return;
   }
-  const next = [entry, ...listDemoInProgress(storage).filter((e) => e.tmdbId !== entry.tmdbId)];
+  // Cap like the completed layer (MAX): in-progress count is normally tiny, but a
+  // bound keeps repeated demo acquisitions from growing sessionStorage unbounded.
+  const next = [entry, ...listDemoInProgress(storage).filter((e) => e.tmdbId !== entry.tmdbId)].slice(
+    0,
+    MAX,
+  );
   try {
     storage.setItem(INPROGRESS_KEY, JSON.stringify(next));
     fireInProgress();

--- a/apps/web/lib/demo-session.ts
+++ b/apps/web/lib/demo-session.ts
@@ -75,12 +75,16 @@ export function recordDemoAcquisition(
   if (!storage) {
     return [];
   }
-  const rest = listDemoAcquisitions(storage).filter((e) => e.tmdbId !== entry.tmdbId);
+  // Read the session list ONCE (untrusted + potentially large), derive both the
+  // existing match and the rest from the same snapshot — avoids a double parse and
+  // any inconsistency from storage changing between two reads.
+  const current = listDemoAcquisitions(storage);
   // Preserve the FIRST acquiredAt: this can be (re)recorded for the same tmdbId by
   // both the playback done-handler and useDemoInProgress's promotion tick. Re-stamping
   // a later time would push createdAt forward and make the 通知 NEW/unread badge
   // wrongly reappear after the user already saw it. Only stamp when truly new.
-  const existing = listDemoAcquisitions(storage).find((e) => e.tmdbId === entry.tmdbId);
+  const existing = current.find((e) => e.tmdbId === entry.tmdbId);
+  const rest = current.filter((e) => e.tmdbId !== entry.tmdbId);
   const stamped: DemoAcquisitionEntry = {
     ...entry,
     // Only a FINITE existing value is worth preserving — a corrupted sessionStorage

--- a/apps/web/lib/demo-session.ts
+++ b/apps/web/lib/demo-session.ts
@@ -75,11 +75,18 @@ export function recordDemoAcquisition(
   if (!storage) {
     return [];
   }
+  const rest = listDemoAcquisitions(storage).filter((e) => e.tmdbId !== entry.tmdbId);
+  // Preserve the FIRST acquiredAt: this can be (re)recorded for the same tmdbId by
+  // both the playback done-handler and useDemoInProgress's promotion tick. Re-stamping
+  // a later time would push createdAt forward and make the 通知 NEW/unread badge
+  // wrongly reappear after the user already saw it. Only stamp when truly new.
+  const existing = listDemoAcquisitions(storage).find((e) => e.tmdbId === entry.tmdbId);
   const stamped: DemoAcquisitionEntry = {
     ...entry,
-    acquiredAt: entry.acquiredAt ?? (typeof Date !== "undefined" ? Date.now() : 0),
+    acquiredAt:
+      entry.acquiredAt ?? existing?.acquiredAt ?? (typeof Date !== "undefined" ? Date.now() : 0),
   };
-  const next = [stamped, ...listDemoAcquisitions(storage).filter((e) => e.tmdbId !== entry.tmdbId)].slice(0, MAX);
+  const next = [stamped, ...rest].slice(0, MAX);
   try {
     storage.setItem(KEY, JSON.stringify(next));
     if (typeof window !== "undefined") {
@@ -314,21 +321,30 @@ export interface DemoSessionNotification {
 /** Fixed fallback for entries lacking acquiredAt (legacy / direct construction). */
 const DEMO_NOTIF_FALLBACK_AT = "2026-06-12T08:00:00.000Z";
 
+/** A finite acquiredAt or null — entries come from untrusted sessionStorage, so a
+ *  corrupted value (string / NaN / Infinity) must never reach Date()/arithmetic
+ *  (`new Date(NaN).toISOString()` throws RangeError, breaking the 通知 page). */
+function safeAcquiredAt(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
 /** Map completed demo acquisitions to 通知-feed session cards, newest first. */
 export function demoSessionNotifications(
   completed: DemoAcquisitionEntry[],
 ): DemoSessionNotification[] {
   return [...completed]
-    .sort((a, b) => (b.acquiredAt ?? 0) - (a.acquiredAt ?? 0))
-    .map((e) => ({
-      id: `demo-notif-${e.tmdbId}`,
-      tmdbId: e.tmdbId,
-      title: e.title,
-      year: e.year,
-      type: e.type,
-      posterPath: e.posterPath,
-      kind: "acquired" as const,
-      createdAt:
-        e.acquiredAt != null ? new Date(e.acquiredAt).toISOString() : DEMO_NOTIF_FALLBACK_AT,
-    }));
+    .sort((a, b) => (safeAcquiredAt(b.acquiredAt) ?? 0) - (safeAcquiredAt(a.acquiredAt) ?? 0))
+    .map((e) => {
+      const at = safeAcquiredAt(e.acquiredAt);
+      return {
+        id: `demo-notif-${e.tmdbId}`,
+        tmdbId: e.tmdbId,
+        title: e.title,
+        year: e.year,
+        type: e.type,
+        posterPath: e.posterPath,
+        kind: "acquired" as const,
+        createdAt: at != null ? new Date(at).toISOString() : DEMO_NOTIF_FALLBACK_AT,
+      };
+    });
 }

--- a/apps/web/lib/demo-session.ts
+++ b/apps/web/lib/demo-session.ts
@@ -83,8 +83,13 @@ export function recordDemoAcquisition(
   const existing = listDemoAcquisitions(storage).find((e) => e.tmdbId === entry.tmdbId);
   const stamped: DemoAcquisitionEntry = {
     ...entry,
+    // Only a FINITE existing value is worth preserving — a corrupted sessionStorage
+    // value (string/NaN/Infinity) is nullish-distinct but useless, so fall through
+    // to a fresh finite stamp rather than carrying the garbage forward.
     acquiredAt:
-      entry.acquiredAt ?? existing?.acquiredAt ?? (typeof Date !== "undefined" ? Date.now() : 0),
+      safeAcquiredAt(entry.acquiredAt) ??
+      safeAcquiredAt(existing?.acquiredAt) ??
+      (typeof Date !== "undefined" ? Date.now() : 0),
   };
   const next = [stamped, ...rest].slice(0, MAX);
   try {
@@ -159,7 +164,10 @@ function isInProgressEntry(value: unknown): value is DemoInProgressEntry {
     typeof e.year === "number" &&
     (e.type === "movie" || e.type === "tv" || e.type === "anime") &&
     (e.posterPath === null || typeof e.posterPath === "string") &&
-    typeof e.startedAt === "number"
+    // Finite, not just `number`: a corrupted NaN/Infinity startedAt would make
+    // demoInProgressView's elapsed NaN → entry never promotes → stuck 获取中 row.
+    typeof e.startedAt === "number" &&
+    Number.isFinite(e.startedAt)
   );
 }
 

--- a/apps/web/lib/use-demo-session.ts
+++ b/apps/web/lib/use-demo-session.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { isDemoModeClient } from "./demo-mode";
 import {
   DEMO_ACQUIRED_EVENT,
   DEMO_INPROGRESS_EVENT,
@@ -48,6 +49,15 @@ export function useDemoAcquiredTmdbIds(): Set<number> {
 export function useDemoInProgress(): DemoInProgressActive[] {
   const [active, setActive] = useState<DemoInProgressActive[]>([]);
   useEffect(() => {
+    // Real mode (or any non-demo page that mounts this hook, e.g. ActivityFeed):
+    // do NO work — no interval, no re-renders. sessionStorage has no key anyway.
+    if (!isDemoModeClient()) {
+      return;
+    }
+    // Only re-render when the active set actually changes — the 500ms tick reads
+    // + diffs cheaply, but skips setState when nothing moved, so an idle demo page
+    // doesn't re-render twice a second.
+    let prevSig = "";
     const tick = () => {
       const view = demoInProgressView(listDemoInProgress(), Date.now());
       for (const d of view.done) {
@@ -60,7 +70,11 @@ export function useDemoInProgress(): DemoInProgressActive[] {
         });
         clearDemoInProgress(d.tmdbId);
       }
-      setActive(view.active);
+      const sig = view.active.map((a) => `${a.tmdbId}:${a.progress}:${a.step}`).join("|");
+      if (sig !== prevSig) {
+        prevSig = sig;
+        setActive(view.active);
+      }
     };
     tick();
     const id = window.setInterval(tick, 500);

--- a/apps/web/lib/use-demo-session.ts
+++ b/apps/web/lib/use-demo-session.ts
@@ -22,6 +22,12 @@ import {
 export function useDemoAcquisitions(): DemoAcquisitionEntry[] {
   const [entries, setEntries] = useState<DemoAcquisitionEntry[]>([]);
   useEffect(() => {
+    // Real mode (or any non-demo page that mounts a consumer, e.g. ActivityFeed):
+    // do NO work — no sessionStorage read, no setState (so no extra render), no
+    // listener. The store has no key anyway → zero impact.
+    if (!isDemoModeClient()) {
+      return;
+    }
     const read = () => setEntries(listDemoAcquisitions());
     read();
     window.addEventListener(DEMO_ACQUIRED_EVENT, read);

--- a/apps/web/lib/use-demo-session.ts
+++ b/apps/web/lib/use-demo-session.ts
@@ -3,8 +3,14 @@
 import { useEffect, useState } from "react";
 import {
   DEMO_ACQUIRED_EVENT,
+  DEMO_INPROGRESS_EVENT,
+  clearDemoInProgress,
+  demoInProgressView,
   listDemoAcquisitions,
+  listDemoInProgress,
+  recordDemoAcquisition,
   type DemoAcquisitionEntry,
+  type DemoInProgressActive,
 } from "./demo-session";
 
 /**
@@ -27,4 +33,42 @@ export function useDemoAcquisitions(): DemoAcquisitionEntry[] {
 export function useDemoAcquiredTmdbIds(): Set<number> {
   const entries = useDemoAcquisitions();
   return new Set(entries.map((e) => e.tmdbId));
+}
+
+/**
+ * Live view of THIS session's IN-PROGRESS demo acquisitions, ticked from the
+ * clock so every mounted surface (library, activity) shows real-time 获取中 +
+ * progress without depending on the playback component staying mounted. On each
+ * tick, any entry whose clock has passed the total is PROMOTED to the completed
+ * layer (record + notification) and cleared — a single promotion exit, idempotent
+ * with the playback component's own done-record (both dedup by tmdbId), so it's
+ * robust whether the user stayed on the page or navigated away mid-playback.
+ * SSR-safe: starts empty, fills on mount.
+ */
+export function useDemoInProgress(): DemoInProgressActive[] {
+  const [active, setActive] = useState<DemoInProgressActive[]>([]);
+  useEffect(() => {
+    const tick = () => {
+      const view = demoInProgressView(listDemoInProgress(), Date.now());
+      for (const d of view.done) {
+        recordDemoAcquisition({
+          tmdbId: d.tmdbId,
+          title: d.title,
+          year: d.year,
+          type: d.type,
+          posterPath: d.posterPath,
+        });
+        clearDemoInProgress(d.tmdbId);
+      }
+      setActive(view.active);
+    };
+    tick();
+    const id = window.setInterval(tick, 500);
+    window.addEventListener(DEMO_INPROGRESS_EVENT, tick);
+    return () => {
+      window.clearInterval(id);
+      window.removeEventListener(DEMO_INPROGRESS_EVENT, tick);
+    };
+  }, []);
+  return active;
 }


### PR DESCRIPTION
## 背景

incident `docs/incident-2026-06-22-agent-acquisition-bugs.md` §3 第二点(#3b):demo 点获取后是**纯客户端 playback**,只在原地跑进度条——其他页不联动(媒体库不冒「获取中」卡、活动页没反应、通知没反应)。本 PR 做成像投产那样的跨页联动。

spec/plan(本地工作文档):`docs/superpowers/{specs,plans}/2026-06-23-demo-inprogress-coherence*`。

## 方案:时钟驱动的「进行中」会话叠加层

镜像既有「完成态会话叠加层」(`demo-session.ts` + `useDemoAcquisitions`),新增**进行中态层**:进行中条目只存 `startedAt`,进度由 `(now-startedAt)/DEMO_PLAYBACK_TOTAL_MS` 经既有 `playbackStateAt` 算出 → 任何页挂 tick 即显实时「获取中」+进度,**不依赖 playback 组件是否还挂着**(镜像投产「run 在服务端继续、切页不影响」,只是用客户端时钟代替服务端)。时钟到点=done → 自动晋升到完成态层 + 一条会话通知。

- `lib/demo-session.ts`:进行中层 store(`start/list/clear` + `DEMO_INPROGRESS_EVENT`)、纯函数 `demoInProgressView`(时钟切分 active/done)、库卡/活动项/通知三映射;`DemoAcquisitionEntry` 加可选 `acquiredAt`(供通知 NEW 角标按 last-seen 水位 diff)。
- `lib/use-demo-session.ts`:`useDemoInProgress` hook(500ms tick 重算 + done 晋升完成态)。
- `components/demo-acquire-playback.tsx`:挂载即 `startDemoInProgress`、done 时 `clearDemoInProgress`(并保留自身完成 record——单一晋升出口由 hook 兜底,但 playback 自记覆盖「停在搜索页不切走」的场景,二者按 tmdbId 去重 → 双保险且幂等)。
- 媒体库 `DemoSessionLibrary`:并入「获取中」占位卡(镜像投产 `InProgressCard`)。
- 活动页 `ActivityFeed`:获取中段并入 demo 进行中行(进度条 + step ticker)。
- 通知:新增 `DemoSessionNotifications` 客户端岛(`data-created-at` → 既有 `NotificationsSeenMarker` 自动标 NEW + 推进 last-seen 水位);`NotificationsNavBadge` 计入 demo 未读。

**全 demo-only、纯加法、真实模式零影响**:所有面 `isDemoModeClient()` 门禁 + 真实模式 sessionStorage 无 key → 空集。

## 验证

- TDD 纯函数:`demo-session.test.ts` +9 用例(store/时钟 view/三映射/通知,含 SSR 守卫、负 elapsed 钳制、坏 shape 丢弃)。
- 全 CI 绿:build:workflow + 三 tsc + **791 测**(12 skip)+ lint 0 warning。
- **live e2e(web-demo 真起 + agent-browser,真 TMDB 搜索)**:点获取未播种片(玩具总动员)→ 媒体库见「获取中」卡 → 活动见「获取中」+ 时钟步进(`验证落盘文件…`,playback 已切走仍在走)→ 到点:库「已获取」/ 活动「已完成」/ 通知卡 / nav 角标「1」→ 看通知后角标清零;**中途刷新进行中态保留**(海底总动员,sessionStorage + 时钟续走);0 console 错。

🤖 Generated with [Claude Code](https://claude.com/claude-code)