### PR TITLE
fix(progress): 内联进度条如实反映工作流(预热即跳70% + 长阶段不动)

### DIFF
--- a/packages/workflow/src/acquisition-v2/activity.ts
+++ b/packages/workflow/src/acquisition-v2/activity.ts
@@ -44,7 +44,13 @@ export function interpretTool(toolName: string, args: Record<string, unknown> = 
     case "inspectStaging":
       return { activity: "正在核对落盘的视频文件…", phase: "verify" };
     case "inspectTargetDir":
-      return { activity: "正在核对入库目录…", phase: "verify" };
+      // EARLY orientation: the agent inspects the landing/library directory to know
+      // where files go — typically BEFORE search/transfer. So it weighs as early
+      // setup (low band), NOT verify. Classing it as `verify` (66%) made the
+      // monotonic bar jump to ~66% right after this step, before any real work, and
+      // pinned it there through the transfer. (inspectStaging — the post-transfer
+      // landed-file check — is the genuine verify above.)
+      return { activity: "正在核对入库目录…", phase: "search" };
     case "moveToSeason": {
       const moves = asArray(args.moves) as Array<{ season?: number }>;
       const seasons = moves.map((move) => move?.season).filter((season): season is number => typeof season === "number");

--- a/packages/workflow/src/acquisition-v2/progress-sink.ts
+++ b/packages/workflow/src/acquisition-v2/progress-sink.ts
@@ -8,9 +8,11 @@ import { phaseProgress, type AgentToolEvent } from "./activity.js";
  * write must NEVER throw and fail an otherwise-good acquisition.
  *
  * `neededHint` (the run's missing-episode count) lets the mark phase show a real
- * obtained/needed fraction; omit it (movies / unknown) and the bar uses the band
- * midpoint instead. `obtained` accumulates across markObtained calls (the MOVIE
- * sentinel is not an episode and is not counted).
+ * obtained/needed fraction. For every other phase the bar advances WITHIN the band
+ * by an asymptotic step-count fraction (n/(n+2)) — so a long phase (several searches
+ * / transfer retries) creeps forward instead of freezing at the midpoint, while
+ * never escaping the band. `obtained` accumulates across markObtained calls (the
+ * MOVIE sentinel is not an episode and is not counted).
  */
 export function makeProgressSink(input: {
   repository: Pick<WorkflowRepository, "updateWorkflowRunProgress">;

--- a/packages/workflow/src/acquisition-v2/progress-sink.ts
+++ b/packages/workflow/src/acquisition-v2/progress-sink.ts
@@ -22,13 +22,27 @@ export function makeProgressSink(input: {
   const needed = input.neededHint ?? 0;
   let percent = 0;
   let obtained = 0;
+  // Track how many tool calls the agent has made in the CURRENT phase, so the bar
+  // creeps forward within a long phase (e.g., several searches / transfer retries)
+  // instead of freezing at the band midpoint — it should reflect ongoing work.
+  let currentPhase: AgentToolEvent["phase"] | null = null;
+  let stepsInPhase = 0;
 
   return (event: AgentToolEvent) => {
     if (event.toolName === "markObtained") {
       const codes = Array.isArray(event.args.codes) ? event.args.codes : [];
       obtained += codes.filter((code) => code !== "MOVIE").length;
     }
-    const subFraction = event.phase === "mark" && needed > 0 ? obtained / needed : undefined;
+    if (event.phase !== currentPhase) {
+      currentPhase = event.phase;
+      stepsInPhase = 0;
+    }
+    stepsInPhase += 1;
+    // The mark phase uses its REAL obtained/needed fraction; every other phase uses
+    // an asymptotic step-count fraction n/(n+2) (1st≈0.33, climbing toward — but
+    // never reaching — the band end, so it stays honest within the band).
+    const subFraction =
+      event.phase === "mark" && needed > 0 ? obtained / needed : stepsInPhase / (stepsInPhase + 2);
     percent = Math.max(percent, phaseProgress(event.phase, subFraction));
     void Promise.resolve(
       input.repository.updateWorkflowRunProgress(input.workflowRunId, {

--- a/packages/workflow/tests/activity.test.ts
+++ b/packages/workflow/tests/activity.test.ts
@@ -19,9 +19,18 @@ describe("interpretTool — real agent tool names → cleaned 中文 + phase", (
     expect(interpretTool("transferUntilLanded", { candidateIds: ["a", "b"] }).phase).toBe("transfer");
   });
 
-  it("inspectStaging / inspectTargetDir → verify phase, no ids leaked", () => {
+  it("inspectStaging → verify (post-transfer file check), no ids leaked", () => {
     expect(interpretTool("inspectStaging", {})).toEqual({ activity: "正在核对落盘的视频文件…", phase: "verify" });
-    expect(interpretTool("inspectTargetDir", { season: 5 }).phase).toBe("verify");
+  });
+
+  it("inspectTargetDir is EARLY orientation → must NOT weigh as verify (else the bar jumps to ~66% before any transfer)", () => {
+    // 2026-06-24 bug: 确认入库目录 runs early (orient the landing dir before transfer),
+    // but was classed as `verify` → the monotonic bar jumped to ~66% right after it,
+    // before the real search/transfer work. Its progress weight must be LOW.
+    const targetDir = interpretTool("inspectTargetDir", { season: 5 });
+    expect(targetDir.activity).toBe("正在核对入库目录…");
+    expect(targetDir.phase).not.toBe("verify");
+    expect(phaseProgress(targetDir.phase)).toBeLessThan(phaseProgress("transfer"));
   });
 
   it("moveToSeason reads the moves plan: single season names it, multi-season generalizes, movie move", () => {

--- a/packages/workflow/tests/progress-sink.test.ts
+++ b/packages/workflow/tests/progress-sink.test.ts
@@ -98,13 +98,13 @@ describe("makeProgressSink", () => {
     const idxOfEarlyTargetDir = 2;
     const idxOfStaging = 7; // first genuine post-transfer verify
     // The early inspectTargetDir must keep the bar low (still in the early/search region).
-    expect(percents[idxOfEarlyTargetDir]).toBeLessThan(25); // below the transfer band start
+    expect(percents[idxOfEarlyTargetDir]!).toBeLessThan(25); // below the transfer band start
     // The bar must not reach verify-territory before the post-transfer file check.
     expect(Math.max(...percents.slice(0, idxOfStaging))).toBeLessThan(60);
     // The transfer steps must actually move the bar (reflecting the real work).
     expect(percents[4]!).toBeGreaterThan(percents[idxOfEarlyTargetDir]!);
     // Monotonic + finishes high.
-    for (let i = 1; i < percents.length; i += 1) expect(percents[i]).toBeGreaterThanOrEqual(percents[i - 1]!);
+    for (let i = 1; i < percents.length; i += 1) expect(percents[i]!).toBeGreaterThanOrEqual(percents[i - 1]!);
     expect(percents.at(-1)!).toBeGreaterThanOrEqual(95);
   });
 });

--- a/packages/workflow/tests/progress-sink.test.ts
+++ b/packages/workflow/tests/progress-sink.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { WorkflowRunProgress } from "../src/index.js";
 import { makeProgressSink } from "../src/acquisition-v2/progress-sink.js";
+import { interpretTool } from "../src/acquisition-v2/activity.js";
 
 function fakeRepo() {
   const writes: Array<{ runId: string; progress: WorkflowRunProgress }> = [];
@@ -59,5 +60,51 @@ describe("makeProgressSink", () => {
       now: () => "t",
     });
     expect(() => sink({ toolName: "finish", args: {}, activity: "收尾", phase: "finalize" })).not.toThrow();
+  });
+
+  it("advances WITHIN a phase as the agent keeps working in it (a long phase must not sit flat at the midpoint)", () => {
+    const repo = fakeRepo();
+    const sink = makeProgressSink({ repository: repo, workflowRunId: "r", now: () => "t" });
+    // Three searches in a row (e.g., the agent trying variants) — the bar should
+    // creep forward with each, reflecting ongoing work, not freeze at one value.
+    sink({ toolName: "searchResources", args: { keyword: "a" }, activity: "搜 a", phase: "search" });
+    sink({ toolName: "searchResources", args: { keyword: "b" }, activity: "搜 b", phase: "search" });
+    sink({ toolName: "searchResources", args: { keyword: "c" }, activity: "搜 c", phase: "search" });
+    const p = repo.writes.map((w) => w.progress.percent);
+    expect(p[1]!).toBeGreaterThan(p[0]!);
+    expect(p[2]!).toBeGreaterThan(p[1]!);
+    // ...but never escape the search band (must not pretend to be transferring).
+    expect(p[2]!).toBeLessThan(25);
+  });
+
+  // Regression for the 2026-06-24 bug: a REAL run's tool order (run 48b20772) has the
+  // agent inspect the入库目录 EARLY (ordinal 2, before search/transfer). The bar must
+  // NOT jump to verify-territory (~66%) then; it should climb monotonically WITH the
+  // work, reaching ~66% only at the post-transfer inspectStaging.
+  it("real tool order: confirming the target dir early must not jump the bar to ~66% before transfer", () => {
+    const repo = fakeRepo();
+    const sink = makeProgressSink({ repository: repo, workflowRunId: "r", now: () => "t" });
+    const sequence = [
+      "readSkill", "readSkill", "inspectTargetDir", "searchResources",
+      "transferCandidate", "transferCandidate", "transferCandidate",
+      "inspectStaging", "moveToSeason", "inspectTargetDir",
+      "markObtained", "discardStaging", "finish",
+    ];
+    for (const toolName of sequence) {
+      const { activity, phase } = interpretTool(toolName, {});
+      sink({ toolName, args: {}, activity, phase });
+    }
+    const percents = repo.writes.map((w) => w.progress.percent);
+    const idxOfEarlyTargetDir = 2;
+    const idxOfStaging = 7; // first genuine post-transfer verify
+    // The early inspectTargetDir must keep the bar low (still in the early/search region).
+    expect(percents[idxOfEarlyTargetDir]).toBeLessThan(25); // below the transfer band start
+    // The bar must not reach verify-territory before the post-transfer file check.
+    expect(Math.max(...percents.slice(0, idxOfStaging))).toBeLessThan(60);
+    // The transfer steps must actually move the bar (reflecting the real work).
+    expect(percents[4]!).toBeGreaterThan(percents[idxOfEarlyTargetDir]!);
+    // Monotonic + finishes high.
+    for (let i = 1; i < percents.length; i += 1) expect(percents[i]).toBeGreaterThanOrEqual(percents[i - 1]!);
+    expect(percents.at(-1)!).toBeGreaterThanOrEqual(95);
   });
 });


### PR DESCRIPTION
用户在真实自部署实例(media.dirtyfancy.sbs)报 #3a 内联进度条两个 bug。systematic-debugging 取证(真实 run 48b20772 的 agent_steps 工具/相位序列)。

## bug 2:刚到「确认转存目录」就涨到约七成
`interpretTool` 把 `inspectTargetDir`(核对入库目录)归为 **verify 相位**(band [60,72]≈66%)。但 agent 把它当**早期定位步**——转存前先确认落库目录结构(真实序列里在 ordinal 2,早于 searchResources/transferCandidate)。进度是**单调钳制**的,于是预热就跳到 ~66% 并**卡住整段转存**(transfer 的 43 < 66),既预热失真又不反映转存进度。
**修**:`inspectTargetDir → search`(早期低相位)。`inspectStaging`(转存后核对落盘文件)仍是 `verify` —— 那才是真正的验证。

## bug 1:进度条一直空、不反映进度
同一相位内进度条卡在 band 中点不动;慢模型的早期(readSkill/search)和转存多次重试时,看起来「一直空着没反映」。
**修**:`progress-sink` 加**阶段内步进** —— 每个相位内按 `n/(n+2)` 渐进(首步≈0.33,趋近但永不越过 band 末端,保持诚实);`mark` 相位仍用真实 `obtained/needed`。

## 效果
真实 run 序列修后:`8→10→11→12 → 37→43→46 → 64 → 76 → 88 → 96→97` —— 平滑爬升、跨相位 + 相位内都在动、无 66 跳。

## 验证
TDD:真实工具序列回放测(断言早期 inspectTargetDir 不把 bar 推过 transfer band、verify territory 只在转存后到达、单调爬升)+ 阶段内步进测 + 改既有 inspectTargetDir→verify 断言。838 测 + 三 tsc + lint 净。⏳ 合并后部署实例,真实 run live 复验曲线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)