### PR TITLE
fix(auth): 多账号 UI 被 cacheComponents 构建期静态预渲染(prod 全失效/站主锁死)

### DIFF
--- a/apps/web/app/api/auth/bootstrap/route.ts
+++ b/apps/web/app/api/auth/bootstrap/route.ts
@@ -1,5 +1,4 @@
-import { connection } from "next/server";
-import { NextResponse } from "next/server";
+import { connection, NextResponse } from "next/server";
 import { isMultiUserEnabled, getBootstrapState } from "../../../../lib/workflow-runtime";
 
 /** Tells the /login page whether the instance is unclaimed (→ show the context-aware

--- a/apps/web/app/api/auth/bootstrap/route.ts
+++ b/apps/web/app/api/auth/bootstrap/route.ts
@@ -1,10 +1,18 @@
+import { connection } from "next/server";
 import { NextResponse } from "next/server";
 import { isMultiUserEnabled, getBootstrapState } from "../../../../lib/workflow-runtime";
 
 /** Tells the /login page whether the instance is unclaimed (→ show the context-aware
  *  claim screen) and whether the default account already owns a library (→ "接管"
- *  copy vs "创建"). Read-only; safe before any auth. */
+ *  copy vs "创建"). Read-only; safe before any auth.
+ *
+ *  `connection()` FIRST: reads runtime env (MEDIA_TRACK_MULTI_USER) + the DB at request
+ *  time. Without it, cacheComponents prerenders the handler at BUILD time (multi-user
+ *  off) and serves a baked {needsClaim:false} forever → the owner can never claim →
+ *  locked out. (Caught in prod live e2e. `export const dynamic` is disallowed under
+ *  cacheComponents, so the opt-in is connection().) */
 export async function GET() {
+  await connection();
   if (!isMultiUserEnabled()) {
     return NextResponse.json({ needsClaim: false, hasExistingLibrary: false });
   }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -116,8 +116,10 @@ async function SettingsSidebar({ searchParams }: { searchParams: Promise<{ w?: s
 }
 
 async function PasswordChangeSection() {
-  if (!isMultiUserEnabled()) return null;
+  // connection() FIRST: cacheComponents would otherwise prerender this at build time
+  // (multi-user off) and bake it as null → never shows in production multi-user.
   await connection();
+  if (!isMultiUserEnabled()) return null;
   return (
     <section id="password" className="panel" style={{ maxWidth: 720, marginTop: 24 }}>
       <div className="panel-header">
@@ -135,8 +137,8 @@ async function PasswordChangeSection() {
 }
 
 async function AccountManagementSection() {
-  if (!isMultiUserEnabled()) return null;
   await connection();
+  if (!isMultiUserEnabled()) return null;
   const me = await getCurrentAccountSummary();
   if (!me?.isOwner) return null;
   const accounts = await listManagedAccounts(await getCurrentAccountId());

--- a/apps/web/components/account-identity-loader.tsx
+++ b/apps/web/components/account-identity-loader.tsx
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import { isMultiUserEnabled, getCurrentAccountSummary } from "../lib/workflow-runtime";
 import { AccountIdentity } from "./account-identity";
 
@@ -5,8 +6,13 @@ import { AccountIdentity } from "./account-identity";
  * Async server loader for the sidebar identity block. Renders nothing in single-user
  * mode (no login) or when there's no valid session. Mounted inside <Suspense> so its
  * DB read never blocks the static sidebar shell (mirrors WorkspaceSwitcherLoader).
+ *
+ * `connection()` FIRST so cacheComponents evaluates this per-request, not at build
+ * time — otherwise it'd be prerendered while multi-user is off, baked as null, and the
+ * identity block would never appear in production even with multi-user on.
  */
 export async function AccountIdentityLoader() {
+  await connection();
   if (!isMultiUserEnabled()) return null;
   const summary = await getCurrentAccountSummary();
   if (!summary) return null;


### PR DESCRIPTION
## 问题(#40 部署后 prod live e2e 抓到)
开 `MEDIA_TRACK_MULTI_USER=1` 后,`/api/auth/bootstrap` 仍返回 `{needsClaim:false,hasExistingLibrary:false}` —— 但实例只有 `acct_default`(空密码)+ 40 季库,正确值应是 `{true,true}`。而 `proxy.ts`(中间件,从不缓存)正确重定向。

→ **cacheComponents/PPR 把读运行时 env(`isMultiUserEnabled()`)的组件在构建期(多用户关)就静态求值并烘焙**。后果:认领屏永不出现 → 站主无法认领 → **被锁死**;整个多账号 UI 在 prod 形同不存在。

## 三处同源
1. `/api/auth/bootstrap` GET —— 无动态信号,整路由被静态生成(返回 `!isMultiUserEnabled()` 字面量)。
2. `AccountIdentityLoader` —— 无 `connection()`,构建期烘焙成 null。
3. `PasswordChangeSection`/`AccountManagementSection` —— `isMultiUserEnabled()` 判断在 `connection()` 之前 → 早 return 被静态化。

## 修
全部把 **`connection()` 前置到 env 判断之前**,强制 per-request 求值。路由用 `connection()`(cacheComponents **禁** `export const dynamic`,第一版这么写直接 build 失败,已改)。

## 验证
- `build:web` 确认 `/api/auth/bootstrap` 从静态变 **`ƒ`(Dynamic)**;三处 tsc + eslint + build 全绿。
- ⏳ 合并部署后 prod live 复验:开多用户 → bootstrap 返回 `{needsClaim:true,hasExistingLibrary:true}` + 认领屏真出现 → 关回。

> 教训:cacheComponents 下,任何读运行时 env/DB 的 server 组件/路由都必须先 `connection()`,否则被构建期静态烘焙;`export const dynamic` 在 cacheComponents 下不可用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)