### PR TITLE
fix(progress): 内联进度条填充 display:block(span inline 致 width 被忽略=0px 永远空)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2943,6 +2943,10 @@ select.setting-control {
   overflow: hidden;
 }
 .demo-playback-fill {
+  /* MUST be block: the fill is a <span> (inline by default), and CSS width/height
+     are IGNORED on inline boxes — so without this the fill collapses to 0×0 and the
+     bar shows NO progress at any percent (the green never renders). */
+  display: block;
   height: 100%;
   background: var(--accent);
   transition: width 0.4s ease;


### PR DESCRIPTION
## 真根因(经隧道真浏览器取证)
作者一直说投产搜索卡进度条「完全没有一丁点进度」——**是对的**。我前两个 PR(#37 标定、#38 trickle)只改了 percent 数值,但 bar 从来就没渲染出来。

用 playwright 经隧道量**真实像素**(不是 style.width):
```
fill: { pxW: 0, pxH: 0, styleW: "16.35%", bg: rgb(30,215,96), disp: "inline" }
```
填充 `<span class="demo-playback-fill">` 是 **`display:inline`**,而 **CSS `width`/`height` 在 inline 盒子上被忽略** → 填充塌成 **0×0**,任何百分比都不渲染绿色。截图证实:灰色轨道在、绿色填充完全没有。

**对照:** demo 的 `demo-acquire-playback.tsx` 用 `<div>`(block)→ 一直正常(所以「demo 的优雅外观」看着没问题);我照它做投产 badge 却用了 `<span>`(inline)→ 0px。flex 父只 blockify 了轨道 span,没 blockify 填充孙节点。

> 我之前的「live 证明」只读了 `style.width`(属性设对了)却没量渲染像素,被骗了。教训:验证渲染必须量 `getBoundingClientRect`,不是 `style.width`。

## 修
`.demo-playback-fill { display: block }`(填充本就该 block;对 demo 的 div 是 no-op,对投产 span 是修复)。

## 验证
- 确定性(实例真样式表注入同款标记):`display:inline → 0px`,`display:block → 26px`(160px 的 16%)。
- ⏳ 合并部署后经隧道**真 live 验**:触发真获取,量 fill pxW>0 + 截图绿色填充随搜索爬升。

🤖 Generated with [Claude Code](https://claude.com/claude-code)