### PR TITLE
fix(worker): 未连网盘时后台 worker 静默跳过,不再每 3s 刷 "PAN115_COOKIE is required"

### DIFF
--- a/apps/web/lib/background-worker.test.ts
+++ b/apps/web/lib/background-worker.test.ts
@@ -51,6 +51,33 @@ describe("drainQueueOnce — the in-process queue drainer (one tick)", () => {
     expect(drained).toBe(0);
     expect(runScheduled).toHaveBeenCalledTimes(1);
   });
+
+  // Fresh instance with no drive connected yet: the worker can't acquire anywhere,
+  // so it must skip BOTH drain and sweep QUIETLY — not call them and let them throw
+  // "PAN115_COOKIE is required" every tick, which spammed the logs and made new users
+  // think the deploy was broken.
+  it("skips drain AND sweep quietly when no drive is configured", async () => {
+    const runNext = vi.fn(async () => ({ status: "idle" as const }));
+    const runScheduled = vi.fn(async () => ({ outcomes: [] }));
+    const isDriveConfigured = vi.fn(async () => false);
+
+    const drained = await drainQueueOnce({ runNext, runScheduled, isDriveConfigured });
+
+    expect(drained).toBe(0);
+    expect(isDriveConfigured).toHaveBeenCalledTimes(1);
+    expect(runNext).not.toHaveBeenCalled(); // never tried → no "drain failed" throw
+    expect(runScheduled).not.toHaveBeenCalled(); // never tried → no "daily sweep failed" throw
+  });
+
+  it("drains + sweeps normally when a drive IS configured", async () => {
+    const runNext = vi.fn(async () => ({ status: "idle" as const }));
+    const runScheduled = vi.fn(async () => ({ outcomes: [] }));
+
+    await drainQueueOnce({ runNext, runScheduled, isDriveConfigured: async () => true });
+
+    expect(runNext).toHaveBeenCalledTimes(1);
+    expect(runScheduled).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("startBackgroundWorker — the in-process worker loop (auto-drive)", () => {

--- a/apps/web/lib/background-worker.ts
+++ b/apps/web/lib/background-worker.ts
@@ -19,6 +19,11 @@ export interface DrainDeps {
   runScheduled: () => Promise<unknown>;
   /** Safety cap on runs per tick so a never-idle queue can't spin forever. */
   maxDrains?: number;
+  /** Whether any drive is connected. When provided and false (a fresh instance
+   *  with no 网盘 yet), the tick skips drain + sweep QUIETLY instead of building a
+   *  drive client that throws "PAN115_COOKIE is required" every poll. Optional so
+   *  existing callers/tests behave unchanged (absent ⇒ assume configured). */
+  isDriveConfigured?: (() => Promise<boolean>) | undefined;
 }
 
 /**
@@ -28,6 +33,12 @@ export interface DrainDeps {
  * threw, so a transient queue failure never starves 巡检.
  */
 export async function drainQueueOnce(deps: DrainDeps): Promise<number> {
+  // Fresh instance, no 网盘 connected yet → nothing the worker can do. Skip QUIETLY
+  // (don't call runNext/runScheduled, which would build a drive client and throw
+  // every poll). Resumes automatically once the user connects a drive.
+  if (deps.isDriveConfigured && !(await deps.isDriveConfigured())) {
+    return 0;
+  }
   const maxDrains = deps.maxDrains ?? 50;
   let drained = 0;
   try {
@@ -66,14 +77,19 @@ export interface WorkerRuntime {
   runScheduled: () => Promise<unknown>;
   /** Requeue orphaned "running" runs left by a dead worker; returns the count. */
   recover: () => Promise<number>;
+  /** Whether any drive is connected (gates the tick — see DrainDeps). Optional so
+   *  test runtimes can omit it (absent ⇒ assume configured). */
+  isDriveConfigured?: () => Promise<boolean>;
 }
 
 async function defaultRuntime(): Promise<WorkerRuntime> {
-  const { runNextQueuedWorkflow, runScheduledType3, recoverOrphanedRuns } = await import("./workflow-runtime");
+  const { runNextQueuedWorkflow, runScheduledType3, recoverOrphanedRuns, workerHasConfiguredDrive } =
+    await import("./workflow-runtime");
   return {
     runNext: () => runNextQueuedWorkflow(),
     runScheduled: () => runScheduledType3(),
     recover: () => recoverOrphanedRuns(),
+    isDriveConfigured: () => workerHasConfiguredDrive(),
   };
 }
 
@@ -111,7 +127,11 @@ export function startBackgroundWorker(options?: { pollMs?: number; runtime?: Wor
     running = true;
     try {
       const runtime = await loadRuntime();
-      const drained = await drainQueueOnce({ runNext: runtime.runNext, runScheduled: runtime.runScheduled });
+      const drained = await drainQueueOnce({
+        runNext: runtime.runNext,
+        runScheduled: runtime.runScheduled,
+        isDriveConfigured: runtime.isDriveConfigured,
+      });
       if (drained > 0) {
         console.log(`[background-worker] drained ${drained} queued run(s) this tick`);
       }

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1507,6 +1507,23 @@ async function probeStorageConnection(
   throw new Error(`unknown storage brand: ${provider}`);
 }
 
+/**
+ * Whether the background worker has a drive it could use — i.e. whether
+ * getWorkerStorageExecutor(acct_default) would succeed rather than throw
+ * "PAN115_COOKIE is required". Returns false ONLY in the genuine fresh-deploy case
+ * (adapter "115", no acct_default 网盘 bound, no env cookie), so the worker can skip
+ * QUIETLY instead of spamming the logs every poll. Cheap + non-throwing.
+ */
+export async function workerHasConfiguredDrive(): Promise<boolean> {
+  if ((process.env.MEDIA_TRACK_STORAGE_ADAPTER ?? "fake") !== "115") {
+    return true; // fake/dev executor never needs a cookie
+  }
+  if ((process.env.PAN115_COOKIE ?? "").trim().length > 0) {
+    return true; // legacy env-cookie bootstrap path
+  }
+  return (await getAccountStorageCredentials(DEFAULT_ACCOUNT_ID)) !== null;
+}
+
 async function getWorkerStorageExecutor(
   accountId: string = DEFAULT_ACCOUNT_ID,
   connectedStorageId?: string | null,


### PR DESCRIPTION
修复本地 fresh 部署(无网盘连接)时 web 日志每 3s 刷屏 `[background-worker] drain failed / daily sweep failed: PAN115_COOKIE is required` 的噪音 bug。

## 根因
worker 每 tick 都 eager 构建 acct_default 网盘执行器,无 cookie 时抛:
- `runNextQueuedWorkflow`: 检查队列前就 `getWorkerStorageExecutor()` → 抛
- `runScheduledType3`: 过时间闸 → claim 当天 → 构建执行器抛 → catch 里 release 当天 → 下个 tick 再试 → 无限刷

应用本身正常(200),但新用户 `docker compose logs` 一看满屏 failed 会误以为部署炸了——现在正有真用户涌进来(122 star),这种「看着像炸了其实没事」的噪音,会催生假 issue。

## 修复
加 `workerHasConfiguredDrive()`(adapter≠115 / 有 env cookie / acct_default 有 connected_storage 任一即 true,非抛),经 `WorkerRuntime.isDriveConfigured` 注入 `drainQueueOnce`;无网盘时 tick 静默 `return 0`(不碰 `runNext`/`runScheduled`),连上盘后自动恢复。

TDD(2 新测:无盘静默跳过、有盘照常);**真验:fresh OrbStack 容器 ~14 tick 零刷屏、`/` 仍 200**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)