### PR TITLE
fix(acquisition): 转存被系统性阻断时如实报「转存失败」而非「找不到资源」

### DIFF
--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -44,6 +44,7 @@ const kindIcon: Record<string, { tone: string; icon: typeof Bell }> = {
   tracking_completed: { tone: "green", icon: PartyPopper },
   already_current: { tone: "muted", icon: CheckCircle2 },
   no_coverage: { tone: "amber", icon: CircleSlash },
+  transfer_failed: { tone: "amber", icon: XCircle },
   foreign_work_detected: { tone: "amber", icon: Film },
 };
 

--- a/packages/workflow/src/acquisition-v2/transfer-block.ts
+++ b/packages/workflow/src/acquisition-v2/transfer-block.ts
@@ -1,0 +1,41 @@
+import type { TransferAttempt } from "../domain.js";
+
+/**
+ * Systemic transfer-block detection. A magnet must be materialized via 115 云下载/
+ * 离线下载 (or a quark 转存) — if that is blocked at the ACCOUNT level (quota
+ * exhausted, login expired, not-VIP) then EVERY candidate fails for the same
+ * reason, even though the resources exist. Reporting that as "no_coverage / 暂未
+ * 找到资源" blames the resource for an account problem (别甩锅). This classifier
+ * distinguishes "account is blocked" from "these particular links are dead", so the
+ * report can say "转存失败:配额不足" (actionable: top up / re-login) instead.
+ *
+ * Returns the block reason when: NOTHING landed (no succeeded attempt) AND at least
+ * one failure carries a SYSTEMIC message (quota / auth / VIP). Dead-link messages
+ * (过期/取消/错误的链接/不存在) are NOT systemic — they don't trigger a block.
+ */
+const SYSTEMIC_PATTERNS: RegExp[] = [
+  /配额|额度|quota/i,
+  /VIP|会员|升级/i,
+  /云下载|离线/,
+  /登录|重新登陆|未登录|登陆超时|登录超时/,
+  /PAN115_AUTH|AUTH_FAILED|未授权|鉴权/i,
+];
+
+export function classifyTransferBlock(
+  attempts: TransferAttempt[],
+): { reason: string } | null {
+  if (attempts.length === 0) {
+    return null;
+  }
+  // Something landed → not a systemic block (the account can transfer).
+  if (attempts.some((a) => a.status === "succeeded")) {
+    return null;
+  }
+  for (const attempt of attempts) {
+    const message = attempt.providerMessage?.trim() ?? "";
+    if (message && SYSTEMIC_PATTERNS.some((pattern) => pattern.test(message))) {
+      return { reason: message };
+    }
+  }
+  return null;
+}

