### PR TITLE
feat(web): demo 站接入 Vercel Web Analytics(仅 demo)

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Analytics } from "@vercel/analytics/next";
 import "./globals.css";
 import { isDemoMode } from "../lib/demo-mode";
 
@@ -25,6 +26,10 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           </div>
         ) : null}
         {children}
+        {/* Vercel Web Analytics — DEMO deploy only: gated on isDemoMode() so a
+            self-hosted instance never loads the Vercel insights script (no 404 /
+            no third-party beacon off-Vercel). */}
+        {isDemoMode() ? <Analytics /> : null}
       </body>
     </html>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@media-track/workflow": "*"
+    "@media-track/workflow": "*",
+    "@vercel/analytics": "^2.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,13 +33,56 @@
         "yaml": "^2.9.0"
       },
       "engines": {
-        "node": ">=22.12.0"
+        "node": ">=22.13.0"
       }
     },
     "apps/web": {
       "name": "@media-track/web",
       "dependencies": {
-        "@media-track/workflow": "*"
+        "@media-track/workflow": "*",
+        "@vercel/analytics": "^2.0.1"
+      }
+    },
+    "apps/web/node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/gateway": {


### PR DESCRIPTION
给公网 demo 站(mediary.dirtyfancy.sbs)加访问统计。

- `apps/web/app/layout.tsx`:加 `<Analytics/>`(`@vercel/analytics/next` v2.0.1),用既有 `isDemoMode()` 门禁包住——**只有 demo 部署**(`MEDIA_TRACK_DEMO_MODE=1`)才渲染。
- **自部署零影响**:非 demo 实例不渲染该组件 → 不加载 Vercel insights 脚本、不产生 `/_vercel/insights` 404、不发任何第三方 beacon。
- `build:web` 绿(exit 0)、apps/web tsc + lint 净。

合并 main 后 Vercel 生产部署生效;Vercel 控制台 Analytics 需已开启(用户操作)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)