### PR TITLE
feat(guangya): 接入光鸭云盘作为第三个网盘品牌(磁力/离线优先)

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -73,6 +73,24 @@ export async function connectQuarkAction(cookie: string): Promise<ConnectQuarkAc
   }
 }
 
+/** Settings "添加网盘 → 光鸭": bind a pasted access_token + refresh_token as a new
+ *  drive. Mirrors connectQuarkAction; the token blob is validated + provisioned in
+ *  connectGuangYa (workflow-runtime). */
+export async function connectGuangYaAction(
+  accessToken: string,
+  refreshToken: string,
+): Promise<ConnectQuarkActionResult> {
+  assertNotDemo();
+  try {
+    const { connectGuangYa } = await import("../lib/workflow-runtime");
+    const { providerUid } = await connectGuangYa(accessToken, refreshToken);
+    revalidatePath("/settings");
+    return { ok: true, message: `光鸭云盘已连接（账号 ${providerUid.slice(0, 10)}…）。` };
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
 export interface RequestTrackingActionResult {
   status: "requested" | "already_tracked" | "active_workflow" | "reserved" | "unsupported";
   message: string;

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -328,7 +328,7 @@ async function Pan115Section() {
             {drives.map((drive) => (
               <li key={drive.id} className="setting-row" style={{ justifyContent: "space-between" }}>
                 <span>
-                  {drive.provider === "pan115" ? "115网盘" : drive.provider === "quark" ? "夸克网盘" : drive.provider}
+                  {drive.provider === "pan115" ? "115网盘" : drive.provider === "quark" ? "夸克网盘" : drive.provider === "guangya" ? "光鸭云盘" : drive.provider}
                   <span className="push-help"> · 账号 {drive.providerUid}</span>
                   {drive.connectedAt ? (
                     <span className="push-help"> · 连接于 {drive.connectedAt.slice(0, 16).replace("T", " ")}</span>
@@ -348,7 +348,7 @@ async function Pan115Section() {
                   <TestConnectionButton storageId={drive.id} />
                   <UnbindStorageButton
                     storageId={drive.id}
-                    label={drive.provider === "pan115" ? "115网盘" : drive.provider === "quark" ? "夸克网盘" : drive.provider}
+                    label={drive.provider === "pan115" ? "115网盘" : drive.provider === "quark" ? "夸克网盘" : drive.provider === "guangya" ? "光鸭云盘" : drive.provider}
                   />
                 </span>
               </li>

--- a/apps/web/components/add-drive-brand-tabs.tsx
+++ b/apps/web/components/add-drive-brand-tabs.tsx
@@ -4,8 +4,9 @@ import { useState } from "react";
 import { Pan115QrConnect } from "./pan115-qr-connect";
 import { QuarkQrConnect } from "./quark-qr-connect";
 import { QuarkCookieConnect } from "./quark-cookie-connect";
+import { GuangYaTokenConnect } from "./guangya-token-connect";
 
-type Brand = "pan115" | "quark";
+type Brand = "pan115" | "quark" | "guangya";
 
 /** Settings "添加网盘": pick a brand, then connect it. Both brands scan a QR; 夸克
  *  keeps a collapsed cookie-paste fallback (the QR cookie-exchange is the fragile
@@ -32,9 +33,19 @@ export function AddDriveBrandTabs() {
         >
           夸克网盘
         </button>
+        <button
+          type="button"
+          className={brand === "guangya" ? "primary-button" : "secondary-button"}
+          onClick={() => setBrand("guangya")}
+          aria-pressed={brand === "guangya"}
+        >
+          光鸭云盘
+        </button>
       </div>
       {brand === "pan115" ? (
         <Pan115QrConnect />
+      ) : brand === "guangya" ? (
+        <GuangYaTokenConnect />
       ) : (
         <div>
           <QuarkQrConnect />

--- a/apps/web/components/guangya-token-connect.tsx
+++ b/apps/web/components/guangya-token-connect.tsx
@@ -37,7 +37,7 @@ export function GuangYaTokenConnect() {
       </p>
       <p className="push-help" style={{ marginBottom: 12 }}>
         光鸭云盘{" "}
-        <a href="https://www.guangyun.com/" target="_blank" rel="noopener noreferrer">
+        <a href="https://www.guangyapan.com" target="_blank" rel="noopener noreferrer">
           官网 <ExternalLink size={12} style={{ verticalAlign: "-1px" }} />
         </a>
       </p>

--- a/apps/web/components/guangya-token-connect.tsx
+++ b/apps/web/components/guangya-token-connect.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Check, ExternalLink, LoaderCircle } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { connectGuangYaAction } from "../app/actions";
+
+/**
+ * 光鸭云盘 token 连接 —— 光鸭用 access_token + refresh_token 鉴权(非 cookie)。
+ * 用户从光鸭 app/web 抓出这两个 token 粘进来;refresh_token 用于 401 时自动续期,
+ * 续期后新 token 会持久化回该盘。
+ */
+export function GuangYaTokenConnect() {
+  const router = useRouter();
+  const [accessToken, setAccessToken] = useState("");
+  const [refreshToken, setRefreshToken] = useState("");
+  const [isPending, startTransition] = useTransition();
+  const [result, setResult] = useState<string | null>(null);
+
+  const handleConnect = () => {
+    startTransition(async () => {
+      const res = await connectGuangYaAction(accessToken, refreshToken);
+      setResult(res.ok ? `✅ ${res.message}` : `❌ ${res.message}`);
+      if (res.ok) {
+        setAccessToken("");
+        setRefreshToken("");
+        router.refresh();
+      }
+    });
+  };
+
+  return (
+    <div className="push-form">
+      <p className="panel-note" style={{ marginBottom: 6 }}>
+        从光鸭云盘 app/网页端的登录态中复制 <code>access_token</code> 与 <code>refresh_token</code>，分别粘到下面两个框。
+        access_token 用于鉴权，refresh_token 在过期时自动续期（续期后新 token 会自动保存）。
+      </p>
+      <p className="push-help" style={{ marginBottom: 12 }}>
+        光鸭云盘{" "}
+        <a href="https://www.guangyun.com/" target="_blank" rel="noopener noreferrer">
+          官网 <ExternalLink size={12} style={{ verticalAlign: "-1px" }} />
+        </a>
+      </p>
+      <textarea
+        className="setting-control"
+        value={accessToken}
+        onChange={(event) => setAccessToken(event.target.value)}
+        placeholder="粘贴 access_token（形如 eyJ…）"
+        aria-label="光鸭 access_token"
+        rows={3}
+        style={{ width: "100%", fontFamily: "monospace", fontSize: 12, resize: "vertical" }}
+      />
+      <textarea
+        className="setting-control"
+        value={refreshToken}
+        onChange={(event) => setRefreshToken(event.target.value)}
+        placeholder="粘贴 refresh_token"
+        aria-label="光鸭 refresh_token"
+        rows={3}
+        style={{ width: "100%", fontFamily: "monospace", fontSize: 12, resize: "vertical", marginTop: 8 }}
+      />
+      <div className="setting-row" style={{ marginTop: 10 }}>
+        <button
+          type="button"
+          className="primary-button"
+          onClick={handleConnect}
+          disabled={isPending || !accessToken.trim() || !refreshToken.trim()}
+        >
+          {isPending ? <LoaderCircle size={14} className="spin" aria-hidden /> : <Check size={14} aria-hidden />}
+          连接光鸭
+        </button>
+      </div>
+      {result ? (
+        <p className="panel-note" style={{ marginTop: 10 }}>
+          {result}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1578,7 +1578,13 @@ export async function testConnection(
   }
   const brand = getStorageBrand(creds.provider);
   try {
-    await probeStorageConnection(creds.provider, creds.cookie, creds.rootCid, creds.credential);
+    await probeStorageConnection(
+      creds.provider,
+      creds.cookie,
+      creds.rootCid,
+      creds.credential,
+      makeGuangYaTokenPersister(accountId, creds.id),
+    );
     await getWorkflowRepository().setConnectedStorageStatus(creds.id, "active", null, null);
     return { ok: true, status: "active", message: "连接正常。" };
   } catch (error) {
@@ -1599,6 +1605,9 @@ async function probeStorageConnection(
   cookie: string,
   rootCid: string | null,
   credential: GuangYaCredential | null,
+  // Persist rotated tokens if validateToken() refreshes during the probe. Wired by
+  // testConnection (an existing drive). Omitted at first-connect (no row yet).
+  onTokensRefreshed?: ((creds: unknown) => Promise<void>) | undefined,
 ): Promise<void> {
   const { Pan115CookieClient, QuarkCookieClient } = await import("@media-track/workflow");
   if (provider === "guangya") {
@@ -1611,6 +1620,9 @@ async function probeStorageConnection(
       // doesn't mint a fresh one (harmless today — validate is account-host — but
       // consistent with the rest of the brand's device-pinning).
       ...(credential?.deviceId === undefined ? {} : { deviceId: credential.deviceId }),
+      // A 401 during the probe refreshes the token pair; persist it so the DB
+      // doesn't keep a stale token that later wrongly freezes the drive.
+      ...(onTokensRefreshed ? { onTokensRefreshed } : {}),
     }).validateToken();
     return;
   }
@@ -2240,13 +2252,16 @@ export async function connectGuangYa(rawAccessToken: string, rawRefreshToken: st
   const payload = { accessToken, refreshToken, deviceId, meta: { connectedAt: new Date().toISOString() } };
   if (decision.action === "refresh" && existing) {
     // Same account re-bind → refresh the token blob, keep the resolved CIDs.
+    // Reuse the already-pinned deviceId (风控: a re-bind must NOT look like a new
+    // device); only fall back to the freshly-generated one if the drive has none.
+    const pinnedDeviceId = (existing.payload as { deviceId?: string } | null)?.deviceId ?? deviceId;
     await repository.upsertConnectedStorage({
       id: existing.id,
       accountId,
       provider: "guangya",
       providerUid,
       label: existing.label,
-      payload,
+      payload: { accessToken, refreshToken, deviceId: pinnedDeviceId, meta: { connectedAt: new Date().toISOString() } },
       rootCid: existing.rootCid,
       moviesCid: existing.moviesCid,
       tvCid: existing.tvCid,

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -43,7 +43,10 @@ import {
   getStorageBrand,
   isRegisteredStorageProvider,
   brandSupportsProwlarr,
+  allowedResourceTypesForKinds,
   parseQuarkUid,
+  parseGuangYaUid,
+  GuangYaClient,
   type ResolveAccountWorkerContext,
   hashPassword,
   verifyPassword,
@@ -1260,9 +1263,8 @@ async function getWorkerResourceProvider(
     const kinds: readonly string[] = isRegisteredStorageProvider(provider)
       ? getStorageBrand(provider).resourceProviderKinds
       : ["pansou-115", "prowlarr"];
-    const allowedTypes: ResourceType[] = kinds.includes("pansou-quark")
-      ? ["quark"]
-      : ["115", "magnet"];
+    // 夸克 → quark-only links; 光鸭(磁力) → magnet-only; 115 → 115 + magnet.
+    const allowedTypes: ResourceType[] = allowedResourceTypesForKinds(kinds);
     const providers: Array<{ name: string; provider: ResourceProvider }> = [
       {
         name: "pansou",
@@ -1306,16 +1308,51 @@ async function getWorkerResourceProvider(
 /** §7: the account's 115 credentials (cookie + category CIDs) from its
  *  connected_storages record. null when the account hasn't connected a 115 yet
  *  (then the worker falls back to the legacy env cookie / env CIDs). */
+interface GuangYaCredential {
+  accessToken: string;
+  refreshToken: string;
+  deviceId?: string;
+}
+
 interface AccountStorageCredentials {
   id: string;
   /** The drive's brand — drives executor/probe/resource dispatch (tree model). */
   provider: string;
   status: "active" | "frozen";
+  /** Cookie credential for cookie-auth brands (115/夸克). Empty for token-auth
+   *  brands (光鸭), which carry their token blob in `credential` instead. */
   cookie: string;
+  /** Token blob for token-auth brands (光鸭: {accessToken,refreshToken,deviceId}).
+   *  null for cookie-auth brands. */
+  credential: GuangYaCredential | null;
   rootCid: string | null;
   moviesCid: string | null;
   tvCid: string | null;
   animeCid: string | null;
+}
+
+/** Pull a drive's brand-appropriate credential out of its connected_storage
+ *  payload. 115/夸克 store a cookie string; 光鸭 stores a token blob. Returns a
+ *  presence flag the resolver uses the SAME way it used a non-empty cookie. */
+function extractStorageCredential(
+  provider: string,
+  payload: unknown,
+): { cookie: string; credential: GuangYaCredential | null } {
+  if (provider === "guangya") {
+    const blob = (payload ?? {}) as { accessToken?: string; refreshToken?: string; deviceId?: string };
+    const accessToken = blob.accessToken?.trim() ?? "";
+    const refreshToken = blob.refreshToken?.trim() ?? "";
+    if (!accessToken || !refreshToken) {
+      return { cookie: "", credential: null };
+    }
+    const credential: GuangYaCredential = { accessToken, refreshToken };
+    if (blob.deviceId !== undefined) {
+      credential.deviceId = blob.deviceId;
+    }
+    return { cookie: "", credential };
+  }
+  const cookie = (payload as { cookie?: string } | null)?.cookie?.trim() ?? "";
+  return { cookie, credential: null };
 }
 
 /**
@@ -1323,12 +1360,23 @@ interface AccountStorageCredentials {
  * account root and return the CIDs. Uses an UNRESTRICTED bootstrap executor — a
  * fresh drive has no write scope yet, and the scope is meant to come FROM these
  * dirs (the catch-22 that left 115 drives stuck "目录待建"). Bounded, idempotent
- * (find-or-create, no deletes). 115 root and 夸克 root are both "0".
+ * (find-or-create, no deletes). 115 root and 夸克 root are both "0"; 光鸭 root is "".
  */
 async function provisionDriveCategoryDirs(
   provider: string,
   cookie: string,
+  credential: GuangYaCredential | null,
 ): Promise<{ rootCid: string; moviesCid: string; tvCid: string; animeCid: string }> {
+  if (provider === "guangya") {
+    const executor = createExecutorForBrand({ provider: "guangya", credential: credential ?? {}, scopeCids: [] });
+    return provisionCategoryDirs({
+      baseParentId: "", // 光鸭 account root
+      storage: {
+        listChildDirs: (parentId: string) => executor.listChildDirectories(parentId),
+        createDirectory: (dir) => executor.createDirectory(dir),
+      },
+    });
+  }
   const executor =
     provider === "quark"
       ? createExecutorForBrand({ provider: "quark", cookie, scopeCids: [] })
@@ -1340,6 +1388,57 @@ async function provisionDriveCategoryDirs(
       createDirectory: (dir) => executor.createDirectory(dir),
     },
   });
+}
+
+/**
+ * Build the persist hook handed to a 光鸭 executor: when the client rotates its
+ * token pair (refresh on 401), write the new {accessToken,refreshToken,deviceId}
+ * back into this drive's connected_storage payload so the next run starts from the
+ * fresh tokens. Re-reads the row at call time to preserve its CIDs/label/meta
+ * (mirrors the cookie-refresh upsert in connectGuangYa). Best-effort: a persist
+ * failure is logged, not thrown — the in-memory client keeps the new tokens for
+ * the rest of the run regardless.
+ */
+function makeGuangYaTokenPersister(
+  accountId: string,
+  storageId: string,
+): (creds: unknown) => Promise<void> {
+  return async (creds) => {
+    try {
+      const tokens = (creds ?? {}) as { accessToken?: string; refreshToken?: string; deviceId?: string };
+      if (!tokens.accessToken || !tokens.refreshToken) {
+        return;
+      }
+      const repository = getWorkflowRepository();
+      const drive = (await repository.listConnectedStorages(accountId)).find((s) => s.id === storageId);
+      if (!drive) {
+        console.warn(`[media-track] 光鸭 token refresh: drive ${storageId} vanished, skip persist`);
+        return;
+      }
+      const prevMeta = (drive.payload as { meta?: unknown } | null)?.meta;
+      const payload = {
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        ...(tokens.deviceId === undefined ? {} : { deviceId: tokens.deviceId }),
+        ...(prevMeta === undefined ? {} : { meta: prevMeta }),
+      };
+      await repository.upsertConnectedStorage({
+        id: drive.id,
+        accountId,
+        provider: drive.provider,
+        providerUid: drive.providerUid,
+        label: drive.label,
+        payload,
+        rootCid: drive.rootCid,
+        moviesCid: drive.moviesCid,
+        tvCid: drive.tvCid,
+        animeCid: drive.animeCid,
+        createdAt: drive.createdAt,
+      });
+    } catch (error) {
+      console.error(`[media-track] 光鸭 token refresh persist failed for ${storageId}: ${String(error)}`);
+    }
+  };
 }
 
 async function getAccountStorageCredentials(
@@ -1357,8 +1456,13 @@ async function getAccountStorageCredentials(
           (storage) => storage.id === connectedStorageId && isRegisteredStorageProvider(storage.provider),
         )
       : storages.find((storage) => isRegisteredStorageProvider(storage.provider));
-    const cookie = (drive?.payload as { cookie?: string } | null)?.cookie?.trim();
-    if (!drive || !cookie) {
+    if (!drive) {
+      return null;
+    }
+    const { cookie, credential } = extractStorageCredential(drive.provider, drive.payload);
+    // No usable credential (no cookie for 115/夸克, no token blob for 光鸭) → treat
+    // as not-connected, exactly like the old empty-cookie guard.
+    if (!cookie && !credential) {
       return null;
     }
     let { rootCid, moviesCid, tvCid, animeCid } = drive;
@@ -1370,7 +1474,7 @@ async function getAccountStorageCredentials(
     const liveMode = process.env.MEDIA_TRACK_STORAGE_ADAPTER === "115";
     if (liveMode && drive.status === "active" && !(rootCid && moviesCid && tvCid && animeCid)) {
       try {
-        const p = await provisionDriveCategoryDirs(drive.provider, cookie);
+        const p = await provisionDriveCategoryDirs(drive.provider, cookie, credential);
         ({ rootCid, moviesCid, tvCid, animeCid } = p);
         await getWorkflowRepository().upsertConnectedStorage({
           id: drive.id,
@@ -1395,6 +1499,7 @@ async function getAccountStorageCredentials(
       provider: drive.provider,
       status: drive.status,
       cookie,
+      credential,
       rootCid,
       moviesCid,
       tvCid,
@@ -1472,7 +1577,7 @@ export async function testConnection(
   }
   const brand = getStorageBrand(creds.provider);
   try {
-    await probeStorageConnection(creds.provider, creds.cookie, creds.rootCid);
+    await probeStorageConnection(creds.provider, creds.cookie, creds.rootCid, creds.credential);
     await getWorkflowRepository().setConnectedStorageStatus(creds.id, "active", null, null);
     return { ok: true, status: "active", message: "连接正常。" };
   } catch (error) {
@@ -1492,8 +1597,18 @@ async function probeStorageConnection(
   provider: string,
   cookie: string,
   rootCid: string | null,
+  credential: GuangYaCredential | null,
 ): Promise<void> {
   const { Pan115CookieClient, QuarkCookieClient } = await import("@media-track/workflow");
+  if (provider === "guangya") {
+    // Token-auth: validateToken() does account/v1/user/me + refresh-retry on 401;
+    // a dead token pair throws GuangYaAuthError (caller freezes). rootCid unused.
+    await new GuangYaClient({
+      accessToken: credential?.accessToken ?? "",
+      refreshToken: credential?.refreshToken ?? "",
+    }).validateToken();
+    return;
+  }
   if (provider === "quark") {
     await new QuarkCookieClient({ cookie }).listItems({ directoryId: rootCid ?? "0" });
     return;
@@ -1540,6 +1655,18 @@ async function getWorkerStorageExecutor(
       const scopeCids = [creds.rootCid, creds.moviesCid, creds.tvCid, creds.animeCid].filter(
         (cid): cid is string => Boolean(cid),
       );
+      // 光鸭 authenticates with a rotating token blob (not a cookie): pass the
+      // credential + a persist hook so a mid-run refresh writes the new tokens back
+      // into this drive's payload. 115/夸克 keep the cookie path untouched.
+      if (creds.provider === "guangya") {
+        return createExecutorForBrand({
+          provider: "guangya",
+          credential: creds.credential ?? {},
+          scopeCids,
+          env: process.env,
+          onCredentialRefresh: makeGuangYaTokenPersister(accountId, creds.id),
+        });
+      }
       return createExecutorForBrand({
         provider: creds.provider,
         cookie: creds.cookie,
@@ -2070,4 +2197,92 @@ export async function completeQuarkQrLogin(serviceTicket: string): Promise<{ pro
   const { QuarkQrLoginClient } = await import("@media-track/workflow");
   const { cookie } = await new QuarkQrLoginClient().exchangeCookie(serviceTicket);
   return connectQuarkCookie(cookie);
+}
+
+/**
+ * 光鸭云盘:粘贴 access_token + refresh_token 绑定为一块新盘。与 connectQuarkCookie
+ * 同构,只是凭证是 token 二元组(非 cookie)且认证走 validateToken()(account/v1/user/me)
+ * 而非 listItems。validateToken() 返回 sub 作为 providerUid(键 UNIQUE(provider,uid));
+ * token 失效会抛 GuangYaAuthError → 报错返回。绑定/provision/refresh 全镜像夸克路径。
+ */
+export async function connectGuangYa(rawAccessToken: string, rawRefreshToken: string): Promise<{ providerUid: string }> {
+  const accessToken = rawAccessToken.trim();
+  const refreshToken = rawRefreshToken.trim();
+  if (!accessToken || !refreshToken) {
+    throw new Error("请填写光鸭 access_token 与 refresh_token。");
+  }
+  // validateToken() confirms the pair is live AND yields the authoritative sub.
+  const client = new GuangYaClient({ accessToken, refreshToken });
+  let providerUid: string;
+  try {
+    providerUid = await client.validateToken();
+  } catch (error) {
+    throw new Error(
+      `无法用该 token 登录光鸭云盘（请确认 access_token / refresh_token 完整且未过期）：${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const accountId = await getCurrentAccountId();
+  const repository = getWorkflowRepository();
+  const existing = await repository.findConnectedStorageByUid("guangya", providerUid);
+  const decision = resolveStorageBinding({ provider: "guangya", providerUid, accountId, existing });
+  if (decision.action === "reject") {
+    throw new StorageOwnedByOtherAccountError();
+  }
+  const payload = { accessToken, refreshToken, meta: { connectedAt: new Date().toISOString() } };
+  if (decision.action === "refresh" && existing) {
+    // Same account re-bind → refresh the token blob, keep the resolved CIDs.
+    await repository.upsertConnectedStorage({
+      id: existing.id,
+      accountId,
+      provider: "guangya",
+      providerUid,
+      label: existing.label,
+      payload,
+      rootCid: existing.rootCid,
+      moviesCid: existing.moviesCid,
+      tvCid: existing.tvCid,
+      animeCid: existing.animeCid,
+      createdAt: existing.createdAt,
+    });
+    return { providerUid };
+  }
+  // insert: provision the category tree under the 光鸭 root (""). Best-effort — a
+  // failure still stores the connection (worker self-heals/falls back later).
+  let cids: { rootCid: string | null; moviesCid: string | null; tvCid: string | null; animeCid: string | null } = {
+    rootCid: null,
+    moviesCid: null,
+    tvCid: null,
+    animeCid: null,
+  };
+  try {
+    const executor = createExecutorForBrand({
+      provider: "guangya",
+      credential: { accessToken, refreshToken },
+      scopeCids: [],
+    });
+    cids = await provisionCategoryDirs({
+      baseParentId: "", // 光鸭 account root
+      storage: {
+        listChildDirs: (parentId: string) => executor.listChildDirectories(parentId),
+        createDirectory: (dir) => executor.createDirectory(dir),
+      },
+    });
+  } catch (error) {
+    console.error(`[media-track] 光鸭 directory provision failed (will store without CIDs): ${String(error)}`);
+  }
+  const idSuffix = providerUid.replace(/[^A-Za-z0-9]/g, "").slice(0, 48);
+  await repository.upsertConnectedStorage({
+    id: `cs_guangya_${idSuffix}`,
+    accountId,
+    provider: "guangya",
+    providerUid,
+    label: null,
+    payload,
+    rootCid: cids.rootCid,
+    moviesCid: cids.moviesCid,
+    tvCid: cids.tvCid,
+    animeCid: cids.animeCid,
+    createdAt: new Date().toISOString(),
+  });
+  return { providerUid };
 }

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1607,6 +1607,10 @@ async function probeStorageConnection(
     await new GuangYaClient({
       accessToken: credential?.accessToken ?? "",
       refreshToken: credential?.refreshToken ?? "",
+      // Pin the SAME persisted device id as connect/worker so "Test connection"
+      // doesn't mint a fresh one (harmless today — validate is account-host — but
+      // consistent with the rest of the brand's device-pinning).
+      ...(credential?.deviceId === undefined ? {} : { deviceId: credential.deviceId }),
     }).validateToken();
     return;
   }

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -46,6 +46,7 @@ import {
   allowedResourceTypesForKinds,
   parseQuarkUid,
   parseGuangYaUid,
+  generateGuangYaDeviceId,
   GuangYaClient,
   type ResolveAccountWorkerContext,
   hashPassword,
@@ -2211,8 +2212,12 @@ export async function connectGuangYa(rawAccessToken: string, rawRefreshToken: st
   if (!accessToken || !refreshToken) {
     throw new Error("请填写光鸭 access_token 与 refresh_token。");
   }
+  // Pin a stable device id ONCE at connect time. Persisting it (vs. letting the
+  // client auto-generate a fresh one each worker run) keeps the `Did` header
+  // constant across runs, so 光鸭's risk control sees one device, not many.
+  const deviceId = generateGuangYaDeviceId();
   // validateToken() confirms the pair is live AND yields the authoritative sub.
-  const client = new GuangYaClient({ accessToken, refreshToken });
+  const client = new GuangYaClient({ accessToken, refreshToken, deviceId });
   let providerUid: string;
   try {
     providerUid = await client.validateToken();
@@ -2228,7 +2233,7 @@ export async function connectGuangYa(rawAccessToken: string, rawRefreshToken: st
   if (decision.action === "reject") {
     throw new StorageOwnedByOtherAccountError();
   }
-  const payload = { accessToken, refreshToken, meta: { connectedAt: new Date().toISOString() } };
+  const payload = { accessToken, refreshToken, deviceId, meta: { connectedAt: new Date().toISOString() } };
   if (decision.action === "refresh" && existing) {
     // Same account re-bind → refresh the token blob, keep the resolved CIDs.
     await repository.upsertConnectedStorage({
@@ -2257,7 +2262,7 @@ export async function connectGuangYa(rawAccessToken: string, rawRefreshToken: st
   try {
     const executor = createExecutorForBrand({
       provider: "guangya",
-      credential: { accessToken, refreshToken },
+      credential: { accessToken, refreshToken, deviceId },
       scopeCids: [],
     });
     cids = await provisionCategoryDirs({

--- a/packages/workflow/src/acquisition-v2/skill.ts
+++ b/packages/workflow/src/acquisition-v2/skill.ts
@@ -80,6 +80,28 @@ When a 夸克转存 fails with a SYSTEMIC message — "配额不足" / "额度�
   - Verified to cover → process it (move / dedup / mark) and finish. Do NOT keep searching for a "better" one.
   - Does not cover → treat it as a dead candidate, clean its staging residue with deleteFiles, try the next.`;
 
+const DEAD_LINKS_BLACK_BOX_GUANGYA = `# Dead magnets, offline tasks, and black-box resources (光鸭云盘)
+
+## How transfer works on THIS drive (光鸭)
+The drive is 光鸭云盘 — a MAGNET / OFFLINE-DOWNLOAD drive (like 115's offline-task path, NOT a share-link/instant-save drive). Every candidate is a 磁力/离线链接 (磁力 / ed2k / BT). transferCandidate runs resolve_res → create_task → polls the offline task until it lands, then returns the TRUE materialized files (the system rereads for you). Trust THAT, not your prediction.
+
+## 仅磁力 (this is the key difference from 115/夸克)
+光鸭 saves ONLY magnet/offline links — it has NO instant-save and NO share-link 转存. So a 115/夸克/光鸭 分享链 (share link) is NOT supported here: forcing one fails LOUD with "GUANGYA_ONLY_MAGNET". The resource provider only surfaces 磁力 candidates for this drive, so you should never see a share link — but if a candidate is a share rather than a magnet, skip it; it cannot land on 光鸭.
+
+## Dead magnets fail (move on)
+A magnet can be dead: resolve_res returns nothing, or the offline task never materializes (no seeds / removed). 光鸭 surfaces this — when nothing lands, treat the magnet as dead and switch to the NEXT covering 磁力 candidate. A dead magnet is the NORM, never a reason to give up — try the next magnet that covers the need (the system burns through dead ones the same way the 115 offline path does).
+
+## SYSTEMIC BLOCK (别甩锅)
+When a 光鸭 transfer fails with a SYSTEMIC message — "配额不足" / "额度已用完" / "VIP会员" / "登录" / "鉴权" / 离线下载被限 — the resource EXISTS but the ACCOUNT is blocked (quota / auth / VIP). The tool result carries \`systemicBlock: { reason: "..." }\`. **立即停 — DO NOT keep transferring.** Every candidate will fail the same way. Report honestly: the resource was found, the account cannot transfer it (not "no resource"). This is actionable (top up / re-login), never blame the resource.
+
+## Black-box gate (same discipline as 115)
+"Transparent" = the title states size / resolution / episodes / release group. "Black-box / opaque" = a bare name or a vague bundle.
+- If a TRANSPARENT magnet clearly covers the need, select ONLY it and STOP. Do NOT also transfer opaque ones "just in case".
+- ONLY when ZERO transparent candidate covers may you fall back to a black-box one. When you do, your VERY NEXT step after it lands MUST be inspectStaging to VERIFY it actually holds the target — black-box coverage is UNPROVEN until you read the real files.
+  - Verified to cover → process it (move / dedup / mark) and finish. Do NOT keep searching for a "better" one.
+  - Does not cover → treat it as a dead candidate, clean its staging residue with deleteFiles, try the next.
+- For an ongoing show's just-aired episode, a black-box resource whose publish time predates that episode's air time almost certainly does NOT contain it — do not bet on it.`;
+
 const DEDUP = `# Deduplication (keep the larger, by real size)
 
 Overlapping ranges (1-10, 8-13) or a fuller pack on top of what a season already has WILL create duplicate episodes once you extract. When the same episode has more than one file:
@@ -210,6 +232,9 @@ export const SKILL_SECTION_NAMES = Object.keys(SECTIONS) as SkillSectionName[];
 export function getStorageSkill(provider: string): string {
   if (provider === "quark") {
     return DEAD_LINKS_BLACK_BOX_QUARK;
+  }
+  if (provider === "guangya") {
+    return DEAD_LINKS_BLACK_BOX_GUANGYA;
   }
   if (provider === "pan115") {
     return DEAD_LINKS_BLACK_BOX;

--- a/packages/workflow/src/acquisition-v2/task-agents.ts
+++ b/packages/workflow/src/acquisition-v2/task-agents.ts
@@ -61,12 +61,17 @@ export interface TaskAgentPromptOptions {
   storageProvider?: string;
 }
 
-/** A brand-specific transfer-model note. 夸克 differs from 115 (转存分享链 / 无磁力),
- *  so make that explicit; 115 keeps the existing in-prompt guidance (no extra line). */
-function transferModelLine(options: TaskAgentPromptOptions): string {
-  return options.storageProvider === "quark"
-    ? `\nTRANSFER MODEL — 夸克网盘 (this drive): every candidate is a 夸克分享链 (转存分享链, the 秒传 equivalent). 夸克 has NO magnet / offline-download API, so there are NO magnet candidates and a magnet would fail loud (QUARK_NO_MAGNET); ignore any 115/magnet wording — it does not apply here. A dead/expired share fails LOUD (分享不存在 / 已取消 / 已过期 / 提取码错误) — switch to the next covering 夸克分享. Read the "dead-links-black-box" skill section: on this drive it is the 夸克 version.`
-    : "";
+/** A brand-specific transfer-model note. 夸克 differs from 115 (转存分享链 / 无磁力)
+ *  and 光鸭 differs again (磁力/离线, 无秒传/分享转存), so make each explicit; 115 keeps
+ *  the existing in-prompt guidance (no extra line). Exported for unit coverage. */
+export function transferModelLine(options: TaskAgentPromptOptions): string {
+  if (options.storageProvider === "quark") {
+    return `\nTRANSFER MODEL — 夸克网盘 (this drive): every candidate is a 夸克分享链 (转存分享链, the 秒传 equivalent). 夸克 has NO magnet / offline-download API, so there are NO magnet candidates and a magnet would fail loud (QUARK_NO_MAGNET); ignore any 115/magnet wording — it does not apply here. A dead/expired share fails LOUD (分享不存在 / 已取消 / 已过期 / 提取码错误) — switch to the next covering 夸克分享. Read the "dead-links-black-box" skill section: on this drive it is the 夸克 version.`;
+  }
+  if (options.storageProvider === "guangya") {
+    return `\nTRANSFER MODEL — 光鸭云盘 (this drive): every candidate is a 磁力/离线链接 (磁力 / ed2k / BT). transferCandidate runs resolve_res → create_task → 轮询 the offline task until it lands. 光鸭 is MAGNET/OFFLINE-ONLY — there is NO instant-save and NO 分享转存, so a 夸克/115/光鸭 分享链 is NOT supported and fails loud (GUANGYA_ONLY_MAGNET); ignore any 115 instant-save / share-link wording — it does not apply here. A dead magnet (resolve_res 空 / 离线任务无种子不落盘) does not error loudly — trust the staging reread, and on nothing-landed switch to the next covering 磁力 candidate. Read the "dead-links-black-box" skill section: on this drive it is the 光鸭 version.`;
+  }
+  return "";
 }
 
 function languageLine(options: TaskAgentPromptOptions): string {

--- a/packages/workflow/src/guangya-client.test.ts
+++ b/packages/workflow/src/guangya-client.test.ts
@@ -81,6 +81,18 @@ describe("GuangYaClient.validateToken", () => {
       Authorization: `Bearer ${ACCESS}`,
     });
   });
+
+  it("throws when /user/me returns 200 but the body has no sub", async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse(200, { name: "Tester" }));
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    await expect(client.validateToken()).rejects.toBeInstanceOf(GuangYaAuthError);
+  });
 });
 
 describe("GuangYaClient.listFiles", () => {
@@ -123,10 +135,12 @@ describe("GuangYaClient.listFiles", () => {
       Did: "dev123",
       Dt: "4",
     });
-    expect(JSON.parse(ri.body as string)).toMatchObject({
+    expect(JSON.parse(ri.body as string)).toEqual({
       parentId: "p0",
       page: 0,
       pageSize: 100,
+      orderBy: 3,
+      sortType: 1,
       fileTypes: [],
     });
   });

--- a/packages/workflow/src/guangya-client.test.ts
+++ b/packages/workflow/src/guangya-client.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GuangYaFetch } from "./guangya-client.js";
+import {
+  GUANGYA_CLIENT_ID,
+  GuangYaAuthError,
+  GuangYaClient,
+  isGuangYaAuthError,
+  parseGuangYaUid,
+} from "./guangya-client.js";
+
+/** A typed mock fetch so `mock.calls` tuples are `[url, init]` under strict tsc. */
+function mockFetch(impl: GuangYaFetch) {
+  return vi.fn<GuangYaFetch>(impl);
+}
+
+const AUTH_HOST = "https://account.guangyapan.com";
+const API_HOST = "https://api.guangyapan.com";
+
+/** Build a fake JWT whose payload (2nd segment, base64url) carries `payload`. */
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+/** A fetch-Response stub matching what GuangYaClient consumes (status + json()). */
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const ACCESS = makeJwt({ sub: "aj6Qo5l86EF4O2AM" });
+const REFRESH = "refresh-token-0";
+
+describe("parseGuangYaUid", () => {
+  it("extracts sub from a JWT payload", () => {
+    expect(parseGuangYaUid(ACCESS)).toBe("aj6Qo5l86EF4O2AM");
+  });
+
+  it("returns null for a non-JWT string", () => {
+    expect(parseGuangYaUid("not-a-jwt")).toBeNull();
+  });
+});
+
+describe("GuangYaAuthError", () => {
+  it("isGuangYaAuthError narrows the error", () => {
+    expect(isGuangYaAuthError(new GuangYaAuthError("x"))).toBe(true);
+    expect(isGuangYaAuthError(new Error("x"))).toBe(false);
+  });
+});
+
+describe("GUANGYA_CLIENT_ID", () => {
+  it("is the live-validated client id", () => {
+    expect(GUANGYA_CLIENT_ID).toBe("aMe-8VSlkrbQXpUR");
+  });
+});
+
+describe("GuangYaClient.validateToken", () => {
+  it("GETs account/v1/user/me with Bearer and returns sub", async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(200, { sub: "aj6Qo5l86EF4O2AM", name: "Tester" }),
+    );
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    const sub = await client.validateToken();
+
+    expect(sub).toBe("aj6Qo5l86EF4O2AM");
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${AUTH_HOST}/v1/user/me`);
+    expect((init as RequestInit).method ?? "GET").toBe("GET");
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: `Bearer ${ACCESS}`,
+    });
+  });
+});
+
+describe("GuangYaClient.listFiles", () => {
+  it("sends Bearer+Did+Dt:4 to get_file_list and parses data.list (code is null)", async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(200, {
+        code: null,
+        msg: "success",
+        data: {
+          list: [
+            {
+              fileId: "f1",
+              parentId: "p0",
+              fileName: "a.mkv",
+              fileSize: 100,
+              resType: 1,
+            },
+          ],
+        },
+      }),
+    );
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    const items = await client.listFiles("p0");
+
+    expect(items).toEqual([
+      { fileId: "f1", parentId: "p0", fileName: "a.mkv", fileSize: 100, resType: 1 },
+    ]);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${API_HOST}/userres/v1/file/get_file_list`);
+    const ri = init as RequestInit;
+    expect(ri.method).toBe("POST");
+    expect(ri.headers).toMatchObject({
+      Authorization: `Bearer ${ACCESS}`,
+      Did: "dev123",
+      Dt: "4",
+    });
+    expect(JSON.parse(ri.body as string)).toMatchObject({
+      parentId: "p0",
+      page: 0,
+      pageSize: 100,
+      fileTypes: [],
+    });
+  });
+});
+
+describe("GuangYaClient 401 -> refresh -> retry", () => {
+  it("refreshes tokens on 401, retries once, and reports new tokens", async () => {
+    const newAccess = makeJwt({ sub: "aj6Qo5l86EF4O2AM" });
+    const newRefresh = "refresh-token-1";
+    const fetchImpl = mockFetch(async (url: string) => {
+      if (url === `${API_HOST}/userres/v1/file/get_file_list`) {
+        // first call 401, second (after refresh) success
+        if (fetchImpl.mock.calls.filter((c) => c[0] === url).length === 1) {
+          return jsonResponse(401, { msg: "unauthorized" });
+        }
+        return jsonResponse(200, { code: null, msg: "success", data: { list: [] } });
+      }
+      if (url === `${AUTH_HOST}/v1/auth/token`) {
+        return jsonResponse(200, {
+          access_token: newAccess,
+          refresh_token: newRefresh,
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    const onTokensRefreshed = vi.fn();
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      onTokensRefreshed,
+      fetchImpl,
+    });
+
+    const items = await client.listFiles("p0");
+
+    expect(items).toEqual([]);
+    expect(onTokensRefreshed).toHaveBeenCalledWith({
+      accessToken: newAccess,
+      refreshToken: newRefresh,
+      deviceId: "dev123",
+    });
+    // refresh body shape
+    const refreshCall = fetchImpl.mock.calls.find((c) => c[0] === `${AUTH_HOST}/v1/auth/token`);
+    expect(refreshCall).toBeDefined();
+    expect(JSON.parse((refreshCall![1] as RequestInit).body as string)).toEqual({
+      client_id: GUANGYA_CLIENT_ID,
+      grant_type: "refresh_token",
+      refresh_token: REFRESH,
+    });
+    // retry used the refreshed access token
+    const retryCall = fetchImpl.mock.calls.filter(
+      (c) => c[0] === `${API_HOST}/userres/v1/file/get_file_list`,
+    )[1]!;
+    expect((retryCall[1] as RequestInit).headers).toMatchObject({
+      Authorization: `Bearer ${newAccess}`,
+    });
+  });
+
+  it("rejects with GuangYaAuthError when refresh fails", async () => {
+    const fetchImpl = mockFetch(async (url: string) => {
+      if (url === `${API_HOST}/userres/v1/file/get_file_list`) {
+        return jsonResponse(401, { msg: "unauthorized" });
+      }
+      if (url === `${AUTH_HOST}/v1/auth/token`) {
+        return jsonResponse(400, {
+          error: "invalid_grant",
+          error_description: "refresh token expired",
+        });
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    await expect(client.listFiles("p0")).rejects.toBeInstanceOf(GuangYaAuthError);
+  });
+});
+
+describe("GuangYaClient file ops", () => {
+  it("createDir returns data.fileId", async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(200, { code: null, msg: "success", data: { fileId: "newdir" } }),
+    );
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    const fileId = await client.createDir("p0", "Movies");
+
+    expect(fileId).toBe("newdir");
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${API_HOST}/nd.bizuserres.s/v1/file/create_dir`);
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      parentId: "p0",
+      dirName: "Movies",
+    });
+  });
+
+  it("renameFile posts fileId+newName", async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse(200, { msg: "success", data: {} }));
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    await client.renameFile("f1", "b.mkv");
+
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${API_HOST}/nd.bizuserres.s/v1/file/rename`);
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      fileId: "f1",
+      newName: "b.mkv",
+    });
+  });
+
+  it("deleteFiles posts fileIds[]", async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse(200, { msg: "success", data: {} }));
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    await client.deleteFiles(["f1", "f2"]);
+
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${API_HOST}/nd.bizuserres.s/v1/file/delete_file`);
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      fileIds: ["f1", "f2"],
+    });
+  });
+
+  it("moveFiles posts fileIds[]+parentId", async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse(200, { msg: "success", data: {} }));
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    await client.moveFiles(["f1"], "p2");
+
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${API_HOST}/nd.bizuserres.s/v1/file/move_file`);
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      fileIds: ["f1"],
+      parentId: "p2",
+    });
+  });
+});
+
+describe("GuangYaClient offline ops", () => {
+  it("resolveRes posts url and returns data", async () => {
+    const data = {
+      resType: 2,
+      url: "magnet:?xt=urn:btih:abc",
+      btResInfo: {
+        infoHash: "abc",
+        fileName: "Show",
+        subfiles: [{ fileName: "ep1.mkv", fileIndex: 0, fileSize: 100 }],
+      },
+    };
+    const fetchImpl = mockFetch(async () => jsonResponse(200, { code: null, msg: "success", data }));
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    const result = await client.resolveRes("magnet:?xt=urn:btih:abc");
+
+    expect(result).toEqual(data);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${API_HOST}/cloudcollection/v1/resolve_res`);
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      url: "magnet:?xt=urn:btih:abc",
+    });
+  });
+
+  it("createTask posts {url,parentId,newName,fileIndexes?} and returns taskId", async () => {
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(200, { msg: "success", data: { taskId: "t1" } }),
+    );
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    const taskId = await client.createTask({
+      url: "magnet:?xt=urn:btih:abc",
+      parentId: "p0",
+      newName: "Show",
+      fileIndexes: [0, 1],
+    });
+
+    expect(taskId).toBe("t1");
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${API_HOST}/cloudcollection/v1/create_task`);
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      url: "magnet:?xt=urn:btih:abc",
+      parentId: "p0",
+      newName: "Show",
+      fileIndexes: [0, 1],
+    });
+  });
+
+  it("listTask posts taskIds[] and returns data.list", async () => {
+    const tasks = [{ taskId: "t1", status: 2, progress: 100, fileId: "f9" }];
+    const fetchImpl = mockFetch(async () =>
+      jsonResponse(200, { code: null, msg: "success", data: { list: tasks } }),
+    );
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      deviceId: "dev123",
+      fetchImpl,
+    });
+
+    const result = await client.listTask(["t1"]);
+
+    expect(result).toEqual(tasks);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe(`${API_HOST}/cloudcollection/v1/list_task`);
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      taskIds: ["t1"],
+    });
+  });
+});
+
+describe("GuangYaClient deviceId", () => {
+  it("auto-generates a 32 hex deviceId when empty", async () => {
+    const fetchImpl = mockFetch(async () => jsonResponse(200, { msg: "success", data: { list: [] } }));
+    const client = new GuangYaClient({
+      accessToken: ACCESS,
+      refreshToken: REFRESH,
+      fetchImpl,
+    });
+
+    await client.listFiles("p0");
+
+    const did = (fetchImpl.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
+    expect(did.Did).toMatch(/^[0-9a-f]{32}$/);
+  });
+});

--- a/packages/workflow/src/guangya-client.ts
+++ b/packages/workflow/src/guangya-client.ts
@@ -139,8 +139,8 @@ export class GuangYaClient {
         parentId,
         page: currentPage,
         pageSize,
-        orderBy: "fileName",
-        sortType: "asc",
+        orderBy: 3,
+        sortType: 1,
         fileTypes: [],
       });
       const list = arrayValue(recordValue(data, "list")).filter(isRecord);
@@ -229,12 +229,12 @@ export class GuangYaClient {
       await this.refreshTokens();
       return this.postAPI(path, body, true);
     }
-    const json = (await response.json()) as unknown;
+    const json = (await response.json().catch(() => ({}))) as unknown;
     const msg = stringValue(recordValue(json, "msg"));
-    if (msg === "" || msg.toLowerCase() === "success") {
+    if (response.ok && (msg === "" || msg.toLowerCase() === "success")) {
       return recordValue(json, "data");
     }
-    throw new Error(`GUANGYA_API_FAILED: ${path} msg=${msg}`);
+    throw new Error(`GUANGYA_API_FAILED: ${path} status=${response.status} msg=${msg}`);
   }
 
   /**

--- a/packages/workflow/src/guangya-client.ts
+++ b/packages/workflow/src/guangya-client.ts
@@ -1,0 +1,342 @@
+/**
+ * 光鸭云盘 (GuangYaPan) HTTP client — the brand-3 analogue of Pan115CookieClient
+ * and QuarkCookieClient. Unlike those two (cookie auth), 光鸭 uses OAuth Bearer
+ * tokens (access_token + refresh_token) issued by `account.guangyapan.com`.
+ *
+ * Two hosts:
+ *  - account.guangyapan.com — auth (validate user, refresh token). Bearer only.
+ *  - api.guangyapan.com     — files + offline. Bearer + `Did:<deviceId>` + `Dt:4`.
+ *
+ * SUCCESS SIGNAL: `msg === ""` OR `msg.toLowerCase() === "success"`. The `code`
+ * field is null on every response and MUST NOT be used as the signal.
+ *
+ * On a 401 the access_token is stale; we refresh once (POST /v1/auth/token with
+ * the refresh_token) and retry the call. A fresh access/refresh pair is surfaced
+ * via `onTokensRefreshed` so the executor can persist it. The executor that uses
+ * this client (StorageExecutor) is a later task — this file is the API layer only.
+ */
+
+export const GUANGYA_CLIENT_ID = "aMe-8VSlkrbQXpUR";
+
+const AUTH_HOST = "https://account.guangyapan.com";
+const API_HOST = "https://api.guangyapan.com";
+
+const DEFAULT_LIST_PAGE_SIZE = 100;
+
+/** A directory listing entry from get_file_list. */
+export interface GuangYaItem {
+  fileId: string;
+  parentId: string;
+  fileName: string;
+  fileSize: number;
+  resType: number;
+}
+
+/** The token pair (+ the device id they were bound to) handed to the persist hook. */
+export interface GuangYaTokens {
+  accessToken: string;
+  refreshToken: string;
+  deviceId: string;
+}
+
+export type GuangYaFetch = (url: string, init: RequestInit) => Promise<Response>;
+
+export interface GuangYaClientOptions {
+  accessToken: string;
+  refreshToken: string;
+  /** Stable per-install device id sent as the `Did` header. Auto-generated (32 hex) if empty. */
+  deviceId?: string;
+  /** Called after a successful refresh so the caller can persist the new tokens. */
+  onTokensRefreshed?: (tokens: GuangYaTokens) => void | Promise<void>;
+  /** Injectable for tests; defaults to global fetch. */
+  fetchImpl?: GuangYaFetch;
+}
+
+/**
+ * The token pair is dead / refresh failed — distinct from a generic API error so
+ * the worker can FREEZE the drive on this specifically. Mirrors QuarkAuthError /
+ * Pan115AuthError.
+ */
+export class GuangYaAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GuangYaAuthError";
+  }
+}
+
+export function isGuangYaAuthError(error: unknown): error is GuangYaAuthError {
+  return error instanceof GuangYaAuthError;
+}
+
+/**
+ * Decode the `sub` (user id) from a 光鸭 access_token (a JWT). Returns the sub
+ * string, or null when the token is malformed / missing a sub. Keys the
+ * instance-wide UNIQUE(provider, provider_uid).
+ */
+export function parseGuangYaUid(accessToken: string): string | null {
+  const segments = accessToken.split(".");
+  const payloadSegment = segments[1];
+  if (!payloadSegment) {
+    return null;
+  }
+  try {
+    const payloadJson = Buffer.from(payloadSegment, "base64url").toString("utf8");
+    const payload = JSON.parse(payloadJson) as unknown;
+    const sub = recordValue(payload, "sub");
+    return typeof sub === "string" && sub.length > 0 ? sub : null;
+  } catch {
+    return null;
+  }
+}
+
+export class GuangYaClient {
+  private accessToken: string;
+  private refreshToken: string;
+  private readonly deviceId: string;
+  private readonly onTokensRefreshed: ((tokens: GuangYaTokens) => void | Promise<void>) | undefined;
+  private readonly fetchImpl: GuangYaFetch;
+
+  constructor(options: GuangYaClientOptions) {
+    this.accessToken = options.accessToken;
+    this.refreshToken = options.refreshToken;
+    this.deviceId = options.deviceId?.trim() || generateDeviceId();
+    this.onTokensRefreshed = options.onTokensRefreshed;
+    this.fetchImpl = options.fetchImpl ?? ((url, init) => fetch(url, init));
+  }
+
+  /** GET account/v1/user/me (Bearer); refresh+retry once on 401. Returns `sub`. */
+  async validateToken(): Promise<string> {
+    const sub = await this.getMeSub(false);
+    if (!sub) {
+      throw new GuangYaAuthError("GUANGYA_VALIDATE_FAILED: response missing sub");
+    }
+    return sub;
+  }
+
+  private async getMeSub(retried: boolean): Promise<string> {
+    const response = await this.fetchImpl(`${AUTH_HOST}/v1/user/me`, {
+      method: "GET",
+      headers: this.authHeaders(),
+    });
+    if (response.status === 401) {
+      if (retried) {
+        throw new GuangYaAuthError("GUANGYA_VALIDATE_FAILED: 401 after refresh");
+      }
+      await this.refreshTokens();
+      return this.getMeSub(true);
+    }
+    const body = (await response.json()) as unknown;
+    const sub = recordValue(body, "sub");
+    return typeof sub === "string" ? sub : "";
+  }
+
+  /** Paginate get_file_list into a flat GuangYaItem[]. */
+  async listFiles(parentId: string, page = 0, pageSize = DEFAULT_LIST_PAGE_SIZE): Promise<GuangYaItem[]> {
+    const items: GuangYaItem[] = [];
+    let currentPage = page;
+    for (;;) {
+      const data = await this.postAPI("/userres/v1/file/get_file_list", {
+        parentId,
+        page: currentPage,
+        pageSize,
+        orderBy: "fileName",
+        sortType: "asc",
+        fileTypes: [],
+      });
+      const list = arrayValue(recordValue(data, "list")).filter(isRecord);
+      for (const raw of list) {
+        items.push(toItem(raw));
+      }
+      if (list.length < pageSize) {
+        break;
+      }
+      currentPage += 1;
+    }
+    return items;
+  }
+
+  /** Create a directory under `parentId`; returns the new fileId. */
+  async createDir(parentId: string, dirName: string): Promise<string> {
+    const data = await this.postAPI("/nd.bizuserres.s/v1/file/create_dir", { parentId, dirName });
+    const fileId = stringValue(recordValue(data, "fileId"));
+    if (!fileId) {
+      throw new Error("GUANGYA_CREATE_DIR_FAILED: response missing data.fileId");
+    }
+    return fileId;
+  }
+
+  async renameFile(fileId: string, newName: string): Promise<void> {
+    await this.postAPI("/nd.bizuserres.s/v1/file/rename", { fileId, newName });
+  }
+
+  async deleteFiles(fileIds: string[]): Promise<void> {
+    await this.postAPI("/nd.bizuserres.s/v1/file/delete_file", { fileIds });
+  }
+
+  async moveFiles(fileIds: string[], parentId: string): Promise<void> {
+    await this.postAPI("/nd.bizuserres.s/v1/file/move_file", { fileIds, parentId });
+  }
+
+  /** Resolve a share/magnet URL to its resType + (for bt) subfile listing. */
+  async resolveRes(url: string): Promise<unknown> {
+    return this.postAPI("/cloudcollection/v1/resolve_res", { url });
+  }
+
+  /** Create an offline-download task; returns the taskId. */
+  async createTask(input: {
+    url: string;
+    parentId: string;
+    newName: string;
+    fileIndexes?: number[];
+  }): Promise<string> {
+    const body: Record<string, unknown> = {
+      url: input.url,
+      parentId: input.parentId,
+      newName: input.newName,
+    };
+    if (input.fileIndexes !== undefined) {
+      body.fileIndexes = input.fileIndexes;
+    }
+    const data = await this.postAPI("/cloudcollection/v1/create_task", body);
+    const taskId = stringValue(recordValue(data, "taskId"));
+    if (!taskId) {
+      throw new Error("GUANGYA_CREATE_TASK_FAILED: response missing data.taskId");
+    }
+    return taskId;
+  }
+
+  /** Poll the status/progress of offline tasks. */
+  async listTask(taskIds: string[]): Promise<unknown[]> {
+    const data = await this.postAPI("/cloudcollection/v1/list_task", { taskIds });
+    return arrayValue(recordValue(data, "list"));
+  }
+
+  /**
+   * POST to the api host with Bearer + Did + Dt:4. On 401 (once) refresh and
+   * retry. Success = `msg===""||msg==="success"`; otherwise throw (GuangYaAuthError
+   * on 401, plain Error otherwise) carrying the server msg.
+   */
+  private async postAPI(path: string, body: unknown, retried = false): Promise<unknown> {
+    const response = await this.fetchImpl(`${API_HOST}${path}`, {
+      method: "POST",
+      headers: this.apiHeaders(),
+      body: JSON.stringify(body),
+    });
+    if (response.status === 401) {
+      if (retried) {
+        throw new GuangYaAuthError(`GUANGYA_AUTH_FAILED: 401 after refresh (${path})`);
+      }
+      await this.refreshTokens();
+      return this.postAPI(path, body, true);
+    }
+    const json = (await response.json()) as unknown;
+    const msg = stringValue(recordValue(json, "msg"));
+    if (msg === "" || msg.toLowerCase() === "success") {
+      return recordValue(json, "data");
+    }
+    throw new Error(`GUANGYA_API_FAILED: ${path} msg=${msg}`);
+  }
+
+  /**
+   * Exchange the refresh_token for a fresh access (and possibly refresh) token.
+   * Updates in-memory tokens and notifies onTokensRefreshed. Throws
+   * GuangYaAuthError on failure (refresh token dead).
+   */
+  private async refreshTokens(): Promise<void> {
+    const response = await this.fetchImpl(`${AUTH_HOST}/v1/auth/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        client_id: GUANGYA_CLIENT_ID,
+        grant_type: "refresh_token",
+        refresh_token: this.refreshToken,
+      }),
+    });
+    const json = (await response.json()) as unknown;
+    const accessToken = stringValue(recordValue(json, "access_token"));
+    if (!response.ok || !accessToken) {
+      const error = stringValue(recordValue(json, "error"));
+      const description = stringValue(recordValue(json, "error_description"));
+      throw new GuangYaAuthError(
+        `GUANGYA_REFRESH_FAILED: ${error || response.status} ${description}`.trim(),
+      );
+    }
+    this.accessToken = accessToken;
+    const refreshToken = stringValue(recordValue(json, "refresh_token"));
+    if (refreshToken) {
+      this.refreshToken = refreshToken;
+    }
+    if (this.onTokensRefreshed) {
+      await this.onTokensRefreshed({
+        accessToken: this.accessToken,
+        refreshToken: this.refreshToken,
+        deviceId: this.deviceId,
+      });
+    }
+  }
+
+  private authHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${this.accessToken}`,
+    };
+  }
+
+  private apiHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${this.accessToken}`,
+      Did: this.deviceId,
+      Dt: "4",
+    };
+  }
+}
+
+function generateDeviceId(): string {
+  return globalThis.crypto.randomUUID().replace(/-/g, "");
+}
+
+function toItem(raw: Record<string, unknown>): GuangYaItem {
+  return {
+    fileId: stringValue(raw.fileId),
+    parentId: stringValue(raw.parentId),
+    fileName: stringValue(raw.fileName),
+    fileSize: numberValue(raw.fileSize),
+    resType: numberValue(raw.resType),
+  };
+}
+
+function recordValue(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return "";
+}
+
+function numberValue(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/workflow/src/guangya-client.ts
+++ b/packages/workflow/src/guangya-client.ts
@@ -32,6 +32,32 @@ export interface GuangYaItem {
   resType: number;
 }
 
+/** One subfile inside a bt/磁力 resource (fileIndex is null when the API omits it). */
+export interface GuangYaSubfile {
+  fileName: string;
+  fileIndex: number | null;
+  fileSize: number;
+}
+
+/** resolve_res result, parsed into the typed shape the executor relies on. */
+export interface GuangYaResolvedRes {
+  resType: number;
+  url?: string;
+  btResInfo?: {
+    infoHash: string;
+    fileName: string;
+    subfiles: GuangYaSubfile[];
+  };
+}
+
+/** One offline-task status row from list_task. */
+export interface GuangYaTaskStatus {
+  taskId: string;
+  status: number;
+  progress: number;
+  fileId: string;
+}
+
 /** The token pair (+ the device id they were bound to) handed to the persist hook. */
 export interface GuangYaTokens {
   accessToken: string;
@@ -178,8 +204,9 @@ export class GuangYaClient {
   }
 
   /** Resolve a share/magnet URL to its resType + (for bt) subfile listing. */
-  async resolveRes(url: string): Promise<unknown> {
-    return this.postAPI("/cloudcollection/v1/resolve_res", { url });
+  async resolveRes(url: string): Promise<GuangYaResolvedRes> {
+    const data = await this.postAPI("/cloudcollection/v1/resolve_res", { url });
+    return toResolvedRes(data);
   }
 
   /** Create an offline-download task; returns the taskId. */
@@ -206,9 +233,9 @@ export class GuangYaClient {
   }
 
   /** Poll the status/progress of offline tasks. */
-  async listTask(taskIds: string[]): Promise<unknown[]> {
+  async listTask(taskIds: string[]): Promise<GuangYaTaskStatus[]> {
     const data = await this.postAPI("/cloudcollection/v1/list_task", { taskIds });
-    return arrayValue(recordValue(data, "list"));
+    return arrayValue(recordValue(data, "list")).filter(isRecord).map(toTaskStatus);
   }
 
   /**
@@ -305,6 +332,41 @@ function toItem(raw: Record<string, unknown>): GuangYaItem {
     fileName: stringValue(raw.fileName),
     fileSize: numberValue(raw.fileSize),
     resType: numberValue(raw.resType),
+  };
+}
+
+function toResolvedRes(data: unknown): GuangYaResolvedRes {
+  const resolved: GuangYaResolvedRes = { resType: numberValue(recordValue(data, "resType")) };
+  const url = recordValue(data, "url");
+  if (typeof url === "string" && url.length > 0) {
+    resolved.url = url;
+  }
+  const btRaw = recordValue(data, "btResInfo");
+  if (isRecord(btRaw)) {
+    resolved.btResInfo = {
+      infoHash: stringValue(recordValue(btRaw, "infoHash")),
+      fileName: stringValue(recordValue(btRaw, "fileName")),
+      subfiles: arrayValue(recordValue(btRaw, "subfiles")).filter(isRecord).map(toSubfile),
+    };
+  }
+  return resolved;
+}
+
+function toSubfile(raw: Record<string, unknown>): GuangYaSubfile {
+  const idx = raw.fileIndex;
+  return {
+    fileName: stringValue(raw.fileName),
+    fileIndex: typeof idx === "number" && Number.isFinite(idx) ? idx : null,
+    fileSize: numberValue(raw.fileSize),
+  };
+}
+
+function toTaskStatus(raw: Record<string, unknown>): GuangYaTaskStatus {
+  return {
+    taskId: stringValue(raw.taskId),
+    status: numberValue(raw.status),
+    progress: numberValue(raw.progress),
+    fileId: stringValue(raw.fileId),
   };
 }
 

--- a/packages/workflow/src/guangya-client.ts
+++ b/packages/workflow/src/guangya-client.ts
@@ -125,7 +125,7 @@ export class GuangYaClient {
   constructor(options: GuangYaClientOptions) {
     this.accessToken = options.accessToken;
     this.refreshToken = options.refreshToken;
-    this.deviceId = options.deviceId?.trim() || generateDeviceId();
+    this.deviceId = options.deviceId?.trim() || generateGuangYaDeviceId();
     this.onTokensRefreshed = options.onTokensRefreshed;
     this.fetchImpl = options.fetchImpl ?? ((url, init) => fetch(url, init));
   }
@@ -321,7 +321,13 @@ export class GuangYaClient {
   }
 }
 
-function generateDeviceId(): string {
+/**
+ * Generate a stable 光鸭 device id (32 hex chars) for the `Did` header. Call this
+ * ONCE at connect time and persist the result so every worker run reuses the same
+ * id — a fresh id each run looks like many devices to 光鸭's risk control. The
+ * client's internal default (when no deviceId is supplied) calls this same helper.
+ */
+export function generateGuangYaDeviceId(): string {
   return globalThis.crypto.randomUUID().replace(/-/g, "");
 }
 

--- a/packages/workflow/src/guangya-storage-executor.test.ts
+++ b/packages/workflow/src/guangya-storage-executor.test.ts
@@ -147,6 +147,41 @@ describe("GuangYaStorageExecutor.createDirectory", () => {
     expect(id).toBe("fresh-dir");
     expect(createDir).toHaveBeenCalledTimes(1);
   });
+
+  it("provisions the connect-time category tree at the 光鸭 root (parentId='')", async () => {
+    // 光鸭's ROOT directory id is the empty string "": get_file_list/create_dir with
+    // parentId:"" operate on root (confirmed live). connectGuangYa →
+    // provisionCategoryDirs calls createDirectory({ name, parentId: "" }) to make the
+    // root category folder. With an EMPTY write scope (connect-time provisioning),
+    // "" must be accepted as the valid root parent, not throw on empty.
+    const fs = new Map<string, GuangYaStorageItem[]>();
+    fs.set("", []);
+    let nextId = 1;
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async (parentId: string) => {
+      return fs.get(parentId) ?? [];
+    });
+    const createDir = vi.fn<GuangYaStorageClient["createDir"]>(async (parentId, dirName) => {
+      const id = `dir-${nextId++}`;
+      fs.set(id, []);
+      const items = fs.get(parentId) ?? [];
+      items.push({ fileId: id, parentId, fileName: dirName, fileSize: 0, resType: 2 });
+      fs.set(parentId, items);
+      return id;
+    });
+    const client = fakeClient({ listFiles, createDir });
+    // Connect-time: empty write scope (dev/provisioning).
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [] });
+
+    // find-or-create the root category folder AT root ("").
+    const rootId = await executor.createDirectory({ name: "Mediary Scout", parentId: "" });
+    expect(rootId).toBe("dir-1");
+    expect(createDir).toHaveBeenCalledWith("", "Mediary Scout");
+
+    // then create a child under that returned id — also succeeds.
+    const moviesId = await executor.createDirectory({ name: "Movies", parentId: rootId });
+    expect(moviesId).toBe("dir-2");
+    expect(createDir).toHaveBeenCalledWith(rootId, "Movies");
+  });
 });
 
 describe("GuangYaStorageExecutor write-scope guard", () => {

--- a/packages/workflow/src/guangya-storage-executor.test.ts
+++ b/packages/workflow/src/guangya-storage-executor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ResourceCandidate, ResourceType } from "./domain.js";
 import { GuangYaAuthError } from "./guangya-client.js";
-import type { GuangYaStorageClient } from "./guangya-storage-executor.js";
+import type { GuangYaStorageClient, GuangYaStorageItem } from "./guangya-storage-executor.js";
 import { GuangYaStorageExecutor } from "./guangya-storage-executor.js";
 
 /** Minimal in-memory fake of the structural client the executor depends on. */
@@ -163,6 +163,81 @@ describe("GuangYaStorageExecutor write-scope guard", () => {
     const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
     await expect(
       executor.createDirectory({ name: "x", parentId: "elsewhere" }),
+    ).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
+  });
+
+  it("authorizes writes into runtime-created NESTED dirs (derived scope), still refuses unknown ids", async () => {
+    // The real workflow provisions the dir chain TOP-DOWN from a scope root via
+    // createDirectory before any write, then transfers/moves into the NESTED leaf —
+    // never into a scope root. Flat-membership wrongly throws here; derived-scope must pass.
+    const TV_SCOPE = "tv-scope";
+    // In-memory FS: each dir id -> its child items. New dirs created lazily.
+    const fs = new Map<string, GuangYaStorageItem[]>();
+    fs.set(TV_SCOPE, []);
+    let nextId = 1;
+    const stagingFiles: GuangYaStorageItem[] = [];
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async (parentId: string) => {
+      return fs.get(parentId) ?? [];
+    });
+    const createDir = vi.fn<GuangYaStorageClient["createDir"]>(async (parentId: string, dirName: string) => {
+      const id = `dir-${nextId++}`;
+      fs.set(id, []);
+      const items = fs.get(parentId) ?? [];
+      items.push({ fileId: id, parentId, fileName: dirName, fileSize: 0, resType: 2 });
+      fs.set(parentId, items);
+      return id;
+    });
+    const moveFiles = vi.fn<GuangYaStorageClient["moveFiles"]>(async () => {});
+    const client = fakeClient({ listFiles, createDir, moveFiles });
+
+    const executor = new GuangYaStorageExecutor({
+      client,
+      writeScopeDirectoryIds: [TV_SCOPE],
+    });
+
+    // Provision chain TOP-DOWN from the scope root.
+    const showId = await executor.createDirectory({ name: "Show", parentId: TV_SCOPE });
+    // Nested 2 levels under TV — flat membership would throw WRITE_SCOPE_VIOLATION here.
+    const stagingId = await executor.createDirectory({ name: "staging", parentId: showId });
+    const seasonId = await executor.createDirectory({ name: "Season 01", parentId: showId });
+
+    // transfer into the nested staging dir succeeds (no WRITE_SCOPE_VIOLATION).
+    // Staging listing: empty on the before-snapshot, one new video on the after-snapshot
+    // (simulating the offline download landing). Other dirs read from the in-memory fs.
+    let stagingListCalls = 0;
+    listFiles.mockImplementation(async (parentId: string) => {
+      if (parentId === stagingId) {
+        stagingListCalls += 1;
+        return stagingListCalls === 1 ? [] : stagingFiles;
+      }
+      return fs.get(parentId) ?? [];
+    });
+    stagingFiles.push({
+      fileId: "ep1",
+      parentId: stagingId,
+      fileName: "ep1.mkv",
+      fileSize: 50 * 1024 * 1024,
+      resType: 1,
+    });
+    const attempt = await executor.transfer({
+      workflowRunId: "run-1",
+      directoryId: stagingId,
+      candidate: candidate(),
+    });
+    expect(attempt.status).toBe("succeeded");
+    expect(attempt.materializedFileIds).toEqual(["ep1"]);
+
+    // moveFiles into the created Season dir under showId succeeds.
+    const moved = await executor.moveFiles({ fileIds: ["ep1"], targetDirectoryId: seasonId });
+    expect(moved.moved).toEqual(["ep1"]);
+
+    // A totally-unknown id (never created under scope) is still refused.
+    await expect(
+      executor.transfer({
+        workflowRunId: "run-2",
+        directoryId: "totally-unknown-id",
+        candidate: candidate(),
+      }),
     ).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
   });
 });

--- a/packages/workflow/src/guangya-storage-executor.test.ts
+++ b/packages/workflow/src/guangya-storage-executor.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ResourceCandidate, ResourceType } from "./domain.js";
+import { GuangYaAuthError } from "./guangya-client.js";
+import type { GuangYaStorageClient } from "./guangya-storage-executor.js";
+import { GuangYaStorageExecutor } from "./guangya-storage-executor.js";
+
+/** Minimal in-memory fake of the structural client the executor depends on. */
+function fakeClient(overrides: Partial<GuangYaStorageClient> = {}): GuangYaStorageClient {
+  return {
+    listFiles: vi.fn(async () => []),
+    createDir: vi.fn(async () => "new-dir"),
+    renameFile: vi.fn(async () => {}),
+    deleteFiles: vi.fn(async () => {}),
+    moveFiles: vi.fn(async () => {}),
+    resolveRes: vi.fn(async () => ({ resType: 1 })),
+    createTask: vi.fn(async () => "task-1"),
+    listTask: vi.fn(async () => [{ taskId: "task-1", status: 2, progress: 100, fileId: "" }]),
+    ...overrides,
+  };
+}
+
+function candidate(overrides: Partial<ResourceCandidate> = {}): ResourceCandidate {
+  return {
+    id: "cand-1",
+    snapshotId: "snap-1",
+    index: 0,
+    title: "Some Movie",
+    type: "magnet" as ResourceType,
+    source: "test",
+    episodeHints: [],
+    qualityHints: [],
+    providerPayload: { url: "magnet:?xt=urn:btih:deadbeef" },
+    ...overrides,
+  };
+}
+
+const SCOPE = "scope-dir";
+
+describe("GuangYaStorageExecutor.transfer", () => {
+  it("offline-downloads a magnet, requests only video subfile indexes, reports succeeded", async () => {
+    const listFiles = vi
+      .fn<GuangYaStorageClient["listFiles"]>()
+      // first call: before-snapshot (empty)
+      .mockResolvedValueOnce([])
+      // second call: after-snapshot (one new video)
+      .mockResolvedValueOnce([
+        { fileId: "v1", parentId: SCOPE, fileName: "movie.mkv", fileSize: 50 * 1024 * 1024, resType: 1 },
+      ]);
+    const resolveRes = vi.fn(async () => ({
+      resType: 2,
+      btResInfo: {
+        infoHash: "deadbeef",
+        fileName: "Some.Movie.2024",
+        subfiles: [
+          { fileName: "movie.mkv", fileIndex: 0, fileSize: 50 * 1024 * 1024 },
+          { fileName: "poster.jpg", fileIndex: 1, fileSize: 1024 },
+        ],
+      },
+    }));
+    const createTask = vi.fn<GuangYaStorageClient["createTask"]>(async () => "task-9");
+    const client = fakeClient({ listFiles, resolveRes, createTask });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+
+    const attempt = await executor.transfer({
+      workflowRunId: "run-1",
+      directoryId: SCOPE,
+      candidate: candidate(),
+    });
+
+    expect(createTask).toHaveBeenCalledTimes(1);
+    expect(createTask.mock.calls[0]![0]).toMatchObject({
+      parentId: SCOPE,
+      fileIndexes: [0],
+    });
+    expect(attempt.status).toBe("succeeded");
+    expect(attempt.materializedFileIds).toEqual(["v1"]);
+    expect(attempt.id).toBe("run-1_transfer_1");
+  });
+
+  it("fails LOUD on a non-magnet share link (GUANGYA_ONLY_MAGNET)", async () => {
+    const client = fakeClient();
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+    await expect(
+      executor.transfer({
+        workflowRunId: "run-1",
+        directoryId: SCOPE,
+        candidate: candidate({
+          type: "quark" as ResourceType,
+          providerPayload: { url: "https://www.guangyapan.com/s/abc" },
+        }),
+      }),
+    ).rejects.toThrow(/GUANGYA_ONLY_MAGNET/);
+    expect(client.createTask).not.toHaveBeenCalled();
+  });
+
+  it("returns failed (not throw) when resolveRes throws on a dead magnet", async () => {
+    const resolveRes = vi.fn(async () => {
+      throw new Error("dead magnet: resolve_res empty");
+    });
+    const client = fakeClient({ resolveRes });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+
+    const attempt = await executor.transfer({
+      workflowRunId: "run-1",
+      directoryId: SCOPE,
+      candidate: candidate(),
+    });
+
+    expect(attempt.status).toBe("failed");
+    expect(attempt.providerMessage).toMatch(/dead magnet/);
+    expect(attempt.materializedFileIds).toEqual([]);
+  });
+
+  it("propagates (rejects) when the client throws an auth error", async () => {
+    const resolveRes = vi.fn(async () => {
+      throw new GuangYaAuthError("GUANGYA_AUTH_FAILED: 401 after refresh");
+    });
+    const client = fakeClient({ resolveRes });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+    await expect(
+      executor.transfer({ workflowRunId: "run-1", directoryId: SCOPE, candidate: candidate() }),
+    ).rejects.toThrow(GuangYaAuthError);
+  });
+});
+
+describe("GuangYaStorageExecutor.createDirectory", () => {
+  it("find-or-create reuses an existing same-name resType===2 folder (createDir not called)", async () => {
+    const listFiles = vi.fn(async () => [
+      { fileId: "existing", parentId: SCOPE, fileName: "Inception", fileSize: 0, resType: 2 },
+      { fileId: "afile", parentId: SCOPE, fileName: "Inception", fileSize: 100, resType: 1 },
+    ]);
+    const createDir = vi.fn(async () => "should-not-be-called");
+    const client = fakeClient({ listFiles, createDir });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+
+    const id = await executor.createDirectory({ name: "Inception", parentId: SCOPE });
+    expect(id).toBe("existing");
+    expect(createDir).not.toHaveBeenCalled();
+  });
+
+  it("creates a new folder when none matches", async () => {
+    const listFiles = vi.fn(async () => []);
+    const createDir = vi.fn(async () => "fresh-dir");
+    const client = fakeClient({ listFiles, createDir });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+    const id = await executor.createDirectory({ name: "Inception", parentId: SCOPE });
+    expect(id).toBe("fresh-dir");
+    expect(createDir).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("GuangYaStorageExecutor write-scope guard", () => {
+  it("refuses transfer to an id not in scope (WRITE_SCOPE_VIOLATION)", async () => {
+    const client = fakeClient();
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+    await expect(
+      executor.transfer({ workflowRunId: "run-1", directoryId: "elsewhere", candidate: candidate() }),
+    ).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
+  });
+
+  it("refuses createDirectory under an out-of-scope parent (WRITE_SCOPE_VIOLATION)", async () => {
+    const client = fakeClient();
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+    await expect(
+      executor.createDirectory({ name: "x", parentId: "elsewhere" }),
+    ).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
+  });
+});
+
+describe("GuangYaStorageExecutor item-adapter", () => {
+  it("listVideoFiles filters by video extension (mirrors quark: extension is the video signal)", async () => {
+    const listFiles = vi.fn(async (parentId: string) => {
+      if (parentId === SCOPE) {
+        return [
+          { fileId: "big", parentId: SCOPE, fileName: "ep.mkv", fileSize: 50 * 1024 * 1024, resType: 1 },
+          { fileId: "vid2", parentId: SCOPE, fileName: "ep2.mp4", fileSize: 30 * 1024 * 1024, resType: 1 },
+          { fileId: "notvid", parentId: SCOPE, fileName: "readme.txt", fileSize: 50 * 1024 * 1024, resType: 1 },
+        ];
+      }
+      return [];
+    });
+    const client = fakeClient({ listFiles });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+    const videos = await executor.listVideoFiles(SCOPE);
+    expect(videos.map((v) => v.id).sort()).toEqual(["big", "vid2"]);
+    expect(videos.find((v) => v.id === "notvid")).toBeUndefined();
+  });
+
+  it("listChildDirectories returns only resType===2 entries", async () => {
+    const listFiles = vi.fn(async () => [
+      { fileId: "d1", parentId: SCOPE, fileName: "Season 1", fileSize: 0, resType: 2 },
+      { fileId: "f1", parentId: SCOPE, fileName: "ep.mkv", fileSize: 100, resType: 1 },
+      { fileId: "d2", parentId: SCOPE, fileName: "Season 2", fileSize: 0, resType: 2 },
+    ]);
+    const client = fakeClient({ listFiles });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+    const dirs = await executor.listChildDirectories(SCOPE);
+    expect(dirs).toEqual([
+      { id: "d1", name: "Season 1" },
+      { id: "d2", name: "Season 2" },
+    ]);
+  });
+});

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -477,10 +477,19 @@ export class GuangYaStorageExecutor implements StorageExecutor {
    * scope (dev) allows everything.
    */
   private assertWithinWriteScope(directoryId: string, action: string): string {
-    const normalized = normalizeId(directoryId);
+    // 光鸭's ROOT directory id is the empty string "": create_dir / get_file_list with
+    // parentId:"" operate on root (confirmed live). connect-time provisioning
+    // (provisionCategoryDirs, empty write scope) creates the root category folder under
+    // "" — so "" is a VALID parent for directory creation there and must NOT be pushed
+    // through normalizeId's throw-on-empty. Handle the empty-scope (dev/connect) "allow
+    // all" branch BEFORE normalizing, so root "" passes. With a non-empty (worker
+    // runtime) scope, "" is never a legitimate write target (production writes go into
+    // provisioned NESTED dirs); it falls through to a clean WRITE_SCOPE_VIOLATION below.
+    const trimmed = directoryId.trim();
     if (this.writeScopeDirectoryIds.size === 0) {
-      return normalized;
+      return trimmed;
     }
+    const normalized = normalizeId(directoryId);
     if (this.writeScopeDirectoryIds.has(normalized) || this.derivedScopeIds.has(normalized)) {
       return normalized;
     }

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -361,13 +361,24 @@ export class GuangYaStorageExecutor implements StorageExecutor {
   }
 
   /** Poll list_task until the task leaves the in-progress state or a cap is hit.
-   *  ⚠️ status semantics (2 = done? is there a distinct failed code?) are a PLACEHOLDER
-   *  to be refined after the live e2e (Task 8) observes real status codes. v1: treat status>=2 as terminal. */
+   *  光鸭 list_task status (observed live 2026-06-27, Big Buck Bunny magnet → real
+   *  account): 1 = in-progress/queued (fileId is ""), 2 = done (fileId is populated
+   *  with the materialized dir/file id). The sequence seen was 1 → 2, with the file
+   *  landing the same instant status flipped to 2. We treat status >= 2 as terminal
+   *  AND break the moment a non-empty fileId materializes (the strongest "file landed"
+   *  signal — it appears exactly at completion). No distinct failed code was observed
+   *  in this run; the transfer()'s before/after listVideoFiles diff remains the source
+   *  of truth for succeeded-vs-failed, so pollTask only needs the correct terminal
+   *  condition + to not waste the full poll budget. If a future run surfaces a higher
+   *  failed code (e.g. 3/4), status >= 2 already breaks on it so the diff can judge. */
   private async pollTask(taskId: string): Promise<void> {
     for (let i = 0; i < this.taskPollMaxPolls; i++) {
       const tasks = await this.client.listTask([taskId]);
       const t = tasks.find((x) => x.taskId === taskId);
       if (!t) {
+        return;
+      }
+      if (t.fileId !== "" && t.fileId !== "0") {
         return;
       }
       if (t.status >= 2) {

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -8,15 +8,23 @@
  *  - 转存 is OFFLINE/磁力 (resolve_res → create_task → poll). This is the OPPOSITE
  *    of quark: a MAGNET works, a share link fails LOUD (GUANGYA_ONLY_MAGNET).
  *    Share-link 转存 is a phase-2 feature.
- *  - 光鸭 has NO parent-walk / breadcrumb API, so the write-scope guard is a flat
- *    membership check: the transfer/createDir target is always a known scope dir
- *    id, so we allow iff the id is in the write scope (empty scope = dev, allow all).
+ *  - 光鸭 has NO parent-walk / breadcrumb API, so the write-scope guard CANNOT walk
+ *    a target's parents the way quark does (quark hops up via getFileInfo). Instead
+ *    the guard is DERIVED-SCOPE: the workflow always provisions the directory chain
+ *    TOP-DOWN from a connect-time scope root (rootDir + Movies/TV/Anime) via
+ *    createDirectory on THIS executor instance before any write. Real write targets
+ *    are NESTED (transfer→TV/<Show>/staging-<runId>, moveFiles→Season NN), never a
+ *    scope root. So each nested dir is authorized by being find-or-created under an
+ *    already-in-scope parent during the same run, and its id is then tracked in
+ *    `derivedScopeIds`. A write is allowed iff its target id is a scope root OR a
+ *    derived id (empty scope = dev, allow all). See assertWithinWriteScope below.
  *  - A 光鸭 item is a directory when `resType === 2`; ids key on `fileId`, names on
  *    `fileName`, sizes on `fileSize`. Directory listing uses `listFiles(dirId)`.
  */
 import type { PackageTreeFile, ResourceCandidate, TransferAttempt, TransferStatus, VerifiedFile } from "./domain.js";
 import { episodeCodeFromFileName } from "./episode-code.js";
 import { isGuangYaAuthError } from "./guangya-client.js";
+import type { GuangYaResolvedRes, GuangYaTaskStatus } from "./guangya-client.js";
 import type { StorageExecutor, UnparsedVideoFile } from "./ports.js";
 
 const MAX_RECURSIVE_COLLECT_DEPTH = 6;
@@ -46,36 +54,11 @@ export interface GuangYaStorageItem {
   resType: number;
 }
 
-/** Resolved subfile inside a bt/磁力 resource. */
-export interface GuangYaSubfile {
-  fileName: string;
-  fileIndex: number;
-  fileSize: number;
-}
-
-/** resolve_res result the executor relies on (bt resources carry btResInfo). */
-export interface GuangYaResolvedRes {
-  resType: number;
-  url?: string;
-  btResInfo?: {
-    infoHash: string;
-    fileName: string;
-    subfiles: GuangYaSubfile[];
-  };
-}
-
-/** One offline-task status row from list_task. */
-export interface GuangYaTaskStatus {
-  taskId: string;
-  status: number;
-  progress?: number;
-  fileId?: string;
-}
-
 /**
- * The structural slice of GuangYaClient the executor depends on. The real
- * GuangYaClient (whose resolveRes/listTask return `unknown`) is adapted to this
- * typed shape by the factory (a later task); tests inject a typed fake directly.
+ * The structural slice of GuangYaClient the executor depends on. resolveRes/listTask
+ * reuse the SAME typed shapes the real GuangYaClient now returns (GuangYaResolvedRes /
+ * GuangYaTaskStatus, imported from ./guangya-client.js), so `new GuangYaClient(...)`
+ * is structurally assignable here with no runtime adapter. Tests inject a typed fake.
  */
 export interface GuangYaStorageClient {
   listFiles(parentId: string): Promise<GuangYaStorageItem[]>;
@@ -118,6 +101,10 @@ interface VideoFact {
 export class GuangYaStorageExecutor implements StorageExecutor {
   private readonly client: GuangYaStorageClient;
   private readonly writeScopeDirectoryIds: Set<string>;
+  /** Ids of nested dirs find-or-created under an already-in-scope parent during this
+   *  run. They become authorized write targets (光鸭 has no parent-walk API to verify
+   *  them otherwise). Populated by createDirectory; consulted by assertWithinWriteScope. */
+  private readonly derivedScopeIds = new Set<string>();
   private readonly protectedDirectoryIds: Set<string>;
   private readonly minVideoSizeBytes: number;
   private readonly videoExtensions: Set<string>;
@@ -146,11 +133,16 @@ export class GuangYaStorageExecutor implements StorageExecutor {
       if (isDirectory(item) && nameOf(item) === input.name) {
         const existingId = idOf(item);
         if (existingId) {
+          // Authorize this nested dir as a future write target (it lives under an
+          // already-in-scope parent). Covers both the find-existing and create branches.
+          this.derivedScopeIds.add(existingId);
           return existingId;
         }
       }
     }
-    return this.client.createDir(safeParentId, input.name);
+    const createdId = await this.client.createDir(safeParentId, input.name);
+    this.derivedScopeIds.add(createdId);
+    return createdId;
   }
 
   async listVideoFiles(directoryId: string): Promise<VerifiedFile[]> {
@@ -465,16 +457,20 @@ export class GuangYaStorageExecutor implements StorageExecutor {
   }
 
   /**
-   * 光鸭 has NO parent-walk / breadcrumb API, so the guard is a flat membership
-   * check: the transfer/createDir target is always a known scope dir id. Allow iff
-   * the id is in the write scope; empty scope (dev) allows everything.
+   * 光鸭 has NO parent-walk / breadcrumb API, so we cannot verify a write target by
+   * walking up to a scope root (the premise that "the target is always a scope-root
+   * id" is FALSE — real targets are nested staging/Season dirs). Instead we use
+   * DERIVED SCOPE: a write is allowed iff its target id is a connect-time scope root
+   * (writeScopeDirectoryIds) OR a nested dir find-or-created under an already-in-scope
+   * parent during this run (derivedScopeIds, populated by createDirectory). Empty
+   * scope (dev) allows everything.
    */
   private assertWithinWriteScope(directoryId: string, action: string): string {
     const normalized = normalizeId(directoryId);
     if (this.writeScopeDirectoryIds.size === 0) {
       return normalized;
     }
-    if (this.writeScopeDirectoryIds.has(normalized)) {
+    if (this.writeScopeDirectoryIds.has(normalized) || this.derivedScopeIds.has(normalized)) {
       return normalized;
     }
     throw new Error(

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -1,0 +1,557 @@
+/**
+ * 光鸭云盘 (GuangYaPan) StorageExecutor — the brand-3 analogue of
+ * QuarkStorageExecutor / Storage115Executor, over GuangYaClient. Implements the
+ * 12 StorageExecutor port methods. Mirrors the quark executor's structure;
+ * only the brand-specific bits differ.
+ *
+ * Differences from quark:
+ *  - 转存 is OFFLINE/磁力 (resolve_res → create_task → poll). This is the OPPOSITE
+ *    of quark: a MAGNET works, a share link fails LOUD (GUANGYA_ONLY_MAGNET).
+ *    Share-link 转存 is a phase-2 feature.
+ *  - 光鸭 has NO parent-walk / breadcrumb API, so the write-scope guard is a flat
+ *    membership check: the transfer/createDir target is always a known scope dir
+ *    id, so we allow iff the id is in the write scope (empty scope = dev, allow all).
+ *  - A 光鸭 item is a directory when `resType === 2`; ids key on `fileId`, names on
+ *    `fileName`, sizes on `fileSize`. Directory listing uses `listFiles(dirId)`.
+ */
+import type { PackageTreeFile, ResourceCandidate, TransferAttempt, TransferStatus, VerifiedFile } from "./domain.js";
+import { episodeCodeFromFileName } from "./episode-code.js";
+import { isGuangYaAuthError } from "./guangya-client.js";
+import type { StorageExecutor, UnparsedVideoFile } from "./ports.js";
+
+const MAX_RECURSIVE_COLLECT_DEPTH = 6;
+const DEFAULT_MIN_VIDEO_SIZE_BYTES = 10 * 1024 * 1024;
+
+const DEFAULT_VIDEO_EXTENSIONS = [
+  ".mp4",
+  ".mkv",
+  ".avi",
+  ".mov",
+  ".wmv",
+  ".flv",
+  ".webm",
+  ".m4v",
+  ".mpg",
+  ".mpeg",
+  ".ts",
+  ".m2ts",
+];
+
+/** A directory-listing entry as the executor consumes it (mirrors GuangYaItem). */
+export interface GuangYaStorageItem {
+  fileId: string;
+  parentId: string;
+  fileName: string;
+  fileSize: number;
+  resType: number;
+}
+
+/** Resolved subfile inside a bt/磁力 resource. */
+export interface GuangYaSubfile {
+  fileName: string;
+  fileIndex: number;
+  fileSize: number;
+}
+
+/** resolve_res result the executor relies on (bt resources carry btResInfo). */
+export interface GuangYaResolvedRes {
+  resType: number;
+  url?: string;
+  btResInfo?: {
+    infoHash: string;
+    fileName: string;
+    subfiles: GuangYaSubfile[];
+  };
+}
+
+/** One offline-task status row from list_task. */
+export interface GuangYaTaskStatus {
+  taskId: string;
+  status: number;
+  progress?: number;
+  fileId?: string;
+}
+
+/**
+ * The structural slice of GuangYaClient the executor depends on. The real
+ * GuangYaClient (whose resolveRes/listTask return `unknown`) is adapted to this
+ * typed shape by the factory (a later task); tests inject a typed fake directly.
+ */
+export interface GuangYaStorageClient {
+  listFiles(parentId: string): Promise<GuangYaStorageItem[]>;
+  createDir(parentId: string, dirName: string): Promise<string>;
+  renameFile(fileId: string, newName: string): Promise<void>;
+  deleteFiles(fileIds: string[]): Promise<void>;
+  moveFiles(fileIds: string[], parentId: string): Promise<void>;
+  resolveRes(url: string): Promise<GuangYaResolvedRes>;
+  createTask(input: {
+    url: string;
+    parentId: string;
+    newName: string;
+    fileIndexes?: number[];
+  }): Promise<string>;
+  listTask(taskIds: string[]): Promise<GuangYaTaskStatus[]>;
+}
+
+export interface GuangYaStorageExecutorOptions {
+  client: GuangYaStorageClient;
+  /** Directory fileIds inside which writes/deletes are allowed (the drive's scope
+   *  roots: rootDir + Movies/TV/Anime). Empty = allow all (dev only). */
+  writeScopeDirectoryIds?: string[];
+  /** Directories that may never be removed (root + scope roots). NOTE: unlike
+   *  quark these are NOT auto-blocked from recursive listing, because 光鸭's write
+   *  target IS a scope dir and transfer must read it before/after. */
+  protectedDirectoryIds?: string[];
+  minVideoSizeBytes?: number;
+  videoExtensions?: string[];
+  /** Poll caps for an offline task (overridable so tests don't sleep). */
+  taskPollMaxPolls?: number;
+  taskPollIntervalMs?: number;
+}
+
+interface VideoFact {
+  file: VerifiedFile;
+  sourceDirectoryId: string;
+  sizeBytes: number;
+}
+
+export class GuangYaStorageExecutor implements StorageExecutor {
+  private readonly client: GuangYaStorageClient;
+  private readonly writeScopeDirectoryIds: Set<string>;
+  private readonly protectedDirectoryIds: Set<string>;
+  private readonly minVideoSizeBytes: number;
+  private readonly videoExtensions: Set<string>;
+  private readonly taskPollMaxPolls: number;
+  private readonly taskPollIntervalMs: number;
+  private nextTransferNumber = 1;
+
+  constructor(options: GuangYaStorageExecutorOptions) {
+    this.client = options.client;
+    this.writeScopeDirectoryIds = new Set(options.writeScopeDirectoryIds ?? []);
+    this.protectedDirectoryIds = new Set(["0", ...(options.protectedDirectoryIds ?? [])]);
+    this.minVideoSizeBytes = options.minVideoSizeBytes ?? DEFAULT_MIN_VIDEO_SIZE_BYTES;
+    this.videoExtensions = new Set(
+      (options.videoExtensions ?? DEFAULT_VIDEO_EXTENSIONS).map((ext) => ext.toLowerCase()),
+    );
+    this.taskPollMaxPolls = options.taskPollMaxPolls ?? 60;
+    this.taskPollIntervalMs = options.taskPollIntervalMs ?? 3000;
+  }
+
+  async createDirectory(input: { name: string; parentId: string }): Promise<string> {
+    const safeParentId = this.assertWithinWriteScope(input.parentId, "create directory");
+    // Find-or-create: seasons of one title initialize at different times and must
+    // land under the SAME show directory (光鸭 happily makes duplicate folders).
+    const items = await this.client.listFiles(safeParentId);
+    for (const item of items) {
+      if (isDirectory(item) && nameOf(item) === input.name) {
+        const existingId = idOf(item);
+        if (existingId) {
+          return existingId;
+        }
+      }
+    }
+    return this.client.createDir(safeParentId, input.name);
+  }
+
+  async listVideoFiles(directoryId: string): Promise<VerifiedFile[]> {
+    const safe = this.assertSafeRecursiveListTarget(directoryId, "list videos in");
+    const videos = await this.collectVideos(safe, safe);
+    return videos.map((v) => v.file);
+  }
+
+  async listUnparsedVideoFiles(directoryId: string): Promise<UnparsedVideoFile[]> {
+    const safe = this.assertSafeRecursiveListTarget(directoryId, "list unparsed videos in");
+    return this.collectUnparsedVideos(safe);
+  }
+
+  async renameFile(input: { directoryId: string; fileId: string; newName: string }): Promise<void> {
+    this.assertWithinWriteScope(input.directoryId, "rename file");
+    await this.client.renameFile(input.fileId, input.newName);
+  }
+
+  async transfer(input: {
+    workflowRunId: string;
+    directoryId: string;
+    candidate: ResourceCandidate;
+  }): Promise<TransferAttempt> {
+    const url = stringValue(input.candidate.providerPayload["url"]);
+    const isMagnet =
+      input.candidate.type === "magnet" || url.startsWith("magnet:") || url.startsWith("ed2k:");
+    if (!isMagnet) {
+      throw new Error(
+        "GUANGYA_ONLY_MAGNET: 光鸭 v1 仅支持磁力/离线候选(分享链转存留 phase 2);请改用磁力候选",
+      );
+    }
+
+    const safe = this.assertWithinWriteScope(input.directoryId, "transfer");
+    const before = new Set((await this.listVideoFiles(safe)).map((f) => f.id));
+
+    let providerMessage = "";
+    try {
+      const resolved = await this.client.resolveRes(url);
+      const subs = resolved.btResInfo?.subfiles ?? [];
+      const videoIndexes = subs
+        .map((s, i) => ({ idx: s.fileIndex ?? i, name: s.fileName }))
+        .filter((s) => isVideoName(s.name, this.videoExtensions))
+        .map((s) => s.idx);
+      const taskInput: Parameters<GuangYaStorageClient["createTask"]>[0] = {
+        url: resolved.url || url,
+        parentId: safe,
+        newName: resolved.btResInfo?.fileName || "offline",
+      };
+      if (videoIndexes.length) {
+        taskInput.fileIndexes = videoIndexes;
+      }
+      const taskId = await this.client.createTask(taskInput);
+      await this.pollTask(taskId);
+    } catch (error) {
+      // Auth failures must surface so the worker freezes the drive — never absorbed.
+      if (isGuangYaAuthError(error)) {
+        throw error;
+      }
+      // Any other failure (dead/expired magnet, bad params) is a FAILED attempt
+      // with a loud message; the agent moves to the next candidate.
+      providerMessage = error instanceof Error ? error.message : String(error);
+    }
+
+    const after = await this.listVideoFiles(safe);
+    const materializedFileIds = after.filter((f) => !before.has(f.id)).map((f) => f.id);
+    const status: TransferStatus = providerMessage
+      ? "failed"
+      : materializedFileIds.length > 0
+        ? "succeeded"
+        : "no_target_change";
+
+    const attempt: TransferAttempt = {
+      id: `${input.workflowRunId}_transfer_${this.nextTransferNumber}`,
+      workflowRunId: input.workflowRunId,
+      candidateId: input.candidate.id,
+      status,
+      providerMessage:
+        providerMessage ||
+        (status === "no_target_change" ? "离线任务完成但目标目录未出现新视频" : ""),
+      materializedFileIds,
+    };
+    this.nextTransferNumber += 1;
+    return attempt;
+  }
+
+  async flattenDirectory(directoryId: string): Promise<{ moved: string[]; removed: string[] }> {
+    const safeDirectoryId = this.assertWithinWriteScope(directoryId, "flatten directory");
+    const videos = await this.collectVideos(safeDirectoryId, safeDirectoryId);
+    const moveCandidates = videos.filter(
+      (v) => v.sourceDirectoryId !== safeDirectoryId && v.sizeBytes >= this.minVideoSizeBytes,
+    );
+    const moved = moveCandidates.map((v) => v.file.providerFileId);
+    if (moved.length > 0) {
+      await this.client.moveFiles(moved, safeDirectoryId);
+    }
+
+    const rootItems = await this.client.listFiles(safeDirectoryId);
+    const removableDirectoryIds: string[] = [];
+    for (const item of rootItems) {
+      if (!isDirectory(item)) {
+        continue;
+      }
+      const childId = idOf(item);
+      if (!childId) {
+        continue;
+      }
+      if (!(await this.directoryContainsLargeVideo(childId))) {
+        removableDirectoryIds.push(childId);
+      }
+    }
+    if (removableDirectoryIds.length > 0) {
+      await this.client.deleteFiles(removableDirectoryIds);
+    }
+    return { moved, removed: removableDirectoryIds };
+  }
+
+  async removeDirectory(directoryId: string): Promise<{ removed: boolean }> {
+    const safe = this.assertWithinWriteScope(directoryId, "remove directory");
+    if (this.protectedDirectoryIds.has(safe) || this.writeScopeDirectoryIds.has(safe)) {
+      throw new Error(`SAFETY_VIOLATION: refusing to remove protected/root directory fileId=${safe}`);
+    }
+    await this.client.deleteFiles([safe]);
+    return { removed: true };
+  }
+
+  async listTree(input: { directoryId: string; maxDepth?: number }): Promise<PackageTreeFile[]> {
+    const safeRoot = this.assertSafeRecursiveListTarget(input.directoryId, "walk the tree of");
+    const maxDepth = input.maxDepth ?? 6;
+    const results: PackageTreeFile[] = [];
+    const walk = async (dirId: string, prefix: string, depth: number): Promise<void> => {
+      if (depth > maxDepth) {
+        return;
+      }
+      const items = await this.client.listFiles(dirId);
+      for (const item of items) {
+        const name = nameOf(item);
+        if (isDirectory(item)) {
+          const childId = idOf(item);
+          if (childId) {
+            await walk(childId, `${prefix}${name}/`, depth + 1);
+          }
+          continue;
+        }
+        const providerFileId = idOf(item);
+        if (!providerFileId) {
+          continue;
+        }
+        results.push({ path: `${prefix}${name}`, providerFileId, sizeBytes: sizeOf(item) });
+      }
+    };
+    await walk(safeRoot, "", 1);
+    return results;
+  }
+
+  async listSubdirectories(input: {
+    directoryId: string;
+    maxDepth?: number;
+  }): Promise<Array<{ id: string; path: string }>> {
+    const safeRoot = this.assertSafeRecursiveListTarget(input.directoryId, "list subdirectories of");
+    const maxDepth = input.maxDepth ?? 6;
+    const results: Array<{ id: string; path: string }> = [];
+    const walk = async (dirId: string, prefix: string, depth: number): Promise<void> => {
+      if (depth > maxDepth) {
+        return;
+      }
+      const items = await this.client.listFiles(dirId);
+      for (const item of items) {
+        if (!isDirectory(item)) {
+          continue;
+        }
+        const childId = idOf(item);
+        if (!childId) {
+          continue;
+        }
+        const path = `${prefix}${nameOf(item)}`;
+        results.push({ id: childId, path });
+        await walk(childId, `${path}/`, depth + 1);
+      }
+    };
+    await walk(safeRoot, "", 1);
+    return results;
+  }
+
+  async listChildDirectories(directoryId: string): Promise<Array<{ id: string; name: string }>> {
+    const items = await this.client.listFiles(directoryId);
+    const dirs: Array<{ id: string; name: string }> = [];
+    for (const item of items) {
+      if (!isDirectory(item)) {
+        continue;
+      }
+      const id = idOf(item);
+      if (id) {
+        dirs.push({ id, name: nameOf(item) });
+      }
+    }
+    return dirs;
+  }
+
+  async moveFiles(input: { fileIds: string[]; targetDirectoryId: string }): Promise<{ moved: string[] }> {
+    if (input.fileIds.length === 0) {
+      return { moved: [] };
+    }
+    const safeTargetId = this.assertWithinWriteScope(input.targetDirectoryId, "move files into");
+    await this.client.moveFiles(input.fileIds, safeTargetId);
+    return { moved: input.fileIds };
+  }
+
+  async deleteFiles(input: { directoryId: string; fileIds: string[] }): Promise<{ deleted: string[] }> {
+    if (input.fileIds.length === 0) {
+      return { deleted: [] };
+    }
+    const safeDirectoryId = this.assertWithinWriteScope(input.directoryId, "delete files");
+    await this.assertFilesBelongToDirectory(safeDirectoryId, input.fileIds);
+    await this.client.deleteFiles(input.fileIds);
+    return { deleted: input.fileIds };
+  }
+
+  /** Poll list_task until the task leaves the in-progress state or a cap is hit.
+   *  ⚠️ status semantics (2 = done? is there a distinct failed code?) are a PLACEHOLDER
+   *  to be refined after the live e2e (Task 8) observes real status codes. v1: treat status>=2 as terminal. */
+  private async pollTask(taskId: string): Promise<void> {
+    for (let i = 0; i < this.taskPollMaxPolls; i++) {
+      const tasks = await this.client.listTask([taskId]);
+      const t = tasks.find((x) => x.taskId === taskId);
+      if (!t) {
+        return;
+      }
+      if (t.status >= 2) {
+        return;
+      }
+      await new Promise((r) => setTimeout(r, this.taskPollIntervalMs));
+    }
+  }
+
+  private async directoryContainsLargeVideo(directoryId: string): Promise<boolean> {
+    const videos = await this.collectVideos(directoryId, directoryId);
+    return videos.some((v) => v.sizeBytes >= this.minVideoSizeBytes);
+  }
+
+  private async collectVideos(rootId: string, currentId: string, depth = 1): Promise<VideoFact[]> {
+    if (depth > MAX_RECURSIVE_COLLECT_DEPTH) {
+      return [];
+    }
+    const items = await this.client.listFiles(currentId);
+    const videos: VideoFact[] = [];
+    for (const item of items) {
+      if (isDirectory(item)) {
+        const childId = idOf(item);
+        if (childId) {
+          videos.push(...(await this.collectVideos(rootId, childId, depth + 1)));
+        }
+        continue;
+      }
+      const file = verifiedFileFromItem(item, rootId, this.videoExtensions);
+      if (file) {
+        videos.push({ file, sourceDirectoryId: currentId, sizeBytes: file.sizeBytes });
+      }
+    }
+    return videos;
+  }
+
+  private async collectUnparsedVideos(directoryId: string, depth = 1): Promise<UnparsedVideoFile[]> {
+    if (depth > MAX_RECURSIVE_COLLECT_DEPTH) {
+      return [];
+    }
+    const items = await this.client.listFiles(directoryId);
+    const unparsed: UnparsedVideoFile[] = [];
+    for (const item of items) {
+      if (isDirectory(item)) {
+        const childId = idOf(item);
+        if (childId) {
+          unparsed.push(...(await this.collectUnparsedVideos(childId, depth + 1)));
+        }
+        continue;
+      }
+      const name = nameOf(item);
+      if (!isVideoName(name, this.videoExtensions) || episodeCodeFromFileName(name) !== null) {
+        continue;
+      }
+      const providerFileId = idOf(item);
+      if (!providerFileId) {
+        continue;
+      }
+      unparsed.push({ providerFileId, name, sizeBytes: sizeOf(item) });
+    }
+    return unparsed;
+  }
+
+  private async assertFilesBelongToDirectory(directoryId: string, fileIds: string[]): Promise<void> {
+    const verified = new Set((await this.listVideoFiles(directoryId)).map((f) => f.providerFileId));
+    const unverified = fileIds.filter((id) => !verified.has(id));
+    if (unverified.length === 0) {
+      return;
+    }
+    throw new Error(
+      "SAFETY_VIOLATION: refusing to delete unverified file ids from target directory; " +
+        `fileId=${directoryId}; fileIds=${unverified.join(",")}`,
+    );
+  }
+
+  /** Refuse recursive listing of root/protected dirs (huge scan / 风控 risk).
+   *  Unlike quark, write-scope dirs are NOT auto-protected here (光鸭's write target
+   *  IS a scope dir, and transfer must read it). */
+  private assertSafeRecursiveListTarget(directoryId: string, action: string): string {
+    const normalized = normalizeId(directoryId);
+    if (this.protectedDirectoryIds.has(normalized)) {
+      throw new Error(
+        `SAFETY_VIOLATION: refusing to recursively ${action} protected directory fileId=${normalized}`,
+      );
+    }
+    return normalized;
+  }
+
+  /**
+   * 光鸭 has NO parent-walk / breadcrumb API, so the guard is a flat membership
+   * check: the transfer/createDir target is always a known scope dir id. Allow iff
+   * the id is in the write scope; empty scope (dev) allows everything.
+   */
+  private assertWithinWriteScope(directoryId: string, action: string): string {
+    const normalized = normalizeId(directoryId);
+    if (this.writeScopeDirectoryIds.size === 0) {
+      return normalized;
+    }
+    if (this.writeScopeDirectoryIds.has(normalized)) {
+      return normalized;
+    }
+    throw new Error(
+      `WRITE_SCOPE_VIOLATION: refusing to ${action} outside configured write scope; fileId=${normalized}`,
+    );
+  }
+}
+
+function verifiedFileFromItem(
+  item: GuangYaStorageItem,
+  storageDirectoryId: string,
+  videoExtensions: Set<string>,
+): VerifiedFile | null {
+  const name = nameOf(item);
+  if (!isVideoName(name, videoExtensions)) {
+    return null;
+  }
+  const providerFileId = idOf(item);
+  if (!providerFileId) {
+    return null;
+  }
+  return {
+    id: providerFileId,
+    storageDirectoryId,
+    name,
+    sizeBytes: sizeOf(item),
+    episodeCode: episodeCodeFromFileName(name),
+    providerFileId,
+  };
+}
+
+function isDirectory(item: GuangYaStorageItem): boolean {
+  return item.resType === 2;
+}
+
+function idOf(item: GuangYaStorageItem): string {
+  return stringValue(item.fileId);
+}
+
+function nameOf(item: GuangYaStorageItem): string {
+  return stringValue(item.fileName);
+}
+
+function sizeOf(item: GuangYaStorageItem): number {
+  return numberValue(item.fileSize);
+}
+
+function isVideoName(name: string, videoExtensions: Set<string>): boolean {
+  const lower = name.toLowerCase();
+  return [...videoExtensions].some((ext) => lower.endsWith(ext));
+}
+
+function normalizeId(directoryId: string): string {
+  const normalized = directoryId.trim();
+  if (!normalized) {
+    throw new Error("directoryId must not be empty");
+  }
+  return normalized;
+}
+
+function stringValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return "";
+}
+
+function numberValue(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -25,6 +25,8 @@ export * from "./pan115-cookie-client.js";
 export * from "./quark-cookie-client.js";
 export * from "./quark-qrcode-login.js";
 export * from "./quark-storage-executor.js";
+export * from "./guangya-client.js";
+export * from "./guangya-storage-executor.js";
 export * from "./storage-brands.js";
 export * from "./storage-executor-factory.js";
 export * from "./pan115-storage-factory.js";

--- a/packages/workflow/src/storage-brands.test.ts
+++ b/packages/workflow/src/storage-brands.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { allowedResourceTypesForKinds, getStorageBrand } from "./storage-brands.js";
+
+describe("allowedResourceTypesForKinds", () => {
+  it("maps a quark brand's kinds to quark-only links", () => {
+    expect(allowedResourceTypesForKinds(getStorageBrand("quark").resourceProviderKinds)).toEqual(["quark"]);
+  });
+
+  it("maps a 光鸭(magnet) brand's kinds to magnet-only links", () => {
+    expect(allowedResourceTypesForKinds(getStorageBrand("guangya").resourceProviderKinds)).toEqual(["magnet"]);
+  });
+
+  it("maps a 115 brand's kinds to 115 + magnet", () => {
+    expect(allowedResourceTypesForKinds(getStorageBrand("pan115").resourceProviderKinds)).toEqual([
+      "115",
+      "magnet",
+    ]);
+  });
+
+  it("falls back to 115 + magnet for an unknown/legacy kind set", () => {
+    expect(allowedResourceTypesForKinds(["pansou-115", "prowlarr"])).toEqual(["115", "magnet"]);
+  });
+});

--- a/packages/workflow/src/storage-brands.ts
+++ b/packages/workflow/src/storage-brands.ts
@@ -11,6 +11,7 @@
  * capabilities (uid parsing, auth-error classification, applicable resource kinds).
  */
 import { parsePan115Uid } from "./account-credentials.js";
+import type { ResourceType } from "./domain.js";
 import { isGuangYaAuthError, parseGuangYaUid } from "./guangya-client.js";
 import { isPan115AuthError } from "./pan115-cookie-client.js";
 import { isQuarkAuthError, parseQuarkUid } from "./quark-cookie-client.js";
@@ -54,6 +55,22 @@ export const STORAGE_BRANDS: StorageBrand[] = [
     resourceProviderKinds: ["pansou-magnet", "prowlarr"],
   },
 ];
+
+/**
+ * Map a brand's resource-provider kinds to the PanSou link types its acquisitions
+ * may transfer. A 夸克 drive can only save 夸克 share links; a 光鸭(磁力) drive can
+ * only offline-download magnets; a 115 drive takes both 115 links and magnets.
+ * Pure + brand-table-driven so the resource assembly stays testable.
+ */
+export function allowedResourceTypesForKinds(kinds: readonly string[]): ResourceType[] {
+  if (kinds.includes("pansou-quark")) {
+    return ["quark"];
+  }
+  if (kinds.includes("pansou-magnet")) {
+    return ["magnet"];
+  }
+  return ["115", "magnet"];
+}
 
 export function getStorageBrand(provider: string): StorageBrand {
   const brand = STORAGE_BRANDS.find((b) => b.provider === provider);

--- a/packages/workflow/src/storage-brands.ts
+++ b/packages/workflow/src/storage-brands.ts
@@ -11,11 +11,12 @@
  * capabilities (uid parsing, auth-error classification, applicable resource kinds).
  */
 import { parsePan115Uid } from "./account-credentials.js";
+import { isGuangYaAuthError, parseGuangYaUid } from "./guangya-client.js";
 import { isPan115AuthError } from "./pan115-cookie-client.js";
 import { isQuarkAuthError, parseQuarkUid } from "./quark-cookie-client.js";
 
-export type StorageProvider = "pan115" | "quark";
-export type ResourceProviderKind = "pansou-115" | "pansou-quark" | "prowlarr";
+export type StorageProvider = "pan115" | "quark" | "guangya";
+export type ResourceProviderKind = "pansou-115" | "pansou-quark" | "pansou-magnet" | "prowlarr";
 
 export interface StorageBrand {
   provider: StorageProvider;
@@ -44,6 +45,13 @@ export const STORAGE_BRANDS: StorageBrand[] = [
     parseUid: parseQuarkUid,
     isAuthError: isQuarkAuthError,
     resourceProviderKinds: ["pansou-quark"],
+  },
+  {
+    provider: "guangya",
+    label: "光鸭云盘",
+    parseUid: parseGuangYaUid,
+    isAuthError: isGuangYaAuthError,
+    resourceProviderKinds: ["pansou-magnet", "prowlarr"],
   },
 ];
 

--- a/packages/workflow/src/storage-executor-factory.ts
+++ b/packages/workflow/src/storage-executor-factory.ts
@@ -7,6 +7,9 @@
  * Lives here (not in storage-brands.ts) because building the 115 executor pulls
  * in env/protected-wrapper concerns the brand-identity registry must stay free of.
  */
+import { GuangYaClient } from "./guangya-client.js";
+import type { GuangYaClientOptions } from "./guangya-client.js";
+import { GuangYaStorageExecutor } from "./guangya-storage-executor.js";
 import { createProtectedPan115CookieStorageExecutorFromEnv } from "./pan115-storage-factory.js";
 import type { StorageExecutor } from "./ports.js";
 import { QuarkCookieClient } from "./quark-cookie-client.js";
@@ -14,23 +17,54 @@ import { QuarkStorageExecutor } from "./quark-storage-executor.js";
 
 export function createExecutorForBrand(input: {
   provider: string;
-  cookie: string;
+  /** Cookie credential for cookie-auth brands (115/夸克). Optional now that 光鸭
+   *  authenticates with a token blob instead — pass `credential` for those. */
+  cookie?: string;
+  /** Opaque credential blob for token-auth brands (光鸭: {accessToken,refreshToken,deviceId}). */
+  credential?: unknown;
   /** The drive's write-scope directory ids (rootCid + Movies/TV/Anime). */
   scopeCids: string[];
   /** Base env for the 115 executor (guard pacing etc); defaults to process.env. */
   env?: Record<string, string | undefined>;
+  /** Persist hook for refreshed token-auth credentials (光鸭 refresh rotates tokens). */
+  onCredentialRefresh?: (creds: unknown) => void | Promise<void>;
 }): StorageExecutor {
   if (input.provider === "pan115") {
+    const cookie = input.cookie ?? "";
     const env = {
       ...(input.env ?? process.env),
-      PAN115_COOKIE: input.cookie,
+      PAN115_COOKIE: cookie,
       ...(input.scopeCids.length > 0 ? { MEDIA_TRACK_115_WRITE_SCOPE_CIDS: input.scopeCids.join(",") } : {}),
     };
     return createProtectedPan115CookieStorageExecutorFromEnv({ env });
   }
   if (input.provider === "quark") {
     return new QuarkStorageExecutor({
-      client: new QuarkCookieClient({ cookie: input.cookie }),
+      client: new QuarkCookieClient({ cookie: input.cookie ?? "" }),
+      writeScopeDirectoryIds: input.scopeCids,
+    });
+  }
+  if (input.provider === "guangya") {
+    const c = (input.credential ?? {}) as {
+      accessToken?: string;
+      refreshToken?: string;
+      deviceId?: string;
+    };
+    // Build options without ever setting optional keys to `undefined`
+    // (exactOptionalPropertyTypes forbids it).
+    const clientOptions: GuangYaClientOptions = {
+      accessToken: c.accessToken ?? "",
+      refreshToken: c.refreshToken ?? "",
+    };
+    if (c.deviceId !== undefined) {
+      clientOptions.deviceId = c.deviceId;
+    }
+    const onRefresh = input.onCredentialRefresh;
+    if (onRefresh) {
+      clientOptions.onTokensRefreshed = (t) => onRefresh(t);
+    }
+    return new GuangYaStorageExecutor({
+      client: new GuangYaClient(clientOptions),
       writeScopeDirectoryIds: input.scopeCids,
     });
   }

--- a/packages/workflow/src/workflow-scope.ts
+++ b/packages/workflow/src/workflow-scope.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_ACCOUNT_ID } from "./domain.js";
+import { getStorageBrand, isRegisteredStorageProvider } from "./storage-brands.js";
 
 /** The data partition key for the multi-drive tree model: an account (identity)
  *  plus the specific connected storage (workspace). `connectedStorageId` may be
@@ -75,6 +76,16 @@ export interface WorkspaceSwitcherItem {
   provider?: string | undefined;
 }
 
+/** The switcher chip's brand label, sourced from the brand registry so every
+ *  brand (115 / 夸克 / 光鸭) reads correctly — not a 夸克-vs-115 ternary that
+ *  mislabels a 光鸭 drive as "115". Falls back to the raw provider for an
+ *  unknown / undefined provider. */
+function providerLabel(provider: string | undefined): string {
+  return provider !== undefined && isRegisteredStorageProvider(provider)
+    ? getStorageBrand(provider).label
+    : (provider ?? "网盘");
+}
+
 /**
  * Build the workspace switcher tabs (pure, testable). The earliest-created drive
  * is primary and routes to "/"; the rest route to /w/<id>. The active tab is the
@@ -109,7 +120,7 @@ export function switcherItems(
       href,
       label:
         storage.label?.trim() ||
-        `${storage.provider === "quark" ? "夸克" : "115"} …${storage.providerUid.slice(-4)}`,
+        `${providerLabel(storage.provider)} …${storage.providerUid.slice(-4)}`,
       isActive,
       frozen: storage.status === "frozen",
       provider: storage.provider,

--- a/packages/workflow/tests/storage-brands.test.ts
+++ b/packages/workflow/tests/storage-brands.test.ts
@@ -9,10 +9,28 @@ import {
   Pan115AuthError,
   QuarkAuthError,
 } from "../src/index.js";
+import { GuangYaAuthError, parseGuangYaUid } from "../src/guangya-client.js";
+
+/** Build a fake 光鸭 JWT whose payload (2nd segment, base64url) carries `payload`. */
+function makeGuangYaJwt(payload: Record<string, unknown>): string {
+  return `eyJhbGciOiJSUzI1NiJ9.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.s`;
+}
 
 describe("storage brand registry", () => {
-  it("registers exactly pan115 + quark", () => {
-    expect(STORAGE_BRANDS.map((b) => b.provider).sort()).toEqual(["pan115", "quark"]);
+  it("registers exactly pan115 + quark + guangya", () => {
+    expect(STORAGE_BRANDS.map((b) => b.provider).sort()).toEqual(["guangya", "pan115", "quark"]);
+  });
+
+  it("getStorageBrand resolves guangya with its label, magnet/prowlarr kinds + uid parsing", () => {
+    const g = getStorageBrand("guangya");
+    expect(g.provider).toBe("guangya");
+    expect(g.label).toBe("光鸭云盘");
+    expect(g.resourceProviderKinds).toContain("pansou-magnet");
+    expect(g.resourceProviderKinds).toContain("prowlarr"); // 光鸭支持磁力
+    expect(g.parseUid).toBe(parseGuangYaUid);
+    expect(g.parseUid(makeGuangYaJwt({ sub: "U1" }))).toBe("U1");
+    expect(g.isAuthError(new GuangYaAuthError("x"))).toBe(true);
+    expect(g.isAuthError(new QuarkAuthError("y"))).toBe(false);
   });
 
   it("getStorageBrand resolves quark with its label + resource kinds (no prowlarr)", () => {
@@ -50,6 +68,7 @@ describe("storage brand registry", () => {
     const { brandSupportsProwlarr } = await import("../src/index.js");
     expect(brandSupportsProwlarr("pan115")).toBe(true);
     expect(brandSupportsProwlarr("quark")).toBe(false);
+    expect(brandSupportsProwlarr("guangya")).toBe(true);
     expect(brandSupportsProwlarr("baidu")).toBe(false);
   });
 });

--- a/packages/workflow/tests/storage-executor-factory.test.ts
+++ b/packages/workflow/tests/storage-executor-factory.test.ts
@@ -4,6 +4,7 @@ import {
   QuarkStorageExecutor,
   Storage115Executor,
 } from "../src/index.js";
+import { GuangYaStorageExecutor } from "../src/guangya-storage-executor.js";
 
 describe("createExecutorForBrand", () => {
   it("pan115 → Storage115Executor (write scope from scopeCids)", () => {
@@ -14,6 +15,15 @@ describe("createExecutorForBrand", () => {
   it("quark → QuarkStorageExecutor", () => {
     const exec = createExecutorForBrand({ provider: "quark", cookie: "__uid=1", scopeCids: ["ROOT"] });
     expect(exec).toBeInstanceOf(QuarkStorageExecutor);
+  });
+
+  it("guangya → GuangYaStorageExecutor (from a token credential blob, no cookie)", () => {
+    const exec = createExecutorForBrand({
+      provider: "guangya",
+      credential: { accessToken: "AT", refreshToken: "RT", deviceId: "d" },
+      scopeCids: ["root"],
+    });
+    expect(exec).toBeInstanceOf(GuangYaStorageExecutor);
   });
 
   it("unknown provider throws", () => {

--- a/packages/workflow/tests/storage-skill.test.ts
+++ b/packages/workflow/tests/storage-skill.test.ts
@@ -18,11 +18,26 @@ describe("brand-aware storage skill", () => {
     expect(pan115).not.toContain("41006"); // 115 has no quark codes
   });
 
+  it("getStorageSkill('guangya') teaches the magnet/offline-task model and does NOT throw", () => {
+    const guangya = getStorageSkill("guangya");
+    expect(guangya).toBeTruthy();
+    expect(guangya.length).toBeGreaterThan(0);
+    // magnet/offline drive: candidates are magnets resolved → offline task → poll
+    expect(guangya).toMatch(/磁力|magnet/i);
+    expect(guangya).toMatch(/光鸭/);
+    // a 115/quark/光鸭 SHARE link is rejected loud on this magnet-only drive
+    expect(guangya).toContain("GUANGYA_ONLY_MAGNET");
+    // must NOT mislead with 115-only 秒传 wording
+    expect(guangya).not.toMatch(/秒传/);
+    // must NOT carry quark fail-loud codes
+    expect(guangya).not.toContain("41006");
+  });
+
   it("getStorageSkill throws for an unknown brand", () => {
     expect(() => getStorageSkill("baidu")).toThrowError(/unknown storage brand/i);
   });
 
-  it.each(["pan115", "quark"])(
+  it.each(["pan115", "quark", "guangya"])(
     "%s teaches the systemic-block STOP rule (quota/auth = account problem, not a dead link)",
     (brand) => {
       const skill = getStorageSkill(brand);
@@ -40,6 +55,7 @@ describe("brand-aware storage skill", () => {
   it("readSkillSection selects the brand variant for dead-links-black-box", () => {
     expect(readSkillSection("dead-links-black-box", "quark")).toBe(getStorageSkill("quark"));
     expect(readSkillSection("dead-links-black-box", "pan115")).toBe(getStorageSkill("pan115"));
+    expect(readSkillSection("dead-links-black-box", "guangya")).toBe(getStorageSkill("guangya"));
     // defaults to 115 when no brand is given (single-user / legacy)
     expect(readSkillSection("dead-links-black-box")).toBe(getStorageSkill("pan115"));
   });

--- a/packages/workflow/tests/switcher-items.test.ts
+++ b/packages/workflow/tests/switcher-items.test.ts
@@ -36,6 +36,18 @@ describe("switcherItems", () => {
     const items = switcherItems(drives, "/"); // top-of-file drives have no provider
     expect(items[0]!.provider).toBeUndefined();
   });
+  it("unnamed label uses the brand registry label per provider (光鸭 ≠ 115)", () => {
+    const branded = [
+      { id: "g", label: null, provider: "guangya", providerUid: "100000003", createdAt: "2026-06-01T00:00:00.000Z", status: "active" as const },
+      { id: "q", label: null, provider: "quark", providerUid: "100000002", createdAt: "2026-06-10T00:00:00.000Z", status: "active" as const },
+      { id: "p", label: null, provider: "pan115", providerUid: "100000001", createdAt: "2026-06-20T00:00:00.000Z", status: "active" as const },
+    ];
+    const items = switcherItems(branded, "/");
+    expect(items.find((i) => i.id === "g")?.label).toContain("光鸭");
+    expect(items.find((i) => i.id === "g")?.label).not.toContain("115");
+    expect(items.find((i) => i.id === "q")?.label).toContain("夸克");
+    expect(items.find((i) => i.id === "p")?.label).toContain("115");
+  });
   it("label falls back to a uid-tail when unnamed; frozen surfaced", () => {
     const frozen = [
       { id: "csOld", label: null, providerUid: "100000001", createdAt: "2026-06-01T00:00:00.000Z", status: "active" as const },

--- a/packages/workflow/tests/v2-task-agents.test.ts
+++ b/packages/workflow/tests/v2-task-agents.test.ts
@@ -7,6 +7,7 @@ import {
   needForTvTarget,
   runMovieTaskAgent,
   runTvAnimeTaskAgent,
+  transferModelLine,
 } from "../src/acquisition-v2/task-agents.js";
 import { TaskSandbox } from "../src/acquisition-v2/sandbox.js";
 import { FakeResourceProviderV2 } from "../src/acquisition-v2/fake-provider.js";
@@ -88,6 +89,43 @@ describe("both prompts carry the systemic-block STOP rule (别甩锅: account bl
     expect(prompt).toMatch(/立即停|不要(再|继续)|别(再|继续)|STOP/i);
     // surfaced field the agent reads
     expect(prompt).toContain("systemicBlock");
+  });
+});
+
+describe("transferModelLine — brand transfer model in the prompt", () => {
+  it("guangya: magnet/offline model, NOT the default 115 秒传/share model", () => {
+    const line = transferModelLine({ storageProvider: "guangya" });
+    expect(line).toBeTruthy();
+    expect(line.length).toBeGreaterThan(0);
+    expect(line).toMatch(/磁力|magnet/i);
+    expect(line).toMatch(/光鸭/);
+    expect(line).toContain("GUANGYA_ONLY_MAGNET");
+    // it is a magnet-only drive: must NOT inherit 115's 秒传 / 115/share wording
+    expect(line).not.toMatch(/秒传/);
+    // distinct from the quark line and from the default (115) empty line
+    expect(line).not.toBe(transferModelLine({ storageProvider: "quark" }));
+    expect(line).not.toBe(transferModelLine({}));
+  });
+
+  it("quark stays the 转存分享链 / 无磁力 model", () => {
+    const line = transferModelLine({ storageProvider: "quark" });
+    expect(line).toMatch(/夸克/);
+    expect(line).toMatch(/QUARK_NO_MAGNET/);
+  });
+
+  it("115 (default) injects no extra transfer-model line", () => {
+    expect(transferModelLine({})).toBe("");
+    expect(transferModelLine({ storageProvider: "pan115" })).toBe("");
+  });
+});
+
+describe("guangya system prompts carry the magnet transfer model", () => {
+  it.each([
+    ["tv", buildTvAnimeSystemPrompt({ storageProvider: "guangya" })],
+    ["movie", buildMovieSystemPrompt({ storageProvider: "guangya" })],
+  ])("%s prompt names the magnet/offline model and GUANGYA_ONLY_MAGNET", (_name, prompt) => {
+    expect(prompt).toMatch(/磁力|magnet/i);
+    expect(prompt).toContain("GUANGYA_ONLY_MAGNET");
   });
 });
 


### PR DESCRIPTION
## Summary
接入**光鸭云盘(迅雷系)**作为继 115、夸克之后的第三个 drive brand。**磁力/离线下载优先**(`resolve_res`→`create_task`→poll `list_task`),**token 鉴权**(access/refresh,自动刷新+持久化)。纯加法,115/夸克零影响。

- 新增 `GuangYaClient`(`api/account.guangyapan.com`,Bearer+Did+Dt:4,成功判据 `msg==="success"`)+ `GuangYaStorageExecutor`(镜像 quark 结构;磁力 transfer,分享链 fail loud `GUANGYA_ONLY_MAGNET`)
- 注册 `STORAGE_BRANDS`(`resourceProviderKinds:["pansou-magnet","prowlarr"]`)+ factory **凭证泛化**(`cookie?` + `credential` blob,token 类品牌通用)
- web 集成:PanSou magnet 资源 + 凭证流通/token 刷新回写 + connect action(粘 access/refresh token)+ token-connect UI + barrel 导出
- 派生写域护栏(光鸭无 parent-walk API → createDirectory 在 in-scope 父下注册子目录)+ 根目录 `parentId=""` 特判 + deviceId 连接时钉(风控)
- 补齐 agent-skill 层:`getStorageSkill`/`transferModelLine` 光鸭臂(否则运行时 throw / 错误转存模型)

API 事实源自开源 AList `guangyapan` driver,**并用真光鸭账号实测过**。

## 验证状态(诚实)
- ✅ **真盘真落盘**:用生产 `GuangYaStorageExecutor.transfer()` 把真磁力(Big Buck Bunny)落进真账号,`Big Buck Bunny.mp4` 276MB 确认(两次);`list_task` 真状态码 `1→2` 已回填 pollTask;token 过期→refresh 真打通
- ✅ **916 单元测试绿** · packages/workflow tsc · **apps/web tsc**(盲区) · build:workflow · eslint 全清
- ⏳ **待真用验证**:完整 web app **agent 驱动**端到端(设置页粘 token→点获取→agent 选磁力→落盘)需一个 LLM key 才能真跑,留给真实使用验证。executor 对真盘那段是铁证,外圈编排为代码级验证(connect/persist/UI 全镜像夸克 + tsc 绿 + 凭证形态逐跳一致)

## Test Plan
- [x] 单元:client(头/msg/401→refresh/parseUid)、executor(磁力选集 diff/fail loud/派生写域/根目录)、brands 注册
- [x] live:真账号 create_task 真落盘 + refresh 路径
- [ ] 真用:web app 连光鸭→真 agent 获取(需 LLM key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)