### PR TITLE
fix(guangya): 连接表单 textarea 样式 + 智能粘贴(整块 JSON 自动拆填 + 清洗)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2277,6 +2277,29 @@ li.hub-season-row.untracked {
   border-color: var(--accent);
 }
 
+/* Multi-line variant of .setting-control for <textarea> (token/cookie boxes).
+   Shares the card bg / border / focus look, but un-does the single-line box:
+   auto height, real vertical padding, soft (non-pill) corners. */
+.setting-textarea {
+  appearance: none;
+  -webkit-appearance: none;
+  height: auto;
+  min-height: 76px;
+  background-color: var(--bg-card);
+  color: var(--text);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  font-size: 13.5px;
+  font-family: inherit;
+  padding: 10px 14px;
+  transition: border-color 0.15s ease;
+}
+
+.setting-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 select.setting-control {
   cursor: pointer;
   padding-right: 42px;

--- a/apps/web/components/guangya-token-connect.tsx
+++ b/apps/web/components/guangya-token-connect.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { Check, ExternalLink, LoaderCircle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { connectGuangYaAction } from "../app/actions";
+import { parseTokenPaste, sanitizeToken } from "../lib/guangya-token-paste";
 
 /**
  * 光鸭云盘 token 连接 —— 光鸭用 access_token + refresh_token 鉴权(非 cookie)。
@@ -16,6 +17,18 @@ export function GuangYaTokenConnect() {
   const [refreshToken, setRefreshToken] = useState("");
   const [isPending, startTransition] = useTransition();
   const [result, setResult] = useState<string | null>(null);
+
+  // 智能粘贴:Console snippet 拷出的整块 JSON({"accessToken":…,"refreshToken":…})
+  // 粘进任一框 → 自动拆填两个字段;裸 token → 仅清洗当前字段。
+  const handleTokenInput = (value: string, setSelf: (v: string) => void) => {
+    const blob = parseTokenPaste(value);
+    if (blob) {
+      setAccessToken(blob.accessToken);
+      setRefreshToken(blob.refreshToken);
+      return;
+    }
+    setSelf(sanitizeToken(value));
+  };
 
   const handleConnect = () => {
     startTransition(async () => {
@@ -34,6 +47,7 @@ export function GuangYaTokenConnect() {
       <p className="panel-note" style={{ marginBottom: 6 }}>
         从光鸭云盘 app/网页端的登录态中复制 <code>access_token</code> 与 <code>refresh_token</code>，分别粘到下面两个框。
         access_token 用于鉴权，refresh_token 在过期时自动续期（续期后新 token 会自动保存）。
+        也可以直接把复制到的整块 JSON（含 accessToken 与 refreshToken）粘到任一框，会自动拆填到两个框。
       </p>
       <p className="push-help" style={{ marginBottom: 12 }}>
         光鸭云盘{" "}
@@ -42,18 +56,18 @@ export function GuangYaTokenConnect() {
         </a>
       </p>
       <textarea
-        className="setting-control"
+        className="setting-textarea"
         value={accessToken}
-        onChange={(event) => setAccessToken(event.target.value)}
-        placeholder="粘贴 access_token（形如 eyJ…）"
+        onChange={(event) => handleTokenInput(event.target.value, setAccessToken)}
+        placeholder="粘贴 access_token（形如 eyJ…），或整块 JSON"
         aria-label="光鸭 access_token"
         rows={3}
         style={{ width: "100%", fontFamily: "monospace", fontSize: 12, resize: "vertical" }}
       />
       <textarea
-        className="setting-control"
+        className="setting-textarea"
         value={refreshToken}
-        onChange={(event) => setRefreshToken(event.target.value)}
+        onChange={(event) => handleTokenInput(event.target.value, setRefreshToken)}
         placeholder="粘贴 refresh_token"
         aria-label="光鸭 refresh_token"
         rows={3}

--- a/apps/web/components/quark-cookie-connect.tsx
+++ b/apps/web/components/quark-cookie-connect.tsx
@@ -40,7 +40,7 @@ export function QuarkCookieConnect() {
         </a>
       </p>
       <textarea
-        className="setting-control"
+        className="setting-textarea"
         value={cookie}
         onChange={(event) => setCookie(event.target.value)}
         placeholder="把完整的 Cookie 粘到这里（形如 __pus=…; __uid=…; __kps=…）"

--- a/apps/web/lib/guangya-token-paste.test.ts
+++ b/apps/web/lib/guangya-token-paste.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { parseTokenPaste, sanitizeToken } from "./guangya-token-paste";
 
+// Invisible chars built from codepoints (reviewable + encoding-stable — never
+// embed the literals in source, which is exactly what we strip).
+const ZWSP = String.fromCodePoint(0x200b); // zero-width space
+const ZWNJ = String.fromCodePoint(0x200c); // zero-width non-joiner
+const ZWJ = String.fromCodePoint(0x200d); // zero-width joiner
+const BOM = String.fromCodePoint(0xfeff); // byte-order mark
+
 describe("sanitizeToken", () => {
   it("strips surrounding/interior whitespace", () => {
     expect(sanitizeToken("  ey J1  ")).toBe("eyJ1");
   });
 
   it("strips zero-width and invisible codepoints", () => {
-    // zero-width space (200b) between J and 1, BOM (feff) leading
-    expect(sanitizeToken("﻿ey​J‌1‍")).toBe("eyJ1");
+    expect(sanitizeToken(`${BOM}ey${ZWSP}J${ZWNJ}1${ZWJ}`)).toBe("eyJ1");
   });
 
   it("combines whitespace + zero-width stripping", () => {
-    expect(sanitizeToken("  ey J​1  ")).toBe("eyJ1");
+    expect(sanitizeToken(`  ey ${ZWSP}J${ZWSP}1  `)).toBe("eyJ1");
   });
 
   it("leaves a clean token untouched", () => {
@@ -41,15 +47,29 @@ describe("parseTokenPaste", () => {
     ).toEqual({ accessToken: "AT", refreshToken: "RT" });
   });
 
-  it("sanitizes zero-width chars inside the blob tokens", () => {
-    expect(parseTokenPaste('{"accessToken":"A​T","refreshToken":"R‌T"}')).toEqual({
+  it("parses a blob with leading/trailing whitespace around the braces", () => {
+    expect(parseTokenPaste('  \n {"accessToken":"AT","refreshToken":"RT"}  ')).toEqual({
       accessToken: "AT",
       refreshToken: "RT",
     });
   });
 
+  it("sanitizes zero-width chars inside the blob tokens", () => {
+    expect(
+      parseTokenPaste(`{"accessToken":"A${ZWSP}T","refreshToken":"R${ZWNJ}T"}`),
+    ).toEqual({ accessToken: "AT", refreshToken: "RT" });
+  });
+
   it("returns null for a bare token string (not JSON)", () => {
     expect(parseTokenPaste("eyJ1.abc.def")).toBeNull();
+  });
+
+  it("never throws on a bare (non-{) token — the hot input path", () => {
+    expect(() => parseTokenPaste("eyJ1.abc.def")).not.toThrow();
+    expect(() => parseTokenPaste("")).not.toThrow();
+    // looks JSON-ish at start but is malformed → still no throw, returns null
+    expect(() => parseTokenPaste("{not json")).not.toThrow();
+    expect(parseTokenPaste("{not json")).toBeNull();
   });
 
   it("returns null when the JSON is missing refreshToken", () => {

--- a/apps/web/lib/guangya-token-paste.test.ts
+++ b/apps/web/lib/guangya-token-paste.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { parseTokenPaste, sanitizeToken } from "./guangya-token-paste";
+
+describe("sanitizeToken", () => {
+  it("strips surrounding/interior whitespace", () => {
+    expect(sanitizeToken("  ey J1  ")).toBe("eyJ1");
+  });
+
+  it("strips zero-width and invisible codepoints", () => {
+    // zero-width space (200b) between J and 1, BOM (feff) leading
+    expect(sanitizeToken("﻿ey​J‌1‍")).toBe("eyJ1");
+  });
+
+  it("combines whitespace + zero-width stripping", () => {
+    expect(sanitizeToken("  ey J​1  ")).toBe("eyJ1");
+  });
+
+  it("leaves a clean token untouched", () => {
+    expect(sanitizeToken("eyJabc.def")).toBe("eyJabc.def");
+  });
+});
+
+describe("parseTokenPaste", () => {
+  it("splits a camelCase JSON blob into both tokens", () => {
+    expect(parseTokenPaste('{"accessToken":"AT","refreshToken":"RT"}')).toEqual({
+      accessToken: "AT",
+      refreshToken: "RT",
+    });
+  });
+
+  it("splits a snake_case JSON blob into both tokens", () => {
+    expect(parseTokenPaste('{"access_token":"AT","refresh_token":"RT"}')).toEqual({
+      accessToken: "AT",
+      refreshToken: "RT",
+    });
+  });
+
+  it("trims whitespace/newlines inside the JSON values", () => {
+    expect(
+      parseTokenPaste('{\n  "accessToken": "  AT  ",\n  "refreshToken": "\\nRT\\n"\n}'),
+    ).toEqual({ accessToken: "AT", refreshToken: "RT" });
+  });
+
+  it("sanitizes zero-width chars inside the blob tokens", () => {
+    expect(parseTokenPaste('{"accessToken":"A​T","refreshToken":"R‌T"}')).toEqual({
+      accessToken: "AT",
+      refreshToken: "RT",
+    });
+  });
+
+  it("returns null for a bare token string (not JSON)", () => {
+    expect(parseTokenPaste("eyJ1.abc.def")).toBeNull();
+  });
+
+  it("returns null when the JSON is missing refreshToken", () => {
+    expect(parseTokenPaste('{"accessToken":"AT"}')).toBeNull();
+  });
+
+  it("returns null when the JSON is missing accessToken", () => {
+    expect(parseTokenPaste('{"refreshToken":"RT"}')).toBeNull();
+  });
+
+  it("returns null for non-object JSON (array)", () => {
+    expect(parseTokenPaste('["AT","RT"]')).toBeNull();
+  });
+});

--- a/apps/web/lib/guangya-token-paste.ts
+++ b/apps/web/lib/guangya-token-paste.ts
@@ -9,8 +9,9 @@
  * 任一 token 框,parseTokenPaste 会自动拆成两个字段;粘裸 token 则走 sanitizeToken。
  */
 
-// 不被正则 \s 类覆盖的不可见码点:零宽空格、零宽非连字、零宽连字、BOM。
-// (NBSP U+00A0 与 BOM U+FEFF 实际在 \s 内,这里仍显式列出 feff 保险。)
+// 不被正则 \s 类覆盖的零宽码点:零宽空格(200b)、零宽非连字(200c)、零宽连字(200d)。
+// 这三个 \s 抓不到,必须显式列出。BOM(FEFF)与 NBSP(00A0)本身已在 \s 内、会被
+// sanitizeToken 的 \s 分支剥掉;FEFF 仍冗余列出一份纯属保险,无害。
 const INVISIBLE_CODEPOINTS = new Set([0x200b, 0x200c, 0x200d, 0xfeff]);
 
 /**
@@ -41,9 +42,15 @@ function pickString(obj: Record<string, unknown>, ...keys: string[]): string | n
  * 否则返回 null(不是 JSON 块,按裸 token 处理)。
  */
 export function parseTokenPaste(raw: string): { accessToken: string; refreshToken: string } | null {
+  // 便宜的前置守卫:onChange 是热路径,绝大多数输入是裸 token(非 `{` 开头)。
+  // 先 startsWith("{") 短路,避免对每次按键都 JSON.parse-抛错-catch(白白制造抖动)。
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{")) {
+    return null;
+  }
   let parsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    parsed = JSON.parse(trimmed);
   } catch {
     return null;
   }

--- a/apps/web/lib/guangya-token-paste.ts
+++ b/apps/web/lib/guangya-token-paste.ts
@@ -1,0 +1,60 @@
+/**
+ * 光鸭 token 智能粘贴 + 清洗 —— 纯函数,客户端安全(不引入任何 server 模块,
+ * 故意不从 @media-track/workflow 引入 sanitizeLlmApiKey:那条 barrel 会把
+ * postgres/worker 等服务端代码拖进客户端 bundle)。这里复刻 agent-model.ts 里
+ * sanitizeLlmApiKey 用的同一套不可见码点集。
+ *
+ * 用户在光鸭 Console 跑的 snippet 会把
+ * `{"accessToken":"…","refreshToken":"…"}`(JSON)拷进剪贴板。把整块 JSON 粘进
+ * 任一 token 框,parseTokenPaste 会自动拆成两个字段;粘裸 token 则走 sanitizeToken。
+ */
+
+// 不被正则 \s 类覆盖的不可见码点:零宽空格、零宽非连字、零宽连字、BOM。
+// (NBSP U+00A0 与 BOM U+FEFF 实际在 \s 内,这里仍显式列出 feff 保险。)
+const INVISIBLE_CODEPOINTS = new Set([0x200b, 0x200c, 0x200d, 0xfeff]);
+
+/**
+ * 从粘贴的 token 里剥掉所有空白 + 不可见字符(token 本身不含空白)。防御网页复制
+ * 带进来的空格/制表/换行/NBSP/零宽字符/BOM——否则会静默存错值,让用户以为 token 坏了。
+ */
+export function sanitizeToken(raw: string): string {
+  let out = "";
+  for (const ch of raw) {
+    if (/\s/.test(ch)) continue;
+    if (INVISIBLE_CODEPOINTS.has(ch.codePointAt(0) ?? -1)) continue;
+    out += ch;
+  }
+  return out;
+}
+
+function pickString(obj: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string") return value;
+  }
+  return null;
+}
+
+/**
+ * 试着把粘贴内容当成光鸭 Console snippet 拷出的 JSON 块解析。若对象同时含
+ * accessToken|access_token 和 refreshToken|refresh_token,返回两者(已清洗);
+ * 否则返回 null(不是 JSON 块,按裸 token 处理)。
+ */
+export function parseTokenPaste(raw: string): { accessToken: string; refreshToken: string } | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const obj = parsed as Record<string, unknown>;
+  const access = pickString(obj, "accessToken", "access_token");
+  const refresh = pickString(obj, "refreshToken", "refresh_token");
+  if (access === null || refresh === null) {
+    return null;
+  }
+  return { accessToken: sanitizeToken(access), refreshToken: sanitizeToken(refresh) };
+}


