### PR TITLE
docs(guangya): 光鸭云盘 配置教程(指向 AList 来源)+ 0.3.0 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="README.zh-CN.md">中文文档</a>
 </p>
 
-You ask for a movie, show, or anime; an LLM agent scouts resources across your indexers, transfers the best match into your own 115 / Quark drive, verifies what landed, and keeps tracking what's still missing.
+You ask for a movie, show, or anime; an LLM agent scouts resources across your indexers, transfers the best match into your own 115 / Quark / 光鸭 drive, verifies what landed, and keeps tracking what's still missing.
 
 ![Mediary Scout — search a title, hit 获取, and the agent searches, transfers, and verifies it into your drive](docs/images/demo.gif)
 
@@ -48,7 +48,7 @@ You ask for a movie, show, or anime; an LLM agent scouts resources across your i
 
 Most "media automation" either searches well but doesn't know what you're actually missing, or moves files but never verifies what landed. Mediary Scout treats acquisition as a **state problem**, driven by an agent that acts from evidence, not vibes:
 
-- **Multi-drive, brand-extensible** — 115 and Quark today, each a first-class workspace (a tree model: one account, many drives). Adding a new drive brand is a contained plugin.
+- **Multi-drive, brand-extensible** — 115, Quark, and 光鸭 (GuangYaPan) today, each a first-class workspace (a tree model: one account, many drives). Adding a new drive brand is a contained plugin.
 - **Agent-driven selection** — the agent reads real search results and picks by quality preference, **Chinese-subtitle** needs, and de-duplication, then verifies the transfer after it happens.
 - **Tracking & scheduled gap-fill** — season-level state machine; a scheduled sweep comes back only for shows that still have missing episodes.
 - **Cloud-native** — it **transfers** shares/magnets straight into your drive (秒传 / save), it does not download to a local disk.
@@ -80,7 +80,7 @@ flowchart LR
     Q --> W["In-process worker"]
     W --> AG["V2 sandbox agent"]
     AG -->|search| SRC["PanSou / Prowlarr"]
-    AG -->|transfer| DR["115 / Quark drive"]
+    AG -->|transfer| DR["115 / Quark / 光鸭 drive"]
     AG -->|read back| DR
     AG -->|verify + mark| Q
     Q -->|realtime| UI
@@ -103,10 +103,10 @@ docker compose up -d
 
 Then open the web UI and, in **Settings**, provide what you want to use (all bring-your-own):
 
