### PR TITLE
feat(acquire): 点击获取时 LLM 预检——未配置直接提示、不入队空转

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -4,6 +4,22 @@ import { revalidatePath } from "next/cache";
 import { queueCandidateSeries, queueCandidateTracking, reserveCandidate } from "../lib/workflow-runtime";
 import { assertNotDemo } from "../lib/demo-mode";
 
+/**
+ * Acquire-time LLM pre-check (issue #52). Returns a not-started result carrying
+ * the friendly "未配置 AI 模型" message when a live (vercel-ai) acquisition can't
+ * run for lack of LLM config — so the click does NOT enqueue a doomed run that
+ * would only fail later in the worker (no wasted spin, no failed card in 活动).
+ * Returns null when an LLM is configured (common case → unchanged behavior) or on
+ * the fake/demo adapter (never needs an LLM → never blocked). Shared by every
+ * acquire entry point. Resolves config the SAME way the worker does
+ * (account-scoped DB → env), via acquireLlmPreflightError.
+ */
+async function acquireLlmNotConfigured(): Promise<RequestTrackingActionResult | null> {
+  const { getCurrentAccountId, acquireLlmPreflightError } = await import("../lib/workflow-runtime");
+  const message = await acquireLlmPreflightError(await getCurrentAccountId());
+  return message ? { status: "llm_not_configured", message } : null;
+}
+
 export interface TestStorageConnectionResult {
   ok: boolean;
   status: "active" | "frozen";
@@ -92,7 +108,16 @@ export async function connectGuangYaAction(
 }
 
 export interface RequestTrackingActionResult {
-  status: "requested" | "already_tracked" | "active_workflow" | "reserved" | "unsupported";
+  status:
+    | "requested"
+    | "already_tracked"
+    | "active_workflow"
+    | "reserved"
+    | "unsupported"
+    // Acquire-time LLM pre-check (issue #52): no live model configured, so nothing
+    // was enqueued. The UI surfaces `message` and keeps the 获取 control clickable
+    // (NOT flipped to 获取中/已请求) — it is a not-started result, like `unsupported`.
+    | "llm_not_configured";
   message: string;
 }
 
@@ -141,6 +166,10 @@ export async function requestTrackingAction(input?: {
   }
 
   if (input?.candidateId) {
+    const preflight = await acquireLlmNotConfigured();
+    if (preflight) {
+      return preflight;
+    }
     const request = await queueCandidateTracking(input.candidateId, input.storageId);
     if (request.status === "already_tracked") {
       return {
@@ -182,6 +211,10 @@ export async function requestSeriesAction(input: {
   storageId: string | undefined;
 }): Promise<RequestTrackingActionResult> {
   assertNotDemo();
+  const preflight = await acquireLlmNotConfigured();
+  if (preflight) {
+    return preflight;
+  }
   const request = await queueCandidateSeries(input.candidateId, input.storageId);
   if (request.status === "already_tracked") {
     return { status: "already_tracked", message: "全剧已追踪，后台会继续按缺集状态检查。" };
@@ -243,6 +276,10 @@ export async function requestSeasonAction(input: {
   storageId: string | undefined;
 }): Promise<RequestTrackingActionResult> {
   assertNotDemo();
+  const preflight = await acquireLlmNotConfigured();
+  if (preflight) {
+    return preflight;
+  }
   const { queueSeasonTracking } = await import("../lib/title-hub");
   const request = await queueSeasonTracking(input.tmdbId, input.seasonNumber, input.storageId);
   if (request.status === "already_tracked") {
@@ -267,6 +304,10 @@ export async function requestRemainingAction(input: {
   storageId: string | undefined;
 }): Promise<RequestTrackingActionResult> {
   assertNotDemo();
+  const preflight = await acquireLlmNotConfigured();
+  if (preflight) {
+    return preflight;
+  }
   const { queueRemainingSeasons } = await import("../lib/title-hub");
   const request = await queueRemainingSeasons(input.tmdbId, input.storageId);
   if (request.status === "already_tracked") {

--- a/apps/web/components/request-series-button.tsx
+++ b/apps/web/components/request-series-button.tsx
@@ -3,7 +3,7 @@
 import { Check, Layers, LoaderCircle } from "lucide-react";
 import { useState, useTransition } from "react";
 import { requestSeriesAction, type RequestTrackingActionResult } from "../app/actions";
-import { isLockedResult } from "./request-state";
+import { AcquireResultNotice, isLockedResult } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
 import type { DemoAcquisitionEntry } from "../lib/demo-session";
@@ -43,27 +43,30 @@ export function RequestSeriesButton({
   }
 
   return (
-    <button
-      className="primary-button series-button"
-      type="button"
-      title={result?.message ?? "获取全部季"}
-      disabled={isPending || isLocked}
-      onClick={() => {
-        if (demo) {
-          setDemoPlaying(true);
-          return;
-        }
-        startTransition(async () => {
-          setResult(await requestSeriesAction({ candidateId, storageId }));
-        });
-      }}
-    >
-      {isPending || isLocked ? (
-        <LoaderCircle size={14} className="spin" aria-hidden />
-      ) : (
-        <Layers size={14} aria-hidden />
-      )}
-      {isLocked ? "已请求" : "获取全剧"}
-    </button>
+    <>
+      <button
+        className="primary-button series-button"
+        type="button"
+        title={result?.message ?? "获取全部季"}
+        disabled={isPending || isLocked}
+        onClick={() => {
+          if (demo) {
+            setDemoPlaying(true);
+            return;
+          }
+          startTransition(async () => {
+            setResult(await requestSeriesAction({ candidateId, storageId }));
+          });
+        }}
+      >
+        {isPending || isLocked ? (
+          <LoaderCircle size={14} className="spin" aria-hidden />
+        ) : (
+          <Layers size={14} aria-hidden />
+        )}
+        {isLocked ? "已请求" : "获取全剧"}
+      </button>
+      <AcquireResultNotice result={result} />
+    </>
   );
 }

--- a/apps/web/components/request-state.tsx
+++ b/apps/web/components/request-state.tsx
@@ -16,6 +16,23 @@ export function isLockedResult(result: RequestTrackingActionResult | null): bool
   );
 }
 
+/**
+ * The acquire-time LLM pre-check (issue #52) returned the "未配置 AI 模型" message
+ * and enqueued NOTHING — so the control must stay clickable (NOT locked) and show
+ * the guidance inline. Shared so the acquire components surface it consistently
+ * instead of only as a hover title. Renders nothing for any other status.
+ */
+export function AcquireResultNotice({
+  result,
+}: {
+  result: RequestTrackingActionResult | null;
+}) {
+  if (result?.status !== "llm_not_configured") {
+    return null;
+  }
+  return <p className="request-result">{result.message}</p>;
+}
+
 /** The standalone "已请求" pill shown after a request is queued (spinner — it is
  *  NOT done, only accepted). Shared by the badge-style acquire controls. It links
  *  to the live 活动 page so the real, persistent progress is one click away instead

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -8,7 +8,7 @@ import {
   requestSeasonAction,
   type RequestTrackingActionResult,
 } from "../app/actions";
-import { isLockedResult } from "./request-state";
+import { AcquireResultNotice, isLockedResult } from "./request-state";
 import { AcquireProgressBadge } from "./acquire-progress-badge";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
@@ -114,25 +114,28 @@ export function SeasonRequestMenu({
     // ambiguous bare "获取" sitting next to "第 1 季已获取".
     const isRemainingOfMany = totalSeasonCount > 1;
     return (
-      <button
-        className="primary-button"
-        type="button"
-        disabled={isPending}
-        onClick={() => {
-          if (demo) {
-            setDemoPlaying(true);
-            return;
-          }
-          setRequestedSeason(onlySeason);
-          startTransition(async () => {
-            setResult(await requestSeasonAction({ tmdbId, seasonNumber: onlySeason, storageId }));
-            router.refresh();
-          });
-        }}
-      >
-        {isPending ? <LoaderCircle size={14} className="spin" aria-hidden /> : <Plus size={14} aria-hidden />}
-        {isRemainingOfMany ? `获取第 ${onlySeason} 季` : "获取"}
-      </button>
+      <>
+        <button
+          className="primary-button"
+          type="button"
+          disabled={isPending}
+          onClick={() => {
+            if (demo) {
+              setDemoPlaying(true);
+              return;
+            }
+            setRequestedSeason(onlySeason);
+            startTransition(async () => {
+              setResult(await requestSeasonAction({ tmdbId, seasonNumber: onlySeason, storageId }));
+              router.refresh();
+            });
+          }}
+        >
+          {isPending ? <LoaderCircle size={14} className="spin" aria-hidden /> : <Plus size={14} aria-hidden />}
+          {isRemainingOfMany ? `获取第 ${onlySeason} 季` : "获取"}
+        </button>
+        <AcquireResultNotice result={result} />
+      </>
     );
   }
 
@@ -190,6 +193,7 @@ export function SeasonRequestMenu({
           ))}
         </ul>
       ) : null}
+      <AcquireResultNotice result={result} />
     </div>
   );
 }

--- a/apps/web/components/title-action-buttons.tsx
+++ b/apps/web/components/title-action-buttons.tsx
@@ -9,7 +9,7 @@ import {
   type RequestTrackingActionResult,
 } from "../app/actions";
 import { useAcquisitionLock } from "./acquisition-lock";
-import { isLockedResult } from "./request-state";
+import { AcquireResultNotice, isLockedResult } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
 import type { DemoAcquisitionEntry } from "../lib/demo-session";
@@ -59,34 +59,37 @@ export function RequestSeasonButton({
   }
 
   return (
-    <button
-      className="season-request-button"
-      type="button"
-      title={
-        othersAcquiring && !inFlight ? "该剧正在获取中，请稍候" : result?.message ?? `获取第 ${seasonNumber} 季`
-      }
-      disabled={isPending || isLocked || othersAcquiring}
-      onClick={() => {
-        if (demo) {
-          setDemoPlaying(true);
-          return;
+    <>
+      <button
+        className="season-request-button"
+        type="button"
+        title={
+          othersAcquiring && !inFlight ? "该剧正在获取中，请稍候" : result?.message ?? `获取第 ${seasonNumber} 季`
         }
-        lock?.lock(scope);
-        startTransition(async () => {
-          setResult(await requestSeasonAction({ tmdbId, seasonNumber, storageId }));
-          router.refresh();
-        });
-      }}
-    >
-      {inFlight ? (
-        <LoaderCircle size={13} className="spin" aria-hidden />
-      ) : isLocked ? (
-        <Check size={13} aria-hidden />
-      ) : (
-        <DownloadCloud size={13} aria-hidden />
-      )}
-      {inFlight ? "获取中" : isLocked ? "已请求" : "获取本季"}
-    </button>
+        disabled={isPending || isLocked || othersAcquiring}
+        onClick={() => {
+          if (demo) {
+            setDemoPlaying(true);
+            return;
+          }
+          lock?.lock(scope);
+          startTransition(async () => {
+            setResult(await requestSeasonAction({ tmdbId, seasonNumber, storageId }));
+            router.refresh();
+          });
+        }}
+      >
+        {inFlight ? (
+          <LoaderCircle size={13} className="spin" aria-hidden />
+        ) : isLocked ? (
+          <Check size={13} aria-hidden />
+        ) : (
+          <DownloadCloud size={13} aria-hidden />
+        )}
+        {inFlight ? "获取中" : isLocked ? "已请求" : "获取本季"}
+      </button>
+      <AcquireResultNotice result={result} />
+    </>
   );
 }
 
@@ -134,31 +137,34 @@ export function RequestRemainingButton({
   }
 
   return (
-    <button
-      className="primary-button"
-      type="button"
-      title={othersAcquiring && !inFlight ? "该剧正在获取中，请稍候" : result?.message ?? label}
-      disabled={isPending || isLocked || othersAcquiring}
-      onClick={() => {
-        if (demo) {
-          setDemoPlaying(true);
-          return;
-        }
-        lock?.lock(scope);
-        startTransition(async () => {
-          setResult(await requestRemainingAction({ tmdbId, storageId }));
-          router.refresh();
-        });
-      }}
-    >
-      {inFlight ? (
-        <LoaderCircle size={14} className="spin" aria-hidden />
-      ) : isLocked ? (
-        <Check size={14} aria-hidden />
-      ) : (
-        <Layers size={14} aria-hidden />
-      )}
-      {inFlight ? "获取中" : isLocked ? "已请求" : label}
-    </button>
+    <>
+      <button
+        className="primary-button"
+        type="button"
+        title={othersAcquiring && !inFlight ? "该剧正在获取中，请稍候" : result?.message ?? label}
+        disabled={isPending || isLocked || othersAcquiring}
+        onClick={() => {
+          if (demo) {
+            setDemoPlaying(true);
+            return;
+          }
+          lock?.lock(scope);
+          startTransition(async () => {
+            setResult(await requestRemainingAction({ tmdbId, storageId }));
+            router.refresh();
+          });
+        }}
+      >
+        {inFlight ? (
+          <LoaderCircle size={14} className="spin" aria-hidden />
+        ) : isLocked ? (
+          <Check size={14} aria-hidden />
+        ) : (
+          <Layers size={14} aria-hidden />
+        )}
+        {inFlight ? "获取中" : isLocked ? "已请求" : label}
+      </button>
+      <AcquireResultNotice result={result} />
+    </>
   );
 }

--- a/apps/web/lib/workflow-runtime.test.ts
+++ b/apps/web/lib/workflow-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  acquireLlmPreflightError,
   getLlmConfig,
   getPanSouBaseUrl,
   getProwlarrConfig,
@@ -8,6 +9,8 @@ import {
   PANSOU_BASE_URL_SETTING_KEY,
   DEFAULT_PANSOU_BASE_URL,
   getTmdbAccesses,
+  LLM_BASE_URL_SETTING_KEY,
+  LLM_MODEL_ID_SETTING_KEY,
   PROWLARR_API_KEY_SETTING_KEY,
   PROWLARR_BASE_URL_SETTING_KEY,
   TMDB_API_KEY_SETTING_KEY,
@@ -50,6 +53,58 @@ describe("getLlmConfig", () => {
     expect(cfg.baseURL).toBeUndefined();
     expect(cfg.apiKey).toBeUndefined();
     expect(cfg.modelId).toBe("x");
+  });
+});
+
+describe("acquireLlmPreflightError (点击获取时的 LLM 预检)", () => {
+  const configured = repoMap({
+    [LLM_BASE_URL_SETTING_KEY]: "https://api.example.com/v1",
+    [LLM_MODEL_ID_SETTING_KEY]: "gpt-4o-mini",
+  });
+  const unconfigured = repoMap({});
+
+  it("live (vercel-ai) + unconfigured → the friendly 未配置 message (blocks enqueue)", async () => {
+    const message = await acquireLlmPreflightError({
+      settings: unconfigured,
+      env: { MEDIA_TRACK_AGENT_ADAPTER: "vercel-ai" } as unknown as NodeJS.ProcessEnv,
+    });
+    expect(message).toContain("未配置 AI 模型");
+  });
+
+  it("live (vercel-ai) + fully configured → null (common case, unchanged behavior)", async () => {
+    const message = await acquireLlmPreflightError({
+      settings: configured,
+      env: { MEDIA_TRACK_AGENT_ADAPTER: "vercel-ai" } as unknown as NodeJS.ProcessEnv,
+    });
+    expect(message).toBeNull();
+  });
+
+  it("fake/demo adapter + nothing configured → null (no LLM needed, never blocks)", async () => {
+    const message = await acquireLlmPreflightError({
+      settings: unconfigured,
+      env: { MEDIA_TRACK_AGENT_ADAPTER: "fake" } as unknown as NodeJS.ProcessEnv,
+    });
+    expect(message).toBeNull();
+  });
+
+  it("default adapter (unset) + nothing configured → null (fake is the default)", async () => {
+    const message = await acquireLlmPreflightError({
+      settings: unconfigured,
+      env: {} as unknown as NodeJS.ProcessEnv,
+    });
+    expect(message).toBeNull();
+  });
+
+  it("live (vercel-ai) + config from env (no DB) → null", async () => {
+    const message = await acquireLlmPreflightError({
+      settings: unconfigured,
+      env: {
+        MEDIA_TRACK_AGENT_ADAPTER: "vercel-ai",
+        AGENT_MODEL_BASE_URL: "https://env.example/v1",
+        AGENT_MODEL_ID: "env-model",
+      } as unknown as NodeJS.ProcessEnv,
+    });
+    expect(message).toBeNull();
   });
 });
 

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1756,6 +1756,32 @@ export async function resolveAgentModelConfig(
   };
 }
 
+/** Acquire-time LLM pre-check (issue #52): the friendly "configure your model"
+ *  message if a LIVE (vercel-ai) acquisition can't run for lack of LLM config,
+ *  else null. Resolves config EXACTLY as the worker's getAgentModel does
+ *  (account-scoped DB → .env) and reuses the SAME llmConfigError predicate, so a
+ *  click that would only die later in the worker is caught NOW — no doomed run is
+ *  enqueued, no failed card piles up in 活动. The fake/demo adapter never needs an
+ *  LLM → always null (never blocks demo/fake). Common case (configured) → null →
+ *  callers behave byte-identically to before (purely additive). Settings/env are
+ *  injectable for unit tests; production calls pass the current account id. */
+export async function acquireLlmPreflightError(
+  arg:
+    | string
+    | {
+        settings: { getSetting(key: string): Promise<string | null> };
+        env?: NodeJS.ProcessEnv;
+      },
+): Promise<string | null> {
+  const settings = typeof arg === "string" ? getAccountScopedSettings(arg) : arg.settings;
+  const env = typeof arg === "string" ? process.env : arg.env ?? process.env;
+  if (env.MEDIA_TRACK_AGENT_ADAPTER !== "vercel-ai") {
+    return null;
+  }
+  const resolved = await resolveAgentModelConfig(settings, env);
+  return llmConfigError(resolved);
+}
+
 async function getAgentModel(repository: {
   getSetting(key: string): Promise<string | null>;
 }): Promise<{


### PR DESCRIPTION
## 问题
未配置 AI 模型时点「获取」,原本会**入队一个注定失败的 run**,几分钟后才在 worker 里报「未配置 AI 模型」,还会在活动页堆一张失败卡。空转 + 噪音。

## 改动
点击/入队前**预检**:无 LLM 配置时立即返回友好提示,**不入队**(不空转、不堆失败卡)。纯加法 —— 配置齐全(常见情况)行为逐字节不变。

- **`workflow-runtime.ts`**:新增 `acquireLlmPreflightError(accountId)`,与 worker 的 `getAgentModel` 用**同一套解析**(account-scoped DB → env)+ **同一 `llmConfigError` 判定**。
- **`actions.ts`**:四个获取入口在入队前预检 —— `requestTrackingAction`(真获取分支)、`requestSeriesAction`、`requestSeasonAction`、`requestRemainingAction`。新增 `llm_not_configured` 状态(未启动结果,UI 不翻成「获取中」)。
- **UI**:`AcquireResultNotice` 在四个获取控件内联展示提示并**保持按钮可点**。

### 覆盖的全部获取入口
确认无独立 movie/type2 server action —— 电影走 `requestTrackingAction`(candidateId),已覆盖。

## 不拦的路径(有意)
- **fake/demo adapter**:`MEDIA_TRACK_AGENT_ADAPTER !== "vercel-ai"` → 永远 null,绝不拦 demo/fake(无需 LLM)。
- **预定(未上映)**:`reserveCandidate` 此刻不跑 agent,预检不拦。

## Test plan
- 单测 `acquireLlmPreflightError`(`workflow-runtime.test.ts`):
  - vercel-ai + 未配置 → 友好「未配置 AI 模型」提示
  - vercel-ai + 配置齐全 → null(常见情况,行为不变)
  - fake / 默认 adapter + 啥都没配 → null(不拦)
  - vercel-ai + 仅 env 配置(无 DB)→ null
- TDD:先红(`is not a function`)→ 实现 → 绿。
- `npm run build:workflow` ✓
- `npx tsc -p apps/web/tsconfig.json --noEmit` ✓ + `npm run typecheck` ✓
- **`npm run build:web` ✓**(`✓ Compiled successfully` —— 无 pg 泄漏进 client bundle)
- `npx vitest run` ✓ 965 passed / 12 skipped
- eslint 改动文件干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)