### PR TITLE
fix(login): 局域网/HTTP 登录踢回(cookie Secure 自动判定) + 国产片跳过中文字幕 floor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,3 +76,6 @@ MOVIES_CID=
 TV_SHOWS_CID=
 # Parent for anime directories: 动漫名 (年份) -> Season N
 ANIME_CID=
+
+# 关闭 secure 标记（适用于 HTTP 场景)
+MEDIA_TRACK_COOKIE_SECURE=0

--- a/.env.example
+++ b/.env.example
@@ -77,5 +77,8 @@ TV_SHOWS_CID=
 # Parent for anime directories: 动漫名 (年份) -> Season N
 ANIME_CID=
 
-# 关闭 secure 标记（适用于 HTTP 场景)
-MEDIA_TRACK_COOKIE_SECURE=0
+# 会话 cookie 的 Secure 标记。默认(不设)= 按请求协议自动判定:HTTPS 加 Secure、
+# 纯 HTTP(局域网/FRP) 不加,登录开箱即用。仅在反代未透传 x-forwarded-proto 时才需手动:
+#   MEDIA_TRACK_COOKIE_SECURE=1  强制开启(确有 HTTPS 但自动判成了 HTTP)
+#   MEDIA_TRACK_COOKIE_SECURE=0  强制关闭(纯 HTTP 部署)
+# MEDIA_TRACK_COOKIE_SECURE=

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   SESSION_COOKIE_NAME,
   isMultiUserEnabled,
+  isCookieSecure,
   loginAccount,
 } from "../../../../lib/workflow-runtime";
 
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, result.signedCookie, {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: isCookieSecure(),
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, result.signedCookie, {
     httpOnly: true,
     sameSite: "lax",
-    secure: isCookieSecure(),
+    secure: isCookieSecure(request),
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { SESSION_COOKIE_NAME, logoutSession } from "../../../../lib/workflow-runtime";
+import { SESSION_COOKIE_NAME, isCookieSecure, logoutSession } from "../../../../lib/workflow-runtime";
 
 /** Destroy the session + clear the cookie. */
 export async function POST(request: NextRequest) {
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, "", {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: isCookieSecure(),
     path: "/",
     maxAge: 0,
   });

--- a/apps/web/app/api/auth/logout/route.ts
+++ b/apps/web/app/api/auth/logout/route.ts
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, "", {
     httpOnly: true,
     sameSite: "lax",
-    secure: isCookieSecure(),
+    secure: isCookieSecure(request),
     path: "/",
     maxAge: 0,
   });

--- a/apps/web/app/api/auth/register/route.ts
+++ b/apps/web/app/api/auth/register/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, result.signedCookie, {
     httpOnly: true,
     sameSite: "lax",
-    secure: isCookieSecure(),
+    secure: isCookieSecure(request),
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });

--- a/apps/web/app/api/auth/register/route.ts
+++ b/apps/web/app/api/auth/register/route.ts
@@ -3,6 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   SESSION_COOKIE_NAME,
   isMultiUserEnabled,
+  isCookieSecure,
   registerAccount,
 } from "../../../../lib/workflow-runtime";
 