### PR DESCRIPTION
## 背景
光鸭云盘连接表单(设置 → 网盘连接 → 添加网盘 → 光鸭云盘 tab)的 token 输入框样式错版,且粘贴体验可优化。

## Part A — CSS bug(已对真实渲染取证)
`guangya-token-connect.tsx` / `quark-cookie-connect.tsx` 里的多行 `<textarea rows={3}>` 误用了**单行** `.setting-control`(`height:44px` / `padding:0 18px` / `border-radius:pill`)→ 高度被压成 44px、零垂直内边距、整圆角药丸,多行框显得很怪(夸克那个藏在折叠 `<details>` 里,只有光鸭会暴露)。

**修复**:新增 `.setting-textarea`(`height:auto` / `min-height:76px` / `padding:10px 14px` / `border-radius:12px`,沿用同样的卡片底色/边框/聚焦色),**光鸭与夸克两个组件都替换**。

**真实像素验证**(把真 `<textarea rows={3}>`+组件同款 inline style 注入到加载了编译版 `globals.css` 的实例页,`getBoundingClientRect` 量真高,非读 `style`):

| | computed height | border-radius | vertical padding |
|---|---|---|---|
| BEFORE `.setting-control` | **44px** | **9999px** (pill) | **0** |
| AFTER `.setting-textarea` | **76px** | **12px** | **10px** |

