### PR TITLE
docs(readme): 加「让 agent 帮你部署」提示词(EN+zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You are deploying Mediary Scout, a self-hosted media-acquisition agent. Follow t
 - `git clone https://github.com/fancydirty/mediary-scout && cd mediary-scout`
 - `docker compose up -d` (first build takes a few minutes)
 - If multi-user: add `MEDIA_TRACK_MULTI_USER=1` to `.env`, then `docker compose up -d web`
-- If Cloudflare Tunnel: follow docs/deploy.md §"方式二" — create the tunnel in the Zero Trust dashboard, put the token in `.env`, `docker compose --profile tunnel up -d`, and **add Cloudflare Access** (never expose the instance without auth)
+- If Cloudflare Tunnel: follow docs/deploy.md §"方式二" — create the tunnel in the Zero Trust dashboard, put the token in `.env` as `TUNNEL_TOKEN=...`, `docker compose --profile tunnel up -d`, and **add Cloudflare Access** (never expose the instance without auth)
 - If build acceleration: `docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com` + a registry mirror in `/etc/docker/daemon.json`
 - Open `http://<host>:3000`, walk the user through Settings (drive / LLM / optional extras)
 - Verify it's up, report the URL, and tell them how to upgrade (`git pull && docker compose up -d --build`)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,41 @@ Then open the web UI and, in **Settings**, provide what you want to use (all bri
 
 Self-host on a NAS, a router (软路由), a spare PC, or a VPS — and reach it from your phone / TV via **Tailscale** or a **Cloudflare Tunnel** (no public IP needed; never expose `:3000` raw). Full walkthrough: **[docs/deploy.md](docs/deploy.md)**.
 
+### Deploy with an agent
+
+Prefer to have an AI agent (Claude Code, Codex, opencode, …) walk you through it? Paste this prompt into it — it'll ask the right questions, then deploy for you:
+
+````markdown
+You are deploying Mediary Scout, a self-hosted media-acquisition agent. Follow the repo's docs/deploy.md. Ask the user the questions below IN ORDER, then execute.
+
+## MUST ask (don't start without answers)
+1. **Where are you deploying?** Which machine (NAS / router / spare PC / VPS), and how do I operate it — SSH in, or run commands on its local terminal?
+2. **Single-user or multi-user?** Default single-user (just you). Multi-user lets family/friends each register, bind their own drives, and keep separate libraries.
+
+## SHOULD ask (have defaults, but confirm preference)
+3. **Local-only, or reach it from outside?**
+   - Local network only (default — open `http://<host>:3000` from devices on the same LAN)
+   - Tailscale (private mesh — recommended for home; no public IP, auto-encrypted)
+   - Cloudflare Tunnel (public HTTPS like `https://media.yourdomain.com` — needs a domain on Cloudflare + Access in front)
+4. **Configure real acquisition now, or just get it running first?** Real acquisition needs a 115/Quark drive + an LLM endpoint (OpenAI-compatible) + 115 directory CIDs. Skipping means it boots and you can look around, configure later in Settings.
+
+## OPTIONAL — one question, skip all if the user doesn't care
+5. Any of these you want to set up now? Reply "none" to skip and use defaults:
+   - Push notifications (Bark / Server酱 / WeChat Work / webhook)
+   - Your own TMDB key (default: works out of the box via the author's proxy)
+   - Prowlarr magnet aggregation (115 only)
+   - Build acceleration (registry mirror + npm mirror — needed in mainland China)
+
+## Then execute
+- `git clone https://github.com/fancydirty/mediary-scout && cd mediary-scout`
+- `docker compose up -d` (first build takes a few minutes)
+- If multi-user: add `MEDIA_TRACK_MULTI_USER=1` to `.env`, then `docker compose up -d web`
+- If Cloudflare Tunnel: follow docs/deploy.md §"方式二" — create the tunnel in the Zero Trust dashboard, put the token in `.env`, `docker compose --profile tunnel up -d`, and **add Cloudflare Access** (never expose the instance without auth)
+- If build acceleration: `docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com` + a registry mirror in `/etc/docker/daemon.json`
+- Open `http://<host>:3000`, walk the user through Settings (drive / LLM / optional extras)
+- Verify it's up, report the URL, and tell them how to upgrade (`git pull && docker compose up -d --build`)
+````
+
 ## Demo
 
 **🔭 Try it live: [mediary.dirtyfancy.sbs](https://mediary.dirtyfancy.sbs)**

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You are deploying Mediary Scout, a self-hosted media-acquisition agent. Follow t
    - Local network only (default — open `http://<host>:3000` from devices on the same LAN)
    - Tailscale (private mesh — recommended for home; no public IP, auto-encrypted)
    - Cloudflare Tunnel (public HTTPS like `https://media.yourdomain.com` — needs a domain on Cloudflare + Access in front)
-4. **Configure real acquisition now, or just get it running first?** Real acquisition needs a 115/Quark drive + an LLM endpoint (OpenAI-compatible) + 115 directory CIDs. Skipping means it boots and you can look around, configure later in Settings.
+4. **Configure real acquisition now, or just get it running first?** Real acquisition needs a 115/Quark drive + an LLM endpoint (OpenAI-compatible) + (if using 115) 115 directory CIDs. Skipping means it boots and you can look around, configure later in Settings.
 
 ## OPTIONAL — one question, skip all if the user doesn't care
 5. Any of these you want to set up now? Reply "none" to skip and use defaults:
@@ -137,10 +137,10 @@ You are deploying Mediary Scout, a self-hosted media-acquisition agent. Follow t
 
 ## Then execute
 - `git clone https://github.com/fancydirty/mediary-scout && cd mediary-scout`
+- If build acceleration (mainland China): `docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com` + a registry mirror in `/etc/docker/daemon.json`, **before** the first `up`
 - `docker compose up -d` (first build takes a few minutes)
 - If multi-user: add `MEDIA_TRACK_MULTI_USER=1` to `.env`, then `docker compose up -d web`
-- If Cloudflare Tunnel: follow docs/deploy.md §"方式二" — create the tunnel in the Zero Trust dashboard, put the token in `.env` as `TUNNEL_TOKEN=...`, `docker compose --profile tunnel up -d`, and **add Cloudflare Access** (never expose the instance without auth)
-- If build acceleration: `docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com` + a registry mirror in `/etc/docker/daemon.json`
+- If Cloudflare Tunnel: follow docs/deploy.md §"方式二" — create the tunnel in the Zero Trust dashboard, put the token in `.env` as `TUNNEL_TOKEN=<your-token>`, `docker compose --profile tunnel up -d`, and **add Cloudflare Access** (never expose the instance without auth)
 - Open `http://<host>:3000`, walk the user through Settings (drive / LLM / optional extras)
 - Verify it's up, report the URL, and tell them how to upgrade (`git pull && docker compose up -d --build`)
 ````

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,7 +126,7 @@ docker compose up -d
    - 只在局域网(默认——同 WiFi 下设备开 `http://<主机IP>:3000`)
    - Tailscale(私有 mesh——家用推荐,无公网 IP、自动加密)
    - Cloudflare Tunnel(公网 HTTPS 如 `https://media.yourdomain.com`——需 Cloudflare 托管域名 + Access 前置鉴权)
-4. **现在就配真实获取,还是先起来看看?** 真实获取需要 115/夸克网盘 + LLM 端点(OpenAI 兼容)+ 115 目录 CID。先不配也能起来看 UI,后续在设置页配。
+4. **现在就配真实获取,还是先起来看看?** 真实获取需要 115/夸克网盘 + LLM 端点(OpenAI 兼容)+ (用 115 时)115 目录 CID。先不配也能起来看 UI,后续在设置页配。
 
 ## 可选——一句话问,都不需要就跳过用默认
 5. 这些可选增强有想现在配的吗?都不需要就回"跳过":
@@ -137,10 +137,10 @@ docker compose up -d
 
 ## 然后执行
 - `git clone https://github.com/fancydirty/mediary-scout && cd mediary-scout`
+- 国内构建加速(首次 `up` **之前**):`docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com` + `/etc/docker/daemon.json` 配 registry mirror
 - `docker compose up -d`(首次构建几分钟)
 - 多账号:在 `.env` 加 `MEDIA_TRACK_MULTI_USER=1`,再 `docker compose up -d web`
-- Cloudflare Tunnel:按 docs/deploy.md §"方式二"——在 Zero Trust 控制台建隧道、把 token 写进 `.env` 的 `TUNNEL_TOKEN=`、`docker compose --profile tunnel up -d`,并**务必加 Cloudflare Access**(别裸挂公网)
-- 国内构建加速:`docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com` + `/etc/docker/daemon.json` 配 registry mirror
+- Cloudflare Tunnel:按 docs/deploy.md §"方式二"——在 Zero Trust 控制台建隧道、把 token 写进 `.env` 的 `TUNNEL_TOKEN=<你的-token>`、`docker compose --profile tunnel up -d`,并**务必加 Cloudflare Access**(别裸挂公网)
 - 打开 `http://<主机>:3000`,带用户走设置页(网盘 / LLM / 可选项)
 - 确认起来、报 URL、告诉怎么升级(`git pull && docker compose up -d --build`)
 ````

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,6 +110,41 @@ docker compose up -d
 
 自部署到 NAS、软路由、闲置 PC 或 VPS,并经 **Tailscale** 或 **Cloudflare Tunnel** 从手机 / 电视访问(无需公网 IP;别把 `:3000` 裸暴露)。完整教程:**[docs/deploy.md](docs/deploy.md)**。
 
+### 让 agent 帮你部署
+
+想让 AI agent(Claude Code、Codex、opencode 等)带你走?把下面这段提示词丢给它——它会问对问题、然后替你部署:
+
+````markdown
+你要部署 Mediary Scout,一个自部署的媒体获取 agent。按仓库 docs/deploy.md 来。按下面顺序问用户,然后执行。
+
+## 必问(没答案别开始)
+1. **部署到哪台机器?** NAS / 软路由 / 闲置 PC / VPS,以及我怎么操作它——SSH 进去,还是在它本机终端跑命令?
+2. **单账号还是多账号?** 默认单账号(就你自己用)。多账号让家人/朋友各注册、各绑自己的网盘、各看各的库。
+
+## 建议问(有默认,但确认偏好)
+3. **只在局域网用,还是出门也要用?**
+   - 只在局域网(默认——同 WiFi 下设备开 `http://<主机IP>:3000`)
+   - Tailscale(私有 mesh——家用推荐,无公网 IP、自动加密)
+   - Cloudflare Tunnel(公网 HTTPS 如 `https://media.yourdomain.com`——需 Cloudflare 托管域名 + Access 前置鉴权)
+4. **现在就配真实获取,还是先起来看看?** 真实获取需要 115/夸克网盘 + LLM 端点(OpenAI 兼容)+ 115 目录 CID。先不起来也能看 UI,后续在设置页配。
+
+## 可选——一句话问,都不需要就跳过用默认
+5. 这些可选增强有想现在配的吗?都不需要就回"跳过":
+   - 通知推送(Bark / Server酱 / 企微 / webhook)
+   - 自己的 TMDB key(不配默认经作者代理开箱即用)
+   - Prowlarr 磁力聚合(115 专属)
+   - 国内构建加速(registry mirror + npm 镜像)
+
+## 然后执行
+- `git clone https://github.com/fancydirty/mediary-scout && cd mediary-scout`
+- `docker compose up -d`(首次构建几分钟)
+- 多账号:在 `.env` 加 `MEDIA_TRACK_MULTI_USER=1`,再 `docker compose up -d web`
+- Cloudflare Tunnel:按 docs/deploy.md §"方式二"——在 Zero Trust 控制台建隧道、token 放 `.env`、`docker compose --profile tunnel up -d`,并**务必加 Cloudflare Access**(别裸挂公网)
+- 国内构建加速:`docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com` + `/etc/docker/daemon.json` 配 registry mirror
+- 打开 `http://<主机>:3000`,带用户走设置页(网盘 / LLM / 可选项)
+- 确认起来、报 URL、告诉怎么升级(`git pull && docker compose up -d --build`)
+````
+
 ## Demo
 
 **🔭 在线体验:[mediary.dirtyfancy.sbs](https://mediary.dirtyfancy.sbs)**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,7 +126,7 @@ docker compose up -d
    - 只在局域网(默认——同 WiFi 下设备开 `http://<主机IP>:3000`)
    - Tailscale(私有 mesh——家用推荐,无公网 IP、自动加密)
    - Cloudflare Tunnel(公网 HTTPS 如 `https://media.yourdomain.com`——需 Cloudflare 托管域名 + Access 前置鉴权)
-4. **现在就配真实获取,还是先起来看看?** 真实获取需要 115/夸克网盘 + LLM 端点(OpenAI 兼容)+ 115 目录 CID。先不起来也能看 UI,后续在设置页配。
+4. **现在就配真实获取,还是先起来看看?** 真实获取需要 115/夸克网盘 + LLM 端点(OpenAI 兼容)+ 115 目录 CID。先不配也能起来看 UI,后续在设置页配。
 
 ## 可选——一句话问,都不需要就跳过用默认
 5. 这些可选增强有想现在配的吗?都不需要就回"跳过":
@@ -139,7 +139,7 @@ docker compose up -d
 - `git clone https://github.com/fancydirty/mediary-scout && cd mediary-scout`
 - `docker compose up -d`(首次构建几分钟)
 - 多账号:在 `.env` 加 `MEDIA_TRACK_MULTI_USER=1`,再 `docker compose up -d web`
-- Cloudflare Tunnel:按 docs/deploy.md §"方式二"——在 Zero Trust 控制台建隧道、token 放 `.env`、`docker compose --profile tunnel up -d`,并**务必加 Cloudflare Access**(别裸挂公网)
+- Cloudflare Tunnel:按 docs/deploy.md §"方式二"——在 Zero Trust 控制台建隧道、把 token 写进 `.env` 的 `TUNNEL_TOKEN=`、`docker compose --profile tunnel up -d`,并**务必加 Cloudflare Access**(别裸挂公网)
 - 国内构建加速:`docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com` + `/etc/docker/daemon.json` 配 registry mirror
 - 打开 `http://<主机>:3000`,带用户走设置页(网盘 / LLM / 可选项)
 - 确认起来、报 URL、告诉怎么升级(`git pull && docker compose up -d --build`)


### PR DESCRIPTION
## 给 README 加一段部署提示词

用户把这段提示词丢给 AI agent(Claude Code / Codex / opencode),agent 就会引导用户完成 Mediary Scout 部署。

## 三问分层(头脑风暴拍板)

**必问(blocker,没答案别开始):**
1. 部署到哪台机器 + 怎么操作它(SSH / 本机终端)
2. 单账号还是多账号(默认单账号,但这是产品形态核心决策)

**建议问(有默认,确认偏好):**
3. 只在局域网 / Tailscale / Cloudflare Tunnel(选 CF 会带出域名+Access 子流程)
4. 现在配真实获取(需 115+LLM+CID)还是先起来看 UI

**可选聚合一句(不关心就跳过用默认):**
5. 通知推送 / 自己的 TMDB key / Prowlarr / 国内构建加速

## 改动
- `README.md`(英文)Deploy 节后加 "Deploy with an agent" 子节
- `README.zh-CN.md` 部署节后加 "让 agent 帮你部署" 子节
- 纯文档,无代码/测试改动

## 范围不含
- 不改 docs/deploy.md(完整教程已在,提示词指向它)
- 不改 Quick start(给想自己跑的人;agent 路径是补充)