### PR TITLE
fix(demo)+feat(web): ensureDemoSeeded 仅 demo 模式种 + 设置页 GitHub 铭牌

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3217,4 +3217,10 @@ select.setting-control {
   .github-nameplate {
     margin-top: 24px;
   }
+  /* Allow the nameplate text to wrap on narrow phones — the one-line string
+     (dots + Chinese + English + "GitHub →") can exceed 320–390px and force
+     horizontal scroll. Desktop keeps the single-line nowrap above. */
+  .github-nameplate-text {
+    white-space: normal;
+  }
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3183,3 +3183,38 @@ select.setting-control {
   display: flex;
   justify-content: flex-end;
 }
+
+/* ---------- GitHub nameplate (Settings page bottom — quiet 暗记 + CTA) ---------- */
+.github-nameplate {
+  margin-top: 32px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border, #2a2a2a);
+  max-width: 720px;
+}
+.github-nameplate-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted, #9a9a9a);
+  font-size: 12px;
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+.github-nameplate-link:hover {
+  color: var(--text, #e6e6e6);
+}
+.github-nameplate-link:hover .github-nameplate-cta {
+  color: var(--accent, #1db954);
+}
+.github-nameplate-text {
+  white-space: nowrap;
+}
+.github-nameplate-cta {
+  color: var(--text, #e6e6e6);
+  transition: color 0.15s ease;
+}
+@media (max-width: 860px) {
+  .github-nameplate {
+    margin-top: 24px;
+  }
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -15,6 +15,7 @@ import { PanSouConfigForm } from "../../components/pansou-config-form";
 import { DailySweepForm } from "../../components/daily-sweep-form";
 import { PasswordChangeForm } from "../../components/password-change-form";
 import { AccountAdminPanel } from "../../components/account-admin-panel";
+import { GithubNameplate } from "../../components/github-nameplate";
 import {
   getAccountConnectedStorages,
   getAccountScopedSettings,
@@ -104,6 +105,7 @@ export default function SettingsPage({
             </Suspense>
           </>
         )}
+        <GithubNameplate />
       </main>
     </div>
   );

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -15,7 +15,7 @@ import { PanSouConfigForm } from "../../components/pansou-config-form";
 import { DailySweepForm } from "../../components/daily-sweep-form";
 import { PasswordChangeForm } from "../../components/password-change-form";
 import { AccountAdminPanel } from "../../components/account-admin-panel";
-import { GithubNameplate } from "../../components/github-nameplate";
+import { GitHubNameplate } from "../../components/github-nameplate";
 import {
   getAccountConnectedStorages,
   getAccountScopedSettings,
@@ -105,7 +105,7 @@ export default function SettingsPage({
             </Suspense>
           </>
         )}
-        <GithubNameplate />
+        <GitHubNameplate />
       </main>
     </div>
   );

--- a/apps/web/components/github-nameplate.tsx
+++ b/apps/web/components/github-nameplate.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
  *  "this is open source, here's the repo". Shows on both demo and self-hosted
  *  (demo visitors are potential self-hosters too). No star count (new repo,
  *  thin numbers look bleak) — just the GitHub mark + a one-line pitch. */
-export function GithubNameplate() {
+export function GitHubNameplate() {
   return (
     <footer className="github-nameplate">
       <Link
@@ -14,8 +14,8 @@ export function GithubNameplate() {
         rel="noopener noreferrer"
         className="github-nameplate-link"
       >
-        {/* GitHub mark (official simplified path, from github/logos — MIT-spirit
-            brand mark, no copyright concern for a link attribution). */}
+        {/* GitHub mark (simplified inline SVG so we don't pull a brand-icon
+            dependency; used here only as a link attribution marker). */}
         <svg
           width="16"
           height="16"

--- a/apps/web/components/github-nameplate.tsx
+++ b/apps/web/components/github-nameplate.tsx
@@ -11,7 +11,7 @@ export function GithubNameplate() {
       <Link
         href="https://github.com/fancydirty/mediary-scout"
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
         className="github-nameplate-link"
       >
         {/* GitHub mark (official simplified path, from github/logos — MIT-spirit

--- a/apps/web/components/github-nameplate.tsx
+++ b/apps/web/components/github-nameplate.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+/** Small open-source nameplate at the bottom of the Settings page — a quiet
+ * 暗记 + CTA: self-hosters who dig into Settings are exactly the audience for
+ *  "this is open source, here's the repo". Shows on both demo and self-hosted
+ *  (demo visitors are potential self-hosters too). No star count (new repo,
+ *  thin numbers look bleak) — just the GitHub mark + a one-line pitch. */
+export function GithubNameplate() {
+  return (
+    <footer className="github-nameplate">
+      <Link
+        href="https://github.com/fancydirty/mediary-scout"
+        target="_blank"
+        rel="noreferrer"
+        className="github-nameplate-link"
+      >
+        {/* GitHub mark (official simplified path, from github/logos — MIT-spirit
+            brand mark, no copyright concern for a link attribution). */}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          aria-hidden
+          fill="currentColor"
+          style={{ flex: "0 0 auto" }}
+        >
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+        </svg>
+        <span className="github-nameplate-text">
+          Mediary Scout · 开源自部署 · <span className="github-nameplate-cta">GitHub →</span>
+        </span>
+      </Link>
+    </footer>
+  );
+}

--- a/apps/web/lib/demo-seed-gate.test.ts
+++ b/apps/web/lib/demo-seed-gate.test.ts
@@ -12,9 +12,21 @@ async function ensureDemoSeeded(repo: InstanceType<typeof InMemoryWorkflowReposi
 }
 
 describe("ensureDemoSeeded — gated on isDemoMode", () => {
-  const original = process.env.MEDIA_TRACK_DEMO_MODE;
-  beforeEach(() => { delete process.env.MEDIA_TRACK_DEMO_MODE; });
-  afterEach(() => { if (original === undefined) delete process.env.MEDIA_TRACK_DEMO_MODE; else process.env.MEDIA_TRACK_DEMO_MODE = original; });
+  const originalDemoMode = process.env.MEDIA_TRACK_DEMO_MODE;
+  const originalDemoSeed = process.env.MEDIA_TRACK_DEMO_SEED;
+  beforeEach(() => {
+    delete process.env.MEDIA_TRACK_DEMO_MODE;
+    // MEDIA_TRACK_DEMO_SEED="0" short-circuits seeding (docker-compose sets it
+    // for self-hosting). Clear it so the "demo=1 → seeds" test is deterministic
+    // and doesn't depend on whatever the outer test runner inherited.
+    delete process.env.MEDIA_TRACK_DEMO_SEED;
+  });
+  afterEach(() => {
+    if (originalDemoMode === undefined) delete process.env.MEDIA_TRACK_DEMO_MODE;
+    else process.env.MEDIA_TRACK_DEMO_MODE = originalDemoMode;
+    if (originalDemoSeed === undefined) delete process.env.MEDIA_TRACK_DEMO_SEED;
+    else process.env.MEDIA_TRACK_DEMO_SEED = originalDemoSeed;
+  });
 
   it("does NOT seed a fresh self-hosted instance (empty DB, not demo mode)", async () => {
     const repo = new InMemoryWorkflowRepository();
@@ -37,5 +49,14 @@ describe("ensureDemoSeeded — gated on isDemoMode", () => {
     const providers = storages.map((s) => s.providerUid).sort();
     expect(providers).toContain("demo115");
     expect(providers).toContain("demoquark");
+  });
+
+  it("respects MEDIA_TRACK_DEMO_SEED=0 even in demo mode (explicit opt-out)", async () => {
+    process.env.MEDIA_TRACK_DEMO_MODE = "1";
+    process.env.MEDIA_TRACK_DEMO_SEED = "0";
+    const repo = new InMemoryWorkflowRepository();
+    await ensureDemoSeeded(repo);
+    const storages = await repo.listConnectedStorages("acct_default");
+    expect(storages.length).toBe(0);
   });
 });

--- a/apps/web/lib/demo-seed-gate.test.ts
+++ b/apps/web/lib/demo-seed-gate.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { InMemoryWorkflowRepository } from "@media-track/workflow";
+
+// isDemoMode reads process.env.MEDIA_TRACK_DEMO_MODE at call time. We toggle it
+// per test to prove the gate.
+async function ensureDemoSeeded(repo: InstanceType<typeof InMemoryWorkflowRepository>) {
+  // Re-import each time so the module-level demoSeedPromise memo doesn't leak
+  // across tests (it would otherwise remember the first call's result forever).
+  vi.resetModules();
+  const mod = await import("./workflow-runtime");
+  return mod.ensureDemoSeeded(repo);
+}
+
+describe("ensureDemoSeeded — gated on isDemoMode", () => {
+  const original = process.env.MEDIA_TRACK_DEMO_MODE;
+  beforeEach(() => { delete process.env.MEDIA_TRACK_DEMO_MODE; });
+  afterEach(() => { if (original === undefined) delete process.env.MEDIA_TRACK_DEMO_MODE; else process.env.MEDIA_TRACK_DEMO_MODE = original; });
+
+  it("does NOT seed a fresh self-hosted instance (empty DB, not demo mode)", async () => {
+    const repo = new InMemoryWorkflowRepository();
+    await ensureDemoSeeded(repo);
+    // No demo drives should have been inserted into any account.
+    const storages = await repo.listConnectedStorages("acct_default");
+    expect(storages.length).toBe(0);
+    // And no tracked seasons.
+    const tracked = await repo.listTrackedSeasonStates({ accountId: "acct_default", connectedStorageId: null });
+    expect(tracked.length).toBe(0);
+  });
+
+  it("DOES seed when MEDIA_TRACK_DEMO_MODE=1 (the public demo deploy)", async () => {
+    process.env.MEDIA_TRACK_DEMO_MODE = "1";
+    const repo = new InMemoryWorkflowRepository();
+    await ensureDemoSeeded(repo);
+    const storages = await repo.listConnectedStorages("acct_default");
+    expect(storages.length).toBeGreaterThan(0);
+    // The demo drives are named demo115/demoquark.
+    const providers = storages.map((s) => s.providerUid).sort();
+    expect(providers).toContain("demo115");
+    expect(providers).toContain("demoquark");
+  });
+});

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -72,6 +72,7 @@ import {
 import { findDemoCandidateById, findDemoCandidateByTmdbId } from "./demo-candidates";
 import { seedDemoWorkflowRepository } from "./demo-workflow";
 import { resolveRegistration, deriveBootstrapState, canManageAccounts } from "./account-bootstrap";
+import { isDemoMode } from "./demo-mode";
 
 export type CandidateTrackingRequestResult =
   | {
@@ -470,6 +471,16 @@ export async function getCurrentAccountId(): Promise<string> {
 }
 
 export async function ensureDemoSeeded(targetRepository: WorkflowRepository): Promise<void> {
+  // Only the public read-only demo deploy should ever be seeded. Without this
+  // gate, a fresh SELF-HOSTED instance (empty DB) would get demo fake drives
+  // (demo115/demoquark) + fake tracked titles auto-inserted into acct_default on
+  // first page load — confusing garbage that looks like the owner bound real
+  // drives. prod with real data skips via seedDemoIfEmpty's emptiness check, but
+  // a brand-new self-host hits the empty branch. Gate on isDemoMode() so only the
+  // Vercel demo (MEDIA_TRACK_DEMO_MODE=1) seeds.
+  if (!isDemoMode()) {
+    return;
+  }
   if (process.env.MEDIA_TRACK_DEMO_SEED === "0") {
     return;
   }

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -475,9 +475,8 @@ export async function ensureDemoSeeded(targetRepository: WorkflowRepository): Pr
   // gate, a fresh SELF-HOSTED instance (empty DB) would get demo fake drives
   // (demo115/demoquark) + fake tracked titles auto-inserted into acct_default on
   // first page load — confusing garbage that looks like the owner bound real
-  // drives. prod with real data skips via seedDemoIfEmpty's emptiness check, but
-  // a brand-new self-host hits the empty branch. Gate on isDemoMode() so only the
-  // Vercel demo (MEDIA_TRACK_DEMO_MODE=1) seeds.
+  // drives. Gate on isDemoMode() so only the Vercel demo (MEDIA_TRACK_DEMO_MODE=1)
+  // reaches the emptiness check below; non-demo instances never seed.
   if (!isDemoMode()) {
     return;
   }


### PR DESCRIPTION
## 两件小事(作者实测 + 头脑风暴产出)

### 修 1: `ensureDemoSeeded` 加 `isDemoMode()` 守门

**问题:** `ensureDemoSeeded`(`workflow-runtime.ts`)只看「DB 空不空」不看「是不是 demo 模式」。全新自部署实例(空库)首次访问首页时,给 `acct_default` 种 `demo115`/`demoquark` 假盘 + 假追踪——看起来像站主绑了真盘的误导垃圾。prod 不暴露(有真实数据跳过 `seedDemoIfEmpty` 的空判断),但任何全新部署必中一次(dev 实测时作者就被误导过,以为站主绑了 103164004 真盘,其实是 demo 假盘 `demo115`)。

**修:** 函数开头加 `if (!isDemoMode()) return;` —— 只有 Vercel demo(`MEDIA_TRACK_DEMO_MODE=1`)才种。

**TDD:** `demo-seed-gate.test.ts` 2 测 —— 非 demo 空 repo 不种(0 盘 0 追踪) / `MEDIA_TRACK_DEMO_MODE=1` 种 `demo115`+`demoquark`。

### 修 2: 设置页底部加 GitHub 铭牌

**背景:** 很多开源自部署项目 web UI 角落放 GitHub 小标,既是暗记(懂的人知道开源、能找源码)也是 CTA(引流 star/PR)。Mediary Scout 公开了 `fancydirty/mediary-scout`,现有 GitHub 链接只在 demo 横幅里(自部署版完全没有)。

**brainstorm 拍板:** 放设置页底部(自部署者翻设置 = 目标受众,不喧宾夺主、不破布局)/ GitHub 图标 + 文字「Mediary Scout · 开源自部署 · GitHub →」/ demo + 自部署都显(demo 访客是潜在自部署者)。lucide-react 此版本无 Github 图标 → inline SVG(官方简化 mark)。

**实现:** 新组件 `GithubNameplate`(`components/github-nameplate.tsx`)+ 设置页 `</main>` 前挂载(在 demo/非 demo 两分支外,都显)+ CSS(灰小字、hover 变 accent、移动端 margin 调)。纯加法,无纯逻辑可单测。

## 验证
- tsc + 129 apps/web 单测全过 + eslint 净
- ⏳ live 验(铭牌真渲染 + 移动端不溢出)待家庭网络恢复(路由器 `media-router` 暂时不可达,ping 100% 丢包);代码侧已绿,部署后肉眼一看即知

## 范围不含
- demo 横幅、其它页面的 GitHub 链接(只加设置页底部一处,符合暗记定位)
- star 计数(YAGNI,新 repo 星少显象激薄)