### PR TITLE
fix(auth): reset-password CLI 自包含 + Dockerfile 拷进 standalone 容器

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,10 @@ COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
 # public asset (e.g. /brands/<provider>.svg for the workspace switcher icons) 404s
 # and BrandMark falls back to a bare dot (demo on Vercel serves public/ natively).
 COPY --from=builder /app/apps/web/public ./apps/web/public
+# Admin CLI escape hatch (forgot-password). standalone ships no scripts/ — copy it
+# in so `docker compose exec web node scripts/reset-password.mjs <user>` works. The
+# script is self-contained (raw pg + scrypt), so it needs no workflow dist (which
+# standalone bundles into .next and doesn't expose as a module).
+COPY --from=builder /app/scripts/reset-password.mjs ./scripts/reset-password.mjs
 EXPOSE 3000
 CMD ["node", "apps/web/server.js"]

--- a/scripts/reset-password.mjs
+++ b/scripts/reset-password.mjs
@@ -54,18 +54,23 @@ if (!connectionString) {
 
 const client = new pg.Client({ connectionString });
 await client.connect();
+// Derive the exit code inside try, exit AFTER finally — calling process.exit() in the
+// try block would skip finally and leak the pg connection.
+let exitCode = 0;
 try {
   const found = await client.query("SELECT id FROM accounts WHERE username = $1", [username]);
   const account = found.rows[0];
   if (!account) {
     console.error(`找不到账号: ${username}`);
-    process.exit(1);
+    exitCode = 1;
+  } else {
+    const hash = await hashPassword(newPassword);
+    await client.query("UPDATE accounts SET password_hash = $1 WHERE id = $2", [hash, account.id]);
+    await client.query("DELETE FROM sessions WHERE account_id = $1", [account.id]);
+    console.log(`已重置账号「${username}」的密码为: ${newPassword}`);
+    console.log("请用该密码登录后到「设置 → 修改密码」改成你自己的。");
   }
-  const hash = await hashPassword(newPassword);
-  await client.query("UPDATE accounts SET password_hash = $1 WHERE id = $2", [hash, account.id]);
-  await client.query("DELETE FROM sessions WHERE account_id = $1", [account.id]);
-  console.log(`已重置账号「${username}」的密码为: ${newPassword}`);
-  console.log("请用该密码登录后到「设置 → 修改密码」改成你自己的。");
 } finally {
   await client.end();
 }
+process.exit(exitCode);

--- a/scripts/reset-password.mjs
+++ b/scripts/reset-password.mjs
@@ -65,8 +65,17 @@ try {
     exitCode = 1;
   } else {
     const hash = await hashPassword(newPassword);
-    await client.query("UPDATE accounts SET password_hash = $1 WHERE id = $2", [hash, account.id]);
-    await client.query("DELETE FROM sessions WHERE account_id = $1", [account.id]);
+    // Atomic: rotate the hash AND revoke sessions together, so a failed DELETE can't
+    // leave the password changed while old session cookies still work.
+    await client.query("BEGIN");
+    try {
+      await client.query("UPDATE accounts SET password_hash = $1 WHERE id = $2", [hash, account.id]);
+      await client.query("DELETE FROM sessions WHERE account_id = $1", [account.id]);
+      await client.query("COMMIT");
+    } catch (txError) {
+      await client.query("ROLLBACK");
+      throw txError;
+    }
     console.log(`已重置账号「${username}」的密码为: ${newPassword}`);
     console.log("请用该密码登录后到「设置 → 修改密码」改成你自己的。");
   }

--- a/scripts/reset-password.mjs
+++ b/scripts/reset-password.mjs
@@ -3,18 +3,41 @@
 //   docker compose exec web node scripts/reset-password.mjs <username> [newPassword]
 // No password arg → a random one is generated and printed. Revokes the account's
 // sessions so the old (forgotten) cookie can't linger.
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { randomBytes } from "node:crypto";
-import { loadDotEnv } from "./_lib/pan115-cookie.mjs";
+//
+// SELF-CONTAINED ON PURPOSE: the Next `output: standalone` runner bundles
+// @media-track/workflow into .next (NOT resolvable as a module) and ships no
+// packages/workflow/dist — so this script must NOT import the workflow package. It
+// uses `pg` (traced into the standalone node_modules) + raw SQL, and replicates the
+// scrypt hash format from packages/workflow/src/auth/password.ts EXACTLY:
+//   stored = `scrypt:<saltHex(16B)>:<keyHex(64B)>`. If that KDF ever changes, update
+// this script too.
+import { randomBytes, scrypt as scryptCb } from "node:crypto";
+import { promisify } from "node:util";
+import { readFileSync } from "node:fs";
+import pg from "pg";
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-loadDotEnv();
+const scrypt = promisify(scryptCb);
 
-const conn =
-  process.env.MEDIA_TRACK_POSTGRES_URL ?? "postgresql://mediatrack:mediatrack@localhost:5432/media_track";
-const mod = await import(path.join(repoRoot, "packages/workflow/dist/index.js"));
-const repo = mod.createPostgresWorkflowRepositorySync({ connectionString: conn });
+async function hashPassword(plain) {
+  const salt = randomBytes(16);
+  const key = await scrypt(plain, salt, 64);
+  return `scrypt:${salt.toString("hex")}:${key.toString("hex")}`;
+}
+
+/** In the container MEDIA_TRACK_POSTGRES_URL is already in the env (docker compose).
+ *  For a dev shell, best-effort read it from ./.env so `node scripts/...` just works. */
+function resolveConnectionString() {
+  if (process.env.MEDIA_TRACK_POSTGRES_URL?.trim()) return process.env.MEDIA_TRACK_POSTGRES_URL.trim();
+  try {
+    const line = readFileSync(".env", "utf8")
+      .split("\n")
+      .find((l) => l.startsWith("MEDIA_TRACK_POSTGRES_URL="));
+    if (line) return line.slice("MEDIA_TRACK_POSTGRES_URL=".length).trim().replace(/^["']|["']$/g, "");
+  } catch {
+    /* no .env — fall through */
+  }
+  return null;
+}
 
 const username = process.argv[2];
 if (!username) {
@@ -23,13 +46,26 @@ if (!username) {
 }
 const newPassword = process.argv[3] ?? randomBytes(6).toString("base64url");
 
-const acct = await repo.getAccountByUsername(username);
-if (!acct) {
-  console.error(`找不到账号: ${username}`);
+const connectionString = resolveConnectionString();
+if (!connectionString) {
+  console.error("缺少 MEDIA_TRACK_POSTGRES_URL(容器内应已注入;dev 请在 .env 或环境变量里设)。");
   process.exit(1);
 }
-await repo.setAccountPassword(acct.id, await mod.hashPassword(newPassword));
-await repo.deleteSessionsForAccount(acct.id);
-console.log(`已重置账号「${username}」的密码为: ${newPassword}`);
-console.log("请用该密码登录后到「设置 → 修改密码」改成你自己的。");
-process.exit(0);
+
+const client = new pg.Client({ connectionString });
+await client.connect();
+try {
+  const found = await client.query("SELECT id FROM accounts WHERE username = $1", [username]);
+  const account = found.rows[0];
+  if (!account) {
+    console.error(`找不到账号: ${username}`);
+    process.exit(1);
+  }
+  const hash = await hashPassword(newPassword);
+  await client.query("UPDATE accounts SET password_hash = $1 WHERE id = $2", [hash, account.id]);
+  await client.query("DELETE FROM sessions WHERE account_id = $1", [account.id]);
+  console.log(`已重置账号「${username}」的密码为: ${newPassword}`);
+  console.log("请用该密码登录后到「设置 → 修改密码」改成你自己的。");
+} finally {
+  await client.end();
+}

--- a/scripts/reset-password.mjs
+++ b/scripts/reset-password.mjs
@@ -79,6 +79,14 @@ try {
     console.log(`已重置账号「${username}」的密码为: ${newPassword}`);
     console.log("请用该密码登录后到「设置 → 修改密码」改成你自己的。");
   }
+} catch (err) {
+  // 42P01 = undefined_table: schema not initialized yet (web never started once).
+  if (err && typeof err === "object" && err.code === "42P01") {
+    console.error("数据库尚未初始化(accounts 表不存在)。请先启动一次 web 服务完成 schema 初始化,再跑本脚本。");
+    exitCode = 1;
+  } else {
+    throw err;
+  }
 } finally {
   await client.end();
 }


### PR DESCRIPTION
## 问题(live e2e 抓到)
#40 合并部署后,在真容器里 `docker compose exec web node scripts/reset-password.mjs` **必然失败**:Next `output: standalone` 的 `/app` 只有 `apps/` + `node_modules/`——没有 `scripts/`,且 `@media-track/workflow` 被打进 `.next` 不作为可 import 的模块存在(`/app/node_modules/@media-track` 不存在)。原脚本 `import packages/workflow/dist/index.js` + `scripts/_lib` 都不在容器里。

## 修
1. **脚本自包含**:裸 `pg`(已被 standalone 追踪进 `/app/node_modules/pg`)+ 内联 scrypt,**精确复刻** `packages/workflow/src/auth/password.ts` 的 `scrypt:<saltHex(16B)>:<keyHex(64B)>` 格式;连接串读 `process.env`(容器已注入)+ 兜底读 `.env`(dev 便利)。不再依赖 workflow dist / scripts/_lib。
2. **Dockerfile** runner stage `COPY scripts/reset-password.mjs ./scripts/reset-password.mjs`(同 public/ 那条修复的思路)。

## 验证
- 真 Postgres round-trip(临时库):跑 CLI → 新密码 hash 合法 scrypt、目标账号会话全撤销、其他账号会话不动。✅
- ⏳ 合并部署后**在真容器内**实跑 `docker compose exec web node scripts/reset-password.mjs <user>` 确认(本来就是为了它)。

> 教训:`output: standalone` 不含 `public/`、`scripts/`,也不暴露 workspace 包为模块——凡要在容器里跑的辅助脚本都得 ① 自包含 ② Dockerfile 显式 COPY。

🤖 Generated with [Claude Code](https://claude.com/claude-code)