### PR TITLE
fix(login): 修复登录后跳回登录页的问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,3 +76,6 @@ MOVIES_CID=
 TV_SHOWS_CID=
 # Parent for anime directories: 动漫名 (年份) -> Season N
 ANIME_CID=
+
+# 关闭 secure 标记（适用于 HTTP 场景)
+MEDIA_TRACK_COOKIE_SECURE=0

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   SESSION_COOKIE_NAME,
   isMultiUserEnabled,
+  isCookieSecure,
   loginAccount,
 } from "../../../../lib/workflow-runtime";
 
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, result.signedCookie, {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: isCookieSecure(),
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { SESSION_COOKIE_NAME, logoutSession } from "../../../../lib/workflow-runtime";
+import { SESSION_COOKIE_NAME, isCookieSecure, logoutSession } from "../../../../lib/workflow-runtime";
 
 /** Destroy the session + clear the cookie. */
 export async function POST(request: NextRequest) {
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, "", {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: isCookieSecure(),
     path: "/",
     maxAge: 0,
   });

--- a/apps/web/app/api/auth/register/route.ts
+++ b/apps/web/app/api/auth/register/route.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   SESSION_COOKIE_NAME,
   isMultiUserEnabled,
+  isCookieSecure,
   registerAccount,
 } from "../../../../lib/workflow-runtime";
 
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, result.signedCookie, {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: isCookieSecure(),
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -311,6 +311,18 @@ export function isMultiUserEnabled(): boolean {
 }
 
 export const SESSION_COOKIE_NAME = "mt_session";
+
+/** Whether the mt_session cookie should carry the Secure flag.
+ *  MEDIA_TRACK_COOKIE_SECURE=0 → false (HTTP/FRP/LAN scenarios).
+ *  MEDIA_TRACK_COOKIE_SECURE=1 → true (enforce HTTPS-only).
+ *  Unset → auto: secure only when NODE_ENV === "production".
+ */
+export function isCookieSecure(): boolean {
+  const explicit = process.env.MEDIA_TRACK_COOKIE_SECURE?.trim();
+  if (explicit === "0") return false;
+  if (explicit === "1") return true;
+  return process.env.NODE_ENV === "production";
+}
 const SESSION_SECRET_SETTING_KEY = "session_secret";
 /** Sentinel account that owns no data — returned in multi-user mode when there
  *  is no valid session, so reads fail CLOSED (empty) instead of leaking the


### PR DESCRIPTION
在 apps/web/app/api/auth/login/route.ts:28（以及 register、logout 路由同样位置）：
    secure: process.env.NODE_ENV === "production",
    Docker 容器里 NODE_ENV 默认是 production，所以 cookie 被标记为 secure: true。


浏览器的行为：标记为 secure 的 cookie，浏览器只在 HTTPS 或安全上下文（localhost）中发送：
    这样就会导致只有本地 127.0.0.1 能登录，但局域网和 FRP HTTP访问时登录后立刻被踢回登录页。