-- **A drive** — connect 115 or Quark (QR-scan login, or paste a cookie).
+- **A drive** — connect 115 or Quark (QR-scan login, or paste a cookie), or 光鸭 (paste `access_token` + `refresh_token` — see [setup guide](docs/deploy.md#光鸭云盘guangyapan连接)).
 - **TMDB** — works out of the box via a proxy; add your own key for direct access.
 - **LLM** — any OpenAI-compatible endpoint (`baseURL` / `apiKey` / `modelId`). The author never sees your key.
-- **Prowlarr** *(optional)* — add your indexers for magnet/torrent sources (115 only; Quark has no magnet API).
+- **Prowlarr** *(optional)* — add your indexers for magnet/torrent sources (115 and 光鸭, which are magnet-capable; Quark has no magnet API).
 
 ## Deploy
 
@@ -128,7 +128,7 @@ You are deploying Mediary Scout, a self-hosted media-acquisition agent. Follow t
    - Local network only (default — open `http://<host>:3000` from devices on the same LAN)
    - Tailscale (private mesh — recommended for home; no public IP, auto-encrypted)
    - Cloudflare Tunnel (public HTTPS like `https://media.yourdomain.com` — needs a domain on Cloudflare + Access in front)
-4. **Configure real acquisition now, or just get it running first?** Real acquisition needs a 115/Quark drive + an LLM endpoint (OpenAI-compatible) + (if using 115) 115 directory CIDs. Skipping means it boots and you can look around, configure later in Settings.
+4. **Configure real acquisition now, or just get it running first?** Real acquisition needs a 115/Quark/光鸭 drive + an LLM endpoint (OpenAI-compatible) + (if using 115) 115 directory CIDs. Skipping means it boots and you can look around, configure later in Settings.
 
 ## OPTIONAL — one question, skip all if the user doesn't care
 5. Any of these you want to set up now? Reply "none" to skip and use defaults:
@@ -155,14 +155,17 @@ A public, **read-only** demo — mock drives, real TMDB search across the whole 
 
 ## Supported drives
 
+Three Chinese cloud drives, each a first-class workspace:
+
 - **115** (`pan115`) — full support, including magnet via Prowlarr.
 - **Quark** (`quark`) — share-link transfer (no magnet web API).
+- **GuangYaPan / 光鸭云盘** (`guangya`) — Xunlei-family drive; **magnet / offline-download first** (transfers magnet/ed2k/BT via its offline-task API, like 115's offline path — it does **not** transfer 115/Quark/光鸭 share-links in v1). Token auth (`access_token` + `refresh_token`). Pairs well with Prowlarr. **[Setup guide → docs/deploy.md#光鸭云盘-guangyapan-连接](docs/deploy.md#光鸭云盘guangyapan连接)**
 
-New brands plug into a storage-brand registry; the bulk of adding one is a cookie client + a storage executor for that drive's transfer API.
+New brands plug into a storage-brand registry; the bulk of adding one is a drive client + a storage executor for that drive's transfer API.
 
 ## Status & limitations
 
-- Self-hosted, for advanced users; you need usable 115/Quark access (a membership is most practical).
+- Self-hosted, for advanced users; you need usable 115/Quark/光鸭 access (a membership is most practical).
 - Scheduled monitoring is most valuable on an always-on host.
 - This is not a hosted product and ships no hosted backend.
 
@@ -173,6 +176,7 @@ Built on top of, and grateful to:
 - [PanSou](https://github.com/fish2018/pansou-web) — resource search backend
 - [Prowlarr](https://github.com/Prowlarr/Prowlarr) — indexer manager (optional)
 - [p115client](https://github.com/ChenyangGao/p115client) — 115 API reference
+- [AList](https://github.com/AlistGo/alist) — GuangYaPan (光鸭云盘) API integration reference (the `drivers/guangyapan` driver)
 - [TMDB](https://www.themoviedb.org/) — metadata (this product is not endorsed or certified by TMDB)
 
-Not affiliated with 115, Quark, TMDB, or any indexer. Mediary Scout is an independent, disciplined workflow built around these pieces.
+Not affiliated with 115, Quark, 光鸭云盘 (GuangYaPan), TMDB, or any indexer. Mediary Scout is an independent, disciplined workflow built around these pieces.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Three Chinese cloud drives, each a first-class workspace:
 
 - **115** (`pan115`) — full support, including magnet via Prowlarr.
 - **Quark** (`quark`) — share-link transfer (no magnet web API).
-- **GuangYaPan / 光鸭云盘** (`guangya`) — Xunlei-family drive; **magnet / offline-download first** (transfers magnet/ed2k/BT via its offline-task API, like 115's offline path — it does **not** transfer 115/Quark/光鸭 share-links in v1). Token auth (`access_token` + `refresh_token`). Pairs well with Prowlarr. **[Setup guide → docs/deploy.md#光鸭云盘-guangyapan-连接](docs/deploy.md#光鸭云盘guangyapan连接)**
+- **GuangYaPan / 光鸭云盘** (`guangya`) — Xunlei-family drive; **magnet / offline-download first** (transfers magnet/ed2k/BT via its offline-task API, like 115's offline path — it does **not** transfer 115/Quark/光鸭 share-links in v1). Token auth (`access_token` + `refresh_token`). Pairs well with Prowlarr. **[Setup guide](docs/deploy.md#光鸭云盘guangyapan连接)**
 
 New brands plug into a storage-brand registry; the bulk of adding one is a drive client + a storage executor for that drive's transfer API.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,7 +24,7 @@
   <a href="README.md">English</a>
 </p>
 
-你说要某部电影 / 剧 / 番,LLM agent 跨索引源搜罗资源、把最合适的转存进你自己的 115 / 夸克网盘、转存后回读验证,并持续追踪还缺什么。
+你说要某部电影 / 剧 / 番,LLM agent 跨索引源搜罗资源、把最合适的转存进你自己的 115 / 夸克 / 光鸭网盘、转存后回读验证,并持续追踪还缺什么。
 
 ![Mediary Scout — 搜片 → 点获取 → agent 自动搜索、转存、验证落进你的网盘](docs/images/demo.gif)
 
@@ -48,7 +48,7 @@
 
 大多数「媒体自动化」要么搜得好但不知道你到底缺哪集,要么会搬文件却从不验证落了什么。Mediary Scout 把获取当成一个**状态问题**,由一个「凭证据而非凭感觉」行动的 agent 驱动:
 
-- **多盘、品牌可扩展** —— 现支持 115 与夸克,每块盘都是一等工作区(树模型:一个账号、多块盘)。接入新网盘品牌是个收敛的插件活。
+- **多盘、品牌可扩展** —— 现支持 115、夸克与光鸭云盘(GuangYaPan),每块盘都是一等工作区(树模型:一个账号、多块盘)。接入新网盘品牌是个收敛的插件活。
 - **agent 选片** —— agent 读真实搜索结果,按画质偏好、**中文字幕**需求、去重来挑,转存后再回读验证。
 - **追踪 + 定时补缺** —— 季级状态机;定时巡检只回来处理仍有缺集的剧。
 - **网盘原生** —— 直接把分享 / 磁力**转存**(秒传 / save)进你的网盘,不往本地磁盘下载。
@@ -80,7 +80,7 @@ flowchart LR
     Q --> W["进程内 worker"]
     W --> AG["V2 沙盒 agent"]
     AG -->|搜索| SRC["PanSou / Prowlarr"]
-    AG -->|转存| DR["115 / 夸克网盘"]
+    AG -->|转存| DR["115 / 夸克 / 光鸭网盘"]
     AG -->|回读| DR
     AG -->|验证 + 标记| Q
     Q -->|实时| UI
@@ -103,10 +103,10 @@ docker compose up -d
 
 打开 web UI,在**设置**里按需提供(全部自带):
 
-- **网盘** —— 连 115 或夸克(扫码登录,或粘贴 cookie)。
+- **网盘** —— 连 115 或夸克(扫码登录,或粘贴 cookie),或光鸭云盘(粘贴 `access_token` + `refresh_token`,见 [连接教程](docs/deploy.md#光鸭云盘guangyapan连接))。
 - **TMDB** —— 经代理开箱即用;想直连可填自己的 key。
 - **LLM** —— 任意 OpenAI 兼容端点(`baseURL` / `apiKey` / `modelId`)。作者看不到你的 key。
-- **Prowlarr**(可选) —— 加你的索引器以获得磁力 / 种子源(仅 115;夸克无磁力 API)。
+- **Prowlarr**(可选) —— 加你的索引器以获得磁力 / 种子源(115 与光鸭这类支持磁力的盘;夸克无磁力 API)。
 
 ## 部署
 
@@ -155,14 +155,17 @@ docker compose up -d
 
 ## 支持的网盘
 
+三个国内网盘品牌,每块盘都是一等工作区:
+
 - **115**(`pan115`) —— 完整支持,含经 Prowlarr 的磁力。
 - **夸克**(`quark`) —— 分享链转存(无磁力 web API)。
+- **光鸭云盘 / GuangYaPan**(`guangya`) —— 迅雷系网盘;**磁力 / 离线下载优先**(经离线任务 API 转存磁力 / ed2k / BT,与 115 的离线路径同理 —— v1 **不**转存 115 / 夸克 / 光鸭的分享链)。token 鉴权(`access_token` + `refresh_token`)。与 Prowlarr 搭配最好。**[连接教程 → docs/deploy.md#光鸭云盘guangyapan连接](docs/deploy.md#光鸭云盘guangyapan连接)**
 
-新品牌接入一个 storage-brand 注册表;大头是为该网盘的转存 API 写一个 cookie 客户端 + 一个 storage executor。
+新品牌接入一个 storage-brand 注册表;大头是为该网盘的转存 API 写一个客户端 + 一个 storage executor。
 
 ## 状态与限制
 
-- 自部署、面向进阶用户;需要可用的 115 / 夸克(有会员最实用)。
+- 自部署、面向进阶用户;需要可用的 115 / 夸克 / 光鸭(有会员最实用)。
 - 定时巡检在常开的主机上价值最大。
 - 这不是托管产品,不附带任何托管后端。
 
@@ -173,6 +176,7 @@ docker compose up -d
 - [PanSou](https://github.com/fish2018/pansou-web) —— 资源搜索后端
 - [Prowlarr](https://github.com/Prowlarr/Prowlarr) —— 索引器管理(可选)
 - [p115client](https://github.com/ChenyangGao/p115client) —— 115 API 参考
+- [AList](https://github.com/AlistGo/alist) —— 光鸭云盘 API 集成参考(`drivers/guangyapan` driver)
 - [TMDB](https://www.themoviedb.org/) —— 元数据(本产品未获 TMDB 认证或背书)
 
-与 115、夸克、TMDB 及任何索引器均无隶属关系。Mediary Scout 是围绕这些组件构建的、克制的独立工作流。
+与 115、夸克、光鸭云盘、TMDB 及任何索引器均无隶属关系。Mediary Scout 是围绕这些组件构建的、克制的独立工作流。

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,6 +1,6 @@
 # Deploy Mediary Scout
 
-> **English summary.** Self-host with one command — `docker compose up -d` brings up web (Next.js + in-process worker) + Postgres + a bundled PanSou. Open `http://<host>:3000`, go to Settings, scan-login your 115 / Quark drive (or paste a 光鸭 / GuangYaPan token), add an OpenAI-compatible LLM endpoint, and you're running. To reach it from your phone / TV / on the go, use **Tailscale** (private mesh — safest) or a **Cloudflare Tunnel** (public HTTPS, no public IP). **Never expose `:3000` raw to the internet.** Full walkthrough below (Chinese).
+> **English summary.** Self-host with one command — `docker compose up -d` brings up web (Next.js + in-process worker) + Postgres + a bundled PanSou. Open `http://<host>:3000`, go to Settings, scan-login your 115 / Quark drive (or paste a 光鸭 / GuangYaPan `access_token` + `refresh_token`), add an OpenAI-compatible LLM endpoint, and you're running. To reach it from your phone / TV / on the go, use **Tailscale** (private mesh — safest) or a **Cloudflare Tunnel** (public HTTPS, no public IP). **Never expose `:3000` raw to the internet.** Full walkthrough below (Chinese).
 
 一行命令起整套:**web(Next + 进程内 worker)+ Postgres + 自带 PanSou**。本指南覆盖:选宿主 → compose 起服务 → 从自己的设备访问 → 安全/升级。
 
@@ -34,7 +34,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 ```
 
 打开 `http://<你的主机>:3000`:
-1. **设置 → 网盘**:115 扫码登录(cookie 持久化到数据库,后续自动转存);夸克在设置选夸克品牌粘贴 cookie;光鸭云盘在设置选光鸭品牌粘贴 token(见 [光鸭云盘连接](#光鸭云盘guangyapan连接))。
+1. **设置 → 网盘**:115 扫码登录(cookie 持久化到数据库,后续自动转存);夸克在设置选夸克品牌粘贴 cookie;光鸭云盘在设置选光鸭品牌粘贴 `access_token` + `refresh_token` 两个值(见 [光鸭云盘连接](#光鸭云盘guangyapan连接))。
 2. 就这样。**TMDB 元数据经作者 CF Worker 开箱即用**(想用自己额度可在设置填 TMDB key);**PanSou 网盘搜索源已自带**。
 
 ### 组成 / 端口

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,12 +1,13 @@
 # Deploy Mediary Scout
 
-> **English summary.** Self-host with one command — `docker compose up -d` brings up web (Next.js + in-process worker) + Postgres + a bundled PanSou. Open `http://<host>:3000`, go to Settings, scan-login your 115 / Quark drive, add an OpenAI-compatible LLM endpoint, and you're running. To reach it from your phone / TV / on the go, use **Tailscale** (private mesh — safest) or a **Cloudflare Tunnel** (public HTTPS, no public IP). **Never expose `:3000` raw to the internet.** Full walkthrough below (Chinese).
+> **English summary.** Self-host with one command — `docker compose up -d` brings up web (Next.js + in-process worker) + Postgres + a bundled PanSou. Open `http://<host>:3000`, go to Settings, scan-login your 115 / Quark drive (or paste a 光鸭 / GuangYaPan token), add an OpenAI-compatible LLM endpoint, and you're running. To reach it from your phone / TV / on the go, use **Tailscale** (private mesh — safest) or a **Cloudflare Tunnel** (public HTTPS, no public IP). **Never expose `:3000` raw to the internet.** Full walkthrough below (Chinese).
 
 一行命令起整套:**web(Next + 进程内 worker)+ Postgres + 自带 PanSou**。本指南覆盖:选宿主 → compose 起服务 → 从自己的设备访问 → 安全/升级。
 
 ## 目录
 - [选择你的宿主](#选择你的宿主)
 - [Compose 快速开始](#compose-快速开始)
+- [光鸭云盘(GuangYaPan)连接](#光鸭云盘guangyapan连接)
 - [想跑真实获取还需要](#想跑真实获取还需要)
 - [可选增强](#可选增强)
 - [从你的设备访问](#从你的设备访问)
@@ -33,7 +34,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 ```
 
 打开 `http://<你的主机>:3000`:
-1. **设置 → 网盘**:115 扫码登录(cookie 持久化到数据库,后续自动转存);夸克在设置选夸克品牌粘贴 cookie。
+1. **设置 → 网盘**:115 扫码登录(cookie 持久化到数据库,后续自动转存);夸克在设置选夸克品牌粘贴 cookie;光鸭云盘在设置选光鸭品牌粘贴 token(见 [光鸭云盘连接](#光鸭云盘guangyapan连接))。
 2. 就这样。**TMDB 元数据经作者 CF Worker 开箱即用**(想用自己额度可在设置填 TMDB key);**PanSou 网盘搜索源已自带**。
 
 ### 组成 / 端口
@@ -48,6 +49,50 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 
 `docker-compose.yml` 的 `environment:` 已设好库连接、PanSou 地址、adapters。要覆盖额外项(TMDB / 115 cookie / LLM / Prowlarr / CID),在仓库根放 `.env`(参照 `.env.example`)——compose 会自动加载(缺失也无妨)。
 
+## 光鸭云盘(GuangYaPan)连接
+
+光鸭云盘(迅雷旗下,2026 年上线)是第三个支持的网盘品牌。它走**磁力 / 离线下载优先**路径:agent 把 PanSou(magnet 类型)与可选 Prowlarr 找到的磁力 / ed2k / BT 候选,经光鸭的离线下载 API 拉进你自己的盘——和 115 的离线任务路径同理。
+
+> ⚠️ **v1 仅支持磁力 / 离线。** 光鸭目前**不**转存 115 / 夸克 / 光鸭自己的**分享链**(这类候选会按设计明确报错 `GUANGYA_ONLY_MAGNET`,不静默失败)。所以光鸭和 **Prowlarr 搭配最好**(磁力覆盖更全)。
+>
+> 和所有获取一样,光鸭也需要先配好 **AI 模型(LLM)**,见下文「[想跑真实获取还需要](#想跑真实获取还需要)」。
+
+光鸭用 **`access_token` + `refresh_token`** 鉴权(不是 cookie、不是扫码)。`access_token` 约 2 小时过期,`refresh_token` 会在过期时自动续期,续期后的新 token 自动写回该盘,无需你手动重粘。
+
+### 1. 在设置页粘 token
+
+**设置 → 网盘连接 → 选「光鸭云盘」标签页**,把下面取到的两个 token 分别粘进 `access_token` 与 `refresh_token` 两个框,点「连接光鸭」。连接时会用 token 校验登录态、并在你盘里建好 `Mediary Scout/{Movies,TV,Anime}` 分类目录。
+
+### 2. 怎么拿到这两个 token
+
+1. 用浏览器登录光鸭云盘网页版:**[https://www.guangyapan.com](https://www.guangyapan.com)**(或 app.guangyapan.com),确保已登录。
+2. 按 **F12** 打开 DevTools → 切到 **Console(控制台)** 标签。
+3. 粘贴并运行下面这段(它从 `localStorage` 里读出登录态。光鸭把凭证存在键 `credentials_<clientid>`,当前 clientid 是 `aMe-8VSlkrbQXpUR`,即键名 `credentials_aMe-8VSlkrbQXpUR`):
+
+   ```js
+   (() => {
+     const clientId = "aMe-8VSlkrbQXpUR"; // 光鸭 web app 的 client_id
+     const raw = localStorage.getItem(`credentials_${clientId}`);
+     if (!raw) { console.warn("没找到 credentials_* —— 请确认已登录光鸭网页版后重试"); return; }
+     const c = JSON.parse(raw);
+     const out = { accessToken: c.access_token, refreshToken: c.refresh_token };
+     console.log("accessToken:\n" + out.accessToken);
+     console.log("\nrefreshToken:\n" + out.refreshToken);
+     try { copy(JSON.stringify(out, null, 2)); console.log("\n(已复制到剪贴板)"); } catch {}
+     return out;
+   })();
+   ```
+
+   > 如果 `credentials_aMe-8VSlkrbQXpUR` 取不到(光鸭后续改了 clientid),在 Console 里跑 `Object.keys(localStorage).filter(k => k.startsWith("credentials_"))` 看实际键名,把后缀换进上面的 `clientId`。
+
+4. 控制台会打印 `accessToken` 与 `refreshToken`(且尝试把 `{accessToken, refreshToken}` JSON 复制到剪贴板)。把这两个值分别粘回设置页对应的框。
+
+> 🔒 **别把 token 贴到任何公开地方**(issue、聊天群、截图、粘贴板网站)。它们等同你光鸭账号的登录态;只该出现在你自己实例的设置页里。
+
+### 3. 来源致谢(API 逆向)
+
+光鸭云盘的网盘 API 集成,基于开源项目 **[AList](https://github.com/AlistGo/alist)** 的 `guangyapan` driver(目录 [`drivers/guangyapan`](https://github.com/AlistGo/alist/tree/main/drivers/guangyapan))。该 driver 是本项目逆向光鸭 API 的来源,在此致谢。
+
 ## 想跑真实获取还需要
 
 - **AI 模型**(设置 → AI 模型):填一个 OpenAI 兼容的 `baseURL / apiKey / modelId`——agent 靠它决策。不填则获取流程无法规划。
@@ -56,7 +101,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 ## 可选增强
 
 - **自己的 TMDB key**(设置 → TMDB 元数据):直连你自己的额度,调不通自动回退作者代理。
-- **Prowlarr**(设置 → 资源提供商):接入索引器聚合,磁力与 PanSou 结果合并、走 115 秒传。
+- **Prowlarr**(设置 → 资源提供商):接入索引器聚合,磁力与 PanSou 结果合并,走 115 或光鸭的离线下载落盘(夸克无磁力 API)。
 - **换 PanSou 实例**(设置 → 资源提供商):默认用 compose 自带的;想指向别的实例/公共域名在此手填。
 
 ## 从你的设备访问

--- a/docs/release-notes-0.3.0.md
+++ b/docs/release-notes-0.3.0.md
@@ -22,10 +22,10 @@
 
 ## 部署与基础设施
 
-- **#47(closes #46)** 修**连不上 Docker Hub 时构建第一步就卡死** —— 首次 `docker compose build` 在拉基础镜像处挂住(`auth.docker.io ... i/o timeout`)。加了镜像加速文档(Docker Desktop / Linux 分别说明,面向国内网络)。
+- **#47(closes #46)** 修复**连不上 Docker Hub 时构建第一步就卡死** —— 首次 `docker compose build` 在拉基础镜像处挂住(`auth.docker.io ... i/o timeout`)。加了镜像加速文档(Docker Desktop / Linux 分别说明,面向国内网络)。
 - **#48** 未连任何网盘时,后台 worker **静默跳过**获取轮询,不再每 3 秒刷一行 `PAN115_COOKIE is required` 日志(新装、还没连盘时日志干净)。
 
 ## 试用
 
-- 免安装只读 demo:https://mediary.dirtyfancy.sbs
+- 免安装只读 demo: https://mediary.dirtyfancy.sbs
 - 自部署:见 [README](../README.md) + [docs/deploy.md](deploy.md)

--- a/docs/release-notes-0.3.0.md
+++ b/docs/release-notes-0.3.0.md
@@ -1,0 +1,31 @@
+# v0.3.0 — 光鸭云盘支持 + LLM 真 BYO(任意 OpenAI 兼容服务)
+
+> 草稿,供维护者发 GitHub Release 时使用。
+
+继 v0.2.0(2026-06-25)之后的累积更新。两件大事:**接入第三个网盘品牌「光鸭云盘」**(磁力 / 离线优先),以及**把 LLM 改成真正的 BYO** —— 去掉硬编码的 MiMo 默认端点,改用标准 `Authorization: Bearer` 发 key,任何 OpenAI 兼容服务(DeepSeek / OpenAI / …)都能直接用,不再 401。
+
+## 网盘:接入光鸭云盘(第三个品牌)
+
+- **#50** 接入**光鸭云盘(GuangYaPan)**作为第三个网盘品牌(继 115、夸克)。迅雷系网盘,走**磁力 / 离线下载优先**路径:把 PanSou(magnet)+ 可选 Prowlarr 的磁力 / ed2k / BT 候选,经光鸭离线任务 API 拉进你自己的盘(与 115 离线路径同理)。鉴权用 `access_token` + `refresh_token`(过期自动续期、续期后回写)。v1 **不**转存 115 / 夸克 / 光鸭的分享链(按设计明确报错 `GUANGYA_ONLY_MAGNET`)。纯加法,115 / 夸克零影响。
+  - 光鸭 API 集成基于开源 [AList](https://github.com/AlistGo/alist) 的 `guangyapan` driver(逆向来源,致谢)。
+  - 连接教程见 [docs/deploy.md → 光鸭云盘连接](deploy.md#光鸭云盘guangyapan连接)。
+
+## LLM:真 BYO(任意 OpenAI 兼容服务)
+
+- **#51(closes #49)** **LLM 真 BYO**:去掉硬编码的 MiMo 默认端点,改用标准 `Authorization: Bearer <key>` 发请求 —— **修复 DeepSeek / OpenAI 等所有 OpenAI 兼容服务此前一律 401 的问题**。同时:LLM **未配置 / 401 时给出友好报错**,不再抛晦涩的底层错误。
+- **#53(closes #49)** **点击「获取」时 LLM 预检** —— 未配置直接提示,不再把任务入队空转(避免「点了没反应、队列里一堆失败」)。
+  > 注:#53 可能在发版前刚合入,本次一并纳入。
+
+## 获取与活动页
+
+- **#52** 活动页全季获取卡片显示**季号列表「第 1 / 2 / 3 / 4 季」**,而非误导的「第 1 季」(一次性收多季时如实呈现实际在收的季)。
+
+## 部署与基础设施
+
+- **#47(closes #46)** 修**连不上 Docker Hub 时构建第一步就卡死** —— 首次 `docker compose build` 在拉基础镜像处挂住(`auth.docker.io ... i/o timeout`)。加了镜像加速文档(Docker Desktop / Linux 分别说明,面向国内网络)。
+- **#48** 未连任何网盘时,后台 worker **静默跳过**获取轮询,不再每 3 秒刷一行 `PAN115_COOKIE is required` 日志(新装、还没连盘时日志干净)。
+
+## 试用
+
+- 免安装只读 demo:https://mediary.dirtyfancy.sbs
+- 自部署:见 [README](../README.md) + [docs/deploy.md](deploy.md)


### PR DESCRIPTION
**Docs only** — no app code touched (4 markdown files).

## What

### 1. 光鸭云盘 (GuangYaPan) — third supported drive brand
- `README.md` / `README.zh-CN.md`: added 光鸭云盘 wherever drives are listed (115 / Quark → 115 / Quark / 光鸭), Supported-drives entry, Prowlarr note, disclaimer/credits. Keeps the honest "Chinese cloud drives" framing.
- Brand facts: Xunlei-family drive, **magnet / offline-download first** (transfers magnet/ed2k/BT via its offline-task API, like 115's offline path; does **not** transfer 115/Quark/光鸭 share-links in v1 — fails loud by design). Token auth (`access_token` + `refresh_token`).

### 2. Connect tutorial (`docs/deploy.md` → 光鸭云盘连接)
- Where: 设置 → 网盘连接 → 「光鸭云盘」tab → paste `access_token` + `refresh_token` → save.
- How to get tokens: log into guangyapan.com web app → DevTools Console → copy-paste snippet reads `localStorage.credentials_aMe-8VSlkrbQXpUR` JSON and prints/copies `{accessToken, refreshToken}`. Includes a fallback to discover the `credentials_*` key if clientid changes. Warns not to paste tokens anywhere public.
- Notes that 光鸭 is magnet/offline-first (pairs with Prowlarr) and needs an LLM configured like all acquisition.

### 3. AList attribution
- The 光鸭 cloud API integration is based on the open-source **AList** `guangyapan` driver (https://github.com/AlistGo/alist, `drivers/guangyapan`). Credited in deploy.md, both READMEs' credits, and the release notes.

### 4. 0.3.0 release notes
- No `CHANGELOG.md` in repo → created `docs/release-notes-0.3.0.md` (draft for the maintainer's GitHub release), matching v0.2.0's Chinese-title themed style.
- Covers #50 (光鸭云盘), #51 closes #49 (LLM 真 BYO — drop hardcoded MiMo, standard `Authorization: Bearer`, fixes 401 on DeepSeek/OpenAI + friendly errors), #53 (LLM preflight on 获取), #52 (全季获取 season-list display), #47 closes #46 (Docker Hub build hang + mirror docs), #48 (worker silent skip when no drive). Headline: **光鸭云盘支持 + LLM 真 BYO**.

## Verify
- `git diff` is docs-only (README.md, README.zh-CN.md, docs/deploy.md, docs/release-notes-0.3.0.md — all `.md`).
- Anchor `#光鸭云盘guangyapan连接` verified against GitHub's slugger (matches the existing `#国内构建加速连不上-docker-hub` anchor convention); all 4 internal links resolve. New section added to deploy.md TOC.