@@ -25,7 +26,7 @@ export async function POST(request: NextRequest) {
   response.cookies.set(SESSION_COOKIE_NAME, result.signedCookie, {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: isCookieSecure(),
     path: "/",
     maxAge: SESSION_MAX_AGE,
   });

--- a/apps/web/lib/workflow-runtime.test.ts
+++ b/apps/web/lib/workflow-runtime.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   acquireLlmPreflightError,
+  isCookieSecure,
   getLlmConfig,
   getPanSouBaseUrl,
   getProwlarrConfig,
@@ -211,5 +212,43 @@ describe("getPanSouBaseUrl", () => {
     const url = await getPanSouBaseUrl(repoMap({}), {} as unknown as NodeJS.ProcessEnv);
     expect(url).toBe(DEFAULT_PANSOU_BASE_URL);
     expect(DEFAULT_PANSOU_BASE_URL).toMatch(/^https?:\/\//);
+  });
+});
+
+describe("isCookieSecure (the LAN/HTTP login-bounce fix, #60)", () => {
+  const req = (opts: { xfp?: string; protocol?: string }) =>
+    ({
+      headers: { get: (n: string) => (n.toLowerCase() === "x-forwarded-proto" ? opts.xfp ?? null : null) },
+      nextUrl: { protocol: opts.protocol },
+    }) as unknown as Parameters<typeof isCookieSecure>[0];
+
+  beforeEach(() => {
+    delete process.env.MEDIA_TRACK_COOKIE_SECURE;
+  });
+
+  it("env=0 forces insecure even over HTTPS (operator opt-out)", () => {
+    process.env.MEDIA_TRACK_COOKIE_SECURE = "0";
+    expect(isCookieSecure(req({ xfp: "https", protocol: "https:" }))).toBe(false);
+  });
+
+  it("env=1 forces secure even over HTTP (operator opt-in)", () => {
+    process.env.MEDIA_TRACK_COOKIE_SECURE = "1";
+    expect(isCookieSecure(req({ protocol: "http:" }))).toBe(true);
+  });
+
+  it("auto: plain-HTTP LAN (no proxy, http) → insecure so the cookie is actually sent (the bug)", () => {
+    expect(isCookieSecure(req({ protocol: "http:" }))).toBe(false);
+  });
+
+  it("auto: reverse proxy / CF Tunnel sets x-forwarded-proto=https → secure", () => {
+    expect(isCookieSecure(req({ xfp: "https", protocol: "http:" }))).toBe(true);
+  });
+
+  it("auto: direct HTTPS → secure", () => {
+    expect(isCookieSecure(req({ protocol: "https:" }))).toBe(true);
+  });
+
+  it("auto: x-forwarded-proto comma list uses the first (client-facing) hop", () => {
+    expect(isCookieSecure(req({ xfp: "https, http", protocol: "http:" }))).toBe(true);
   });
 });

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -313,15 +313,26 @@ export function isMultiUserEnabled(): boolean {
 export const SESSION_COOKIE_NAME = "mt_session";
 
 /** Whether the mt_session cookie should carry the Secure flag.
- *  MEDIA_TRACK_COOKIE_SECURE=0 → false (HTTP/FRP/LAN scenarios).
- *  MEDIA_TRACK_COOKIE_SECURE=1 → true (enforce HTTPS-only).
- *  Unset → auto: secure only when NODE_ENV === "production".
- */
-export function isCookieSecure(): boolean {
+ *  MEDIA_TRACK_COOKIE_SECURE=0 → false (force off, HTTP-only operators).
+ *  MEDIA_TRACK_COOKIE_SECURE=1 → true (force on, enforce HTTPS-only).
+ *  Unset → AUTO from the client-facing request scheme: Secure over HTTPS, NOT over
+ *  plain HTTP. This is the #60 fix — keying off NODE_ENV (which the Docker image
+ *  hard-sets to "production") marked the cookie Secure even on a plain-HTTP LAN/FRP
+ *  origin, so the browser never sent it back and login bounced. A reverse proxy /
+ *  Cloudflare Tunnel terminates TLS and forwards `x-forwarded-proto`; trust its
+ *  first (client-facing) hop, else fall back to the request's own protocol. */
+export function isCookieSecure(request: {
+  headers: { get(name: string): string | null };
+  nextUrl?: { protocol?: string };
+}): boolean {
   const explicit = process.env.MEDIA_TRACK_COOKIE_SECURE?.trim();
   if (explicit === "0") return false;
   if (explicit === "1") return true;
-  return process.env.NODE_ENV === "production";
+  const forwarded = request.headers.get("x-forwarded-proto");
+  if (forwarded) {
+    return forwarded.split(",")[0]!.trim().toLowerCase() === "https";
+  }
+  return (request.nextUrl?.protocol ?? "").toLowerCase() === "https:";
 }
 const SESSION_SECRET_SETTING_KEY = "session_secret";
 /** Sentinel account that owns no data — returned in multi-user mode when there

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -311,6 +311,18 @@ export function isMultiUserEnabled(): boolean {
 }
 
 export const SESSION_COOKIE_NAME = "mt_session";
+
+/** Whether the mt_session cookie should carry the Secure flag.
+ *  MEDIA_TRACK_COOKIE_SECURE=0 → false (HTTP/FRP/LAN scenarios).
+ *  MEDIA_TRACK_COOKIE_SECURE=1 → true (enforce HTTPS-only).
+ *  Unset → auto: secure only when NODE_ENV === "production".
+ */
+export function isCookieSecure(): boolean {
+  const explicit = process.env.MEDIA_TRACK_COOKIE_SECURE?.trim();
+  if (explicit === "0") return false;
+  if (explicit === "1") return true;
+  return process.env.NODE_ENV === "production";
+}
 const SESSION_SECRET_SETTING_KEY = "session_secret";
 /** Sentinel account that owns no data — returned in multi-user mode when there
  *  is no valid session, so reads fail CLOSED (empty) instead of leaking the

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -46,6 +46,9 @@ export interface RunAcquisitionV2Request {
   searchBudget?: number;
   maxSteps?: number;
   preferredLanguage?: string;
+  /** TMDB origin_country of the title — when it includes CN the movie prompt skips
+   *  the 中文 subtitle floor (国产片 natively Chinese-spoken). */
+  originCountries?: string[];
   /** This title's per-media-type PanSou keyword recipe, injected into the prompt. */
   searchHints?: string;
   /** Rendered quality-preference guidance (召回后选片优先级), injected into the prompt. */
@@ -111,6 +114,7 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
     model: request.model,
     ...(request.maxSteps === undefined ? {} : { maxSteps: request.maxSteps }),
     ...(request.preferredLanguage === undefined ? {} : { preferredLanguage: request.preferredLanguage }),
+    ...(request.originCountries === undefined ? {} : { originCountries: request.originCountries }),
     ...(request.searchHints === undefined ? {} : { searchHints: request.searchHints }),
     ...(request.qualityGuidance === undefined ? {} : { qualityGuidance: request.qualityGuidance }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),

--- a/packages/workflow/src/acquisition-v2/task-agents.ts
+++ b/packages/workflow/src/acquisition-v2/task-agents.ts
@@ -64,6 +64,10 @@ export interface TaskAgentPromptOptions {
    *  reachable, flagged 可能无中字) instead of the HARD reportNoCoverage. Set by
    *  buildMovieSystemPrompt; TV/anime leave it false so the floor stays hard. */
   subtitleFallback?: boolean;
+  /** TMDB origin_country of the title (e.g. ["CN"], ["US"]). When it includes CN,
+   *  the work is natively Chinese-spoken → the 中文 subtitle floor is irrelevant
+   *  (no 中字 to hunt), so languageLine skips it. Empty/absent → normal floor. */
+  originCountries?: string[];
 }
 
 /** A brand-specific transfer-model note. 夸克 differs from 115 (转存分享链 / 无磁力)
@@ -88,6 +92,12 @@ function languageLine(options: TaskAgentPromptOptions): string {
   // "the title contains Chinese chars" (PanSou prepends the show's 中文片名 to English
   // scene filenames, which fools that). The 中字 resource MUST win when reachable.
   if (lang.includes("中")) {
+    // 国产 (CN-origin) titles are natively Chinese-spoken — there is no 中字 to hunt
+    // and no 生肉 risk. Skip the whole subtitle floor (the 环太平洋 follow-up): don't
+    // burn budget on 中字/国语 markers, just pick on quality/completeness.
+    if ((options.originCountries ?? []).includes("CN")) {
+      return `\nLANGUAGE PREFERENCE: 这是中国大陆出品(国产)作品,原生中文对白 —— 无需做任何中文字幕判定,也不要把 中字/国语/双语 等词拼进搜索关键词。直接按画质/完整性正常选片即可。`;
+    }
     const head = `\nLANGUAGE PREFERENCE: the user reads 中文 subtitles — ${
       options.subtitleFallback ? "strongly preferred; search hard for it first" : "a HARD requirement, not a nice-to-have"
     }. Judge Chinese subs from the RELEASE, NOT from "the title contains Chinese characters": PanSou often prepends the show's 中文片名 to an English scene filename (中文片名-Name.Year.1080p.WEB-DL.Codec-GROUP) — mentally STRIP that prefix and judge what remains.

--- a/packages/workflow/src/domain.ts
+++ b/packages/workflow/src/domain.ts
@@ -36,8 +36,9 @@ export interface MediaTitle {
   year: number;
   aliases: string[];
   /** TMDB origin_country (e.g. ["JP"], ["CN"]) — drives the per-media-type search
-   *  recipe (searchProfile). Set for tv/anime; absent for movies (movie search is
-   *  origin-independent) and for demo titles. */
+   *  recipe (searchProfile) for tv/anime, and lets the movie agent skip the 中文
+   *  subtitle floor for 国产片 (CN-origin). Set for tv/anime AND movies (movie
+   *  search itself stays origin-independent); absent only for demo titles. */
   originCountries?: string[];
   /** TMDB release date (YYYY-MM-DD) for a movie — the air-time gate for reserve:
    *  an unreleased film (date in the future) is reserved, not acquired, until it

--- a/packages/workflow/src/movie-workflow-v2.ts
+++ b/packages/workflow/src/movie-workflow-v2.ts
@@ -87,6 +87,8 @@ export async function runMovieAcquisitionV2(
     ...(request.searchBudget === undefined ? {} : { searchBudget: request.searchBudget }),
     ...(request.maxSteps === undefined ? {} : { maxSteps: request.maxSteps }),
     ...(request.preferredLanguage === undefined ? {} : { preferredLanguage: request.preferredLanguage }),
+    // 国产片(CN origin)→ 电影 prompt 跳过中文字幕 floor(原生中文对白,无中字可寻)。
+    ...(request.title.originCountries === undefined ? {} : { originCountries: request.title.originCountries }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
     ...(request.deadLinkStore ? { deadLinkStore: request.deadLinkStore } : {}),
     ...(request.onProgress ? { onProgress: request.onProgress } : {}),

--- a/packages/workflow/src/tmdb-provider.ts
+++ b/packages/workflow/src/tmdb-provider.ts
@@ -340,6 +340,10 @@ export async function prepareMovieTarget(input: {
         genreIds: details.genres,
         originCountries: details.origin_country,
       }),
+      // Carried so the movie agent can skip the 中文 subtitle floor for 国产片
+      // (CN-origin = natively Chinese-spoken; details.origin_country is mapped from
+      // the movie's production_countries). Search itself stays origin-independent.
+      originCountries: details.origin_country,
       title,
       originalTitle: normalizeTitle(details.original_title) || title,
       year: yearFromDate(details.release_date),

--- a/packages/workflow/tests/task-agents-language.test.ts
+++ b/packages/workflow/tests/task-agents-language.test.ts
@@ -32,3 +32,23 @@ describe("languageLine — Chinese-subtitle selection guidance", () => {
     expect(p).toContain("English");
   });
 });
+
+describe("languageLine — 国产 (CN-origin) content needs no 中字 judgement (国产电影 fix)", () => {
+  it("movie + 中文 + CN origin → 国产 native line, the 中字 floor is skipped entirely", () => {
+    const p = buildMovieSystemPrompt({ preferredLanguage: "中文", originCountries: ["CN"] });
+    expect(p).toMatch(/国产|原生中文|中文对白/);
+    expect(p).toMatch(/无需|不需要/);
+    expect(p).not.toContain("subtitleFallback"); // no fallback machinery
+    expect(p).not.toContain("HARD requirement"); // no hard floor
+  });
+
+  it("movie + 中文 + foreign origin (US) → soft subtitle fallback (unchanged)", () => {
+    const p = buildMovieSystemPrompt({ preferredLanguage: "中文", originCountries: ["US"] });
+    expect(p).toContain("subtitleFallback");
+    expect(p).not.toMatch(/国产/);
+  });
+
+  it("movie + 中文 + no origin info → soft fallback (unchanged default)", () => {
+    expect(buildMovieSystemPrompt({ preferredLanguage: "中文" })).toContain("subtitleFallback");
+  });
+})

--- a/packages/workflow/tests/tmdb-provider.test.ts
+++ b/packages/workflow/tests/tmdb-provider.test.ts
@@ -377,6 +377,9 @@ describe("TmdbSearchProvider", () => {
 
     expect(target.title.year).toBe(2001);
     expect(target.title.releaseDate).toBe("2001-07-20"); // full date kept for the reserve air-time gate
+    // origin_country (mapped from production_countries) is carried so the movie agent
+    // can skip the 中文 subtitle floor for 国产片 (a CN movie would carry ["CN"]).
+    expect(target.title.originCountries).toEqual(["JP"]);
     expect(target.keyword).toBe("千与千寻"); // bare title — no quality token in the keyword
   });
 });


### PR DESCRIPTION
两件事一起修。

## 1. 局域网/HTTP 登录被踢回登录页(承接 @TastSong #60)
**根因**(TastSong 诊断正确):Docker 镜像硬设 `NODE_ENV=production` → 会话 cookie 被标 `Secure` → 浏览器在纯 HTTP(局域网/FRP)下不回传 → 登录后立刻被踢回。

本 PR cherry-pick 了 @TastSong 的两个提交(保留署名),并按 Copilot review 改进:
- **Copilot #2(关键)**:原修复的 auto 仍看 `NODE_ENV`,Docker 下**默认仍坏**、要用户手动设环境变量。改 `isCookieSecure(request)`:未配置时**按客户端协议自动判定**——HTTPS(`x-forwarded-proto` 首跳 / `nextUrl.protocol`)加 `Secure`、纯 HTTP 不加,**开箱即用**;反代/CF Tunnel 透传 `x-forwarded-proto=https` 仍正确加。`MEDIA_TRACK_COOKIE_SECURE=0/1` 仍可强制覆盖。
- **Copilot #1**:`.env.example` 改为注释说明、不再默认 `=0`(抄到 HTTPS 部署会丢 Secure)。
- 三个 auth 路由(login/register/logout)统一传 `request`。

## 2. 国产片(CN origin)跳过中文字幕 floor
用户观察:国产电影本身中文对白,agent 却仍按中文字幕 floor 去找中字、浪费搜索预算。
- `languageLine`:`title.originCountries` 含 `CN` → 输出「国产作品,原生中文对白,无需中字判定」,**整个 floor 跳过**(无 floor、无软兜底)。外国片维持 #59 的软兜底;无 origin 信息维持默认。
- 穿线:`prepareMovieTarget` 把 `origin_country`(电影由 `production_countries` 映射)写到 movie title(此前仅 TV 携带)→ movie-workflow → orchestrator → prompt。逻辑在共享 `languageLine`,TV/动漫将来传 `originCountries` 即可同样受益。

## 测试(TDD)
`isCookieSecure` env 覆盖 + 协议自动判定(6)/ `languageLine` CN·外国·无 origin 三分支 / `prepareMovieTarget` 携带 origin_country。**832 workflow + 179 apps/web + 三处 tsc(root/apps-web/build:workflow)全绿。**

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)