### PR TITLE
fix(deploy): 连不上 Docker Hub 时 build 第一步就卡死(#46)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ MEDIA_TRACK_STORAGE_ADAPTER=fake
 MEDIA_TRACK_WORKER_SECRET=
 # Default public PanSou service. Replace this with your own deployment URL if you self-host.
 PANSOU_BASE_URL=https://so.252035.xyz
+# The bundled pansou container image (from ghcr.io). If ghcr is blocked (mainland
+# China) and you can't pull it even with a Docker Hub mirror, point this at a ghcr
+# mirror/proxy, e.g. PANSOU_IMAGE=ghcr.nju.edu.cn/fish2018/pansou-web:latest
+# PANSOU_IMAGE=ghcr.io/fish2018/pansou-web:latest
 # Your authenticated 115 cookie string
 # IMPORTANT: Wrap in double quotes! The cookie contains semicolons which
 # break shell parsing when loaded via `source .env`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
-# syntax=docker/dockerfile:1
 # media-track self-host image: Next.js app + in-process queue worker
 # (started via apps/web/instrumentation.ts). One container = web + worker.
+#
+# No `# syntax=docker/dockerfile:1` on purpose: this image uses only baseline
+# Dockerfile features (multi-stage, COPY --from, ARG), so the external frontend
+# buys us nothing — and that directive forces BuildKit to fetch the frontend image
+# from Docker Hub at build start, which (a) is the FIRST thing to fail when Hub is
+# unreachable and (b) can bypass a configured registry mirror. Dropping it keeps the
+# whole build on the mirror once one is set. (See #46.)
 
 FROM node:22-slim AS builder
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ cp .env.example .env   # optional — most config can be set in the UI
 docker compose up -d
 ```
 
+> 🇨🇳 **Can't reach Docker Hub (mainland China)?** A first build failing with `auth.docker.io ... i/o timeout` / `DeadlineExceeded` means Docker Hub is blocked — **configure a registry mirror first** (Docker Desktop and Linux differ): see **[docs/deploy.md → registry mirror](docs/deploy.md#国内构建加速连不上-docker-hub)**.
+
 Then open the web UI and, in **Settings**, provide what you want to use (all bring-your-own):
 
 - **A drive** — connect 115 or Quark (QR-scan login, or paste a cookie).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,6 +99,8 @@ cp .env.example .env   # 可选——大多数配置可在 UI 里填
 docker compose up -d
 ```
 
+> 🇨🇳 **国内连不上 Docker Hub?** 首次构建报 `auth.docker.io ... i/o timeout` / `DeadlineExceeded` = Docker Hub 被墙,**先配镜像加速**(Docker Desktop 与 Linux 方式不同):见 **[docs/deploy.md → 国内构建加速](docs/deploy.md#国内构建加速连不上-docker-hub)**。
+
 打开 web UI,在**设置**里按需提供(全部自带):
 
 - **网盘** —— 连 115 或夸克(扫码登录,或粘贴 cookie)。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
     restart: unless-stopped
 
   pansou:
-    image: ghcr.io/fish2018/pansou-web:latest
+    # From ghcr.io — a Docker Hub registry mirror does NOT cover this. If ghcr is
+    # blocked (mainland China), set PANSOU_IMAGE in .env to a ghcr mirror/proxy.
+    image: ${PANSOU_IMAGE:-ghcr.io/fish2018/pansou-web:latest}
     restart: unless-stopped
 
   web:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -139,11 +139,38 @@ Mediary Scout 默认单用户、无登录,公网入口必须靠 Access 这类前
 
 即便开了多用户,也仍建议放在 Tailscale / Cloudflare Access 之后——登录只为隔离用户数据,不是给公网当门禁。
 
-## 国内构建加速
+## 国内构建加速(连不上 Docker Hub)
 
-Docker Hub / ghcr 在国内常连不上,首次 `docker compose up` 构建 / 拉取会卡住:
-- 给 Docker 配 registry mirror(如 `https://docker.1ms.run`,写进 `/etc/docker/daemon.json` 的 `registry-mirrors` 后 `systemctl restart docker`)。
-- 构建 web 镜像时换 npm 源:`docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com`。
+Docker Hub / ghcr 在国内常连不上,首次 `docker compose up` 构建 / 拉取会卡住。典型报错(任一即是此问题):
+
+```
+failed to fetch oauth token: Post "https://auth.docker.io/token": ... i/o timeout
+DeadlineExceeded / dial tcp ...:443: i/o timeout
+```
+
+解决办法是**给 Docker 配一个国内 registry 镜像**。按你的平台来 —— ⚠️ 两者方式不同,别搞混:
+
+**Docker Desktop(macOS / Windows)** — 不是改 `daemon.json` 文件、也没有 `systemctl`:
+1. 打开 **Settings(设置)→ Docker Engine**;
+2. 在那段 JSON 里加上 `registry-mirrors`(和已有字段并列):
+   ```json
+   {
+     "registry-mirrors": ["https://docker.1ms.run"]
+   }
+   ```
+3. **Apply & Restart**(应用并重启),等鲸鱼图标变绿再重试 `docker compose up -d`。
+
+**Linux(含软路由 / NAS,直接装的 Docker Engine)**:把镜像写进 `/etc/docker/daemon.json` 的 `registry-mirrors`,然后 `sudo systemctl restart docker`:
+```json
+{ "registry-mirrors": ["https://docker.1ms.run"] }
+```
+
+**npm 也慢的话**,构建时换国内源:
+```bash
+docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com
+```
+
+> 镜像地址会失效/限速,`docker.1ms.run` 只是示例;搜「Docker 镜像加速 可用」找当前能用的即可。配好后整条构建(基础镜像 + 我们的 web 镜像)都会走镜像 —— 本仓库 Dockerfile 已**特意不写 `# syntax=` 指令**,避免它绕过镜像、第一步就卡死(见 #46)。
 
 作者实测在带镜像加速的软路由(iStoreOS)上一把过。
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -11,7 +11,7 @@
 - [可选增强](#可选增强)
 - [从你的设备访问](#从你的设备访问)
 - [安全](#安全)
-- [国内构建加速](#国内构建加速)
+- [国内构建加速](#国内构建加速连不上-docker-hub)
 - [升级](#升级)
 
 ## 选择你的宿主
@@ -141,7 +141,7 @@ Mediary Scout 默认单用户、无登录,公网入口必须靠 Access 这类前
 
 ## 国内构建加速(连不上 Docker Hub)
 
-Docker Hub / ghcr 在国内常连不上,首次 `docker compose up` 构建 / 拉取会卡住。典型报错(任一即是此问题):
+Docker Hub 和 ghcr 在国内常连不上,首次 `docker compose up` 构建 / 拉取会卡住。下面的镜像加速**只解决 Docker Hub**(占绝大多数镜像);来自 ghcr 的 `pansou` 是例外,见本节末尾。典型报错(任一即是此问题):
 
 ```
 failed to fetch oauth token: Post "https://auth.docker.io/token": ... i/o timeout
@@ -170,7 +170,11 @@ DeadlineExceeded / dial tcp ...:443: i/o timeout
 docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com
 ```
 
-> 镜像地址会失效/限速,`docker.1ms.run` 只是示例;搜「Docker 镜像加速 可用」找当前能用的即可。配好后整条构建(基础镜像 + 我们的 web 镜像)都会走镜像 —— 本仓库 Dockerfile 已**特意不写 `# syntax=` 指令**,避免它绕过镜像、第一步就卡死(见 #46)。
+> 镜像地址会失效/限速,`docker.1ms.run` 只是示例;搜「Docker 镜像加速 可用」找当前能用的即可。配好后,所有 **Docker Hub** 镜像(`postgres`、构建 web 用的 `node`、`cloudflared`)都会走镜像 —— 本仓库 Dockerfile 已**特意不写 `# syntax=` 指令**,避免它绕过镜像、第一步就卡死(见 #46)。
+
+**⚠️ 注意 `pansou` 例外**:它来自 **ghcr.io**(`ghcr.io/fish2018/pansou-web`),而 Docker 的 `registry-mirrors` **只对 Docker Hub 生效、管不到 ghcr**。若 ghcr 也连不上,二选一:
+- 在 `.env` 设 `PANSOU_IMAGE=` 指向一个 ghcr 镜像/代理(如 `ghcr.nju.edu.cn/fish2018/pansou-web:latest`,镜像可用性自行确认),再 `docker compose up -d`;
+- 或者不用自带 pansou —— 把 `PANSOU_BASE_URL` 指到一个外部 PanSou 实例,然后 `docker compose up -d web`(不起 pansou 容器)。
 
 作者实测在带镜像加速的软路由(iStoreOS)上一把过。
 


### PR DESCRIPTION
Fixes the root cause behind #46 (first user issue — Mac deploy failed).

## 现象
`docker compose up` 在 **Dockerfile 第 1 行**就炸:
```
failed to fetch oauth token: Post "https://auth.docker.io/token": ... i/o timeout / DeadlineExceeded
```
= Docker Hub 在用户网络(国内)不可达。非代码逻辑 bug,但暴露两个真实部署缺口。

## 两处修复
1. **删掉 `# syntax=docker/dockerfile:1`** —— 本镜像只用基础特性(多阶段 / `COPY --from` / `ARG`),外部 frontend 毫无用处;而该指令强制 BuildKit 在 build 开始就从 Docker Hub 拉 frontend 镜像(用户第一步失败点),且这一步**可能绕过已配的 registry mirror**。删掉后整条 build 都走镜像。`docker build --check` 验证:无 syntax 行仍合法、`node:22-slim` 正常解析。
2. **deploy.md 镜像加速分平台重写** —— 原指引只有 Linux(`/etc/docker/daemon.json` + `systemctl restart docker`),但报告者是 **Mac / Docker Desktop**(Settings → Docker Engine 配 `registry-mirrors`,Apply & Restart,无 systemctl)。新增 Docker Desktop 步骤 + 贴出用户会搜索的报错原文;README(中/英)quick-start 的 `docker compose up` 旁加一行国内连不上指引,免得复制即撞墙。

## 验证
- `docker build --check .` → `Check complete, no warnings found`(无 syntax 行)。
- 纯 docs/Dockerfile 改动,不动应用代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)