### PR TITLE
fix(activity): 全季获取卡片显示季号列表(第 1/2/3/4 季)而非误导的「第 1 季」

### DIFF
--- a/apps/web/components/activity-feed.tsx
+++ b/apps/web/components/activity-feed.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { CheckCircle2, ChevronDown, ChevronRight, Clock3, Loader2, RotateCcw, TriangleAlert, X } from "lucide-react";
 import { showHref } from "@media-track/workflow/scope";
 import type { ActivityActiveRun, ActivityCompletedItem, ActivityView } from "../lib/activity-view";
-import { seasonLabelText } from "../lib/activity-view";
+import { seasonLabelText } from "../lib/activity-season-label";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { demoCompletedItems, demoInProgressActivityItems } from "../lib/demo-session";
 import { useDemoAcquisitions, useDemoInProgress } from "../lib/use-demo-session";

--- a/apps/web/components/activity-feed.tsx
+++ b/apps/web/components/activity-feed.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { CheckCircle2, ChevronDown, ChevronRight, Clock3, Loader2, RotateCcw, TriangleAlert, X } from "lucide-react";
 import { showHref } from "@media-track/workflow/scope";
 import type { ActivityActiveRun, ActivityCompletedItem, ActivityView } from "../lib/activity-view";
+import { seasonLabelText } from "../lib/activity-view";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { demoCompletedItems, demoInProgressActivityItems } from "../lib/demo-session";
 import { useDemoAcquisitions, useDemoInProgress } from "../lib/use-demo-session";
