### PR TITLE
feat(web): 投产搜索卡内联实时进度条 (#3a)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2958,6 +2958,14 @@ select.setting-control {
   font-size: 11px;
   color: var(--accent);
 }
+/* Production inline acquire progress: reuse the demo-playback bar/step visual on a
+   clickable Link (→ 活动). Inherits color/no-underline from the global `a` rule. */
+.acquire-progress {
+  cursor: pointer;
+}
+.acquire-progress:hover .demo-playback-step {
+  color: var(--text);
+}
 .workspace-switcher .ws-icon {
   width: 16px;
   height: 16px;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,6 +4,7 @@ import { CalendarClock, CheckCircle2, Clock3, Library, LoaderCircle, Search, Tri
 import { AcquiringPoller } from "../components/acquiring-poller";
 import { AppSidebar } from "../components/app-sidebar";
 import { RequestTrackButton } from "../components/request-track-button";
+import { AcquireProgressBadge } from "../components/acquire-progress-badge";
 import { DemoSessionLibrary } from "../components/demo-session-library";
 import { RememberQuery } from "../components/search-memory";
 import { SearchForm } from "../components/search-form";
@@ -290,17 +291,18 @@ function CandidateCard({
           </div>
           <div className="candidate-actions">
             {acquiring ? (
-              // #6: the persistent post-获取 pill links to the live 活动 page so the
-              // real progress is one click away (the gap the author flagged: "真实情况
-              // 要去活动里看"). storageId scopes it with ?w (mirrors globalNavHref).
-              <Link
-                className="hub-badge tone-green"
-                href={storageId ? `/activity?w=${encodeURIComponent(storageId)}` : "/activity"}
+              // #3a: while the run is RUNNING, show an inline live progress bar in
+              // place (real /api/activity data) — the demo-style elegance the author
+              // wanted instead of a bare spinner. When queued/just-finished it falls
+              // back to the static 已请求 pill, which still links to the live 活动 page
+              // (#6: "真实情况要去活动里看"). seasonNumber null = match this title's
+              // running season; storageId scopes the 活动 link with ?w.
+              <AcquireProgressBadge
+                tmdbId={candidate.tmdbId}
+                seasonNumber={null}
+                storageId={storageId}
                 title="后台正在获取——点查看进度（活动）"
-              >
-                <LoaderCircle size={12} className="spin" aria-hidden />
-                获取中
-              </Link>
+              />
             ) : null}
             {!acquiring && isTv && untrackedSeasons.length > 0 ? (
               <SeasonRequestMenu

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -331,6 +331,7 @@ function CandidateCard({
             {!acquiring && !isTv && trackedLabel === null ? (
               <RequestTrackButton
                 candidateId={candidate.id}
+                tmdbId={candidate.tmdbId}
                 actionState={candidate.action.state}
                 disabled={candidate.action.disabled}
                 label={candidate.action.label}

--- a/apps/web/components/acquire-progress-badge.tsx
+++ b/apps/web/components/acquire-progress-badge.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { LoaderCircle } from "lucide-react";
+import { RequestedBadge } from "./request-state";
+import { useActiveRun } from "../lib/use-active-run";
+import { inlineProgressView } from "../lib/inline-progress";
+
+/**
+ * Production inline acquire progress. While THIS card's run is actively running,
+ * show a live progress bar + step (real /api/activity data, reusing the demo's
+ * elegant inline visual), still clickable through to 活动. Queued / not-yet-matched
+ * / finished → the existing static 已请求 pill (AcquiringPoller's router.refresh
+ * flips it to 已获取 on finish).
+ */
+export function AcquireProgressBadge({
+  tmdbId,
+  seasonNumber = null,
+  storageId,
+  title,
+}: {
+  tmdbId: number;
+  seasonNumber?: number | null;
+  storageId?: string | undefined;
+  title?: string | undefined;
+}) {
+  const run = useActiveRun(tmdbId, seasonNumber, storageId);
+  const view = inlineProgressView(run);
+
+  if (!view.running) {
+    return <RequestedBadge title={title} storageId={storageId} />;
+  }
+
+  const href = storageId ? `/activity?w=${encodeURIComponent(storageId)}` : "/activity";
+  return (
+    <Link
+      className="demo-playback acquire-progress"
+      href={href}
+      title="查看获取进度（活动）"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="demo-playback-bar">
+        <span className="demo-playback-fill" style={{ width: `${view.percent}%` }} />
+      </span>
+      <span className="demo-playback-step">
+        <LoaderCircle size={14} className="spin" aria-hidden />
+        <span>{view.step}</span>
+      </span>
+    </Link>
+  );
+}

--- a/apps/web/components/acquire-progress-badge.tsx
+++ b/apps/web/components/acquire-progress-badge.tsx
@@ -33,17 +33,13 @@ export function AcquireProgressBadge({
 
   const href = storageId ? `/activity?w=${encodeURIComponent(storageId)}` : "/activity";
   return (
-    <Link
-      className="demo-playback acquire-progress"
-      href={href}
-      title="查看获取进度（活动）"
-      role="status"
-      aria-live="polite"
-    >
+    <Link className="demo-playback acquire-progress" href={href} title="查看获取进度（活动）">
       <span className="demo-playback-bar">
         <span className="demo-playback-fill" style={{ width: `${view.percent}%` }} />
       </span>
-      <span className="demo-playback-step">
+      {/* aria-live on the step text (NOT the anchor): keeps the element a proper
+          link for assistive tech while still announcing progress updates. */}
+      <span className="demo-playback-step" aria-live="polite">
         <LoaderCircle size={14} className="spin" aria-hidden />
         <span>{view.step}</span>
       </span>

--- a/apps/web/components/acquire-progress-badge.tsx
+++ b/apps/web/components/acquire-progress-badge.tsx
@@ -33,7 +33,7 @@ export function AcquireProgressBadge({
 
   const href = storageId ? `/activity?w=${encodeURIComponent(storageId)}` : "/activity";
   return (
-    <Link className="demo-playback acquire-progress" href={href} title="查看获取进度（活动）">
+    <Link className="demo-playback acquire-progress" href={href} title={title ?? "查看获取进度（活动）"}>
       <span className="demo-playback-bar">
         <span className="demo-playback-fill" style={{ width: `${view.percent}%` }} />
       </span>

--- a/apps/web/components/request-track-button.tsx
+++ b/apps/web/components/request-track-button.tsx
@@ -11,6 +11,7 @@ import { requestTrackingAction, type RequestTrackingActionResult } from "../app/
 // leaf modules (domain, workflow-scope), so the type can never carry pg in.
 import type { SearchActionState } from "@media-track/workflow/search-view";
 import { RequestedBadge } from "./request-state";
+import { AcquireProgressBadge } from "./acquire-progress-badge";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
 import type { DemoAcquisitionEntry } from "../lib/demo-session";
@@ -29,6 +30,7 @@ import { useDemoAcquiredTmdbIds } from "../lib/use-demo-session";
  */
 export function RequestTrackButton({
   candidateId,
+  tmdbId,
   actionState = "can_request",
   label = "获取",
   disabled = false,
@@ -36,6 +38,9 @@ export function RequestTrackButton({
   demoEntry,
 }: {
   candidateId?: string;
+  /** Production: the candidate's tmdbId, so the in-progress badge can match this
+   *  title's live run in /api/activity and show inline progress. */
+  tmdbId?: number;
   actionState?: SearchActionState;
   label?: string;
   disabled?: boolean;
@@ -88,7 +93,14 @@ export function RequestTrackButton({
   }
 
   if (inProgress) {
-    return <RequestedBadge title={result?.message} storageId={storageId} />;
+    // With a tmdbId, upgrade to an inline live-progress bar while the run is
+    // actually running (falls back to the static 已请求 pill when queued/finished);
+    // without one (legacy callers), keep the static pill.
+    return tmdbId != null ? (
+      <AcquireProgressBadge tmdbId={tmdbId} seasonNumber={null} storageId={storageId} title={result?.message} />
+    ) : (
+      <RequestedBadge title={result?.message} storageId={storageId} />
+    );
   }
 
   if (reserved) {

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -8,7 +8,8 @@ import {
   requestSeasonAction,
   type RequestTrackingActionResult,
 } from "../app/actions";
-import { isLockedResult, RequestedBadge } from "./request-state";
+import { isLockedResult } from "./request-state";
+import { AcquireProgressBadge } from "./acquire-progress-badge";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
 import type { DemoAcquisitionEntry } from "../lib/demo-session";
@@ -69,7 +70,11 @@ export function SeasonRequestMenu({
   }
 
   if (isLockedResult(result)) {
-    return <RequestedBadge title={result?.message} storageId={storageId} />;
+    // Match by tmdbId (seasonNumber null = any of this show's seasons), preferring
+    // the running one → inline live progress while running, static 已请求 pill otherwise.
+    return (
+      <AcquireProgressBadge tmdbId={tmdbId} seasonNumber={null} storageId={storageId} title={result?.message} />
+    );
   }
 
   const submit = () => {

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -70,10 +70,17 @@ export function SeasonRequestMenu({
   }
 
   if (isLockedResult(result)) {
-    // Match by tmdbId (seasonNumber null = any of this show's seasons), preferring
-    // the running one → inline live progress while running, static 已请求 pill otherwise.
+    // Match the SEASON that was just requested: a specific season → that number (so
+    // we don't show another season's running progress); "all remaining" → null
+    // (match any of this show's running seasons). → inline live progress while
+    // running, static 已请求 pill otherwise.
     return (
-      <AcquireProgressBadge tmdbId={tmdbId} seasonNumber={null} storageId={storageId} title={result?.message} />
+      <AcquireProgressBadge
+        tmdbId={tmdbId}
+        seasonNumber={selected === "all" ? null : selected}
+        storageId={storageId}
+        title={result?.message}
+      />
     );
   }
 

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -49,6 +49,10 @@ export function SeasonRequestMenu({
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
   const [selected, setSelected] = useState<number | "all">("all");
+  // The scope ACTUALLY requested (set at submit). The single-season path requests
+  // `onlySeason` while `selected` stays "all", so the locked badge must read this,
+  // not `selected`, to match the right season's run.
+  const [requestedSeason, setRequestedSeason] = useState<number | "all">("all");
   const [result, setResult] = useState<RequestTrackingActionResult | null>(null);
   // Read-only demo: any acquire trigger plays the scripted, client-only playback
   // (the server actions below are gated server-side anyway).
@@ -77,7 +81,7 @@ export function SeasonRequestMenu({
     return (
       <AcquireProgressBadge
         tmdbId={tmdbId}
-        seasonNumber={selected === "all" ? null : selected}
+        seasonNumber={requestedSeason === "all" ? null : requestedSeason}
         storageId={storageId}
         title={result?.message}
       />
@@ -89,6 +93,7 @@ export function SeasonRequestMenu({
       setDemoPlaying(true);
       return;
     }
+    setRequestedSeason(selected);
     startTransition(async () => {
       setOpen(false);
       setResult(
@@ -118,6 +123,7 @@ export function SeasonRequestMenu({
             setDemoPlaying(true);
             return;
           }
+          setRequestedSeason(onlySeason);
           startTransition(async () => {
             setResult(await requestSeasonAction({ tmdbId, seasonNumber: onlySeason, storageId }));
             router.refresh();

--- a/apps/web/lib/inline-progress.test.ts
+++ b/apps/web/lib/inline-progress.test.ts
@@ -57,6 +57,10 @@ describe("inlineProgressView", () => {
     expect(inlineProgressView(run({ status: "running", progress: progress(250, "x") })).percent).toBe(100);
     expect(inlineProgressView(run({ status: "running", progress: null })).step).toBe("正在准备…");
   });
+  it("treats empty/whitespace activity as missing → fallback step", () => {
+    expect(inlineProgressView(run({ status: "running", progress: progress(50, "") })).step).toBe("正在准备…");
+    expect(inlineProgressView(run({ status: "running", progress: progress(50, "   ") })).step).toBe("正在准备…");
+  });
   it("queued or null → running:false", () => {
     expect(inlineProgressView(run({ status: "queued" })).running).toBe(false);
     expect(inlineProgressView(null).running).toBe(false);

--- a/apps/web/lib/inline-progress.test.ts
+++ b/apps/web/lib/inline-progress.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { findActiveRun, inlineProgressView } from "./inline-progress";
+import type { ActivityActiveRun } from "./activity-view";
+
+function run(over: Partial<ActivityActiveRun>): ActivityActiveRun {
+  return {
+    runId: "r",
+    tmdbId: 1,
+    title: "T",
+    year: 2026,
+    type: "movie",
+    posterPath: null,
+    seasonNumber: null,
+    status: "running",
+    queuePosition: null,
+    missingCount: 0,
+    progress: null,
+    ...over,
+  };
+}
+
+function progress(percent: number, activity: string): ActivityActiveRun["progress"] {
+  return { percent, activity, phase: "transfer", updatedAt: "2026-06-23T00:00:00.000Z" };
+}
+
+describe("findActiveRun", () => {
+  it("matches a movie by tmdbId (seasonNumber null = any)", () => {
+    const a = [run({ runId: "x", tmdbId: 5 }), run({ runId: "y", tmdbId: 9 })];
+    expect(findActiveRun(a, 9, null)?.runId).toBe("y");
+  });
+  it("matches a series by tmdbId + seasonNumber", () => {
+    const a = [
+      run({ runId: "s2", tmdbId: 5, seasonNumber: 2 }),
+      run({ runId: "s3", tmdbId: 5, seasonNumber: 3 }),
+    ];
+    expect(findActiveRun(a, 5, 3)?.runId).toBe("s3");
+  });
+  it("seasonNumber null prefers a running run over a queued one (same tmdbId)", () => {
+    const a = [
+      run({ runId: "q", tmdbId: 5, seasonNumber: 2, status: "queued" }),
+      run({ runId: "run", tmdbId: 5, seasonNumber: 3, status: "running" }),
+    ];
+    expect(findActiveRun(a, 5, null)?.runId).toBe("run");
+  });
+  it("returns null when no run matches", () => {
+    expect(findActiveRun([run({ tmdbId: 1 })], 999, null)).toBeNull();
+  });
+});
+
+describe("inlineProgressView", () => {
+  it("running run → running:true, percent clamped, step from activity", () => {
+    const v = inlineProgressView(run({ status: "running", progress: progress(42, "转存中…") }));
+    expect(v).toEqual({ running: true, percent: 42, step: "转存中…" });
+  });
+  it("clamps percent to [3,100] and falls back step", () => {
+    expect(inlineProgressView(run({ status: "running", progress: progress(0, "") })).percent).toBe(3);
+    expect(inlineProgressView(run({ status: "running", progress: progress(250, "x") })).percent).toBe(100);
+    expect(inlineProgressView(run({ status: "running", progress: null })).step).toBe("正在准备…");
+  });
+  it("queued or null → running:false", () => {
+    expect(inlineProgressView(run({ status: "queued" })).running).toBe(false);
+    expect(inlineProgressView(null).running).toBe(false);
+  });
+});

--- a/apps/web/lib/inline-progress.ts
+++ b/apps/web/lib/inline-progress.ts
@@ -1,0 +1,24 @@
+import type { ActivityActiveRun } from "./activity-view";
+
+/** Find THIS card's active run: same tmdbId, and (movie) seasonNumber omitted →
+ *  match any season, preferring a running run; (series) exact seasonNumber. */
+export function findActiveRun(
+  active: ActivityActiveRun[],
+  tmdbId: number,
+  seasonNumber: number | null,
+): ActivityActiveRun | null {
+  const matches = active.filter(
+    (r) => r.tmdbId === tmdbId && (seasonNumber == null || r.seasonNumber === seasonNumber),
+  );
+  return matches.find((r) => r.status === "running") ?? matches[0] ?? null;
+}
+
+/** Derive the inline progress display from the matched run. */
+export function inlineProgressView(
+  run: ActivityActiveRun | null,
+): { running: boolean; percent: number; step: string } {
+  const running = run?.status === "running";
+  const percent = Math.max(3, Math.min(100, run?.progress?.percent ?? 3));
+  const step = run?.progress?.activity ?? "正在准备…";
+  return { running, percent, step };
+}

--- a/apps/web/lib/inline-progress.ts
+++ b/apps/web/lib/inline-progress.ts
@@ -19,6 +19,8 @@ export function inlineProgressView(
 ): { running: boolean; percent: number; step: string } {
   const running = run?.status === "running";
   const percent = Math.max(3, Math.min(100, run?.progress?.percent ?? 3));
-  const step = run?.progress?.activity ?? "正在准备…";
+  // Empty/whitespace activity (?? only guards null/undefined) would render a blank
+  // label — treat it as missing and fall back.
+  const step = run?.progress?.activity?.trim() || "正在准备…";
   return { running, percent, step };
 }

--- a/apps/web/lib/inline-progress.ts
+++ b/apps/web/lib/inline-progress.ts
@@ -1,7 +1,9 @@
 import type { ActivityActiveRun } from "./activity-view";
 
-/** Find THIS card's active run: same tmdbId, and (movie) seasonNumber omitted →
- *  match any season, preferring a running run; (series) exact seasonNumber. */
+/** Find THIS card's active run: same tmdbId, and `seasonNumber === null` matches
+ *  ANY season (movies, and the TV "all remaining seasons" scope), preferring a
+ *  running run; a concrete `seasonNumber` matches exactly (a specific-season TV
+ *  request, so another season's run isn't shown). */
 export function findActiveRun(
   active: ActivityActiveRun[],
   tmdbId: number,

--- a/apps/web/lib/use-active-run.ts
+++ b/apps/web/lib/use-active-run.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ActivityActiveRun, ActivityView } from "./activity-view";
+import { findActiveRun } from "./inline-progress";
+
+/**
+ * Poll /api/activity for THIS card's active run (by tmdbId [+season]). Returns the
+ * matched ActivityActiveRun or null. SSR-safe (starts null, fills on mount); keeps
+ * the last value on a transient fetch error. 2.6s cadence matches ActivityFeed.
+ */
+export function useActiveRun(
+  tmdbId: number,
+  seasonNumber: number | null,
+  storageId: string | undefined,
+): ActivityActiveRun | null {
+  const [run, setRun] = useState<ActivityActiveRun | null>(null);
+  useEffect(() => {
+    let alive = true;
+    const poll = async () => {
+      try {
+        const url = storageId ? `/api/activity?w=${encodeURIComponent(storageId)}` : "/api/activity";
+        const res = await fetch(url, { cache: "no-store" });
+        if (!res.ok) return;
+        const data = (await res.json()) as ActivityView;
+        if (alive) setRun(findActiveRun(data.active, tmdbId, seasonNumber));
+      } catch {
+        // transient — keep last value, retry next tick
+      }
+    };
+    void poll();
+    const id = setInterval(() => void poll(), 2600);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, [tmdbId, seasonNumber, storageId]);
+  return run;
+}

--- a/apps/web/lib/use-active-run.ts
+++ b/apps/web/lib/use-active-run.ts
@@ -17,6 +17,10 @@ export function useActiveRun(
   const [run, setRun] = useState<ActivityActiveRun | null>(null);
   useEffect(() => {
     let alive = true;
+    // Reset on key change (tmdbId/season/storage define the lookup) so a reused
+    // instance doesn't briefly show a different card/workspace's stale progress
+    // until the first poll returns.
+    setRun(null);
     const poll = async () => {
       try {
         const url = storageId ? `/api/activity?w=${encodeURIComponent(storageId)}` : "/api/activity";


### PR DESCRIPTION
## 背景

incident `docs/incident-2026-06-22-agent-acquisition-bugs.md`(line 38):demo 点获取**动画跑在点击处、很优雅**;投产版没有——投产点获取**只有个「已请求」小药丸在转,真实进度要去活动里看**。#3a 补这个 parity。

作者两处拍板:① 范围=**搜索卡(电影 + 剧)**;② **仅 run 正在跑(running)时**变进度条,排队中仍静态药丸。

## 方案(纯加法)

把搜索卡在获取期间的呈现,从静态「获取中」药丸升级为喂**真实数据**(`/api/activity` 的 `progress.percent`/`activity`)的内联进度条,复用 demo 的 `.demo-playback` 视觉。

- `lib/inline-progress.ts`:`findActiveRun`(按 tmdbId[+季]匹配,prefer running)+ `inlineProgressView`(clamp 3–100 / step 兜底)。
- `lib/use-active-run.ts`:`useActiveRun` hook 轮询 `/api/activity`(2.6s)取本卡 run。
- `components/acquire-progress-badge.tsx`:`AcquireProgressBadge` —— running → 内联进度条(Link 进活动,保 #6 直达);queued / 未匹配 / 完成 → 回落现有静态「已请求」药丸(完成由 `AcquiringPoller` 的 `router.refresh` 翻「已获取」)。
- **接线**:主出口是 `page.tsx` 的 `acquiring` 服务端分支(run 在跑时 `getInProgressTitles` 让候选卡走这里、supersede 获取按钮)——换成 `AcquireProgressBadge`(电影+剧统一)。`RequestTrackButton`(穿 tmdbId)/`SeasonRequestMenu` 的 in-progress 分支也换,作点击后 `router.refresh` 前的乐观续接。

全 demo-only 不动(demo 仍走 `DemoAcquirePlayback`);真实模式无 demo run,`/api/activity` 驱动,互不干扰。

## 验证

- 纯函数 TDD(`inline-progress.test.ts` 7 例:匹配电影/剧/prefer-running/无匹配;running/clamp/兜底/queued/null)。全 web 101 测 + tsc(三)+ lint 净。
- **真 agent live e2e**(dev `media-track-web` + 真 worker/115/PanSou/LLM):真点获取《心灵奇旅》→ 搜索卡内联进度条随真数据填充(`width=43%`、step「正在转存到网盘…」,与 `/api/activity` 一致);再点《声之形》→ queued(qpos 1)→ 其卡为静态「已请求」药丸(非进度条),证「仅 running 才进度条」。
- ⚠️ live 抓到并修的真缺口:run 在跑时服务端走 `acquiring` 分支、supersede 获取按钮——内联进度必须接到该分支(已修),否则只在点击后的乐观窗口一闪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)