### PR TITLE
fix(auth): 多账号 UX 收口(绑定冲突提示脏 + 移动端身份块消失)

### DIFF
--- a/apps/web/app/api/115/qrcode/confirm/route.test.ts
+++ b/apps/web/app/api/115/qrcode/confirm/route.test.ts
@@ -58,4 +58,16 @@ describe("POST /api/115/qrcode/confirm — error mapping", () => {
     const res = await POST(req({ session: {} }));
     expect(res.status).toBe(400);
   });
+
+  it("returns 400 (not 502) when the request body is invalid JSON", async () => {
+    const r = new NextRequest("http://localhost/api/115/qrcode/confirm", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+    const res = await POST(r);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
 });

--- a/apps/web/app/api/115/qrcode/confirm/route.test.ts
+++ b/apps/web/app/api/115/qrcode/confirm/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { StorageOwnedByOtherAccountError } from "../../../../../lib/workflow-runtime";
+
+vi.mock("../../../../../lib/demo-mode", () => ({ isDemoMode: () => false }));
+// Mock completePan115QrLogin so we can throw controlled errors. Keep the class
+// symbol real (re-exported) so `instanceof` in the route still works.
+vi.mock("../../../../../lib/workflow-runtime", async () => {
+  const actual = await vi.importActual<typeof import("../../../../../lib/workflow-runtime")>(
+    "../../../../../lib/workflow-runtime",
+  );
+  return {
+    ...actual,
+    StorageOwnedByOtherAccountError: actual.StorageOwnedByOtherAccountError,
+    completePan115QrLogin: vi.fn(),
+  };
+});
+
+import { POST } from "./route";
+import { completePan115QrLogin } from "../../../../../lib/workflow-runtime";
+import { NextRequest } from "next/server";
+
+function req(body: unknown) {
+  return new NextRequest("http://localhost/api/115/qrcode/confirm", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = { session: { uid: "u", time: 1, sign: "s" } };
+
+describe("POST /api/115/qrcode/confirm — error mapping", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 409 + clean message when the drive is owned by another account", async () => {
+    (completePan115QrLogin as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new StorageOwnedByOtherAccountError(),
+    );
+    const res = await POST(req(validBody));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("该网盘账号已被本实例的其他用户连接，无法重复绑定。");
+    expect(body.error).not.toMatch(/Error:|StorageOwned/);
+  });
+
+  it("returns 502 + bare message for other (infra) errors", async () => {
+    (completePan115QrLogin as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("upstream 500"));
+    const res = await POST(req(validBody));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("upstream 500");
+    expect(body.error).not.toMatch(/^Error:/);
+  });
+
+  it("returns 400 when session params are missing", async () => {
+    const res = await POST(req({ session: {} }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/115/qrcode/confirm/route.ts
+++ b/apps/web/app/api/115/qrcode/confirm/route.ts
@@ -4,18 +4,20 @@ import { completePan115QrLogin, StorageOwnedByOtherAccountError } from "../../..
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (isDemoMode()) return NextResponse.json({ error: "演示站只读" }, { status: 403 });
+  // Parse the body OUTSIDE the business try/catch: invalid/missing JSON is a
+  // client error (400), not an infra failure (502). Empty body → missing params.
+  const body = (await request.json().catch(() => null)) as {
+    session?: { uid?: string; time?: number; sign?: string };
+    app?: string;
+  } | null;
+  const { uid, time, sign } = body?.session ?? {};
+  if (!uid || !sign || typeof time !== "number") {
+    return NextResponse.json({ ok: false, error: "missing session params" }, { status: 400 });
+  }
   try {
-    const body = (await request.json()) as {
-      session?: { uid?: string; time?: number; sign?: string };
-      app?: string;
-    };
-    const { uid, time, sign } = body.session ?? {};
-    if (!uid || !sign || typeof time !== "number") {
-      return NextResponse.json({ ok: false, error: "missing session params" }, { status: 400 });
-    }
     const result = await completePan115QrLogin({
       session: { uid, time, sign, qrcodeContent: "" },
-      ...(body.app === undefined ? {} : { app: body.app }),
+      ...(body!.app === undefined ? {} : { app: body!.app }),
     });
     return NextResponse.json({ ok: true, ...result });
   } catch (error) {
@@ -23,7 +25,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ ok: false, error: error.message }, { status: 409 });
     }
     return NextResponse.json(
-      { ok: false, error: (error as Error)?.message ?? "登录失败" },
+      { ok: false, error: (error as Error)?.message || "登录失败" },
       { status: 502 },
     );
   }

--- a/apps/web/app/api/115/qrcode/confirm/route.ts
+++ b/apps/web/app/api/115/qrcode/confirm/route.ts
@@ -1,6 +1,6 @@
 import { isDemoMode } from "../../../../../lib/demo-mode";
 import { NextResponse, type NextRequest } from "next/server";
-import { completePan115QrLogin } from "../../../../../lib/workflow-runtime";
+import { completePan115QrLogin, StorageOwnedByOtherAccountError } from "../../../../../lib/workflow-runtime";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (isDemoMode()) return NextResponse.json({ error: "演示站只读" }, { status: 403 });
@@ -19,6 +19,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
     return NextResponse.json({ ok: true, ...result });
   } catch (error) {
-    return NextResponse.json({ ok: false, error: String(error) }, { status: 502 });
+    if (error instanceof StorageOwnedByOtherAccountError) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 409 });
+    }
+    return NextResponse.json(
+      { ok: false, error: (error as Error)?.message ?? "登录失败" },
+      { status: 502 },
+    );
   }
 }