@@ -105,7 +106,7 @@ function poster(posterPath: string | null, title: string, tone: string) {
 }
 
 function seasonLabel(run: ActivityActiveRun): string {
-  return run.type === "movie" || run.seasonNumber === null ? "" : `第 ${run.seasonNumber} 季`;
+  return seasonLabelText(run.type, run.seasonNumbers ?? [], run.seasonNumber);
 }
 
 function RunningRow({ run, storageId }: { run: ActivityActiveRun; storageId?: string | undefined }) {

--- a/apps/web/lib/activity-season-label.test.ts
+++ b/apps/web/lib/activity-season-label.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { EpisodeState } from "@media-track/workflow";
+// Import from the PURE module (not activity-view) — this is the client-safe home
+// for these helpers, kept free of the Postgres-backed runtime.
+import { distinctSeasons, seasonLabelText } from "./activity-season-label";
+
+function episode(seasonNumber: number, episodeNumber: number): EpisodeState {
+  return {
+    trackedSeasonId: "s",
+    episodeCode: `S${String(seasonNumber).padStart(2, "0")}E${String(episodeNumber).padStart(2, "0")}`,
+    airDate: null,
+    title: `Episode ${episodeNumber}`,
+    airStatus: "aired",
+    obtained: false,
+    metadataStatus: "confirmed",
+    verifiedFileIds: [],
+  };
+}
+
+describe("distinctSeasons", () => {
+  it("returns distinct, sorted season numbers from episode codes", () => {
+    const episodes = [episode(1, 1), episode(1, 2), episode(2, 1), episode(3, 1), episode(3, 2)];
+    expect(distinctSeasons(episodes)).toEqual([1, 2, 3]);
+  });
+  it("single season → [n]", () => {
+    expect(distinctSeasons([episode(1, 1), episode(1, 2)])).toEqual([1]);
+    expect(distinctSeasons([episode(2, 1)])).toEqual([2]);
+  });
+  it("empty → []", () => {
+    expect(distinctSeasons([])).toEqual([]);
+  });
+  it("sorts numerically (not lexically) and dedupes out-of-order codes", () => {
+    expect(distinctSeasons([episode(10, 1), episode(2, 1), episode(2, 2), episode(1, 1)])).toEqual([1, 2, 10]);
+  });
+});
+
+describe("seasonLabelText", () => {
+  it("movie → empty string regardless of seasons", () => {
+    expect(seasonLabelText("movie", [1, 2], 1)).toBe("");
+  });
+  it("no seasons (empty list, null single) → empty string", () => {
+    expect(seasonLabelText("tv", [], null)).toBe("");
+  });
+  it("single season → 第 N 季", () => {
+    expect(seasonLabelText("tv", [2], 2)).toBe("第 2 季");
+  });
+  it("multiple seasons → joined 第 1/2/3/4 季", () => {
+    expect(seasonLabelText("tv", [1, 2, 3, 4], 1)).toBe("第 1/2/3/4 季");
+  });
+  it("falls back to the single seasonNumber when the list is empty", () => {
+    expect(seasonLabelText("tv", [], 3)).toBe("第 3 季");
+  });
+});

--- a/apps/web/lib/activity-season-label.ts
+++ b/apps/web/lib/activity-season-label.ts
@@ -1,0 +1,44 @@
+// Client-safe, pure season-label helpers. This module MUST have ZERO runtime
+// imports — only `import type` — so it can be value-imported from a "use client"
+// component without dragging the server runtime (and transitively the `pg`
+// Postgres driver) into the browser bundle. `activity-view.ts` re-exports these
+// for server-side callers; the activity-feed client component imports them here.
+import type { EpisodeState, MediaType } from "@media-track/workflow";
+
+/**
+ * Distinct, sorted (numeric) season numbers present in an episode set, derived
+ * from each episode's `SxxExx` code (EpisodeState carries no explicit season).
+ * A whole-show ("全季") run has episodes across many seasons even though its
+ * `season.seasonNumber` is a single placeholder → this exposes the real span.
+ * Pure + defensive: episodes with an unparseable code are skipped.
+ */
+export function distinctSeasons(episodes: readonly EpisodeState[]): number[] {
+  const seasons = new Set<number>();
+  for (const episode of episodes) {
+    const match = /^S(\d{2,})E\d{2,}$/.exec(episode.episodeCode);
+    if (match) {
+      seasons.add(Number(match[1]));
+    }
+  }
+  return Array.from(seasons).sort((a, b) => a - b);
+}
+
+/**
+ * The season label for an active-run card. Movies and season-less runs → "".
+ * One season → "第 N 季"; several → "第 1/2/3/4 季". Prefers the covered-season
+ * list; falls back to the single `seasonNumber` when the list is empty. Pure.
+ */
+export function seasonLabelText(
+  type: MediaType,
+  seasonNumbers: readonly number[],
+  seasonNumber: number | null,
+): string {
+  if (type === "movie") {
+    return "";
+  }
+  const seasons = seasonNumbers.length > 0 ? seasonNumbers : seasonNumber === null ? [] : [seasonNumber];
+  if (seasons.length === 0) {
+    return "";
+  }
+  return `第 ${seasons.join("/")} 季`;
+}

--- a/apps/web/lib/activity-view.test.ts
+++ b/apps/web/lib/activity-view.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   InMemoryWorkflowRepository,
+  type EpisodeState,
   type MediaTitle,
   type PersistWorkflowRunSnapshotInput,
   type TrackedSeason,
   type WorkflowStatus,
 } from "@media-track/workflow";
-import { getActivityView } from "./activity-view";
+import { distinctSeasons, getActivityView, seasonLabelText } from "./activity-view";
 
 function title(tmdbId: number, name: string): MediaTitle {
   return { id: `t${tmdbId}`, tmdbId, type: "tv", title: name, originalTitle: name, year: 2026, aliases: [], posterPath: `/p${tmdbId}.jpg` };
@@ -24,6 +25,18 @@ function season(titleId: string, seasonNumber: number): TrackedSeason {
     latestAiredSource: "metadata",
   };
 }
