### PR TITLE
fix(progress): 内联进度条在长步骤间平滑缓爬,不再冻结看着空

### DIFF
--- a/apps/web/components/acquire-progress-badge.tsx
+++ b/apps/web/components/acquire-progress-badge.tsx
@@ -16,13 +16,13 @@ import { advanceTrickle, initialTrickleState, inlineProgressView } from "../lib/
  * the CSS `width` transition bridges each step. Stateful only in the ref + interval.
  */
 function useTrickledPercent(serverPercent: number, running: boolean, runKey: string): number {
-  const stateRef = useRef(initialTrickleState(serverPercent, Date.now(), runKey));
+  // One clock read per render, shared by init + advance, so the first paint sits EXACTLY
+  // at the server value (no sub-tick creep) and render stays consistent.
+  const nowMs = Date.now();
+  const stateRef = useRef<ReturnType<typeof initialTrickleState> | null>(null);
+  stateRef.current ??= initialTrickleState(serverPercent, nowMs, runKey);
   const [, force] = useState(0);
-  stateRef.current = advanceTrickle(stateRef.current, {
-    serverPercent,
-    nowMs: Date.now(),
-    key: runKey,
-  });
+  stateRef.current = advanceTrickle(stateRef.current, { serverPercent, nowMs, key: runKey });
   useEffect(() => {
     if (!running) return;
     const id = setInterval(() => force((n) => n + 1), 400);

--- a/apps/web/components/acquire-progress-badge.tsx
+++ b/apps/web/components/acquire-progress-badge.tsx
@@ -1,10 +1,34 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 import { LoaderCircle } from "lucide-react";
 import { RequestedBadge } from "./request-state";
 import { useActiveRun } from "../lib/use-active-run";
-import { inlineProgressView } from "../lib/inline-progress";
+import { inlineProgressView, trickleDisplayPercent } from "../lib/inline-progress";
+
+/**
+ * Smoothly trickle the displayed bar forward between server updates. Server progress
+ * only advances on a real agent tool call, but a single step (e.g. a ~90s search) can
+ * dominate the run — so without this the bar sits frozen and looks empty. We anchor on
+ * the last server percent (+ when it changed) and ease toward a soft ceiling; a ~400ms
+ * re-render drives it while the CSS `width` transition bridges each step. `max(server,
+ * trickle)` + rebasing only when the server value rises keeps it monotonic (no rewind).
+ */
+function useTrickledPercent(serverPercent: number, running: boolean, runKey: string): number {
+  const anchor = useRef({ percent: serverPercent, atMs: Date.now(), key: runKey });
+  const [, force] = useState(0);
+  if (anchor.current.key !== runKey || serverPercent > anchor.current.percent) {
+    anchor.current = { percent: serverPercent, atMs: Date.now(), key: runKey };
+  }
+  useEffect(() => {
+    if (!running) return;
+    const id = setInterval(() => force((n) => n + 1), 400);
+    return () => clearInterval(id);
+  }, [running]);
+  const elapsed = Date.now() - anchor.current.atMs;
+  return Math.max(serverPercent, trickleDisplayPercent(anchor.current.percent, elapsed));
+}
 
 /**
  * Production inline acquire progress. While THIS card's run is actively running,
@@ -26,6 +50,8 @@ export function AcquireProgressBadge({
 }) {
   const run = useActiveRun(tmdbId, seasonNumber, storageId);
   const view = inlineProgressView(run);
+  // Hooks must run unconditionally — compute the trickled width before any early return.
+  const displayPercent = useTrickledPercent(view.percent, view.running, run?.runId ?? "none");
 
   if (!view.running) {
     return <RequestedBadge title={title} storageId={storageId} />;
@@ -35,7 +61,7 @@ export function AcquireProgressBadge({
   return (
     <Link className="demo-playback acquire-progress" href={href} title={title ?? "查看获取进度（活动）"}>
       <span className="demo-playback-bar">
-        <span className="demo-playback-fill" style={{ width: `${view.percent}%` }} />
+        <span className="demo-playback-fill" style={{ width: `${displayPercent}%` }} />
       </span>
       {/* aria-live on the step text (NOT the anchor): keeps the element a proper
           link for assistive tech while still announcing progress updates. */}

--- a/apps/web/components/acquire-progress-badge.tsx
+++ b/apps/web/components/acquire-progress-badge.tsx
@@ -5,29 +5,30 @@ import { useEffect, useRef, useState } from "react";
 import { LoaderCircle } from "lucide-react";
 import { RequestedBadge } from "./request-state";
 import { useActiveRun } from "../lib/use-active-run";
-import { inlineProgressView, trickleDisplayPercent } from "../lib/inline-progress";
+import { advanceTrickle, initialTrickleState, inlineProgressView } from "../lib/inline-progress";
 
 /**
  * Smoothly trickle the displayed bar forward between server updates. Server progress
  * only advances on a real agent tool call, but a single step (e.g. a ~90s search) can
- * dominate the run — so without this the bar sits frozen and looks empty. We anchor on
- * the last server percent (+ when it changed) and ease toward a soft ceiling; a ~400ms
- * re-render drives it while the CSS `width` transition bridges each step. `max(server,
- * trickle)` + rebasing only when the server value rises keeps it monotonic (no rewind).
+ * dominate the run — so without this the bar sits frozen and looks empty. The pure
+ * `advanceTrickle` reducer eases toward a soft ceiling and clamps the result monotonic
+ * (never rewinds, even on small server increments); a ~400ms re-render drives it while
+ * the CSS `width` transition bridges each step. Stateful only in the ref + interval.
  */
 function useTrickledPercent(serverPercent: number, running: boolean, runKey: string): number {
-  const anchor = useRef({ percent: serverPercent, atMs: Date.now(), key: runKey });
+  const stateRef = useRef(initialTrickleState(serverPercent, Date.now(), runKey));
   const [, force] = useState(0);
-  if (anchor.current.key !== runKey || serverPercent > anchor.current.percent) {
-    anchor.current = { percent: serverPercent, atMs: Date.now(), key: runKey };
-  }
+  stateRef.current = advanceTrickle(stateRef.current, {
+    serverPercent,
+    nowMs: Date.now(),
+    key: runKey,
+  });
   useEffect(() => {
     if (!running) return;
     const id = setInterval(() => force((n) => n + 1), 400);
     return () => clearInterval(id);
   }, [running]);
-  const elapsed = Date.now() - anchor.current.atMs;
-  return Math.max(serverPercent, trickleDisplayPercent(anchor.current.percent, elapsed));
+  return stateRef.current.displayed;
 }
 
 /**

--- a/apps/web/lib/inline-progress.test.ts
+++ b/apps/web/lib/inline-progress.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { findActiveRun, inlineProgressView, trickleDisplayPercent } from "./inline-progress";
+import {
+  advanceTrickle,
+  findActiveRun,
+  initialTrickleState,
+  inlineProgressView,
+  trickleDisplayPercent,
+} from "./inline-progress";
 import type { ActivityActiveRun } from "./activity-view";
 
 function run(over: Partial<ActivityActiveRun>): ActivityActiveRun {
@@ -92,6 +98,11 @@ describe("trickleDisplayPercent — keep the bar alive during a long opaque step
   it("never claims completion (capped below 100 even from a high base)", () => {
     expect(trickleDisplayPercent(96, 10_000_000)).toBeLessThanOrEqual(99);
   });
+  it("never trickles BACKWARD for a base at/above the cap (Copilot: base 100 → stays 100)", () => {
+    expect(trickleDisplayPercent(100, 0)).toBe(100);
+    expect(trickleDisplayPercent(100, 60_000)).toBe(100); // not 99 — no negative slope
+    expect(trickleDisplayPercent(100, 600_000)).toBeGreaterThanOrEqual(100);
+  });
   it("monotonic non-decreasing in elapsed (never rewinds)", () => {
     let prev = -1;
     for (const ms of [0, 1_000, 10_000, 60_000, 300_000]) {
@@ -99,5 +110,52 @@ describe("trickleDisplayPercent — keep the bar alive during a long opaque step
       expect(v).toBeGreaterThanOrEqual(prev);
       prev = v;
     }
+  });
+});
+
+describe("advanceTrickle — display stays monotonic across polls/ticks", () => {
+  it("Copilot: a small server increment must NOT rewind the displayed bar", () => {
+    // base 10, crept to ~13 after 10s; next poll reports server=11 → must stay ≥13.
+    let s = initialTrickleState(10, 0, "run1");
+    s = advanceTrickle(s, { serverPercent: 10, nowMs: 10_000, key: "run1" });
+    const crept = s.displayed;
+    expect(crept).toBeGreaterThan(11);
+    s = advanceTrickle(s, { serverPercent: 11, nowMs: 10_400, key: "run1" });
+    expect(s.displayed).toBeGreaterThanOrEqual(crept); // no drop to 11
+  });
+  it("eases from a real jump (search 11% → transfer 37%) and keeps climbing", () => {
+    let s = initialTrickleState(11, 0, "r");
+    s = advanceTrickle(s, { serverPercent: 11, nowMs: 90_000, key: "r" }); // long search creep
+    expect(s.displayed).toBeGreaterThan(11);
+    expect(s.displayed).toBeLessThan(30); // never crossed toward 37
+    s = advanceTrickle(s, { serverPercent: 37, nowMs: 92_000, key: "r" }); // transfer jump
+    expect(s.displayed).toBeGreaterThanOrEqual(37);
+  });
+  it("a new run (key change) resets the bar to that run's value", () => {
+    let s = initialTrickleState(80, 0, "old");
+    s = advanceTrickle(s, { serverPercent: 80, nowMs: 30_000, key: "old" });
+    expect(s.displayed).toBeGreaterThan(80);
+    s = advanceTrickle(s, { serverPercent: 8, nowMs: 30_100, key: "new" });
+    expect(s.displayed).toBe(8); // fresh, not carrying old run's 80+
+  });
+  it("monotonic across a full real sequence (never rewinds at any tick)", () => {
+    const ticks: Array<{ serverPercent: number; nowMs: number }> = [
+      { serverPercent: 8, nowMs: 0 },
+      { serverPercent: 10, nowMs: 3_000 },
+      { serverPercent: 11, nowMs: 7_000 }, // then frozen 94s of trickle:
+      { serverPercent: 11, nowMs: 30_000 },
+      { serverPercent: 11, nowMs: 101_000 },
+      { serverPercent: 37, nowMs: 121_000 },
+      { serverPercent: 64, nowMs: 135_000 },
+      { serverPercent: 96, nowMs: 170_000 },
+    ];
+    let s = initialTrickleState(8, 0, "r");
+    let prev = -1;
+    for (const t of ticks) {
+      s = advanceTrickle(s, { ...t, key: "r" });
+      expect(s.displayed).toBeGreaterThanOrEqual(prev);
+      prev = s.displayed;
+    }
+    expect(prev).toBeGreaterThanOrEqual(96);
   });
 });

--- a/apps/web/lib/inline-progress.test.ts
+++ b/apps/web/lib/inline-progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { findActiveRun, inlineProgressView } from "./inline-progress";
+import { findActiveRun, inlineProgressView, trickleDisplayPercent } from "./inline-progress";
 import type { ActivityActiveRun } from "./activity-view";
 
 function run(over: Partial<ActivityActiveRun>): ActivityActiveRun {
@@ -64,5 +64,40 @@ describe("inlineProgressView", () => {
   it("queued or null → running:false", () => {
     expect(inlineProgressView(run({ status: "queued" })).running).toBe(false);
     expect(inlineProgressView(null).running).toBe(false);
+  });
+});
+
+// 2026-06-24 bug: a single `searchResources` tool call ran 94s (half the run); the
+// bar is event-driven (only writes on a tool call) so it sat FROZEN at 11% the whole
+// time → looked empty / "no progress". Fix: client trickles the bar forward between
+// server updates. trickleDisplayPercent eases from the last server % toward a soft
+// ceiling just above it (decelerating, never reaching), so a long opaque step shows
+// continuous life without claiming completion.
+describe("trickleDisplayPercent — keep the bar alive during a long opaque step", () => {
+  it("no creep at t=0 (shows exactly the server value)", () => {
+    expect(trickleDisplayPercent(11, 0)).toBe(11);
+  });
+  it("creeps forward over time, strictly increasing (the frozen-94s symptom)", () => {
+    const early = trickleDisplayPercent(11, 5_000);
+    const mid = trickleDisplayPercent(11, 30_000);
+    const late = trickleDisplayPercent(11, 90_000);
+    expect(early).toBeGreaterThan(11);
+    expect(mid).toBeGreaterThan(early);
+    expect(late).toBeGreaterThan(mid);
+  });
+  it("never crosses the next real milestone (search 11% must not creep toward transfer 37%)", () => {
+    // Even after an absurdly long wait, the soft ceiling stays well below the next jump.
+    expect(trickleDisplayPercent(11, 10_000_000)).toBeLessThan(30);
+  });
+  it("never claims completion (capped below 100 even from a high base)", () => {
+    expect(trickleDisplayPercent(96, 10_000_000)).toBeLessThanOrEqual(99);
+  });
+  it("monotonic non-decreasing in elapsed (never rewinds)", () => {
+    let prev = -1;
+    for (const ms of [0, 1_000, 10_000, 60_000, 300_000]) {
+      const v = trickleDisplayPercent(20, ms);
+      expect(v).toBeGreaterThanOrEqual(prev);
+      prev = v;
+    }
   });
 });

--- a/apps/web/lib/inline-progress.ts
+++ b/apps/web/lib/inline-progress.ts
@@ -15,6 +15,29 @@ export function findActiveRun(
   return matches.find((r) => r.status === "running") ?? matches[0] ?? null;
 }
 
+/**
+ * Server progress is event-driven: it only advances on a real agent tool call.
+ * But the biggest wall-clock costs happen BETWEEN calls — a single `searchResources`
+ * can run ~90s (PanSou/Prowlarr + slow model) — so the bar would otherwise sit FROZEN
+ * at one value for most of the run, reading as "empty / no progress" (measured: a real
+ * movie run spent 94 of 193s frozen at 11% during search).
+ *
+ * Between server updates the client trickles the bar forward: it eases from the last
+ * server percent toward a soft ceiling just above it (decelerating, asymptotic — never
+ * reaching), so a long opaque step shows continuous life WITHOUT claiming completion or
+ * crossing the next real milestone. The caller anchors on the last server percent and
+ * takes max(serverPercent, trickle), rebasing when the server value increases, so the
+ * displayed bar is always monotonic (never rewinds). Pure + monotonic in `elapsedMs`.
+ */
+const TRICKLE_MARGIN = 14; // soft ceiling = serverPercent + this (stays below the next jump)
+const TRICKLE_TAU_MS = 32_000; // easing time constant: ~63% of the margin reached by ~32s
+export function trickleDisplayPercent(serverPercent: number, elapsedMs: number): number {
+  const base = Math.max(0, serverPercent);
+  const ceiling = Math.min(99, base + TRICKLE_MARGIN);
+  const fraction = 1 - Math.exp(-Math.max(0, elapsedMs) / TRICKLE_TAU_MS);
+  return base + (ceiling - base) * fraction;
+}
+
 /** Derive the inline progress display from the matched run. */
 export function inlineProgressView(
   run: ActivityActiveRun | null,

--- a/apps/web/lib/inline-progress.ts
+++ b/apps/web/lib/inline-progress.ts
@@ -33,9 +33,51 @@ const TRICKLE_MARGIN = 14; // soft ceiling = serverPercent + this (stays below t
 const TRICKLE_TAU_MS = 32_000; // easing time constant: ~63% of the margin reached by ~32s
 export function trickleDisplayPercent(serverPercent: number, elapsedMs: number): number {
   const base = Math.max(0, serverPercent);
-  const ceiling = Math.min(99, base + TRICKLE_MARGIN);
+  // `Math.max(0, …)` on the span so a base already at/above the 99 cap never yields a
+  // negative slope (would trickle BACKWARD); the helper is monotonic for any input.
+  const span = Math.max(0, Math.min(99, base + TRICKLE_MARGIN) - base);
   const fraction = 1 - Math.exp(-Math.max(0, elapsedMs) / TRICKLE_TAU_MS);
-  return base + (ceiling - base) * fraction;
+  return base + span * fraction;
+}
+
+/**
+ * Per-run trickle state, folded across renders so the DISPLAYED bar is provably
+ * monotonic (never rewinds) — even when the server advances in small increments
+ * (the trickle can creep past the next polled value; rebasing must not drop below
+ * what's already shown). A new `key` (new run) resets the bar to that run's value.
+ */
+export interface TrickleState {
+  anchorPercent: number; // server % the current ease starts from
+  anchorAtMs: number; // when that anchor was set
+  displayed: number; // last shown % — only ever increases within a run
+  key: string; // run identity; a change resets the bar
+}
+
+export function initialTrickleState(serverPercent: number, nowMs: number, key: string): TrickleState {
+  const p = Math.max(0, serverPercent);
+  return { anchorPercent: p, anchorAtMs: nowMs, displayed: p, key };
+}
+
+/** One tick/poll: advance the eased value and clamp it monotonic. Pure (takes nowMs). */
+export function advanceTrickle(
+  state: TrickleState,
+  input: { serverPercent: number; nowMs: number; key: string },
+): TrickleState {
+  // New run → start fresh (bars are per-run; never carry the old run's high value over).
+  if (input.key !== state.key) {
+    return initialTrickleState(input.serverPercent, input.nowMs, input.key);
+  }
+  // Rebase the ease anchor only when the server ADVANCES (a real jump like search→
+  // transfer eases from the new value); otherwise keep easing from the same anchor.
+  let { anchorPercent, anchorAtMs } = state;
+  if (input.serverPercent > anchorPercent) {
+    anchorPercent = input.serverPercent;
+    anchorAtMs = input.nowMs;
+  }
+  const crept = trickleDisplayPercent(anchorPercent, input.nowMs - anchorAtMs);
+  // Monotonic floor: never below what we already showed, nor below the server truth.
+  const displayed = Math.max(state.displayed, input.serverPercent, crept);
+  return { anchorPercent, anchorAtMs, displayed, key: input.key };
 }
 
 /** Derive the inline progress display from the matched run. */


### PR DESCRIPTION
## 问题
投产搜索卡内联进度条仍被报「点获取后没进度」(截图:活动文字「正在搜索资源」在显示,但进度条无填充/不动)。

## 根因(systematic-debugging,实例真数据取证)
实例真 run `aefd659b`(续命之徒,movie 559969)的 `agent_steps` 时间戳:

| 步 | 工具 | 相位 | 时刻 | 间隔 | bar% |
|---|---|---|---|---|---|
| 2 | searchResources | search | 06:40:01 | — | 11% |
| 3 | readSkill | search | 06:41:**35** | **+94s** | 11%(冻结) |
| 4 | transferUntilLanded | transfer | 06:42:02 | +27s | 37% |

**单次 `searchResources` 跑了 94 秒,占整个 193 秒 run 的一半。** 进度条是**事件驱动**的(只在每次工具调用瞬间写一次),所以这 94 秒里 bar 冻死在 11%——看着像空的/没进度。

- 非渲染 bug(CSS 11% 会显绿条)、非数据 bug(activity 与 percent 同一 `progress` 对象,都写了)、#37 也确已部署(70% 跳变已消失)。
- 真因 = bar 只在工具调用边界跳动,而最耗时的操作(搜索/慢模型)发生在调用**之间**,长时间冻结;又因搜索在低 band,冻结点在最左边,像没动过。
- 对照:demo 那条进度条是时间驱动(平滑),投产这条复用其外观却喂事件驱动的服务端 percent → 两事件间无运动。

## 修法(NProgress / YouTube 式 trickle)
两次服务端更新之间,客户端让 bar 从上次服务端 percent **指数减速缓爬**向「稍高的软上限」(`serverPercent + 14`,封顶 99)——**永不越过下一个真里程碑、绝不回退**;服务端真值跳升时取 `max` 贴上。那 94 秒里 bar 从 11% 缓爬到 ~25%,看着一直在动、诚实不撒谎,到转存再真跳 37。

- 纯函数 `trickleDisplayPercent(serverPercent, elapsedMs)` —— TDD(5 新测:t=0 不爬 / 随时间严格递增 / 不越过下一里程碑 / 不声称完成 / 单调不回退)。
- 组件锚定上次服务端 percent + 变化时刻,`~400ms` 重渲染驱动,CSS `width 0.4s` 过渡桥接成平滑动画;`max(server, trickle)` + 仅在服务端值上升时 rebase → 单调不回退。

## 验证
- apps/web tsc + eslint 净;web lib vitest 105/105(含 13 inline-progress)。
- ⏳ 合并部署后经隧道**真 live 验**:实例触发一次电影获取,盯搜索那 ~90s 看 bar 持续爬升(而非冻结),截图为证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)