### PR TITLE
fix(guangya): 电影清洗残留——派生写域漏了离线下载建的壳目录

### DIFF
--- a/packages/workflow/src/guangya-storage-executor.test.ts
+++ b/packages/workflow/src/guangya-storage-executor.test.ts
@@ -201,6 +201,48 @@ describe("GuangYaStorageExecutor write-scope guard", () => {
     ).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
   });
 
+  it("authorizes removeDirectory of an offline-created subdir discovered under an in-scope dir (movie flatten clean-up)", async () => {
+    // A movie magnet offline-downloads as a WRAPPER subdir the SERVER created (NOT via
+    // createDirectory) directly under the in-scope movie dir. flattenMovie lifts the video
+    // out, then removeDirectory(wrapper) to clear the residue. The wrapper is provably under
+    // an in-scope parent (discovered by listing it) — derived scope must authorize its
+    // removal, exactly like a createDirectory'd dir. Regression: WRITE_SCOPE_VIOLATION here
+    // left empty wrapper dirs + non-video junk behind on 光鸭 movies (TV is clean because
+    // discardStaging removes the createDirectory'd staging dir wholesale).
+    const MOVIE = "movie-dir";
+    const wrapperId = "wrapper-1";
+    const fs = new Map<string, GuangYaStorageItem[]>();
+    fs.set(MOVIE, [{ fileId: wrapperId, parentId: MOVIE, fileName: "Oppenheimer.2023.1080p", fileSize: 0, resType: 2 }]);
+    fs.set(wrapperId, []);
+    const deleteFiles = vi.fn<GuangYaStorageClient["deleteFiles"]>(async () => {});
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async (p: string) => fs.get(p) ?? []);
+    const executor = new GuangYaStorageExecutor({
+      client: fakeClient({ listFiles, deleteFiles }),
+      writeScopeDirectoryIds: [MOVIE],
+    });
+
+    const subdirs = await executor.listSubdirectories({ directoryId: MOVIE });
+    expect(subdirs.map((d) => d.id)).toContain(wrapperId);
+
+    await expect(executor.removeDirectory(wrapperId)).resolves.toEqual({ removed: true });
+    expect(deleteFiles).toHaveBeenCalledWith([wrapperId]);
+  });
+
+  it("does NOT authorize removal of children discovered by listing an OUT-of-scope dir", async () => {
+    // Listing is a read and may target dirs outside the write scope; discovering a child
+    // there must NOT make it writable. Only listing an IN-scope dir extends derived scope.
+    const fs = new Map<string, GuangYaStorageItem[]>();
+    fs.set("elsewhere", [{ fileId: "stranger", parentId: "elsewhere", fileName: "x", fileSize: 0, resType: 2 }]);
+    fs.set("stranger", []);
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async (p: string) => fs.get(p) ?? []);
+    const executor = new GuangYaStorageExecutor({
+      client: fakeClient({ listFiles }),
+      writeScopeDirectoryIds: [SCOPE],
+    });
+    await executor.listSubdirectories({ directoryId: "elsewhere" });
+    await expect(executor.removeDirectory("stranger")).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
+  });
+
   it("authorizes writes into runtime-created NESTED dirs (derived scope), still refuses unknown ids", async () => {
     // The real workflow provisions the dir chain TOP-DOWN from a scope root via
     // createDirectory before any write, then transfers/moves into the NESTED leaf —

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -308,6 +308,15 @@ export class GuangYaStorageExecutor implements StorageExecutor {
       if (depth > maxDepth) {
         return;
       }
+      // A subdir DISCOVERED under an in-scope parent is itself within scope (the same
+      // top-down derivation createDirectory relies on) — register it so a later
+      // removeDirectory can clear it. 光鸭's offline download creates wrapper subdirs
+      // SERVER-SIDE (not via createDirectory), so without this the movie flatten's
+      // removeDirectory(wrapper) hits WRITE_SCOPE_VIOLATION and leaves empty wrapper dirs
+      // + non-video junk behind (TV is clean: discardStaging removes the createDirectory'd
+      // staging dir wholesale). Listing an OUT-of-scope dir does NOT widen scope (read ≠
+      // write); registration is gated on the parent already being in scope.
+      const parentInScope = this.isWithinWriteScope(dirId);
       const items = await this.client.listFiles(dirId);
       for (const item of items) {
         if (!isDirectory(item)) {
@@ -316,6 +325,9 @@ export class GuangYaStorageExecutor implements StorageExecutor {
         const childId = idOf(item);
         if (!childId) {
           continue;
+        }
+        if (parentInScope) {
+          this.derivedScopeIds.add(normalizeId(childId));
         }
         const path = `${prefix}${nameOf(item)}`;
         results.push({ id: childId, path });
@@ -476,6 +488,21 @@ export class GuangYaStorageExecutor implements StorageExecutor {
    * parent during this run (derivedScopeIds, populated by createDirectory). Empty
    * scope (dev) allows everything.
    */
+  /** Non-throwing scope membership check (mirrors assertWithinWriteScope). Empty scope
+   *  (dev) treats everything as in-scope; root "" is never a write target under a real
+   *  scope. Used to gate derived-scope registration during listing. */
+  private isWithinWriteScope(directoryId: string): boolean {
+    if (this.writeScopeDirectoryIds.size === 0) {
+      return true;
+    }
+    const trimmed = directoryId.trim();
+    if (trimmed === "") {
+      return false;
+    }
+    const normalized = normalizeId(directoryId);
+    return this.writeScopeDirectoryIds.has(normalized) || this.derivedScopeIds.has(normalized);
+  }
+
   private assertWithinWriteScope(directoryId: string, action: string): string {
     // 光鸭's ROOT directory id is the empty string "": create_dir / get_file_list with
     // parentId:"" operate on root (confirmed live). connect-time provisioning


### PR DESCRIPTION
## 问题
光鸭**电影**获取后影片目录残留**空目录 + 非视频/字幕垃圾**;TV/动画获取却清理干净(用户软路由投产实测发现,4 个资源:2 动画干净、2 电影残留)。

## 根因(软路由日志取证)
`flattenMovie` 把视频/字幕挪进影片目录后,对壳子目录调 `removeDirectory` 清壳,**每次都抛**:
```
flattenMovie: {"error":"WRITE_SCOPE_VIOLATION: refusing to remove directory outside configured write scope; fileId=..."}
```
壳目录是光鸭**离线下载在服务端创建**的(不是 `createDirectory`),不在派生写域 → 护栏拒绝 → 壳没删 → 残留。
- **TV/动画干净**:`discardStaging` 删的是 `createDirectory` 建的 staging **整目录**(光鸭递归删,子节点不逐个过护栏)。
- **115/夸克不受影响**:`removeDirectory` 走 parent-walk,域内根下的壳直接放行;只有光鸭无 parent-walk、用派生域,漏了"域内目录下、但非自己创建的子目录"。

## 修复(仅光鸭 executor)
`listSubdirectories` 列举一个**已在写域内**的目录时,把发现的子目录登记进派生域 —— 与 `createDirectory` 的 top-down 派生模型一致("在已在域内的父目录下发现的嵌套目录"即在域内)。列举**域外**目录**不放权**(读≠写)。`removeDirectory` 随后即可清掉离线建的壳目录。

## 测试(TDD)
- 复现测试:域内壳目录(模拟离线创建)`removeDirectory` 原抛 `WRITE_SCOPE_VIOLATION`,修复后放行。
- 安全护栏:列举**域外**目录不得放权(其子目录 `removeDirectory` 仍拒绝)。
- 全量 **813 测试 + typecheck 绿**。

## 已知小尾巴(非本 PR 范围,非回归)
`flattenMovie` 遍历的是**递归** `listSubdirectories`;嵌套壳(如 `wrapper/Sample`)时,删完顶层壳(递归删)后会对已删的子 id 再调一次 delete,光鸭可能回非 success 报一条无害日志(残留已清掉)。修复前这类电影在第一个壳就抛错(残留更糟),故本 PR 严格优于现状;若实测有日志噪音再单独收。

🤖 Generated with [Claude Code](https://claude.com/claude-code)