+function episode(seasonNumber: number, episodeNumber: number, trackedSeasonId = "s"): EpisodeState {
+  return {
+    trackedSeasonId,
+    episodeCode: `S${String(seasonNumber).padStart(2, "0")}E${String(episodeNumber).padStart(2, "0")}`,
+    airDate: null,
+    title: `Episode ${episodeNumber}`,
+    airStatus: "aired",
+    obtained: false,
+    metadataStatus: "confirmed",
+    verifiedFileIds: [],
+  };
+}
 function run(input: {
   id: string;
   tmdbId: number;
@@ -31,6 +44,7 @@ function run(input: {
   status: WorkflowStatus;
   startedAt: string;
   finishedAt?: string;
+  episodes?: EpisodeState[];
 }): PersistWorkflowRunSnapshotInput {
   const t = title(input.tmdbId, input.name);
   const s = season(t.id, 1);
@@ -46,7 +60,7 @@ function run(input: {
       finishedAt: input.finishedAt ?? null,
       auditEvents: [],
     },
-    episodes: [],
+    episodes: input.episodes ?? [],
     resourceSnapshots: [],
     decisions: [],
     transferAttempts: [],
@@ -77,7 +91,59 @@ function run(input: {
   };
 }
 
+describe("distinctSeasons", () => {
+  it("returns distinct, sorted season numbers from episode codes", () => {
+    const episodes = [episode(1, 1), episode(1, 2), episode(2, 1), episode(3, 1), episode(3, 2)];
+    expect(distinctSeasons(episodes)).toEqual([1, 2, 3]);
+  });
+  it("single season → [n]", () => {
+    expect(distinctSeasons([episode(1, 1), episode(1, 2)])).toEqual([1]);
+    expect(distinctSeasons([episode(2, 1)])).toEqual([2]);
+  });
+  it("empty → []", () => {
+    expect(distinctSeasons([])).toEqual([]);
+  });
+  it("sorts numerically (not lexically) and dedupes out-of-order codes", () => {
+    expect(distinctSeasons([episode(10, 1), episode(2, 1), episode(2, 2), episode(1, 1)])).toEqual([1, 2, 10]);
+  });
+});
+
+describe("seasonLabelText", () => {
+  it("movie → empty string regardless of seasons", () => {
+    expect(seasonLabelText("movie", [1, 2], 1)).toBe("");
+  });
+  it("no seasons (empty list, null single) → empty string", () => {
+    expect(seasonLabelText("tv", [], null)).toBe("");
+  });
+  it("single season → 第 N 季", () => {
+    expect(seasonLabelText("tv", [2], 2)).toBe("第 2 季");
+  });
+  it("multiple seasons → joined 第 1/2/3/4 季", () => {
+    expect(seasonLabelText("tv", [1, 2, 3, 4], 1)).toBe("第 1/2/3/4 季");
+  });
+  it("falls back to the single seasonNumber when the list is empty", () => {
+    expect(seasonLabelText("tv", [], 3)).toBe("第 3 季");
+  });
+});
+
 describe("getActivityView", () => {
+  it("active run over multiple seasons exposes the distinct sorted seasonNumbers", async () => {
+    const repo = new InMemoryWorkflowRepository();
+    const snap = run({
+      id: "r_multi",
+      tmdbId: 9,
+      name: "Ozark",
+      status: "running",
+      startedAt: "2026-06-17T00:00:00Z",
+      episodes: [episode(1, 1, "t9_s1"), episode(2, 1, "t9_s1"), episode(3, 1, "t9_s1"), episode(4, 1, "t9_s1")],
+    });
+    await repo.saveWorkflowRunSnapshot(snap);
+
+    const view = await getActivityView({ repository: repo });
+    const r = view.active.find((x) => x.runId === "r_multi")!;
+    expect(r.seasonNumbers).toEqual([1, 2, 3, 4]);
+  });
+
   it("returns active queued+running runs with queue positions; running carries progress", async () => {
     const repo = new InMemoryWorkflowRepository();
     await repo.saveWorkflowRunSnapshot(run({ id: "r_run", tmdbId: 1, name: "Running", status: "running", startedAt: "2026-06-17T00:00:00Z" }));

--- a/apps/web/lib/activity-view.test.ts
+++ b/apps/web/lib/activity-view.test.ts
@@ -7,7 +7,7 @@ import {
   type TrackedSeason,
   type WorkflowStatus,
 } from "@media-track/workflow";
-import { distinctSeasons, getActivityView, seasonLabelText } from "./activity-view";
+import { getActivityView } from "./activity-view";
 
 function title(tmdbId: number, name: string): MediaTitle {
   return { id: `t${tmdbId}`, tmdbId, type: "tv", title: name, originalTitle: name, year: 2026, aliases: [], posterPath: `/p${tmdbId}.jpg` };
@@ -90,41 +90,6 @@ function run(input: {
         : [],
   };
 }
-
-describe("distinctSeasons", () => {
-  it("returns distinct, sorted season numbers from episode codes", () => {
-    const episodes = [episode(1, 1), episode(1, 2), episode(2, 1), episode(3, 1), episode(3, 2)];
-    expect(distinctSeasons(episodes)).toEqual([1, 2, 3]);
-  });
-  it("single season → [n]", () => {
-    expect(distinctSeasons([episode(1, 1), episode(1, 2)])).toEqual([1]);
-    expect(distinctSeasons([episode(2, 1)])).toEqual([2]);
-  });
-  it("empty → []", () => {
-    expect(distinctSeasons([])).toEqual([]);
-  });
-  it("sorts numerically (not lexically) and dedupes out-of-order codes", () => {
-    expect(distinctSeasons([episode(10, 1), episode(2, 1), episode(2, 2), episode(1, 1)])).toEqual([1, 2, 10]);
-  });
-});
-
-describe("seasonLabelText", () => {
-  it("movie → empty string regardless of seasons", () => {
-    expect(seasonLabelText("movie", [1, 2], 1)).toBe("");
-  });
-  it("no seasons (empty list, null single) → empty string", () => {
-    expect(seasonLabelText("tv", [], null)).toBe("");
-  });
-  it("single season → 第 N 季", () => {
-    expect(seasonLabelText("tv", [2], 2)).toBe("第 2 季");
-  });
-  it("multiple seasons → joined 第 1/2/3/4 季", () => {
-    expect(seasonLabelText("tv", [1, 2, 3, 4], 1)).toBe("第 1/2/3/4 季");
-  });
-  it("falls back to the single seasonNumber when the list is empty", () => {
-    expect(seasonLabelText("tv", [], 3)).toBe("第 3 季");
-  });
-});
 
 describe("getActivityView", () => {
   it("active run over multiple seasons exposes the distinct sorted seasonNumbers", async () => {

--- a/apps/web/lib/activity-view.ts
+++ b/apps/web/lib/activity-view.ts
@@ -1,5 +1,6 @@
 import {
   landedSize,
+  type EpisodeState,
   type MediaType,
   type NotificationReportStatus,
   type WorkflowRepository,
@@ -14,7 +15,12 @@ export interface ActivityActiveRun {
   year: number | null;
   type: MediaType;
   posterPath: string | null;
+  /** Single requested season; null for movies and whole-show ("全季") runs. */
   seasonNumber: number | null;
+  /** Distinct, sorted seasons actually covered by this run (derived from the
+   *  episode set). A 全季 run spans many seasons even though `seasonNumber` is
+   *  null — use this to label the card "第 1/2/3/4 季" instead of just "第 1 季". */
+  seasonNumbers: number[];
   status: "queued" | "running";
   /** 1-based position among queued items; null for the running one. */
   queuePosition: number | null;
@@ -43,6 +49,44 @@ export interface ActivityView {
    *  browser session by only showing the ones whose runId it observed active —
    *  robust to notification createdAt timing (which ≈ run-start, not finish). */
   recentCompleted: ActivityCompletedItem[];
+}
+
+/**
+ * Distinct, sorted (numeric) season numbers present in an episode set, derived
+ * from each episode's `SxxExx` code (EpisodeState carries no explicit season).
+ * A whole-show ("全季") run has episodes across many seasons even though its
+ * `season.seasonNumber` is a single placeholder → this exposes the real span.
+ * Pure + defensive: episodes with an unparseable code are skipped.
+ */
+export function distinctSeasons(episodes: readonly EpisodeState[]): number[] {
+  const seasons = new Set<number>();
+  for (const episode of episodes) {
+    const match = /^S(\d{2,})E\d{2,}$/.exec(episode.episodeCode);
+    if (match) {
+      seasons.add(Number(match[1]));
+    }
+  }
+  return Array.from(seasons).sort((a, b) => a - b);
+}
+
+/**
+ * The season label for an active-run card. Movies and season-less runs → "".
+ * One season → "第 N 季"; several → "第 1/2/3/4 季". Prefers the covered-season
+ * list; falls back to the single `seasonNumber` when the list is empty. Pure.
+ */
+export function seasonLabelText(
+  type: MediaType,
+  seasonNumbers: readonly number[],
+  seasonNumber: number | null,
+): string {
+  if (type === "movie") {
+    return "";
+  }
+  const seasons = seasonNumbers.length > 0 ? seasonNumbers : seasonNumber === null ? [] : [seasonNumber];
+  if (seasons.length === 0) {
+    return "";
+  }
+  return `第 ${seasons.join("/")} 季`;
 }
 
 /**
@@ -100,6 +144,7 @@ export async function getActivityView(input: {
       type: snapshot.title.type,
       posterPath: snapshot.title.posterPath ?? null,
       seasonNumber: snapshot.season.seasonNumber ?? null,
+      seasonNumbers: distinctSeasons(snapshot.episodes),
       status,
       queuePosition: status === "queued" && queueIndex >= 0 ? queueIndex + 1 : null,
       missingCount,

--- a/apps/web/lib/activity-view.ts
+++ b/apps/web/lib/activity-view.ts
@@ -1,11 +1,17 @@
 import {
   landedSize,
-  type EpisodeState,
   type MediaType,
   type NotificationReportStatus,
   type WorkflowRepository,
   type WorkflowRunProgress,
 } from "@media-track/workflow";
+import { distinctSeasons, seasonLabelText } from "./activity-season-label";
+
+// Re-export the pure season-label helpers so existing server-side imports from
+// this module keep working. The CANONICAL home is the runtime-free
+// `activity-season-label.ts` — the "use client" activity-feed must import from
+// there (not here), since this module pulls the Postgres-backed runtime.
+export { distinctSeasons, seasonLabelText };
 
 /** One title currently in the pipeline (queued or running). */
 export interface ActivityActiveRun {
@@ -15,11 +21,14 @@ export interface ActivityActiveRun {
   year: number | null;
   type: MediaType;
   posterPath: string | null;
-  /** Single requested season; null for movies and whole-show ("全季") runs. */
+  /** The snapshot's primary/placeholder season number (`snapshot.season`). May
+   *  be a real number even for a whole-show ("全季") run, where it's just the
+   *  scope's anchor season — NOT the full set of covered seasons. null only for
+   *  movies / season-less snapshots. For display, prefer `seasonNumbers`. */
   seasonNumber: number | null;
-  /** Distinct, sorted seasons actually covered by this run (derived from the
-   *  episode set). A 全季 run spans many seasons even though `seasonNumber` is
-   *  null — use this to label the card "第 1/2/3/4 季" instead of just "第 1 季". */
+  /** The distinct, sorted seasons the run actually covers, derived from its
+   *  episode set. This is what the UI labels (e.g. "第 1/2/3/4 季"); a 全季 run
+   *  spans many seasons even though `seasonNumber` is a single anchor value. */
   seasonNumbers: number[];
   status: "queued" | "running";
   /** 1-based position among queued items; null for the running one. */
@@ -49,44 +58,6 @@ export interface ActivityView {
    *  browser session by only showing the ones whose runId it observed active —
    *  robust to notification createdAt timing (which ≈ run-start, not finish). */
   recentCompleted: ActivityCompletedItem[];
-}
-
-/**
- * Distinct, sorted (numeric) season numbers present in an episode set, derived
- * from each episode's `SxxExx` code (EpisodeState carries no explicit season).
- * A whole-show ("全季") run has episodes across many seasons even though its
- * `season.seasonNumber` is a single placeholder → this exposes the real span.
- * Pure + defensive: episodes with an unparseable code are skipped.
- */
-export function distinctSeasons(episodes: readonly EpisodeState[]): number[] {
-  const seasons = new Set<number>();
-  for (const episode of episodes) {
-    const match = /^S(\d{2,})E\d{2,}$/.exec(episode.episodeCode);
-    if (match) {
-      seasons.add(Number(match[1]));
-    }
-  }
-  return Array.from(seasons).sort((a, b) => a - b);
-}
-
-/**
- * The season label for an active-run card. Movies and season-less runs → "".
- * One season → "第 N 季"; several → "第 1/2/3/4 季". Prefers the covered-season
- * list; falls back to the single `seasonNumber` when the list is empty. Pure.
- */
-export function seasonLabelText(
-  type: MediaType,
-  seasonNumbers: readonly number[],
-  seasonNumber: number | null,
-): string {
-  if (type === "movie") {
-    return "";
-  }
-  const seasons = seasonNumbers.length > 0 ? seasonNumbers : seasonNumber === null ? [] : [seasonNumber];
-  if (seasons.length === 0) {
-    return "";
-  }
-  return `第 ${seasons.join("/")} 季`;
 }
 
 /**

--- a/apps/web/lib/inline-progress.test.ts
+++ b/apps/web/lib/inline-progress.test.ts
@@ -17,6 +17,7 @@ function run(over: Partial<ActivityActiveRun>): ActivityActiveRun {
     type: "movie",
     posterPath: null,
     seasonNumber: null,
+    seasonNumbers: [],
     status: "running",
     queuePosition: null,
     missingCount: 0,


### PR DESCRIPTION
## 问题
活动(活动页)中,一个**全季 / whole-show** 获取的运行卡片只显示「第 1 季」,即使该 run 覆盖全部季。例如 Ozark 黑钱胜地:卡片显示「第 1 季」+「已确认 0 / 44 集」(44 = 全 4 季的总集数),误导用户以为只在抓第 1 季。

## 根因
- `activity-feed.tsx` 的 `seasonLabel(run)` 只读单个 `run.seasonNumber`。
- `activity-view.ts` 构建 `ActivityActiveRun` 时 `seasonNumber = snapshot.season.seasonNumber`(单个占位),但 `snapshot.episodes` 才是真实的全集列表 —— 全季 run 横跨多季,可从中派生真实覆盖季号。
- `EpisodeState` 无显式 `seasonNumber` 字段,季号编码在 `episodeCode`(`SxxExx`)里,需解析。

## 改动
1. `activity-view.ts`:`ActivityActiveRun` 新增 `seasonNumbers: number[]`(保留 `seasonNumber` 向后兼容),由 `snapshot.episodes` 的 `episodeCode` 派生**去重 + 数值升序**的季号集合。抽出纯函数 `distinctSeasons(episodes)` 与 `seasonLabelText(type, seasons, single)` 便于单测。
2. `activity-feed.tsx` `seasonLabel`:改用 `seasonLabelText` —— 电影/无季 → `""`、单季 → `第 N 季`、多季 → `第 1/2/3/4 季`;优先 `seasonNumbers`,列表为空时回退 `seasonNumber`。
3. 排查其它渲染站点:活动卡片季号仅此一处。剧集页内联进度(`inline-progress.ts`)不渲染季号,无需改动;`ActivityActiveRun` 也只在 `activity-view.ts` 一处构建(demo 用独立的 `DemoActivityItem`,其行不渲染季号),无需额外改 demo。

## 测试计划
- 新增单测(`activity-view.test.ts`):
  - `distinctSeasons`:`[1,1,2,3,3]` → `[1,2,3]`;单季 → `[1]`;空 → `[]`;数值排序(`[10,2,2,1]` → `[1,2,10]`)。
  - `seasonLabelText`:`[1,2,3,4]` → `第 1/2/3/4 季`;`[2]` → `第 2 季`;`[]`/movie → `""`;列表空时回退 single。
  - `getActivityView`:多季 run 暴露 `seasonNumbers = [1,2,3,4]`。
- 严格 TDD:先写失败测试 → 看红 → 实现 → 转绿。
- `npx tsc -p apps/web/tsconfig.json --noEmit` 绿(web 盲区)。
- `npx vitest run` 全量:**941 passed / 12 skipped / 0 failed**。
- `npx eslint` 改动文件:0 errors。

🤖 Generated with [Claude Code](https://claude.com/claude-code)