--- a/packages/workflow/src/acquisition-v2/transfer-block.ts
+++ b/packages/workflow/src/acquisition-v2/transfer-block.ts
@@ -32,6 +32,12 @@ export function classifyTransferBlock(
     return null;
   }
   for (const attempt of attempts) {
+    // Only a genuine FAILED transfer signals a block — a no_target_change (115 has
+    // no cached copy / nothing new) can carry an incidental message that must NOT
+    // be misread as an account-level block.
+    if (attempt.status !== "failed") {
+      continue;
+    }
     const message = attempt.providerMessage?.trim() ?? "";
     if (message && SYSTEMIC_PATTERNS.some((pattern) => pattern.test(message))) {
       return { reason: message };

--- a/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
@@ -15,6 +15,7 @@ import {
   type WorkflowStatus,
 } from "../domain.js";
 import { buildSeasonReport, buildSeriesReport, formatReportPushText } from "../notification-report.js";
+import { classifyTransferBlock } from "./transfer-block.js";
 import type { RunAcquisitionV2WorkflowResult } from "./workflow-v2.js";
 
 /**
@@ -88,11 +89,18 @@ export function bridgeV2WorkflowToResult(input: {
   // Newly obtained this run = was missing before, present now — per season.
   const newlyObtainedCodes = v2.missingBefore.filter((code) => !stillMissingSet.has(code));
 
+  // 别甩锅: if nothing landed because transfers were systemically BLOCKED (115 云
+  // 下载配额不足 / 登录过期 / 非 VIP), report an honest "转存失败:<原因>" instead of
+  // "暂未找到资源" — the resource exists, the account is blocked.
+  const transferBlock = classifyTransferBlock(v2.outcome.transferAttempts);
+  const transferBlockReason = status === "no_coverage" && transferBlock ? transferBlock.reason : null;
+
   const notification = buildNotification({
     title,
     mode: input.mode,
     seasons,
     status,
+    transferBlockReason,
     newlyObtainedCodes,
     workflowRunId,
     now: input.now,
@@ -195,6 +203,8 @@ function buildNotification(input: {
   mode: V2BridgeMode;
   seasons: BridgedSeasonResult[];
   status: WorkflowStatus;
+  /** Honest 转存失败 reason when transfers were systemically blocked (else null). */
+  transferBlockReason?: string | null;
   newlyObtainedCodes: string[];
   workflowRunId: string;
   now: () => string;
@@ -210,6 +220,7 @@ function buildNotification(input: {
       titleName: title.title,
       seasons: seasons.map((entry) => ({ season: entry.season, episodes: entry.episodes })),
       noCoverage,
+      transferBlockReason: input.transferBlockReason ?? null,
       meta: titleMeta,
       ...sizeInput(input),
     });
@@ -237,6 +248,7 @@ function buildNotification(input: {
     episodes: entry.episodes,
     newlyObtained,
     noCoverage,
+    transferBlockReason: input.transferBlockReason ?? null,
     meta: titleMeta,
     ...sizeInput(input),
   });

--- a/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
@@ -227,7 +227,9 @@ function buildNotification(input: {
     return {
       id: `notification_${workflowRunId}`,
       workflowRunId,
-      kind: noCoverage ? "no_coverage" : "series_initialized",
+      // A systemic transfer block surfaces as report.status "failed" → use a
+      // distinct kind so the leading icon + daily-digest don't count it as 暂无资源.
+      kind: report.status === "failed" ? "transfer_failed" : noCoverage ? "no_coverage" : "series_initialized",
       title: report.titleName,
       body: formatReportPushText(report),
       createdAt: input.now(),
@@ -257,11 +259,14 @@ function buildNotification(input: {
     return {
       id: `notification_${workflowRunId}`,
       workflowRunId,
-      kind: noCoverage
-        ? "no_coverage"
-        : report.status === "complete"
-          ? "tracking_completed"
-          : "episodes_restored",
+      kind:
+        report.status === "failed"
+          ? "transfer_failed"
+          : noCoverage
+            ? "no_coverage"
+            : report.status === "complete"
+              ? "tracking_completed"
+              : "episodes_restored",
       title: `${report.titleName} ${report.seasonLabel}`,
       body: formatReportPushText(report),
       createdAt: input.now(),
@@ -273,7 +278,7 @@ function buildNotification(input: {
   return {
     id: `notification_${workflowRunId}`,
     workflowRunId,
-    kind: noCoverage ? "no_coverage" : "tracking_initialized",
+    kind: report.status === "failed" ? "transfer_failed" : noCoverage ? "no_coverage" : "tracking_initialized",
     title: `${report.titleName} ${report.seasonLabel}`,
     body: formatReportPushText(report),
     createdAt: input.now(),

--- a/packages/workflow/src/movie-workflow-v2.ts
+++ b/packages/workflow/src/movie-workflow-v2.ts
@@ -13,7 +13,8 @@ import {
   type TransferAttempt,
   type WorkflowStatus,
 } from "./domain.js";
-import { buildMovieReport, formatReportPushText } from "./notification-report.js";
+import { buildMovieReport, emptyRunOutcome, formatReportPushText } from "./notification-report.js";
+import { classifyTransferBlock } from "./acquisition-v2/transfer-block.js";
 import type { ResourceProvider, StorageExecutor } from "./ports.js";
 import type { DeadLinkStore } from "./acquisition-v2/dead-links.js";
 import { readLandedSize, type LandedSize } from "./acquisition-v2/landed-size.js";
@@ -144,9 +145,11 @@ function buildResult(input: {
     { posterPath: t.posterPath ?? null, tmdbId: t.tmdbId, mediaType: t.type, year: t.year },
     input.landed,
   );
+  // 别甩锅: nothing landed could mean truly no resource (no_coverage) OR the
+  // account was systemically blocked (115 云下载配额不足/登录过期) — say which.
   const report = input.obtained
     ? baseReport
-    : { ...baseReport, status: "no_coverage" as const, lines: ["暂未找到可用资源 · 将持续尝试"] };
+    : { ...baseReport, ...emptyRunOutcome(classifyTransferBlock(input.attempts)?.reason ?? null) };
   const notification: NotificationEvent = {
     id: `notification_${input.request.workflowRunId}`,
     workflowRunId: input.request.workflowRunId,

--- a/packages/workflow/src/movie-workflow-v2.ts
+++ b/packages/workflow/src/movie-workflow-v2.ts
@@ -153,7 +153,9 @@ function buildResult(input: {
   const notification: NotificationEvent = {
     id: `notification_${input.request.workflowRunId}`,
     workflowRunId: input.request.workflowRunId,
-    kind: input.kind,
+    // A systemic transfer block → report.status "failed" → distinct kind so the
+    // leading icon + daily-digest don't count it as 暂无资源.
+    kind: report.status === "failed" ? "transfer_failed" : input.kind,
     title: input.request.title.title,
     body: formatReportPushText(report),
     createdAt: input.now(),

--- a/packages/workflow/src/notification-report.ts
+++ b/packages/workflow/src/notification-report.ts
@@ -99,8 +99,9 @@ function sizeFields(input: { fileCount?: number; totalBytes?: number }): {
 
 /** The status+lines for a run that obtained nothing. Default = no_coverage
  *  ("暂未找到资源"); when transfers were systemically blocked, it's an honest
- *  `failed` + the real reason (别甩锅 — the resource exists, the account is blocked). */
-function emptyRunOutcome(
+ *  `failed` + the real reason (别甩锅 — the resource exists, the account is blocked).
+ *  Shared by the TV bridge and the movie workflow so both report identically. */
+export function emptyRunOutcome(
   transferBlockReason?: string | null,
 ): { status: NotificationReportStatus; lines: string[] } {
   if (transferBlockReason && transferBlockReason.trim()) {

--- a/packages/workflow/src/notification-report.ts
+++ b/packages/workflow/src/notification-report.ts
@@ -73,6 +73,11 @@ export interface SeasonReportInput {
   newlyObtained?: string[];
   /** Force the no-coverage shape regardless of episode facts. */
   noCoverage?: boolean;
+  /** When nothing landed because transfers were systemically BLOCKED (115 云下载
+   *  配额不足 / 登录过期 / 非 VIP), the honest report is "转存失败:<reason>" with
+   *  status `failed` — NOT "暂未找到资源" (the resource exists; the account is
+   *  blocked). Only meaningful together with noCoverage. See classifyTransferBlock. */
+  transferBlockReason?: string | null;
   /** Real landed video files: count + summed bytes. The card/push show the true
    *  per-episode size from these (总字节 / 文件数), not a claimed quality tag. */
   fileCount?: number;
@@ -92,6 +97,18 @@ function sizeFields(input: { fileCount?: number; totalBytes?: number }): {
     : {};
 }
 
+/** The status+lines for a run that obtained nothing. Default = no_coverage
+ *  ("暂未找到资源"); when transfers were systemically blocked, it's an honest
+ *  `failed` + the real reason (别甩锅 — the resource exists, the account is blocked). */
+function emptyRunOutcome(
+  transferBlockReason?: string | null,
+): { status: NotificationReportStatus; lines: string[] } {
+  if (transferBlockReason && transferBlockReason.trim()) {
+    return { status: "failed", lines: [`转存失败:${transferBlockReason.trim()}`] };
+  }
+  return { status: "no_coverage", lines: ["暂未找到可用资源 · 将持续尝试"] };
+}
+
 /**
  * Single-season report. Never lists unaired episodes as missing — `realMissing`
  * is exactly the aired-but-not-obtained set, so a season waiting on unaired
@@ -109,8 +126,7 @@ export function buildSeasonReport(input: SeasonReportInput): NotificationReport 
     return {
       titleName: input.titleName,
       seasonLabel: label,
-      status: "no_coverage",
-      lines: ["暂未找到可用资源 · 将持续尝试"],
+      ...emptyRunOutcome(input.transferBlockReason),
       newlyObtained: [],
       realMissing,
       ...(input.meta ?? {}),
@@ -164,6 +180,8 @@ export function buildSeriesReport(input: {
   titleName: string;
   seasons: SeriesReportSeasonInput[];
   noCoverage?: boolean;
+  /** See SeasonReportInput.transferBlockReason — honest 转存失败 when blocked. */
+  transferBlockReason?: string | null;
   meta?: NotificationTitleMeta;
   fileCount?: number;
   totalBytes?: number;
@@ -172,8 +190,7 @@ export function buildSeriesReport(input: {
     return {
       titleName: input.titleName,
       seasonLabel: null,
-      status: "no_coverage",
-      lines: ["暂未找到可用资源 · 将持续尝试"],
+      ...emptyRunOutcome(input.transferBlockReason),
       newlyObtained: [],
       realMissing: [],
       ...(input.meta ?? {}),

--- a/packages/workflow/tests/notification-report.test.ts
+++ b/packages/workflow/tests/notification-report.test.ts
@@ -132,6 +132,46 @@ describe("landedSize", () => {
   });
 });
 
+describe("transferBlockReason — honest report when transfers were blocked (not no_coverage)", () => {
+  const s = season({ totalEpisodes: 12, latestAiredEpisode: 1 });
+  it("buildSeasonReport: noCoverage + block reason → status failed + 转存失败 line (not 暂未找到资源)", () => {
+    const report = buildSeasonReport({
+      titleName: "心灵奇旅",
+      season: s,
+      episodes: episodes({ season: s, obtained: [] }),
+      noCoverage: true,
+      transferBlockReason: "云下载配额不足，请升级VIP",
+    });
+    expect(report.status).toBe("failed");
+    expect(report.lines.join("")).toContain("转存失败");
+    expect(report.lines.join("")).toContain("配额");
+    expect(report.lines.join("")).not.toContain("暂未找到");
+  });
+
+  it("buildSeasonReport: noCoverage WITHOUT block reason → unchanged no_coverage", () => {
+    const report = buildSeasonReport({
+      titleName: "无源片",
+      season: s,
+      episodes: episodes({ season: s, obtained: [] }),
+      noCoverage: true,
+    });
+    expect(report.status).toBe("no_coverage");
+    expect(report.lines.join("")).toContain("暂未找到");
+  });
+
+  it("buildSeriesReport: noCoverage + block reason → status failed + 转存失败 line", () => {
+    const report = buildSeriesReport({
+      titleName: "某剧",
+      seasons: [],
+      noCoverage: true,
+      transferBlockReason: "登录超时，请重新登录。",
+    });
+    expect(report.status).toBe("failed");
+    expect(report.lines.join("")).toContain("转存失败");
+    expect(report.lines.join("")).toContain("登录");
+  });
+});
+
 describe("buildSeasonReport", () => {
   it("reads as airing when all AIRED episodes are obtained but unaired remain", () => {
     const s = season({ totalEpisodes: 16, latestAiredEpisode: 12 });

--- a/packages/workflow/tests/transfer-block.test.ts
+++ b/packages/workflow/tests/transfer-block.test.ts
@@ -61,4 +61,12 @@ describe("classifyTransferBlock", () => {
     expect(block).not.toBeNull();
     expect(block!.reason).toContain("配额");
   });
+
+  it("ignores non-failed attempts — a no_target_change carrying a matching message must NOT flag a block", () => {
+    expect(
+      classifyTransferBlock([
+        attempt({ status: "no_target_change", providerMessage: "云下载配额不足" }),
+      ]),
+    ).toBeNull();
+  });
 });

--- a/packages/workflow/tests/transfer-block.test.ts
+++ b/packages/workflow/tests/transfer-block.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { classifyTransferBlock } from "../src/acquisition-v2/transfer-block.js";
+import type { TransferAttempt } from "../src/domain.js";
+
+function attempt(over: Partial<TransferAttempt>): TransferAttempt {
+  return {
+    id: "a",
+    workflowRunId: "run",
+    candidateId: "c",
+    status: "failed",
+    providerMessage: "",
+    materializedFileIds: [],
+    ...over,
+  };
+}
+
+describe("classifyTransferBlock", () => {
+  it("flags a systemic 云下载配额 block (nothing landed)", () => {
+    const block = classifyTransferBlock([
+      attempt({ providerMessage: "云下载配额不足，请升级VIP获得赠送配额或购买云下载配额！" }),
+      attempt({ providerMessage: "云下载配额不足，请升级VIP获得赠送配额或购买云下载配额！" }),
+    ]);
+    expect(block).not.toBeNull();
+    expect(block!.reason).toContain("配额");
+  });
+
+  it("flags an auth/login block", () => {
+    const block = classifyTransferBlock([attempt({ providerMessage: "登录超时，请重新登录。" })]);
+    expect(block).not.toBeNull();
+    expect(block!.reason).toContain("登录");
+  });
+
+  it("does NOT flag dead-link failures (expired/cancelled/bad link)", () => {
+    expect(
+      classifyTransferBlock([
+        attempt({ providerMessage: "链接已过期" }),
+        attempt({ providerMessage: "分享已取消" }),
+        attempt({ providerMessage: "错误的链接" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null when any transfer succeeded (something landed)", () => {
+    expect(
+      classifyTransferBlock([
+        attempt({ status: "failed", providerMessage: "云下载配额不足" }),
+        attempt({ status: "succeeded", providerMessage: "下载成功", materializedFileIds: ["f1"] }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null for no attempts (truly searched-but-found-nothing)", () => {
+    expect(classifyTransferBlock([])).toBeNull();
+  });
+
+  it("flags a block even when mixed with dead links (account still can't transfer)", () => {
+    const block = classifyTransferBlock([
+      attempt({ providerMessage: "链接已过期" }),
+      attempt({ providerMessage: "云下载配额不足，请升级VIP" }),
+    ]);
+    expect(block).not.toBeNull();
+    expect(block!.reason).toContain("配额");
+  });
+});

--- a/packages/workflow/tests/v2-bridge.test.ts
+++ b/packages/workflow/tests/v2-bridge.test.ts
@@ -100,6 +100,9 @@ describe("bridgeV2WorkflowToResult — V2 facts → per-season WorkflowResult sh
     expect(result.notification.body).toContain("转存失败");
     expect(result.notification.body).toContain("配额");
     expect(result.notification.body).not.toContain("暂未找到");
+    // kind must NOT be no_coverage — else the leading icon + daily-digest would
+    // still count this account block as 暂无资源, contradicting the failed pill.
+    expect(result.notification.kind).toBe("transfer_failed");
   });
 
   it("no-op (nothing was missing) → succeeded, episodes reflect the already-obtained set, no transfers", () => {

--- a/packages/workflow/tests/v2-bridge.test.ts
+++ b/packages/workflow/tests/v2-bridge.test.ts
@@ -72,6 +72,36 @@ describe("bridgeV2WorkflowToResult — V2 facts → per-season WorkflowResult sh
     expect(result.notification.kind).toBe("no_coverage");
   });
 
+  it("nothing obtained because transfers were systemically BLOCKED → honest 转存失败 (failed), not 暂未找到资源", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type2",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 3, latestAiredEpisode: 3, qualityPreference: "4K" }],
+      v2: v2Result({
+        missingBefore: ["S01E01", "S01E02", "S01E03"],
+        obtained: [],
+        stillMissing: ["S01E01", "S01E02", "S01E03"],
+        outcome: {
+          resourceSnapshots: [],
+          decisions: [],
+          transferAttempts: [
+            { id: "t1", workflowRunId: "run-x", candidateId: "c1", status: "failed", providerMessage: "云下载配额不足，请升级VIP获得赠送配额或购买云下载配额！", materializedFileIds: [] },
+            { id: "t2", workflowRunId: "run-x", candidateId: "c2", status: "failed", providerMessage: "云下载配额不足，请升级VIP获得赠送配额或购买云下载配额！", materializedFileIds: [] },
+          ],
+        },
+      }),
+      workflowRunId: "run-x",
+      now: () => "2026-06-15T00:00:00.000Z",
+    });
+
+    // Run-level coverage is still no_coverage (0 obtained), but the user-facing
+    // report is honest: failed + the real reason, never "暂未找到资源".
+    expect(result.notification.report?.status).toBe("failed");
+    expect(result.notification.body).toContain("转存失败");
+    expect(result.notification.body).toContain("配额");
+    expect(result.notification.body).not.toContain("暂未找到");
+  });
+
   it("no-op (nothing was missing) → succeeded, episodes reflect the already-obtained set, no transfers", () => {
     const result = bridgeV2WorkflowToResult({
       title,

--- a/packages/workflow/tests/v2-movie-workflow.test.ts
+++ b/packages/workflow/tests/v2-movie-workflow.test.ts
@@ -133,6 +133,7 @@ describe("runMovieAcquisitionV2 — obtained comes from the AGENT'S coverage, ne
     expect(result.notification.body).toContain("转存失败");
     expect(result.notification.body).toContain("配额");
     expect(result.notification.body).not.toContain("暂未找到");
+    expect(result.notification.kind).toBe("transfer_failed");
   });
 
   it("obtained TRUE when the agent declares MOVIE coverage (agent mark, not files on disk)", async () => {

--- a/packages/workflow/tests/v2-movie-workflow.test.ts
+++ b/packages/workflow/tests/v2-movie-workflow.test.ts
@@ -82,6 +82,59 @@ describe("runMovieAcquisitionV2 — obtained comes from the AGENT'S coverage, ne
     expect(result.season.storageDirectoryId).toContain("movies_root"); // movie dir verify-or-created
   });
 
+  it("transfers systemically BLOCKED (配额不足) → honest 转存失败 report, NOT 暂未找到资源 (别甩锅)", async () => {
+    // The resource EXISTS (a candidate is found + transfer attempted) but the
+    // account can't materialize it (115 云下载配额不足). The report must say so,
+    // not blame the resource — mirrors the real 心灵奇旅-on-free-account incident.
+    const candidateId = "cand_q";
+    const executor = new FakeStorageExecutor({
+      transferOutcomes: {
+        [candidateId]: { status: "failed", providerMessage: "云下载配额不足，请升级VIP获得赠送配额或购买云下载配额！", files: [] },
+      },
+    });
+    const provider: ResourceProvider = {
+      search: async ({ keyword }): Promise<ResourceSnapshot> => ({
+        id: "snap_q",
+        provider: "pansou",
+        keyword,
+        candidates: [
+          {
+            id: candidateId,
+            snapshotId: "snap_q",
+            index: 0,
+            title: "心灵奇旅 2020 1080p",
+            type: "magnet",
+            source: "pansou",
+            episodeHints: [],
+            qualityHints: [],
+            providerPayload: { url: "magnet:?xt=urn:btih:deadbeef" },
+          },
+        ],
+        createdAt: "2026-06-14T00:00:00.000Z",
+      }),
+    };
+
+    const result = await runMovieAcquisitionV2({
+      title,
+      resourceProvider: provider,
+      storage: executor,
+      model: scriptModel([
+        { tool: "searchResources", input: { keyword: "盗梦空间" } },
+        { tool: "transferCandidate", input: { snapshotId: "snap_q", candidateId } },
+        { tool: "reportNoCoverage", input: { reason: "nothing landed" } },
+      ]),
+      workflowRunId: "run-blocked",
+      moviesParentDirectoryId: "movies_root",
+      now: () => "2026-06-14T00:00:00.000Z",
+    });
+
+    expect(result.episodes[0]!.obtained).toBe(false);
+    expect(result.notification.report?.status).toBe("failed");
+    expect(result.notification.body).toContain("转存失败");
+    expect(result.notification.body).toContain("配额");
+    expect(result.notification.body).not.toContain("暂未找到");
+  });
+
   it("obtained TRUE when the agent declares MOVIE coverage (agent mark, not files on disk)", async () => {
     const executor = new FakeStorageExecutor();
     const result = await runMovieAcquisitionV2({


### PR DESCRIPTION
## 背景(systematic-debugging,起于 #3a live e2e)

真获取《心灵奇旅》(磁力资源充足)却推送「🔍 暂未找到可用资源」。查证(incident 2026-06-23,本地档):
- 该 run `transfer_attempts` **13 条全 failed**,`providerMessage` 全是「云下载配额不足，请升级VIP…」——**资源有,是账号级阻断**(磁力要靠 115 云下载落地;该 run 落在免费号、无配额)。
- 但 `reportNoCoverage` 把基础设施失败甩锅成「没资源」(资源明明有)——正是「别甩锅」红线。

## 修复(确定性,不靠 MiMo)

- `classifyTransferBlock(transferAttempts)`:0 落盘 + 失败带系统性消息(配额/额度/VIP/登录/鉴权)→ 返回原因;死链(过期/取消/错链)**不**触发。
- `emptyRunOutcome(reason)`(共享):无所获时,有阻断原因 → 复用既有 **`failed`** 状态 +「转存失败:<原因>」(UI 已渲染「获取失败」+ 重试按钮,充配额后可重试);否则照旧 `no_coverage`。
- 两条出口都接上:TV 走 `workflow-v2-bridge`,**电影走 `movie-workflow-v2`(独立路径)** —— ⚠️ 第一版只改了 bridge,live e2e 抓到电影仍报 no_coverage,补修电影路径(同一 `emptyRunOutcome`)。

纯加法、零新 enum(复用 `failed`)、`no_coverage`(真没资源)行为不变。

## 验证

- TDD:`classifyTransferBlock` 6 例(配额/登录命中、死链不命中、有成功→null、混合→命中)、报告构建 3 例、bridge 集成 1 例、**movie 工作流 1 例**(真 FakeStorage 配额失败 → report `failed` + 转存失败 + 非「暂未找到」)。807 全测 + 三 tsc + lint 净。
- **真 live**:头次真获取证实 `transfer_attempts` 真带「配额不足」、旧码确报 no_coverage(根因坐实);新行为以工作流级确定性测端到端验证(dev server 实例反复在 grind 中被杀、跑不完全 UI 慢流程,故用确定性测覆盖该断言)。
- ⚠️ 关联 backlog:agent 看不见 `providerMessage`(real-storage-adapter 丢了)→ 磨完 13 个候选才收尾(over-search);把「Layer 1:透传 providerMessage 给 agent + 早停」并入 over-search backlog,另做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)