### PR TITLE
feat(guangya): 识别并拆分 token 按钮 + robust 提取(JSON/标签文本/启发式)

### DIFF
--- a/apps/web/components/guangya-token-connect.tsx
+++ b/apps/web/components/guangya-token-connect.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { Check, ExternalLink, LoaderCircle } from "lucide-react";
+import { Check, ExternalLink, LoaderCircle, Wand2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { connectGuangYaAction } from "../app/actions";
-import { parseTokenPaste, sanitizeToken } from "../lib/guangya-token-paste";
+import { extractGuangYaTokens, parseTokenPaste, sanitizeToken } from "../lib/guangya-token-paste";
 
 /**
  * 光鸭云盘 token 连接 —— 光鸭用 access_token + refresh_token 鉴权(非 cookie)。
@@ -17,10 +17,12 @@ export function GuangYaTokenConnect() {
   const [refreshToken, setRefreshToken] = useState("");
   const [isPending, startTransition] = useTransition();
   const [result, setResult] = useState<string | null>(null);
+  const [extractNote, setExtractNote] = useState<string | null>(null);
 
   // 智能粘贴:Console snippet 拷出的整块 JSON({"accessToken":…,"refreshToken":…})
   // 粘进任一框 → 自动拆填两个字段;裸 token → 仅清洗当前字段。
   const handleTokenInput = (value: string, setSelf: (v: string) => void) => {
+    setExtractNote(null);
     const blob = parseTokenPaste(value);
     if (blob) {
       setAccessToken(blob.accessToken);
@@ -28,6 +30,21 @@ export function GuangYaTokenConnect() {
       return;
     }
     setSelf(sanitizeToken(value));
+  };
+
+  // 显式「识别并拆分」:鲁棒提取(JSON / 标签文本 / 启发式),不管粘的是 Console 打印的
+  // 两段还是复制的 JSON,一次粘 box1 + 一次点击就能把两个框都填好。
+  const handleExtract = () => {
+    const r = extractGuangYaTokens(accessToken);
+    if (r) {
+      setAccessToken(r.accessToken);
+      setRefreshToken(r.refreshToken);
+      setExtractNote("✅ 已识别 access + refresh");
+    } else {
+      setExtractNote(
+        "没识别出两个 token —— 请确认粘贴内容里同时含 access_token 和 refresh_token(可直接粘 Console 打印的两段或复制的 JSON)。",
+      );
+    }
   };
 
   const handleConnect = () => {
@@ -47,7 +64,8 @@ export function GuangYaTokenConnect() {
       <p className="panel-note" style={{ marginBottom: 6 }}>
         从光鸭云盘 app/网页端的登录态中复制 <code>access_token</code> 与 <code>refresh_token</code>，分别粘到下面两个框。
         access_token 用于鉴权，refresh_token 在过期时自动续期（续期后新 token 会自动保存）。
-        也可以直接把复制到的整块 JSON（含 accessToken 与 refreshToken）粘到任一框，会自动拆填到两个框。
+        最省事：把粘贴内容（Console 打印的两段、或复制的 JSON 都行）粘到第一个框，再点
+        <strong>「识别并拆分」</strong>，两个框会自动填好。
       </p>
       <p className="push-help" style={{ marginBottom: 12 }}>
         光鸭云盘{" "}
@@ -64,6 +82,24 @@ export function GuangYaTokenConnect() {
         rows={3}
         style={{ width: "100%", fontFamily: "monospace", fontSize: 12, resize: "vertical" }}
       />
+      {accessToken.trim() ? (
+        <div style={{ marginTop: 6 }}>
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={handleExtract}
+            style={{ fontSize: 12, padding: "4px 10px" }}
+          >
+            <Wand2 size={12} aria-hidden style={{ verticalAlign: "-2px", marginRight: 4 }} />
+            识别并拆分 token
+          </button>
+          {extractNote ? (
+            <p className="panel-note" style={{ marginTop: 6, marginBottom: 0 }}>
+              {extractNote}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
       <textarea
         className="setting-textarea"
         value={refreshToken}

--- a/apps/web/lib/guangya-token-paste.test.ts
+++ b/apps/web/lib/guangya-token-paste.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseTokenPaste, sanitizeToken } from "./guangya-token-paste";
+import { extractGuangYaTokens, parseTokenPaste, sanitizeToken } from "./guangya-token-paste";
 
 // Invisible chars built from codepoints (reviewable + encoding-stable — never
 // embed the literals in source, which is exactly what we strip).
@@ -82,5 +82,78 @@ describe("parseTokenPaste", () => {
 
   it("returns null for non-object JSON (array)", () => {
     expect(parseTokenPaste('["AT","RT"]')).toBeNull();
+  });
+});
+
+describe("extractGuangYaTokens", () => {
+  it("handles a camelCase JSON blob", () => {
+    expect(extractGuangYaTokens('{"accessToken":"eyJa.b.c","refreshToken":"gy.RT"}')).toEqual({
+      accessToken: "eyJa.b.c",
+      refreshToken: "gy.RT",
+    });
+  });
+
+  it("handles a snake_case JSON blob", () => {
+    expect(extractGuangYaTokens('{"access_token":"eyJa.b.c","refresh_token":"gy.RT"}')).toEqual({
+      accessToken: "eyJa.b.c",
+      refreshToken: "gy.RT",
+    });
+  });
+
+  it("handles the Console-printed labeled block (with trailing noise)", () => {
+    const pasted = "accessToken:\neyJabc.def.ghi\n\nrefreshToken:\ngy.RT123\n(已复制到剪贴板)";
+    expect(extractGuangYaTokens(pasted)).toEqual({
+      accessToken: "eyJabc.def.ghi",
+      refreshToken: "gy.RT123",
+    });
+  });
+
+  it("handles concatenated / newline-collapsed text via heuristic + label", () => {
+    expect(extractGuangYaTokens("eyJabc.def.ghirefreshToken:gy.RT123")).toEqual({
+      accessToken: "eyJabc.def.ghi",
+      refreshToken: "gy.RT123",
+    });
+  });
+
+  it("does not let a labeled access value swallow a following refresh label", () => {
+    // Real-product shape: the onChange sanitize strips ALL whitespace from the
+    // pasted Console block BEFORE extract runs, so labels+values are glued:
+    // `accessToken:<JWT>refreshToken:gy.<rt>`. The access capture must stop at the
+    // next `refreshToken` label, not eat it.
+    expect(extractGuangYaTokens("accessToken:eyJabc.def.ghirefreshToken:gy.RT123")).toEqual({
+      accessToken: "eyJabc.def.ghi",
+      refreshToken: "gy.RT123",
+    });
+  });
+
+  it("handles two bare lines with no labels (pure heuristic)", () => {
+    expect(extractGuangYaTokens("eyJabc.def.ghi\ngy.RT123")).toEqual({
+      accessToken: "eyJabc.def.ghi",
+      refreshToken: "gy.RT123",
+    });
+  });
+
+  it("sanitizes zero-width chars inside extracted tokens", () => {
+    const pasted = `accessToken: eyJabc.def.ghi\nrefreshToken: gy.${ZWSP}RT${ZWNJ}123`;
+    expect(extractGuangYaTokens(pasted)).toEqual({
+      accessToken: "eyJabc.def.ghi",
+      refreshToken: "gy.RT123",
+    });
+  });
+
+  it("returns null when only one token is present", () => {
+    expect(extractGuangYaTokens("accessToken: eyJabc.def.ghi")).toBeNull();
+    expect(extractGuangYaTokens("refreshToken: gy.RT123")).toBeNull();
+    expect(extractGuangYaTokens("eyJabc.def.ghi")).toBeNull();
+  });
+
+  it("returns null for garbage", () => {
+    expect(extractGuangYaTokens("hello world, no tokens here")).toBeNull();
+    expect(extractGuangYaTokens("")).toBeNull();
+  });
+
+  it("never throws on arbitrary input", () => {
+    expect(() => extractGuangYaTokens("{not json")).not.toThrow();
+    expect(() => extractGuangYaTokens("random ::: text")).not.toThrow();
   });
 });

--- a/apps/web/lib/guangya-token-paste.test.ts
+++ b/apps/web/lib/guangya-token-paste.test.ts
@@ -133,6 +133,23 @@ describe("extractGuangYaTokens", () => {
     });
   });
 
+  it("JWT heuristic does not swallow a following refresh LABEL (no separator)", () => {
+    // The JWT's final segment is all [A-Za-z0-9_-], so `eyJa.b.crefreshToken`
+    // would over-consume `refreshToken` into the signature. Bounding access to
+    // the text before the refresh start fixes it regardless of separators.
+    expect(extractGuangYaTokens("eyJa.b.crefreshToken:gy.RT1")).toEqual({
+      accessToken: "eyJa.b.c",
+      refreshToken: "gy.RT1",
+    });
+  });
+
+  it("JWT heuristic does not swallow a following gy. token (bare concatenation)", () => {
+    expect(extractGuangYaTokens("eyJa.b.cgy.RT1")).toEqual({
+      accessToken: "eyJa.b.c",
+      refreshToken: "gy.RT1",
+    });
+  });
+
   it("sanitizes zero-width chars inside extracted tokens", () => {
     const pasted = `accessToken: eyJabc.def.ghi\nrefreshToken: gy.${ZWSP}RT${ZWNJ}123`;
     expect(extractGuangYaTokens(pasted)).toEqual({

--- a/apps/web/lib/guangya-token-paste.ts
+++ b/apps/web/lib/guangya-token-paste.ts
@@ -79,8 +79,10 @@ export function parseTokenPaste(raw: string): { accessToken: string; refreshToke
   return { accessToken: sanitizeToken(access), refreshToken: sanitizeToken(refresh) };
 }
 
-// 光鸭 refresh token 以 `gy.` 开头(启发式锚点)。
-const REFRESH_HEURISTIC = /\bgy\.[A-Za-z0-9._~+/=-]+/;
+// 光鸭 refresh token 以 `gy.` 开头(启发式锚点)。不加 \b:真实粘贴里 access JWT 常与
+// refresh 紧贴无分隔(eyJa.b.cgy.RT1),前一个字符是词字符会让 \b 失配 → 漏掉 refresh。
+// `gy\.` 字面锚点已足够具体,匹配第一个出现处即可。
+const REFRESH_HEURISTIC = /gy\.[A-Za-z0-9._~+/=-]+/;
 // JWT(access token)启发式:三段点分,字符集不含点本身(避免吃进后面的 refreshToken: 等噪声)。
 const JWT_HEURISTIC = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
 // 标签 + 值:标签(access_token / accessToken …)后跟 :/引号/空白,再抓值。值字符集
@@ -109,24 +111,27 @@ export function extractGuangYaTokens(raw: string): { accessToken: string; refres
   // 只剩 gy.),必须先去掉;但普通空白/换行是 label 与值之间的有用边界,保留。
   const text = stripInvisible(raw);
 
-  // 先定位 refresh(标签优先,回退 gy. 启发式),记下它在文本里的起点。
+  // 定位 refresh:取值用「标签优先、回退 gy. 启发式」;但 access 的定界用 refresh 的
+  // 「最早起点」——即 gy. 命中位置 与 refresh 标签位置 二者中更靠前的那个。这样无论分隔符
+  // 如何(甚至 access JWT 与 refresh 紧贴无分隔:eyJa.b.cgy.RT1),access 都被钳在 refresh
+  // 之前,JWT 的末段([A-Za-z0-9_-]+)不会把后面的 refreshToken/gy. 吞进签名(Copilot #57)。
   let refresh: string | null = null;
-  let refreshIndex = text.length;
+  let refreshStart = Number.POSITIVE_INFINITY;
   const refreshLabel = text.match(REFRESH_LABEL);
   if (refreshLabel && refreshLabel[1]) {
     refresh = refreshLabel[1];
-    refreshIndex = refreshLabel.index ?? text.length;
-  } else {
-    const refreshHeur = text.match(REFRESH_HEURISTIC);
-    if (refreshHeur) {
-      refresh = refreshHeur[0];
-      refreshIndex = refreshHeur.index ?? text.length;
-    }
+    refreshStart = refreshLabel.index ?? refreshStart;
   }
+  const refreshHeur = text.match(REFRESH_HEURISTIC);
+  if (refreshHeur) {
+    // 标签没拿到值时,gy. 启发式补上 refresh 值。
+    if (refresh === null) refresh = refreshHeur[0];
+    // access 定界取更早者(gy. 可能出现在标签之前)。
+    refreshStart = Math.min(refreshStart, refreshHeur.index ?? Number.POSITIVE_INFINITY);
+  }
+  const refreshIndex = Number.isFinite(refreshStart) ? refreshStart : text.length;
 
-  // access 只在 refresh 标记之前的片段(head)里找——无论标签还是启发式。否则在「换行被
-  // onChange 清洗吞掉」的真实粘贴里(accessToken:<JWT>refreshToken:gy.<rt>),access 的值
-  // 捕获会越过下一个 refreshToken 标签、把它一并吃进去(实测踩坑)。
+  // access 只在 refresh 起点之前的片段(head)里找——无论标签还是启发式。
   const head = text.slice(0, refreshIndex);
   let access: string | null = null;
   const accessLabel = head.match(ACCESS_LABEL);

--- a/apps/web/lib/guangya-token-paste.ts
+++ b/apps/web/lib/guangya-token-paste.ts
@@ -15,6 +15,19 @@
 const INVISIBLE_CODEPOINTS = new Set([0x200b, 0x200c, 0x200d, 0xfeff]);
 
 /**
+ * 只剥掉零宽/不可见码点,保留普通空白。提取器用它做正则前处理:零宽字符会打断
+ * 值捕获(gy.<ZWSP>RT → 只剩 gy.),但普通空白/换行是 label↔值 的有用边界,必须留。
+ */
+function stripInvisible(raw: string): string {
+  let out = "";
+  for (const ch of raw) {
+    if (INVISIBLE_CODEPOINTS.has(ch.codePointAt(0) ?? -1)) continue;
+    out += ch;
+  }
+  return out;
+}
+
+/**
  * 从粘贴的 token 里剥掉所有空白 + 不可见字符(token 本身不含空白)。防御网页复制
  * 带进来的空格/制表/换行/NBSP/零宽字符/BOM——否则会静默存错值,让用户以为 token 坏了。
  */
@@ -64,4 +77,73 @@ export function parseTokenPaste(raw: string): { accessToken: string; refreshToke
     return null;
   }
   return { accessToken: sanitizeToken(access), refreshToken: sanitizeToken(refresh) };
+}
+
+// 光鸭 refresh token 以 `gy.` 开头(启发式锚点)。
+const REFRESH_HEURISTIC = /\bgy\.[A-Za-z0-9._~+/=-]+/;
+// JWT(access token)启发式:三段点分,字符集不含点本身(避免吃进后面的 refreshToken: 等噪声)。
+const JWT_HEURISTIC = /eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/;
+// 标签 + 值:标签(access_token / accessToken …)后跟 :/引号/空白,再抓值。值字符集
+// 不含点之外的 token 合法字符;用 sanitizeToken 兜底去掉尾巴噪声。
+const ACCESS_LABEL = /access[_\s]*token["':\s]+([A-Za-z0-9._~+/=-]+)/i;
+const REFRESH_LABEL = /refresh[_\s]*token["':\s]+([A-Za-z0-9._~+/=-]+)/i;
+
+/**
+ * 鲁棒提取光鸭 access + refresh token —— parseTokenPaste(纯 JSON)的超集。按序尝试:
+ *   1) JSON 块(复用 parseTokenPaste)。
+ *   2) 标签文本:`access_token: …` / `refresh_token: …`(容忍 :/引号/空白)。
+ *   3) 启发式:access = 第一个 JWT(eyJ…三段);refresh = 第一个 `gy.…`。
+ * 仅当 access 与 refresh 都找到才返回(两者都过 sanitizeToken,去空白/零宽/尾部噪声);
+ * 否则 null。永不抛错(供 onClick 直接调用)。
+ *
+ * 为什么先定位 refresh、再在其之前找 access:粘贴常是
+ * `…eyJa.b.crefreshToken:gy.…`(换行被吞),JWT 启发式会贪婪吃进 `refreshToken`,
+ * 故 access 只在 refresh 标记之前的片段里找。
+ */
+export function extractGuangYaTokens(raw: string): { accessToken: string; refreshToken: string } | null {
+  // 1) JSON 优先(用原文,JSON.parse 自己容忍空白)。
+  const json = parseTokenPaste(raw);
+  if (json) return json;
+
+  // 2/3) 在「去零宽、保留普通空白」的副本上跑正则:零宽字符会打断值捕获(gy.<ZWSP>RT
+  // 只剩 gy.),必须先去掉;但普通空白/换行是 label 与值之间的有用边界,保留。
+  const text = stripInvisible(raw);
+
+  // 先定位 refresh(标签优先,回退 gy. 启发式),记下它在文本里的起点。
+  let refresh: string | null = null;
+  let refreshIndex = text.length;
+  const refreshLabel = text.match(REFRESH_LABEL);
+  if (refreshLabel && refreshLabel[1]) {
+    refresh = refreshLabel[1];
+    refreshIndex = refreshLabel.index ?? text.length;
+  } else {
+    const refreshHeur = text.match(REFRESH_HEURISTIC);
+    if (refreshHeur) {
+      refresh = refreshHeur[0];
+      refreshIndex = refreshHeur.index ?? text.length;
+    }
+  }
+
+  // access 只在 refresh 标记之前的片段(head)里找——无论标签还是启发式。否则在「换行被
+  // onChange 清洗吞掉」的真实粘贴里(accessToken:<JWT>refreshToken:gy.<rt>),access 的值
+  // 捕获会越过下一个 refreshToken 标签、把它一并吃进去(实测踩坑)。
+  const head = text.slice(0, refreshIndex);
+  let access: string | null = null;
+  const accessLabel = head.match(ACCESS_LABEL);
+  if (accessLabel && accessLabel[1]) {
+    access = accessLabel[1];
+  } else {
+    const jwt = head.match(JWT_HEURISTIC);
+    if (jwt) access = jwt[0];
+  }
+
+  if (access === null || refresh === null) {
+    return null;
+  }
+  const accessToken = sanitizeToken(access);
+  const refreshToken = sanitizeToken(refresh);
+  if (accessToken === "" || refreshToken === "") {
+    return null;
+  }
+  return { accessToken, refreshToken };
 }

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -61,7 +61,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 
 ### 1. 在设置页粘 token
 
-**设置 → 网盘连接 → 选「光鸭云盘」标签页**,把下面取到的两个 token 分别粘进 `access_token` 与 `refresh_token` 两个框,点「连接光鸭」。连接时会用 token 校验登录态、并在你盘里建好 `Mediary Scout/{Movies,TV,Anime}` 分类目录。
+**设置 → 网盘连接 → 选「光鸭云盘」标签页**。最省事:把下面 Console 打印出来的内容(打印的两段、或它复制到剪贴板的 JSON,都行)整段粘到**第一个框**,再点框下方的 **「识别并拆分 token」**,两个框会自动填好;确认无误后点「连接光鸭」。(也可以仍按老办法手动把两个值分别粘进两个框。)连接时会用 token 校验登录态、并在你盘里建好 `Mediary Scout/{Movies,TV,Anime}` 分类目录。
 
 ### 2. 怎么拿到这两个 token
 
@@ -85,7 +85,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 
    > 如果 `credentials_aMe-8VSlkrbQXpUR` 取不到(光鸭后续改了 clientid),在 Console 里跑 `Object.keys(localStorage).filter(k => k.startsWith("credentials_"))` 看实际键名,把后缀换进上面的 `clientId`。
 
-4. 控制台会打印 `accessToken` 与 `refreshToken`(且尝试把 `{accessToken, refreshToken}` JSON 复制到剪贴板)。把这两个值分别粘回设置页对应的框。
+4. 控制台会打印 `accessToken` 与 `refreshToken`(且尝试把 `{accessToken, refreshToken}` JSON 复制到剪贴板)。把打印的两段、或复制的 JSON,整段粘到设置页**第一个框**,点 **「识别并拆分 token」**即可自动填好两个框(不必手动分辨哪段是哪个)。
 
 > 🔒 **别把 token 贴到任何公开地方**(issue、聊天群、截图、粘贴板网站)。它们等同你光鸭账号的登录态;只该出现在你自己实例的设置页里。
 


### PR DESCRIPTION
## 为什么之前智能粘贴对用户失效
上一版 `parseTokenPaste` 只在 JSON(`startsWith "{"`)时触发。但我们教用户在 Console 跑的 snippet **同时**会打印一段带标签的文本:
```
accessToken:
eyJ...
refreshToken:
gy....
(已复制到剪贴板)
```
用户粘的往往是**这段打印**(而非 `copy()` 写进剪贴板的 JSON)→ 非 JSON → 不自动拆分 → 只有 box1 有内容、box2 空 → 「连接光鸭」因「两框都需填」一直 `disabled` → 用户卡死。

## 修复 —— 鲁棒提取器 + 显式「识别并拆分」按钮
1. `apps/web/lib/guangya-token-paste.ts` 新增 `extractGuangYaTokens(raw)`(`parseTokenPaste` 的超集),按序:
   - **JSON**(复用 `parseTokenPaste`)
   - **标签正则**:`access/refresh[_\s]*token` 后跟 `:`/引号/空白再抓值
   - **启发式**:access = 首个 JWT `eyJ…` 三段;refresh = 首个 `gy.…`(光鸭 refresh 前缀)
   - 两者都过 `sanitizeToken`;仅当 access+refresh 都找到才返回,否则 `null`,**永不抛**(供 onClick 直调)。
   - 先定位 refresh,access 只在其**之前的片段**里找,避免值捕获越过下一个标签。
   - 保留 `parseTokenPaste` / `sanitizeToken` 原样;新增 `stripInvisible`(只去零宽、保留普通空白,因为零宽会打断值捕获、而普通空白是 label↔值 的有用边界)。
2. `apps/web/components/guangya-token-connect.tsx`:box1 有内容时,框下显示 **「识别并拆分 token」** 小按钮 → onClick 调 `extractGuangYaTokens(accessToken)` → 成功则填两框 + 「✅ 已识别 access + refresh」;失败给提示。一次粘 box1 + 一次点击就能填好两框,不论格式。onChange 仍保留轻量 `sanitizeToken` + 干净 JSON 自动拆(锦上添花)。
3. `docs/deploy.md` 光鸭教程改为「整段粘第一个框 → 点识别并拆分 → 两框自动填好」。

## TDD + 真机 e2e 抓到的产品 bug
`guangya-token-paste.test.ts` 加真实格式用例(JSON camel/snake、Console 标签块带尾噪声、拼接/换行被吞、纯启发式两行、单 token→null、垃圾→null、零宽清洗;invisibles 一律 `String.fromCodePoint`)。先红后绿。

⚠️ **单测绿 ≠ 产品可用**:在 preview 实例上跑真 e2e(点 光鸭 tab → 粘 Console 块进 box1 → 点按钮)发现一个单测漏掉的 bug —— 组件 onChange 的 `sanitizeToken` 会**先把粘贴块的空白全吞掉**再 extract,使 `accessToken:<JWT>refreshToken:gy.<rt>` 里标签 access 的值越过 `refreshToken` 标签、把它一并吃进(box1 残留 `…refreshToken`)。补了对应失败用例,并把 access 搜索限定到 refresh 标记之前的片段修复。

修复后真 e2e 复测:
- 粘 Console 标签块 → onChange 清洗成 `accessToken:eyJabc.def.ghirefreshToken:gy.RT123(已复制到剪贴板)` → 点「识别并拆分」→ **box1=`eyJabc.def.ghi`、box2=`gy.RT123`**、note「✅ 已识别 access + refresh」、连接键启用。
- 垃圾输入 → 显示提示、不动两框。

## 验证
- `npx vitest run` → **989 passed | 12 skipped**(含新增提取用例 + bug 回归用例)
- `npx tsc -p apps/web/tsconfig.json --noEmit` → 0 error
- `npm run build:web` → **✓ Compiled successfully**(客户端安全,无 server import)
- `npx eslint`(改动文件)→ 0 error
- 真机渲染:preview 实例 e2e 确认按钮出现 + 点击拆分两框(成功路径 PASS、失败路径提示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)