### PR TITLE
fix(agent): LLM 真 BYO(去 MiMo 硬默认)+ 未配置/401 友好报错 (#49)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,12 +55,11 @@ TUNNEL_TOKEN=
 # HTTP/2 over TCP.
 TUNNEL_TRANSPORT_PROTOCOL=
 
-# Optional model adapter for structured agent nodes.
-# Keep the real API key in local env only; never commit it.
-XIAOMI_MIMO_API_KEY=
-XIAOMI_MIMO_BASE_URL=https://token-plan-sgp.xiaomimimo.com/v1
-# Default in code is mimo-v2.5-pro; confirm the model id your token plan exposes.
-XIAOMI_MIMO_MODEL_ID=mimo-v2.5-pro
+# 获取 agent 用的大模型 —— 任意 OpenAI 兼容服务,自带(必填:Base URL + 模型;云端还需 Key,本地模型 Key 可空)
+# 示例:OpenAI / DeepSeek / 通义 / 本地 ollama(http://localhost:11434/v1) / 小米 MiMo —— 任选其一
+AGENT_MODEL_BASE_URL=
+AGENT_MODEL_ID=
+AGENT_MODEL_API_KEY=
 
 # Required 115 directory targets
 # Directory shape:

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -457,18 +457,21 @@ export async function testLlmConnectionAction(): Promise<{ ok: boolean; message:
       "../lib/workflow-runtime"
     );
     const accountId = await getCurrentAccountId();
-    // Resolve EXACTLY as the worker does (account-scoped → env → defaults).
+    // Resolve EXACTLY as the worker does (account-scoped → env). No default endpoint.
     const cfg = await resolveAgentModelConfig(getAccountScopedSettings(accountId));
-    if (!cfg.apiKey) {
-      return { ok: false, message: "未配置 API Key —— 请先填写并保存。" };
+    const { createAgentModel, llmConfigError } = await import("@media-track/workflow");
+    // BYO + agnostic: baseURL + 模型 are required; API Key is optional (keyless
+    // local LLM). Surface the same actionable, model-agnostic message the agent uses.
+    const configError = llmConfigError(cfg);
+    if (configError) {
+      return { ok: false, message: configError };
     }
-    const { createAgentModel } = await import("@media-track/workflow");
     const { generateText } = await import("ai");
     const model = createAgentModel(cfg);
-    // A tiny real call — proves the key/base_url/model actually work, killing the
-    // "stored a wrong value silently" 大误会. Not reached unless apiKey is set.
+    // A tiny real call — proves the base_url/model (and key, if any) actually work,
+    // killing the "stored a wrong value silently" 大误会.
     await generateText({ model, prompt: "ping" });
-    return { ok: true, message: `连接正常 · ${cfg.modelId ?? "mimo-v2.5-pro"}` };
+    return { ok: true, message: `连接正常 · ${cfg.modelId}` };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     return { ok: false, message: `连接失败：${msg.slice(0, 200)}` };

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -218,7 +218,9 @@ async function LlmConfigSection() {
             <Bot size={16} aria-hidden style={{ verticalAlign: "-2px", marginRight: 8 }} />
             AI 模型
           </h2>
-          <p className="panel-note">驱动获取 agent 的大模型(OpenAI 兼容);自带 key,只存你本机</p>
+          <p className="panel-note">
+            获取 agent 用的大模型(任意 OpenAI 兼容服务,自带);<strong>必填</strong>,未配置时获取会失败。本地模型 Key 可留空。只存你本机
+          </p>
         </div>
       </div>
       <LlmConfigForm baseURL={baseURL} modelId={modelId} apiKeySet={apiKeySet} />

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -16,6 +16,7 @@ import {
   createAgentModel,
   createAgentModelFromEnv,
   createStubAcquisitionModel,
+  llmConfigError,
   dispatchNotifications,
   formatDailyDigestPushText,
   getTrackedSeasonStatusView,
@@ -1735,9 +1736,11 @@ async function getWorkerStorageParents(
  * passed to each workflow as standing context, not baked into the model instance.
  */
 /** Resolve the live agent model config the SAME way the worker builds it: DB
- *  (pass an account-scoped repo) → .env → built-in MiMo defaults (filled later by
- *  createAgentModel). Shared by getAgentModel and testLlmConnectionAction so the
- *  Settings「测试连接」exercises exactly what acquisitions use. */
+ *  (pass an account-scoped repo) → .env (AGENT_MODEL_* with XIAOMI_MIMO_* as a
+ *  back-compat fallback) → undefined. There is NO built-in default endpoint —
+ *  baseURL/modelId must be configured (truly BYO, issue #49). Shared by
+ *  getAgentModel and testLlmConnectionAction so the Settings「测试连接」exercises
+ *  exactly what acquisitions use. */
 export async function resolveAgentModelConfig(
   repository: { getSetting(key: string): Promise<string | null> },
   env: NodeJS.ProcessEnv = process.env,
@@ -1767,9 +1770,21 @@ async function getAgentModel(repository: {
   const qualityPreference = await getQualityPreference(repository);
 
   // Resolve the live model config the SAME way the test action does (shared
-  // resolver) — DB-first, then .env, then built-in MiMo defaults.
+  // resolver) — DB-first, then .env. No built-in default endpoint.
   const resolved = await resolveAgentModelConfig(repository, env);
   const { apiKey, baseURL, modelId } = resolved;
+  // Fail-fast pre-check (issue #49): on the live (vercel-ai) path, if baseURL or
+  // modelId is missing the run would die on its first model call (or hit the
+  // author endpoint keyless → 401). Throw the actionable, agnostic guidance NOW
+  // — before building/using the model — so the user gets guidance at 获取 time
+  // instead of a raw failure after a long agent run. apiKey may be empty (keyless
+  // local LLM is valid); the fake/stub adapter never needs a model config.
+  if (adapter === "vercel-ai") {
+    const configError = llmConfigError(resolved);
+    if (configError) {
+      throw new Error(configError);
+    }
+  }
   // Cache per resolved config signature (so a Settings edit takes effect without
   // a restart AND different accounts' models coexist).
   const signature = `${adapter}|${baseURL ?? ""}|${modelId ?? ""}|${apiKey ?? ""}`;

--- a/packages/workflow/src/agent-error.test.ts
+++ b/packages/workflow/src/agent-error.test.ts
@@ -37,13 +37,61 @@ describe("describeAgentRunError", () => {
     expect(describeAgentRunError("Workflow failed")).toBe("Workflow failed");
   });
 
+  it("maps an 'incorrect api key' message to the guidance", () => {
+    expect(describeAgentRunError(new Error("Incorrect API key provided"))).toBe(LLM_AUTH_GUIDANCE);
+  });
+
   it("never mentions MiMo in the auth guidance", () => {
     expect(LLM_AUTH_GUIDANCE.toLowerCase()).not.toContain("mimo");
   });
 
-  it("uses the approved agnostic 401 guidance text", () => {
+  it("uses the approved agnostic runtime-401 guidance text", () => {
     expect(LLM_AUTH_GUIDANCE).toBe(
       "AI 模型鉴权失败(401):请到 设置 → AI 模型 检查 API Key 是否有效、模型是否有权限(任意 OpenAI 兼容服务,自带 key)。",
     );
+  });
+});
+
+// C3 (Copilot #51): the LLM-auth classifier must NOT swallow netdisk (brand) auth
+// errors. They carry "401"/"403" in their message (e.g. GUANGYA_AUTH_FAILED: 401
+// after refresh) but are a 网盘 token problem, not an AI-模型 problem — showing the
+// "AI 模型鉴权失败" guidance for them is misleading.
+describe("describeAgentRunError — does NOT misclassify netdisk (brand) auth errors as LLM-auth", () => {
+  it("leaves a GuangYa 401 auth error UNCHANGED (not the AI 模型 message)", () => {
+    const msg = "GUANGYA_AUTH_FAILED: 401 after refresh (/file/list)";
+    expect(describeAgentRunError(new Error(msg))).toBe(msg);
+  });
+
+  it("leaves a GuangYa validate 401 error UNCHANGED", () => {
+    const msg = "GUANGYA_VALIDATE_FAILED: 401 after refresh";
+    expect(describeAgentRunError(new Error(msg))).toBe(msg);
+  });
+
+  it("leaves a Quark 403 auth error UNCHANGED", () => {
+    const msg = "QUARK_AUTH_FAILED: 需要验证 (code 403)";
+    expect(describeAgentRunError(new Error(msg))).toBe(msg);
+  });
+
+  it("leaves a Pan115 auth error UNCHANGED", () => {
+    const msg = "PAN115_AUTH_FAILED: 登录失效 401";
+    expect(describeAgentRunError(new Error(msg))).toBe(msg);
+  });
+
+  it("leaves a brand auth error with a 401 statusCode UNCHANGED (brand prefix wins)", () => {
+    const brand = Object.assign(new Error("GUANGYA_AUTH_FAILED: 401 after refresh"), {
+      statusCode: 401,
+      name: "GuangYaAuthError",
+    });
+    expect(describeAgentRunError(brand)).toBe("GUANGYA_AUTH_FAILED: 401 after refresh");
+  });
+
+  it("still maps a real AI-SDK 401 (no brand prefix) to the guidance", () => {
+    const apiError = Object.assign(new Error("Unauthorized"), { statusCode: 401 });
+    expect(describeAgentRunError(apiError)).toBe(LLM_AUTH_GUIDANCE);
+  });
+
+  it("does NOT map a bare numeric 401 in an unrelated message to the guidance", () => {
+    const msg = "HTTP 401 while fetching subtitle index";
+    expect(describeAgentRunError(new Error(msg))).toBe(msg);
   });
 });

--- a/packages/workflow/src/agent-error.test.ts
+++ b/packages/workflow/src/agent-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { LLM_AUTH_GUIDANCE, describeAgentRunError } from "./agent-error.js";
+
+describe("describeAgentRunError", () => {
+  it("maps a bare 'Unauthorized' error to the actionable LLM-auth guidance", () => {
+    expect(describeAgentRunError(new Error("Unauthorized"))).toBe(LLM_AUTH_GUIDANCE);
+  });
+
+  it("maps a 401 status-code APICallError-shaped error to the guidance", () => {
+    const apiError = Object.assign(new Error("Request failed"), { statusCode: 401 });
+    expect(describeAgentRunError(apiError)).toBe(LLM_AUTH_GUIDANCE);
+  });
+
+  it("maps a 403 'Forbidden' error to the guidance", () => {
+    expect(describeAgentRunError(new Error("Forbidden"))).toBe(LLM_AUTH_GUIDANCE);
+  });
+
+  it("maps an 'invalid api key' message to the guidance", () => {
+    expect(describeAgentRunError(new Error("invalid api key"))).toBe(LLM_AUTH_GUIDANCE);
+  });
+
+  it("detects an auth failure wrapped in the error cause chain (AI SDK wrapping)", () => {
+    const inner = new Error("invalid api key");
+    const outer = new Error("model call failed");
+    (outer as Error & { cause?: unknown }).cause = inner;
+    expect(describeAgentRunError(outer)).toBe(LLM_AUTH_GUIDANCE);
+  });
+
+  it("leaves a non-LLM error message unchanged (e.g. a transfer failure)", () => {
+    expect(describeAgentRunError(new Error("QUARK_TRANSFER_FAILED: dead share"))).toBe(
+      "QUARK_TRANSFER_FAILED: dead share",
+    );
+  });
+
+  it("returns a stable string for a non-Error value", () => {
+    expect(describeAgentRunError("Workflow failed")).toBe("Workflow failed");
+  });
+
+  it("never mentions MiMo in the auth guidance", () => {
+    expect(LLM_AUTH_GUIDANCE.toLowerCase()).not.toContain("mimo");
+  });
+
+  it("uses the approved agnostic 401 guidance text", () => {
+    expect(LLM_AUTH_GUIDANCE).toBe(
+      "AI 模型鉴权失败(401):请到 设置 → AI 模型 检查 API Key 是否有效、模型是否有权限(任意 OpenAI 兼容服务,自带 key)。",
+    );
+  });
+});

--- a/packages/workflow/src/agent-error.ts
+++ b/packages/workflow/src/agent-error.ts
@@ -18,15 +18,32 @@
 export const LLM_AUTH_GUIDANCE =
   "AI 模型鉴权失败(401):请到 设置 → AI 模型 检查 API Key 是否有效、模型是否有权限(任意 OpenAI 兼容服务,自带 key)。";
 
-// Message substrings that indicate an LLM authentication failure (case-insensitive).
-const AUTH_PATTERNS = [
+// LLM-SPECIFIC auth markers (case-insensitive). Deliberately NOT the bare numeric
+// "401"/"403" substrings — those over-match netdisk (brand) auth errors whose
+// messages carry the status number (e.g. "GUANGYA_AUTH_FAILED: 401 after refresh")
+// and would be misreported as an AI-模型 problem (Copilot #51 C3). These words are
+// what an OpenAI-compatible endpoint actually returns on a key/permission failure.
+const LLM_AUTH_PATTERNS = [
   "unauthorized",
-  "401",
   "forbidden",
-  "403",
   "invalid api key",
   "invalid_api_key",
+  "incorrect api key",
   "authentication",
+];
+
+// Netdisk (storage brand) auth errors are a TOKEN problem with the user's drive,
+// not the AI model. They are thrown as Pan115AuthError / QuarkAuthError /
+// GuangYaAuthError with these message prefixes (and class names). If any of these
+// markers is present anywhere in the error (or its cause chain), it is NEVER an
+// LLM-auth error — even if it carries a 401/403 statusCode or the word in its text.
+const BRAND_AUTH_MARKERS = [
+  "guangya",
+  "quark",
+  "pan115",
+  "pan115autherror",
+  "quarkautherror",
+  "guangyaautherror",
 ];
 
 function messageOf(error: unknown): string {
@@ -49,13 +66,26 @@ function statusCodeOf(error: unknown): number | undefined {
   return undefined;
 }
 
+/** True if this error (one node, name+message) is a netdisk brand auth error —
+ *  which must NEVER be reported as an AI-模型 auth failure. */
+function isBrandAuthError(error: unknown): boolean {
+  const msg = messageOf(error);
+  return BRAND_AUTH_MARKERS.some((marker) => msg.includes(marker));
+}
+
 /**
  * True if `error` (or anything in its `cause` chain — the AI SDK wraps the real
- * error) is an LLM authentication failure: a 401/403 status code (e.g. an AI-SDK
- * APICallError), or a message matching a known auth pattern. Recursion-bounded.
+ * error) is an LLM authentication failure: an AI-SDK APICallError with a 401/403
+ * statusCode, OR a message matching an LLM-specific auth marker. A netdisk (brand)
+ * auth error short-circuits to false — even with a 401 statusCode — so a drive
+ * token problem is never mislabeled an AI-模型 problem. Recursion-bounded.
  */
 export function isLlmAuthError(error: unknown, depth = 0): boolean {
   if (error === null || error === undefined || depth > 5) {
+    return false;
+  }
+  // A brand auth error anywhere short-circuits: NOT an LLM-auth error.
+  if (isBrandAuthError(error)) {
     return false;
   }
   const status = statusCodeOf(error);
@@ -63,7 +93,7 @@ export function isLlmAuthError(error: unknown, depth = 0): boolean {
     return true;
   }
   const msg = messageOf(error);
-  if (AUTH_PATTERNS.some((pattern) => msg.includes(pattern))) {
+  if (LLM_AUTH_PATTERNS.some((pattern) => msg.includes(pattern))) {
     return true;
   }
   const cause = (error as { cause?: unknown }).cause;

--- a/packages/workflow/src/agent-error.ts
+++ b/packages/workflow/src/agent-error.ts
@@ -1,0 +1,89 @@
+/**
+ * User-facing error mapping for the acquisition agent's LLM layer.
+ *
+ * The live acquisition agent is truly BYO (issue #49): it drives an
+ * OpenAI-compatible model the self-hoster configures (Settings → AI 模型 / env).
+ * There is no built-in author endpoint, so a real auth failure at runtime is a
+ * problem with the user's OWN key/permissions — which previously surfaced verbatim
+ * as a raw HTTP 401 ("Unauthorized") in the failure notification with zero
+ * guidance.
+ *
+ * `describeAgentRunError` maps an LLM auth/401 failure onto an actionable,
+ * provider-agnostic Chinese message; every other error passes through unchanged so
+ * "no coverage" / transfer failures read exactly as before. It does NOT touch the
+ * original error — logs keep the raw detail.
+ */
+
+/** The actionable, model-agnostic message shown when the agent's LLM call fails auth. */
+export const LLM_AUTH_GUIDANCE =
+  "AI 模型鉴权失败(401):请到 设置 → AI 模型 检查 API Key 是否有效、模型是否有权限(任意 OpenAI 兼容服务,自带 key)。";
+
+// Message substrings that indicate an LLM authentication failure (case-insensitive).
+const AUTH_PATTERNS = [
+  "unauthorized",
+  "401",
+  "forbidden",
+  "403",
+  "invalid api key",
+  "invalid_api_key",
+  "authentication",
+];
+
+function messageOf(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name} ${error.message}`.toLowerCase();
+  }
+  if (typeof error === "string") {
+    return error.toLowerCase();
+  }
+  return "";
+}
+
+function statusCodeOf(error: unknown): number | undefined {
+  if (error !== null && typeof error === "object") {
+    const code = (error as { statusCode?: unknown }).statusCode;
+    if (typeof code === "number") {
+      return code;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * True if `error` (or anything in its `cause` chain — the AI SDK wraps the real
+ * error) is an LLM authentication failure: a 401/403 status code (e.g. an AI-SDK
+ * APICallError), or a message matching a known auth pattern. Recursion-bounded.
+ */
+export function isLlmAuthError(error: unknown, depth = 0): boolean {
+  if (error === null || error === undefined || depth > 5) {
+    return false;
+  }
+  const status = statusCodeOf(error);
+  if (status === 401 || status === 403) {
+    return true;
+  }
+  const msg = messageOf(error);
+  if (AUTH_PATTERNS.some((pattern) => msg.includes(pattern))) {
+    return true;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  return cause === undefined ? false : isLlmAuthError(cause, depth + 1);
+}
+
+/**
+ * Map a captured agent-run error to a USER-FACING message. LLM auth/401 failures
+ * become actionable, provider-agnostic guidance; every other error keeps its
+ * original message. Does NOT touch the original error — logs keep the raw detail.
+ */
+export function describeAgentRunError(error: unknown): string {
+  if (isLlmAuthError(error)) {
+    return LLM_AUTH_GUIDANCE;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "Workflow failed";
+}

--- a/packages/workflow/src/agent-model.ts
+++ b/packages/workflow/src/agent-model.ts
@@ -40,7 +40,7 @@ export function llmConfigError(cfg: { apiKey?: string; baseURL?: string; modelId
   const baseURL = (cfg.baseURL ?? "").trim();
   const modelId = (cfg.modelId ?? "").trim();
   if (baseURL === "" || modelId === "") {
-    return "未配置 AI 模型:请到 设置 → AI 模型 填写 Base URL 和 模型名(任意 OpenAI 兼容服务,自带);云端服务还需 API Key,本地模型可留空。";
+    return "未配置 AI 模型。请到「设置 → AI 模型」填写 Base URL 和模型名(任意 OpenAI 兼容服务,自带);云端服务还需 API Key,本地模型可留空。";
   }
   return null;
 }
@@ -57,12 +57,19 @@ export function createAgentProviderConfig(options: AgentModelOptions = {}): {
   if (configError) {
     throw new Error(configError);
   }
+  // Trim before building: llmConfigError validates on trimmed values, so the
+  // provider must use the trimmed values too (a pasted "  https://x/v1  " would
+  // otherwise hit a malformed endpoint). The api-key header is attached ONLY for
+  // a non-empty trimmed key — a blank/whitespace key (e.g. AGENT_MODEL_API_KEY=
+  // in .env) means keyless local LLM; sending `api-key: ""` would cause an
+  // avoidable 401 (Copilot #51 C1).
+  const key = options.apiKey?.trim();
   const providerSettings: OpenAICompatibleProviderSettings = {
     name: options.providerName ?? DEFAULT_PROVIDER_NAME,
-    baseURL: options.baseURL!,
-    ...(options.apiKey === undefined ? {} : { headers: { "api-key": options.apiKey } }),
+    baseURL: options.baseURL!.trim(),
+    ...(key ? { headers: { "api-key": key } } : {}),
   };
-  return { providerSettings, modelId: options.modelId! };
+  return { providerSettings, modelId: options.modelId!.trim() };
 }
 
 /** Build the live LanguageModel from explicit options (DB settings). Honors the

--- a/packages/workflow/src/agent-model.ts
+++ b/packages/workflow/src/agent-model.ts
@@ -59,15 +59,25 @@ export function createAgentProviderConfig(options: AgentModelOptions = {}): {
   }
   // Trim before building: llmConfigError validates on trimmed values, so the
   // provider must use the trimmed values too (a pasted "  https://x/v1  " would
-  // otherwise hit a malformed endpoint). The api-key header is attached ONLY for
-  // a non-empty trimmed key — a blank/whitespace key (e.g. AGENT_MODEL_API_KEY=
-  // in .env) means keyless local LLM; sending `api-key: ""` would cause an
-  // avoidable 401 (Copilot #51 C1).
+  // otherwise hit a malformed endpoint).
+  //
+  // Send the key BOTH ways when present (#49 real root cause):
+  //  - `apiKey`  → the provider emits `Authorization: Bearer <key>`. This is how
+  //    STANDARD OpenAI-compatible services authenticate — DeepSeek, OpenAI, Groq,
+  //    OpenRouter, … — and they IGNORE a custom `api-key` header. Without this a
+  //    correctly-configured DeepSeek key still 401s.
+  //  - `headers: { "api-key": <key> }` → MiMo / Azure-OpenAI read this header.
+  // They coexist safely: the provider merges
+  // `{ ...(apiKey && { Authorization }), ...headers }`, and our header key is
+  // `api-key` (not `Authorization`), so neither clobbers the other.
+  //
+  // A blank/whitespace key (e.g. AGENT_MODEL_API_KEY= in .env) → send NEITHER
+  // (keyless local LLM — ollama/LM Studio; sending an empty key would 401) (C1).
   const key = options.apiKey?.trim();
   const providerSettings: OpenAICompatibleProviderSettings = {
     name: options.providerName ?? DEFAULT_PROVIDER_NAME,
     baseURL: options.baseURL!.trim(),
-    ...(key ? { headers: { "api-key": key } } : {}),
+    ...(key ? { apiKey: key, headers: { "api-key": key } } : {}),
   };
   return { providerSettings, modelId: options.modelId!.trim() };
 }

--- a/packages/workflow/src/agent-model.ts
+++ b/packages/workflow/src/agent-model.ts
@@ -2,7 +2,7 @@ import { createOpenAICompatible, type OpenAICompatibleProviderSettings } from "@
 import type { LanguageModel } from "ai";
 
 /**
- * The live acquisition agent model factory — a bare OpenAI-compatible (MiMo)
+ * The live acquisition agent model factory — a bare OpenAI-compatible
  * LanguageModel that drives the V2 sandbox tool-loop. This was lost in Phase 8
  * (764ae19) when the dead structured-output agent (`ai-sdk-agent.ts`) was deleted
  * wholesale; but the FACTORY is live — `apps/web` `getAgentModel` calls
@@ -10,14 +10,17 @@ import type { LanguageModel } from "ai";
  * interrogation script uses it too. Restored here as a focused, dependency-light
  * module (no dead agent attached).
  *
- * The MiMo OpenAI-compatible endpoint does NOT support `response_format`; the V2
- * agent never relies on it (it uses the AI SDK tool-loop with zod inputSchemas),
- * so a bare model is all that is needed.
+ * Truly BYO + model-AGNOSTIC (issue #49): the self-hoster supplies their own
+ * OpenAI-compatible endpoint (Settings → AI 模型 / env). `baseURL` + `modelId` are
+ * REQUIRED — the factory invents NO default endpoint. `apiKey` is OPTIONAL: cloud
+ * services need it (sent as the `api-key` header); keyless local LLMs
+ * (ollama / LM Studio) legitimately omit it. There is NO silent author default.
+ *
+ * A bare model (no `response_format`) is all the V2 agent needs — it uses the AI
+ * SDK tool-loop with zod inputSchemas, never structured output.
  */
 
 const DEFAULT_PROVIDER_NAME = "agent-model";
-const DEFAULT_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1";
-const DEFAULT_MODEL_ID = "mimo-v2.5-pro";
 
 export interface AgentModelOptions {
   apiKey?: string;
@@ -26,22 +29,45 @@ export interface AgentModelOptions {
   providerName?: string;
 }
 
-/** Map options (with MiMo defaults) onto OpenAI-compatible provider settings. */
+/**
+ * Agnostic (model-vendor-neutral) error for an LLM config that cannot build a
+ * model: returns a message when `baseURL` or `modelId` is missing/blank, else
+ * null. `apiKey` is NOT required (keyless local LLMs are valid). PURE + exported
+ * so the fail-fast upstream pre-check reuses the SAME predicate the factory
+ * enforces. NEVER mentions a specific provider.
+ */
+export function llmConfigError(cfg: { apiKey?: string; baseURL?: string; modelId?: string }): string | null {
+  const baseURL = (cfg.baseURL ?? "").trim();
+  const modelId = (cfg.modelId ?? "").trim();
+  if (baseURL === "" || modelId === "") {
+    return "未配置 AI 模型:请到 设置 → AI 模型 填写 Base URL 和 模型名(任意 OpenAI 兼容服务,自带);云端服务还需 API Key,本地模型可留空。";
+  }
+  return null;
+}
+
+/** Map options onto OpenAI-compatible provider settings. baseURL + modelId are
+ *  REQUIRED (no invented default); apiKey is optional (keyless local LLMs). Throws
+ *  the agnostic config error as a backstop — the friendly pre-check upstream
+ *  catches the same gap first. */
 export function createAgentProviderConfig(options: AgentModelOptions = {}): {
   providerSettings: OpenAICompatibleProviderSettings;
   modelId: string;
 } {
+  const configError = llmConfigError(options);
+  if (configError) {
+    throw new Error(configError);
+  }
   const providerSettings: OpenAICompatibleProviderSettings = {
     name: options.providerName ?? DEFAULT_PROVIDER_NAME,
-    baseURL: options.baseURL ?? DEFAULT_BASE_URL,
+    baseURL: options.baseURL!,
     ...(options.apiKey === undefined ? {} : { headers: { "api-key": options.apiKey } }),
   };
-  return { providerSettings, modelId: options.modelId ?? DEFAULT_MODEL_ID };
+  return { providerSettings, modelId: options.modelId! };
 }
 
-/** Build the live LanguageModel from explicit options (DB settings), with the
- *  built-in MiMo defaults filling any gap. Used by the web layer to honor the
- *  user's Settings → AI 模型 config (BYO-key self-host). */
+/** Build the live LanguageModel from explicit options (DB settings). Honors the
+ *  user's Settings → AI 模型 config (BYO self-host). Throws the agnostic config
+ *  error when baseURL/modelId are missing. */
 export function createAgentModel(options: AgentModelOptions = {}): LanguageModel {
   const { providerSettings, modelId } = createAgentProviderConfig(options);
   return createOpenAICompatible(providerSettings)(modelId);
@@ -49,7 +75,8 @@ export function createAgentModel(options: AgentModelOptions = {}): LanguageModel
 
 /**
  * Build the live LanguageModel from env. Reads AGENT_MODEL_* with XIAOMI_MIMO_*
- * as the fallback (same precedence the web/worker and interrogation use).
+ * as the fallback (back-compat: existing instances that set the legacy keys keep
+ * working). Same precedence the web/worker and interrogation use.
  */
 export function createAgentModelFromEnv(env: NodeJS.ProcessEnv = process.env): LanguageModel {
   const options: AgentModelOptions = {};

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./domain.js";
 export * from "./agent-model.js";
+export * from "./agent-error.js";
 export * from "./media-classification.js";
 export * from "./movie-workflow-v2.js";
 export * from "./notification-report.js";

--- a/packages/workflow/src/worker.ts
+++ b/packages/workflow/src/worker.ts
@@ -18,6 +18,7 @@ import {
   requeueWorkflowRunForRetry,
 } from "./repository.js";
 import { isTransientAcquisitionError } from "./acquisition-v2/transient-error.js";
+import { describeAgentRunError } from "./agent-error.js";
 import { formatReportPushText } from "./notification-report.js";
 import { isMovieUnreleased } from "./domain.js";
 import {
@@ -174,7 +175,12 @@ export async function handleWorkflowRunFailure(input: {
 }): Promise<{ status: "auto_requeued" | "failed"; workflowRunId: string; errorMessage: string }> {
   const { claimed, error, repository } = input;
   const nowIso = input.now();
-  const errorMessage = error instanceof Error ? error.message : "Workflow failed";
+  // describeAgentRunError maps an LLM auth/401 failure (the agent dying on its
+  // first model call when the BYO LLM key is missing/invalid, issue #49) onto
+  // actionable, provider-agnostic guidance; every other error keeps its original
+  // message. The raw `error` object is untouched, so transient classification +
+  // any logging stay accurate.
+  const errorMessage = describeAgentRunError(error);
   const priorCount = claimed.workflowRun.autoRequeueCount ?? 0;
   const transient = isTransientAcquisitionError(error);
   const willRetry = transient && priorCount < AUTO_REQUEUE_MAX;

--- a/packages/workflow/tests/agent-model.test.ts
+++ b/packages/workflow/tests/agent-model.test.ts
@@ -30,50 +30,60 @@ describe("agent-model — the live OpenAI-compatible (BYO) LanguageModel factory
     expect(providerSettings.baseURL).toBe("https://example.test/v1");
   });
 
-  it("sends the api-key header when apiKey is set", () => {
+  // #49 real root cause: the key must go out BOTH ways. Standard OpenAI-compatible
+  // providers (DeepSeek/OpenAI/Groq/OpenRouter) authenticate via
+  // `Authorization: Bearer <key>`, which @ai-sdk/openai-compatible emits ONLY from
+  // the provider's `apiKey` field — they IGNORE the `api-key` header. MiMo/Azure
+  // read the `api-key` header. Sending both = universal compatibility.
+  it("sends the key BOTH ways when apiKey is set (apiKey→Bearer AND api-key header)", () => {
     const { providerSettings } = createAgentProviderConfig({
       apiKey: "secret",
       baseURL: "https://example.test/v1",
       modelId: "custom-model",
     });
+    expect(providerSettings.apiKey).toBe("secret");
     expect(providerSettings.headers).toEqual({ "api-key": "secret" });
   });
 
-  it("omits the api-key header for a keyless local LLM", () => {
+  it("omits BOTH apiKey and headers for a keyless local LLM", () => {
     const { providerSettings } = createAgentProviderConfig({
       baseURL: "http://localhost:11434/v1",
       modelId: "qwen2.5",
     });
+    expect(providerSettings.apiKey).toBeUndefined();
     expect(providerSettings.headers).toBeUndefined();
   });
 
   // C1 (Copilot #51): a blank/whitespace apiKey (e.g. AGENT_MODEL_API_KEY= in
-  // .env) must NOT send `api-key: ""` — that breaks keyless local LLMs with an
-  // avoidable 401. Only attach the header for a non-empty key (trimmed).
-  it("omits the api-key header for an EMPTY-STRING apiKey (keyless)", () => {
+  // .env) must NOT send a key at all — neither Bearer nor `api-key: ""` — that
+  // breaks keyless local LLMs with an avoidable 401.
+  it("omits BOTH apiKey and headers for an EMPTY-STRING apiKey (keyless)", () => {
     const { providerSettings } = createAgentProviderConfig({
       apiKey: "",
       baseURL: "http://localhost:11434/v1",
       modelId: "qwen2.5",
     });
+    expect(providerSettings.apiKey).toBeUndefined();
     expect(providerSettings.headers).toBeUndefined();
   });
 
-  it("omits the api-key header for a whitespace-only apiKey (keyless)", () => {
+  it("omits BOTH apiKey and headers for a whitespace-only apiKey (keyless)", () => {
     const { providerSettings } = createAgentProviderConfig({
       apiKey: "   ",
       baseURL: "http://localhost:11434/v1",
       modelId: "qwen2.5",
     });
+    expect(providerSettings.apiKey).toBeUndefined();
     expect(providerSettings.headers).toBeUndefined();
   });
 
-  it("trims the api-key, baseURL and modelId before building provider settings", () => {
+  it("trims the key (both Bearer + header), baseURL and modelId before building provider settings", () => {
     const { providerSettings, modelId } = createAgentProviderConfig({
       apiKey: "  secret  ",
       baseURL: "  https://example.test/v1  ",
       modelId: "  custom-model  ",
     });
+    expect(providerSettings.apiKey).toBe("secret");
     expect(providerSettings.headers).toEqual({ "api-key": "secret" });
     expect(providerSettings.baseURL).toBe("https://example.test/v1");
     expect(modelId).toBe("custom-model");

--- a/packages/workflow/tests/agent-model.test.ts
+++ b/packages/workflow/tests/agent-model.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  createAgentModel,
   createAgentProviderConfig,
   createAgentModelFromEnv,
+  llmConfigError,
   normalizeLlmBaseUrl,
   sanitizeLlmApiKey,
 } from "../src/agent-model.js";
@@ -12,36 +14,101 @@ import {
  * calls createAgentModelFromEnv for every real (vercel-ai) run, and the §6a
  * interrogation script uses it. Losing it breaks live e2e at runtime even though
  * tsc stayed green (the web typechecked against a stale dist .d.ts).
+ *
+ * BYO model: the factory is model-AGNOSTIC. baseURL + modelId are REQUIRED;
+ * apiKey is OPTIONAL (keyless local LLMs — ollama/LM Studio — are valid). There
+ * is NO silent MiMo default (issue #49).
  */
-describe("agent-model — the live OpenAI-compatible (MiMo) LanguageModel factory", () => {
-  it("maps options to provider settings with the MiMo defaults", () => {
-    const { providerSettings, modelId } = createAgentProviderConfig({});
-    expect(modelId).toBe("mimo-v2.5-pro");
-    expect(providerSettings.name).toBe("agent-model");
-    expect(providerSettings.baseURL).toBe("https://token-plan-sgp.xiaomimimo.com/v1");
-  });
-
-  it("honors explicit apiKey / baseURL / modelId overrides", () => {
+describe("agent-model — the live OpenAI-compatible (BYO) LanguageModel factory", () => {
+  it("maps explicit options onto provider settings (no invented defaults)", () => {
     const { providerSettings, modelId } = createAgentProviderConfig({
-      apiKey: "secret",
       baseURL: "https://example.test/v1",
       modelId: "custom-model",
     });
     expect(modelId).toBe("custom-model");
+    expect(providerSettings.name).toBe("agent-model");
     expect(providerSettings.baseURL).toBe("https://example.test/v1");
+  });
+
+  it("sends the api-key header when apiKey is set", () => {
+    const { providerSettings } = createAgentProviderConfig({
+      apiKey: "secret",
+      baseURL: "https://example.test/v1",
+      modelId: "custom-model",
+    });
     expect(providerSettings.headers).toEqual({ "api-key": "secret" });
   });
 
-  it("builds a model from AGENT_MODEL_* env (XIAOMI_MIMO_* as fallback)", () => {
+  it("omits the api-key header for a keyless local LLM", () => {
+    const { providerSettings } = createAgentProviderConfig({
+      baseURL: "http://localhost:11434/v1",
+      modelId: "qwen2.5",
+    });
+    expect(providerSettings.headers).toBeUndefined();
+  });
+
+  it("throws an agnostic error (no MiMo) when baseURL is missing", () => {
+    expect(() => createAgentProviderConfig({ modelId: "x" })).toThrow();
+    try {
+      createAgentProviderConfig({ modelId: "x" });
+    } catch (error) {
+      expect((error as Error).message.toLowerCase()).not.toContain("mimo");
+    }
+  });
+
+  it("throws an agnostic error when modelId is missing", () => {
+    expect(() => createAgentModel({ baseURL: "https://example.test/v1" })).toThrow();
+  });
+
+  it("builds a model from AGENT_MODEL_* env", () => {
     const model = createAgentModelFromEnv({
       AGENT_MODEL_API_KEY: "k",
-      AGENT_MODEL_ID: "mimo-v2.5-pro",
+      AGENT_MODEL_BASE_URL: "https://example.test/v1",
+      AGENT_MODEL_ID: "some-model",
     } as NodeJS.ProcessEnv);
     expect(model).toBeDefined();
-    expect((model as { modelId?: string }).modelId).toBe("mimo-v2.5-pro");
+    expect((model as { modelId?: string }).modelId).toBe("some-model");
+  });
 
-    const fallback = createAgentModelFromEnv({ XIAOMI_MIMO_API_KEY: "k2" } as NodeJS.ProcessEnv);
+  it("still reads the XIAOMI_MIMO_* env fallback (back-compat for existing instances)", () => {
+    const fallback = createAgentModelFromEnv({
+      XIAOMI_MIMO_API_KEY: "k2",
+      XIAOMI_MIMO_BASE_URL: "https://token-plan-sgp.xiaomimimo.com/v1",
+      XIAOMI_MIMO_MODEL_ID: "mimo-v2.5-pro",
+    } as NodeJS.ProcessEnv);
     expect((fallback as { modelId?: string }).modelId).toBe("mimo-v2.5-pro");
+  });
+
+  it("throws (no silent default) when env configures nothing", () => {
+    expect(() => createAgentModelFromEnv({} as NodeJS.ProcessEnv)).toThrow();
+  });
+});
+
+describe("llmConfigError — agnostic, BYO required-config predicate", () => {
+  it("flags a missing baseURL", () => {
+    expect(llmConfigError({ modelId: "x" })).not.toBeNull();
+  });
+
+  it("flags a blank baseURL", () => {
+    expect(llmConfigError({ baseURL: "  ", modelId: "x" })).not.toBeNull();
+  });
+
+  it("flags a missing modelId", () => {
+    expect(llmConfigError({ baseURL: "https://x/v1" })).not.toBeNull();
+  });
+
+  it("returns null when baseURL + modelId are present and no apiKey (keyless local LLM OK)", () => {
+    expect(llmConfigError({ baseURL: "http://localhost:11434/v1", modelId: "qwen" })).toBeNull();
+  });
+
+  it("returns null when all three are present", () => {
+    expect(
+      llmConfigError({ apiKey: "sk-x", baseURL: "https://x/v1", modelId: "gpt-4o" }),
+    ).toBeNull();
+  });
+
+  it("never mentions MiMo in the message", () => {
+    expect((llmConfigError({}) ?? "").toLowerCase()).not.toContain("mimo");
   });
 });
 

--- a/packages/workflow/tests/agent-model.test.ts
+++ b/packages/workflow/tests/agent-model.test.ts
@@ -47,6 +47,38 @@ describe("agent-model — the live OpenAI-compatible (BYO) LanguageModel factory
     expect(providerSettings.headers).toBeUndefined();
   });
 
+  // C1 (Copilot #51): a blank/whitespace apiKey (e.g. AGENT_MODEL_API_KEY= in
+  // .env) must NOT send `api-key: ""` — that breaks keyless local LLMs with an
+  // avoidable 401. Only attach the header for a non-empty key (trimmed).
+  it("omits the api-key header for an EMPTY-STRING apiKey (keyless)", () => {
+    const { providerSettings } = createAgentProviderConfig({
+      apiKey: "",
+      baseURL: "http://localhost:11434/v1",
+      modelId: "qwen2.5",
+    });
+    expect(providerSettings.headers).toBeUndefined();
+  });
+
+  it("omits the api-key header for a whitespace-only apiKey (keyless)", () => {
+    const { providerSettings } = createAgentProviderConfig({
+      apiKey: "   ",
+      baseURL: "http://localhost:11434/v1",
+      modelId: "qwen2.5",
+    });
+    expect(providerSettings.headers).toBeUndefined();
+  });
+
+  it("trims the api-key, baseURL and modelId before building provider settings", () => {
+    const { providerSettings, modelId } = createAgentProviderConfig({
+      apiKey: "  secret  ",
+      baseURL: "  https://example.test/v1  ",
+      modelId: "  custom-model  ",
+    });
+    expect(providerSettings.headers).toEqual({ "api-key": "secret" });
+    expect(providerSettings.baseURL).toBe("https://example.test/v1");
+    expect(modelId).toBe("custom-model");
+  });
+
   it("throws an agnostic error (no MiMo) when baseURL is missing", () => {
     expect(() => createAgentProviderConfig({ modelId: "x" })).toThrow();
     try {
@@ -109,6 +141,13 @@ describe("llmConfigError — agnostic, BYO required-config predicate", () => {
 
   it("never mentions MiMo in the message", () => {
     expect((llmConfigError({}) ?? "").toLowerCase()).not.toContain("mimo");
+  });
+
+  // C2 (Copilot #51): clean, user-facing wording.
+  it("uses the approved cleaned-up wording", () => {
+    expect(llmConfigError({})).toBe(
+      "未配置 AI 模型。请到「设置 → AI 模型」填写 Base URL 和模型名(任意 OpenAI 兼容服务,自带);云端服务还需 API Key,本地模型可留空。",
+    );
   });
 });
 

--- a/packages/workflow/tests/handle-workflow-failure.test.ts
+++ b/packages/workflow/tests/handle-workflow-failure.test.ts
@@ -111,6 +111,34 @@ describe("handleWorkflowRunFailure", () => {
     expect(saved.episodes[0]?.episodeCode).toBe("S01E01");
   });
 
+  it("maps an LLM 401 'Unauthorized' failure to actionable guidance in the user-facing message (#49)", async () => {
+    const save = vi.fn(async (_input: PersistWorkflowRunSnapshotInput) => {});
+    const out = await handleWorkflowRunFailure({
+      claimed: snapshot(),
+      error: new Error("Unauthorized"),
+      repository: { saveWorkflowRunSnapshot: save },
+      now,
+    });
+    expect(out.status).toBe("failed");
+    expect(out.errorMessage).toContain("AI 模型鉴权失败");
+    expect(out.errorMessage).not.toBe("Unauthorized");
+    const saved = save.mock.calls[0]![0];
+    const body = saved.notifications[0]?.body ?? "";
+    expect(body).toContain("设置 → AI 模型");
+    expect(body).not.toContain("Unauthorized");
+  });
+
+  it("leaves a non-LLM failure message unchanged (no false positive)", async () => {
+    const save = vi.fn(async (_input: PersistWorkflowRunSnapshotInput) => {});
+    const out = await handleWorkflowRunFailure({
+      claimed: snapshot(),
+      error: new Error("QUARK_TRANSFER_FAILED: dead share"),
+      repository: { saveWorkflowRunSnapshot: save },
+      now,
+    });
+    expect(out.errorMessage).toBe("QUARK_TRANSFER_FAILED: dead share");
+  });
+
   it("terminally fails a NON-transient error immediately (count=0)", async () => {
     const save = vi.fn(async (_input: PersistWorkflowRunSnapshotInput) => {});
     const out = await handleWorkflowRunFailure({

--- a/scripts/agent-planning-smoke.mjs
+++ b/scripts/agent-planning-smoke.mjs
@@ -118,7 +118,7 @@ const input = {
 
 console.log("=== acquisition planning live smoke (read-only) ===");
 console.log(JSON.stringify(input, null, 2));
-console.log("model:", process.env.AGENT_MODEL_ID ?? "mimo-v2.5-pro (default)");
+console.log("model:", process.env.AGENT_MODEL_ID ?? "(unset — required)");
 
 const startedAt = Date.now();
 const result = await runAcquisitionPlanningSmoke({

--- a/scripts/interrogate-acquisition-agent.mjs
+++ b/scripts/interrogate-acquisition-agent.mjs
@@ -82,7 +82,7 @@ const only = args.only ? args.only.split(",").map((s) => s.trim()).filter(Boolea
 
 console.log("=== §6a interrogation (read-only — verifies 聪明 before spending) ===");
 console.log("agent:", agent);
-console.log("model:", process.env.AGENT_MODEL_ID ?? process.env.XIAOMI_MIMO_MODEL_ID ?? "mimo-v2.5-pro (default)");
+console.log("model:", process.env.AGENT_MODEL_ID ?? process.env.XIAOMI_MIMO_MODEL_ID ?? "(unset — required)");
 console.log("scenario:", scenario);
 if (only) console.log("only:", only.join(", "));
 console.log("");


### PR DESCRIPTION
## Problem (#49)
A self-hoster's acquisition failed with a raw "Unauthorized" notification. Root cause: the agent's LLM was **not truly BYO** — the code hardcoded the author's personal MiMo endpoint (`https://token-plan-sgp.xiaomimimo.com/v1` + `mimo-v2.5-pro`) as the silent default. A self-hoster who configured nothing had their agent call the author's MiMo endpoint **keyless → HTTP 401**, surfaced verbatim with zero guidance. MiMo is not special — it's just what the author personally uses; it must not be the product baseline.

## Fix — truly BYO + model-agnostic
1. **Drop the MiMo hard defaults** (`agent-model.ts`): `baseURL` + `modelId` are now **REQUIRED**; `apiKey` is **OPTIONAL** (keyless local LLMs — ollama/LM Studio — send no `api-key` header; cloud services still do). `createAgentProviderConfig`/`createAgentModel` throw a clear, agnostic error (no "MiMo") when baseURL/modelId is missing. New pure, exported `llmConfigError(cfg)` helper returns the agnostic message or null.
2. **Fail-fast pre-check** (`getAgentModel` in `workflow-runtime.ts`): on the `vercel-ai` path, throw the agnostic guidance immediately when baseURL/modelId is missing — actionable guidance at 获取 time instead of a 401 after a long agent run. Empty apiKey does **not** trigger it (local LLM). Fake adapter unaffected.
3. **Friendly runtime 401 mapping** (`agent-error.ts` `describeAgentRunError`): real LLM auth failures (message `unauthorized|401|forbidden|invalid api key|authentication`, or AI-SDK `APICallError` statusCode 401/403, incl. wrapped `cause`) map to an agnostic actionable message; every other error passes through unchanged. Applied at the user-facing failure-notification site (`handleWorkflowRunFailure`); logs keep the raw error.
4. **`.env.example` de-MiMo'd**: generic `AGENT_MODEL_*` (empty). The `XIAOMI_MIMO_*` env fallback is **still READ** in `resolveAgentModelConfig`/`createAgentModelFromEnv` (back-compat) — just no longer presented as the default.
5. **Settings note**: AI 模型 is now **必填** + agnostic; local Key may be blank.

## Migration
Instances now need `baseURL` + `model` set (env `AGENT_MODEL_*` or Settings → AI 模型). No silent MiMo fallback. Existing instances that set `XIAOMI_MIMO_*` keep working (still read).

## Test plan (strict TDD — failing test first)
- `llmConfigError`: missing baseURL → message; blank baseURL → message; missing modelId → message; baseURL+modelId, no apiKey → null (local LLM OK); all present → null; never says MiMo.
- `createAgentProviderConfig`/`createAgentModel`: omit api-key header when keyless; throw agnostic (no MiMo) when baseURL/modelId missing; `createAgentModelFromEnv` still reads `XIAOMI_MIMO_*`, throws when env configures nothing.
- `describeAgentRunError`: "Unauthorized"/403/401-statusCode/invalid-api-key/wrapped-cause → agnostic 401 guidance; "QUARK_TRANSFER_FAILED: dead share" → unchanged.
- `handleWorkflowRunFailure`: 401 → user-facing notification body shows 设置 → AI 模型 guidance, never "Unauthorized"; non-LLM error unchanged.

## Verification
- `npm run build:workflow` ✓
- `npx tsc -p apps/web/tsconfig.json --noEmit` ✓ · `npx tsc --noEmit` packages/workflow ✓
- `npx vitest run` full: **938 passed / 12 skipped / 0 failed**
- `npx eslint` changed source files: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)