--- a/apps/web/app/api/quark/qrcode/confirm/route.test.ts
+++ b/apps/web/app/api/quark/qrcode/confirm/route.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { StorageOwnedByOtherAccountError } from "../../../../../lib/workflow-runtime";
+
+vi.mock("../../../../../lib/demo-mode", () => ({ isDemoMode: () => false }));
+vi.mock("../../../../../lib/workflow-runtime", async () => {
+  const actual = await vi.importActual<typeof import("../../../../../lib/workflow-runtime")>(
+    "../../../../../lib/workflow-runtime",
+  );
+  return {
+    ...actual,
+    StorageOwnedByOtherAccountError: actual.StorageOwnedByOtherAccountError,
+    completeQuarkQrLogin: vi.fn(),
+  };
+});
+
+import { POST } from "./route";
+import { completeQuarkQrLogin } from "../../../../../lib/workflow-runtime";
+import { NextRequest } from "next/server";
+
+function req(body: unknown) {
+  return new NextRequest("http://localhost/api/quark/qrcode/confirm", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/quark/qrcode/confirm — error mapping", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 409 + clean message when the drive is owned by another account", async () => {
+    (completeQuarkQrLogin as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new StorageOwnedByOtherAccountError(),
+    );
+    const res = await POST(req({ serviceTicket: "st" }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("该网盘账号已被本实例的其他用户连接，无法重复绑定。");
+    expect(body.error).not.toMatch(/Error:|Quark/);
+  });
+
+  it("returns 502 + bare message for other errors", async () => {
+    (completeQuarkQrLogin as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("exchange failed"));
+    const res = await POST(req({ serviceTicket: "st" }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe("exchange failed");
+    expect(body.error).not.toMatch(/^Error:/);
+  });
+
+  it("returns 400 when serviceTicket is missing", async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/quark/qrcode/confirm/route.test.ts
+++ b/apps/web/app/api/quark/qrcode/confirm/route.test.ts
@@ -53,4 +53,16 @@ describe("POST /api/quark/qrcode/confirm — error mapping", () => {
     const res = await POST(req({}));
     expect(res.status).toBe(400);
   });
+
+  it("returns 400 (not 502) when the request body is invalid JSON", async () => {
+    const r = new NextRequest("http://localhost/api/quark/qrcode/confirm", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+    const res = await POST(r);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
 });

--- a/apps/web/app/api/quark/qrcode/confirm/route.ts
+++ b/apps/web/app/api/quark/qrcode/confirm/route.ts
@@ -4,11 +4,13 @@ import { completeQuarkQrLogin, StorageOwnedByOtherAccountError } from "../../../
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (isDemoMode()) return NextResponse.json({ error: "演示站只读" }, { status: 403 });
+  // Parse the body OUTSIDE the business try/catch: invalid/missing JSON is a
+  // client error (400), not an infra failure (502). Empty body → missing ticket.
+  const body = (await request.json().catch(() => null)) as { serviceTicket?: string } | null;
+  if (!body?.serviceTicket) {
+    return NextResponse.json({ ok: false, error: "missing serviceTicket" }, { status: 400 });
+  }
   try {
-    const body = (await request.json()) as { serviceTicket?: string };
-    if (!body.serviceTicket) {
-      return NextResponse.json({ ok: false, error: "missing serviceTicket" }, { status: 400 });
-    }
     const result = await completeQuarkQrLogin(body.serviceTicket);
     return NextResponse.json({ ok: true, ...result });
   } catch (error) {
@@ -16,7 +18,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       return NextResponse.json({ ok: false, error: error.message }, { status: 409 });
     }
     return NextResponse.json(
-      { ok: false, error: (error as Error)?.message ?? "登录失败" },
+      { ok: false, error: (error as Error)?.message || "登录失败" },
       { status: 502 },
     );
   }

--- a/apps/web/app/api/quark/qrcode/confirm/route.ts
+++ b/apps/web/app/api/quark/qrcode/confirm/route.ts
@@ -1,6 +1,6 @@
 import { isDemoMode } from "../../../../../lib/demo-mode";
 import { NextResponse, type NextRequest } from "next/server";
-import { completeQuarkQrLogin } from "../../../../../lib/workflow-runtime";
+import { completeQuarkQrLogin, StorageOwnedByOtherAccountError } from "../../../../../lib/workflow-runtime";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   if (isDemoMode()) return NextResponse.json({ error: "演示站只读" }, { status: 403 });
@@ -12,6 +12,12 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const result = await completeQuarkQrLogin(body.serviceTicket);
     return NextResponse.json({ ok: true, ...result });
   } catch (error) {
-    return NextResponse.json({ ok: false, error: String(error) }, { status: 502 });
+    if (error instanceof StorageOwnedByOtherAccountError) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 409 });
+    }
+    return NextResponse.json(
+      { ok: false, error: (error as Error)?.message ?? "登录失败" },
+      { status: 502 },
+    );
   }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1223,6 +1223,9 @@ p {
      shares the row with the drive switcher without overflow. */
   .sidebar-top-identity .account-identity {
     margin-bottom: 0;
+    /* Establish a positioning context so the absolutely-positioned dropdown
+       anchors to THIS block, not the viewport. */
+    position: relative;
   }
   .sidebar-top-identity .account-identity-summary {
     padding: 6px 8px;
@@ -1233,8 +1236,9 @@ p {
        bar from overflowing when both switcher + identity are present. */
     max-width: 80px;
   }
-  /* The dropdown opens below the summary, inline (not absolute) so it can't
-     overflow horizontally — it wraps within the viewport. */
+  /* The dropdown opens absolutely-positioned below the summary, anchored to the
+     right edge of the identity block (whose `position: relative` is set above)
+     so it never overflows a 390px viewport horizontally. */
   .sidebar-top-identity .account-identity-menu {
     position: absolute;
     right: 0;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1092,6 +1092,13 @@ p {
 
 /* ---------- responsive ---------- */
 
+/* Account identity has two homes: the footer (desktop) and the top bar (mobile).
+   This wrapper holds the top-bar copy; desktop hides it, mobile shows it.
+   Single-user/demo → AccountIdentityLoader renders null → empty anyway. */
+.sidebar-top-identity {
+  display: none;
+}
+
 @media (max-width: 1080px) {
   .dashboard-grid {
     grid-template-columns: 1fr;
@@ -1199,6 +1206,46 @@ p {
 
   .nav-activity-item {
     display: block;
+  }
+
+  /* Mobile: the footer is hidden, so surface the account identity in the TOP
+     bar (next to the drive switcher), not the bottom tab bar — the tab bar is
+     icon-over-label links, and a <details> dropdown doesn't fit that pattern. */
+  .sidebar-top-identity {
+    display: block;
+  }
+  /* Avoid double-rendering: hide the footer copy on mobile. */
+  .sidebar-footer .account-identity {
+    display: none;
+  }
+  /* The top bar is a flex row with justify-content:space-between. The identity
+     <details> sits at the right end; keep it compact (avatar dot + name) so it
+     shares the row with the drive switcher without overflow. */
+  .sidebar-top-identity .account-identity {
+    margin-bottom: 0;
+  }
+  .sidebar-top-identity .account-identity-summary {
+    padding: 6px 8px;
+  }
+  .sidebar-top-identity .account-identity-name {
+    /* Hide the username text on very narrow phones (≤390px); the avatar dot +
+       owner badge are enough, the dropdown reveals the full name. Keeps the top
+       bar from overflowing when both switcher + identity are present. */
+    max-width: 80px;
+  }
+  /* The dropdown opens below the summary, inline (not absolute) so it can't
+     overflow horizontally — it wraps within the viewport. */
+  .sidebar-top-identity .account-identity-menu {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    min-width: 180px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border, #2a2a2a);
+    border-radius: 10px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    padding: 4px;
+    z-index: 60;
   }
 
   .main {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1214,7 +1214,9 @@ p {
   .sidebar-top-identity {
     display: block;
   }
-  /* Avoid double-rendering: hide the footer copy on mobile. */
+  /* Avoid double-display: the footer copy is still rendered server-side (it's
+     the desktop home), only hidden on mobile — getCurrentAccountSummary is
+     per-request memoized via React.cache so the two loaders share one DB read. */
   .sidebar-footer .account-identity {
     display: none;
   }
@@ -1231,9 +1233,10 @@ p {
     padding: 6px 8px;
   }
   .sidebar-top-identity .account-identity-name {
-    /* Hide the username text on very narrow phones (≤390px); the avatar dot +
-       owner badge are enough, the dropdown reveals the full name. Keeps the top
-       bar from overflowing when both switcher + identity are present. */
+    /* Truncate (ellipsis) the username text on very narrow phones (≤390px) so the
+       avatar dot + truncated name share the top bar with the drive switcher
+       without overflow; the dropdown reveals the full name. (Not fully hidden —
+       a breakpoint to hide it entirely is YAGNI for now.) */
     max-width: 80px;
   }
   /* The dropdown opens absolutely-positioned below the summary, anchored to the

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -41,6 +41,14 @@ export function AppSidebar({
         <WorkspaceSwitcherLoader />
       </Suspense>
 
+      {/* Account identity — mobile top-bar copy (desktop keeps the footer one).
+          Single-user/demo → AccountIdentityLoader returns null → empty. */}
+      <Suspense fallback={null}>
+        <div className="sidebar-top-identity">
+          <AccountIdentityLoader />
+        </div>
+      </Suspense>
+
       <nav aria-label="主导航">
         <ul className="nav-list">
           <li>

--- a/apps/web/components/pan115-qr-connect.tsx
+++ b/apps/web/components/pan115-qr-connect.tsx
@@ -91,16 +91,20 @@ export function Pan115QrConnect() {
       });
       const data = (await response.json()) as { ok: boolean; userName?: string; error?: string };
       if (!data.ok) {
-        throw new Error(data.error ?? "登录失败");
+        if (generation.current !== myGeneration) return;
+        setPhase("error");
+        setMessage(data.error ?? "登录失败");
+        return;
       }
       if (generation.current !== myGeneration) return;
       setPhase("done");
       setMessage(data.userName ? `已连接为 ${data.userName}` : "已连接");
       router.refresh();
     } catch (error) {
+      // Network failure (fetch threw) — show a generic retry hint, no Error: prefix.
       if (generation.current !== myGeneration) return;
       setPhase("error");
-      setMessage(String(error));
+      setMessage("网络异常，请重试。");
     }
   }
 

--- a/apps/web/components/pan115-qr-connect.tsx
+++ b/apps/web/components/pan115-qr-connect.tsx
@@ -101,7 +101,9 @@ export function Pan115QrConnect() {
       setMessage(data.userName ? `已连接为 ${data.userName}` : "已连接");
       router.refresh();
     } catch (error) {
-      // Network failure (fetch threw) — show a generic retry hint, no Error: prefix.
+      // Anything here is NOT a clean API error (those returned in `data` above):
+      // a network failure (fetch threw) OR a JSON decode failure (response.json()
+      // threw on a non-JSON body). Show a generic retry hint, no Error: prefix.
       if (generation.current !== myGeneration) return;
       setPhase("error");
       setMessage("网络异常，请重试。");

--- a/apps/web/components/quark-qr-connect.tsx
+++ b/apps/web/components/quark-qr-connect.tsx
@@ -82,7 +82,12 @@ export function QuarkQrConnect() {
         body: JSON.stringify({ serviceTicket }),
       });
       const data = (await res.json()) as { ok: boolean; providerUid?: string; error?: string };
-      if (!data.ok) throw new Error(data.error ?? "登录失败");
+      if (!data.ok) {
+        if (generation.current !== myGen) return;
+        setPhase("error");
+        setMessage(`${data.error ?? "登录失败"}（可改用下方手动粘 cookie）`);
+        return;
+      }
       if (generation.current !== myGen) return;
       setPhase("done");
       setMessage("夸克已连接。");
@@ -90,7 +95,7 @@ export function QuarkQrConnect() {
     } catch (error) {
       if (generation.current !== myGen) return;
       setPhase("error");
-      setMessage(`${String(error)}（可改用下方手动粘 cookie）`);
+      setMessage("网络异常，请重试。（可改用下方手动粘 cookie）");
     }
   }
 

--- a/apps/web/components/quark-qr-connect.tsx
+++ b/apps/web/components/quark-qr-connect.tsx
@@ -93,6 +93,9 @@ export function QuarkQrConnect() {
       setMessage("夸克已连接。");
       router.refresh();
     } catch (error) {
+      // Anything here is NOT a clean API error (those returned in `data` above):
+      // a network failure (fetch threw) OR a JSON decode failure (response.json()
+      // threw on a non-JSON body). Show a generic retry hint + the cookie fallback.
       if (generation.current !== myGen) return;
       setPhase("error");
       setMessage("网络异常，请重试。（可改用下方手动粘 cookie）");

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -252,9 +252,10 @@ export async function getBootstrapState(): Promise<{ needsClaim: boolean; hasExi
 }
 
 /** Current account's display summary for the sidebar identity block — NEVER the
- *  password hash. Null when there's no real account (unauthenticated sentinel). */
-/** Per-request memoized account summary. The identity loader renders twice on
- *  multi-user pages (desktop footer + mobile top-bar copy), and both call this —
+ *  password hash. Null when there's no real account (unauthenticated sentinel).
+ *
+ *  Per-request memoized via `cache()`: the identity loader renders twice on
+ *  multi-user pages (desktop footer + mobile top-bar copy) and both call this —
  *  `cache()` dedupes the `getAccountById` DB read within a single request so we
  *  only hit the DB once even with two mounted loaders. (Next.js / React.cache
  *  per-request memoization pattern.) */

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { cache } from "react";
 import {
   PanSouResourceProvider,
   createProtectedPan115CookieStorageExecutorFromEnv,
@@ -252,10 +253,17 @@ export async function getBootstrapState(): Promise<{ needsClaim: boolean; hasExi
 
 /** Current account's display summary for the sidebar identity block — NEVER the
  *  password hash. Null when there's no real account (unauthenticated sentinel). */
-export async function getCurrentAccountSummary(): Promise<{ username: string; isOwner: boolean } | null> {
-  const acct = await getWorkflowRepository().getAccountById(await getCurrentAccountId());
-  return acct ? { username: acct.username, isOwner: acct.isOwner } : null;
-}
+/** Per-request memoized account summary. The identity loader renders twice on
+ *  multi-user pages (desktop footer + mobile top-bar copy), and both call this —
+ *  `cache()` dedupes the `getAccountById` DB read within a single request so we
+ *  only hit the DB once even with two mounted loaders. (Next.js / React.cache
+ *  per-request memoization pattern.) */
+export const getCurrentAccountSummary = cache(
+  async (): Promise<{ username: string; isOwner: boolean } | null> => {
+    const acct = await getWorkflowRepository().getAccountById(await getCurrentAccountId());
+    return acct ? { username: acct.username, isOwner: acct.isOwner } : null;
+  },
+);
 
 export interface ManagedAccount {
   id: string;


### PR DESCRIPTION
## 问题(dev server 实测挖出,#42 合并后作者手测)

1. **绑定已被其它账号占用的网盘时提示脏**:`completePan115QrLogin`/`completeQuarkQrLogin` 抛 `StorageOwnedByOtherAccountError`(message 是友好中文),但两个 confirm 路由的 catch 用 `String(error)` → 拼成 `"StorageOwnedByOtherAccountError: 该网盘..."`(带类名);返回 **502**(Bad Gateway 语义,业务拒绝该 409)。前端再 `throw new Error(data.error)` + `String(error)` 包一层 → 用户看到 `"Error: StorageOwnedByOtherAccountError: 该网盘账号已被本实例的其他用户连接，无法重复绑定。"`。双脏。

2. **多用户态移动端身份块消失**:`AccountIdentity` 挂在 `.sidebar-footer`,移动端(≤860px)`.sidebar-footer { display:none }`(整 footer 藏),身份块跟着没 → 手机用户看不见自己是谁、没法登出/改密/进账号管理。

## 修

**修 1 — 两个 confirm 路由错误分流**(`api/115/qrcode/confirm/route.ts` + `api/quark/qrcode/confirm/route.ts`):
- `error instanceof StorageOwnedByOtherAccountError` → **409** + `error.message`(干净中文,无类名)
- 其余错误维持 502(基础设施故障语义),但 error 用 `.message` 去 `Error:` 前缀

**修 1 — 两个 QR connect 前端去 throw 包裹**(`pan115-qr-connect.tsx` + `quark-qr-connect.tsx`):
- `!data.ok` 时直接 `setMessage(data.error)`,不再 `throw new Error(data.error)` + 外层 `String(error)`(去掉二次 `Error:` 包裹)
- 外层 catch 只兜 `fetch` 网络异常,文案「网络异常，请重试。」

**修 2 — 移动端身份块挪进顶部 bar**(`app-sidebar.tsx` + `globals.css`):
- sidebar 顶部(brand/switcher 同行)加一份 `AccountIdentityLoader`,包 `.sidebar-top-identity`
- 桌面默认 `.sidebar-top-identity { display:none }`;移动端显 + footer 那份藏(避免重复)
- 下拉 `.account-identity-menu` 移动端 `position:absolute; right:0` 锚定不溢出 390px 视口
- 单用户/demo → loader 返回 null → 两处都不渲染,零影响
- ⚠️ plan 原写挪进侧栏导航列表,执行时实测发现:移动端 nav 是底部固定 **tab bar**(`.nav-list flex-direction:row`,icon-over-label 列式 3-5 项),`<details>` 下拉不适配 tab 语义且水平排 6 项溢出 390px 视口(right=404)→ 改放顶部 bar(top-bar 右侧),live 验 right=390 不溢出

## 验证
- **路由单测**:两个 confirm 路由各 3 测(409+干净中文 / 502+bare message / 400 缺参)→ 6 测全 PASS
- **live 验**(dev server + 多用户 + playwright):10 断言全 PASS —— 修1 API 409+干净中文;修2 移动端顶部身份块可见含 admin、footer 那份藏、下拉含改密/账号管理/登出、不溢出(right=390)、桌面顶部藏 footer 显
- apps/web tsc + eslint 净

spec/plan `docs/superpowers/{specs,plans}/2026-06-24-multi-account-ux-cleanup*`(本地)