底色 `rgb(37,37,37)` + 边框 `rgba(255,255,255,0.12)` 两者一致,视觉统一。截图已确认。

## Part B — 智能粘贴 + 清洗
光鸭 Console snippet 会把 `{"accessToken":"…","refreshToken":"…"}`(JSON)拷进剪贴板。现在把整块 JSON 粘进**任一** token 框 → 自动拆填到两个框;粘裸 token → 清洗当前框。

- 新增纯逻辑模块 `apps/web/lib/guangya-token-paste.ts`(客户端安全,不从 `@media-track/workflow` 引入——那条 barrel 会把 postgres/worker 等服务端代码拖进客户端 bundle,故复刻 `sanitizeLlmApiKey` 的码点集 `0x200b/0c/0d/feff` + `\s`):
  - `sanitizeToken(raw)` — 剥所有空白 + 零宽/不可见字符
  - `parseTokenPaste(raw)` — `JSON.parse`,同时含 accessToken|access_token 且 refreshToken|refresh_token 才返回两者(已清洗),否则 null
- 接进 `guangya-token-connect.tsx` 两个框的 onChange,并更新提示文案。

## TDD
`apps/web/lib/guangya-token-paste.test.ts` 先红(模块不存在)后绿,12 cases:camelCase / snake_case JSON、JSON 内含空白换行的 trim、零宽清洗、裸 token → null、缺字段 → null、数组 → null、sanitizeToken 空白+零宽。

## 验证
- `npx vitest run` → **977 passed | 12 skipped**(含新 12 case)
- `npx tsc -p apps/web/tsconfig.json --noEmit` → 0 error
- `npm run build:web` → **✓ Compiled successfully**(客户端/服务端边界保持,新 lib 客户端安全)
- `npx eslint`(改动文件)→ 0 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)