### PR TITLE
fix(login): cookie Secure 归一化 scheme(https/https: 两种写法都判对)

### DIFF
--- a/apps/web/lib/workflow-runtime.test.ts
+++ b/apps/web/lib/workflow-runtime.test.ts
@@ -251,4 +251,19 @@ describe("isCookieSecure (the LAN/HTTP login-bounce fix, #60)", () => {
   it("auto: x-forwarded-proto comma list uses the first (client-facing) hop", () => {
     expect(isCookieSecure(req({ xfp: "https, http", protocol: "http:" }))).toBe(true);
   });
+
+  // Copilot #61: scheme strings vary by proxy/framework — x-forwarded-proto is
+  // usually "https" but some send "https:"; nextUrl.protocol is usually "https:"
+  // but could be "https". Normalize (strip trailing colon) so neither form drops Secure.
+  it("auto: x-forwarded-proto with a trailing colon (https:) → still secure", () => {
+    expect(isCookieSecure(req({ xfp: "https:", protocol: "http:" }))).toBe(true);
+  });
+
+  it("auto: nextUrl.protocol without a colon (https) → still secure", () => {
+    expect(isCookieSecure(req({ protocol: "https" }))).toBe(true);
+  });
+
+  it("auto: x-forwarded-proto http with a colon (http:) → insecure", () => {
+    expect(isCookieSecure(req({ xfp: "http:", protocol: "http:" }))).toBe(false);
+  });
 });

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -328,11 +328,15 @@ export function isCookieSecure(request: {
   const explicit = process.env.MEDIA_TRACK_COOKIE_SECURE?.trim();
   if (explicit === "0") return false;
   if (explicit === "1") return true;
+  // Scheme spelling varies by proxy/framework: x-forwarded-proto is usually "https"
+  // but some send "https:"; nextUrl.protocol is usually "https:" but could be "https".
+  // Normalize (lowercase, trim, strip trailing colon) so neither form drops Secure.
+  const normalizeScheme = (raw: string) => raw.trim().toLowerCase().replace(/:$/, "");
   const forwarded = request.headers.get("x-forwarded-proto");
   if (forwarded) {
-    return forwarded.split(",")[0]!.trim().toLowerCase() === "https";
+    return normalizeScheme(forwarded.split(",")[0]!) === "https";
   }
-  return (request.nextUrl?.protocol ?? "").toLowerCase() === "https:";
+  return normalizeScheme(request.nextUrl?.protocol ?? "") === "https";
 }
 const SESSION_SECRET_SETTING_KEY = "session_secret";
 /** Sentinel account that owns no data — returned in multi-user mode when there


### PR DESCRIPTION
跟进 #61 的 Copilot review。

**问题**:`isCookieSecure` 判 HTTPS 时,`x-forwarded-proto` 分支只认 `"https"`(无冒号),`nextUrl.protocol` 分支只认 `"https:"`(带冒号)。但 scheme 拼写因代理/框架而异——有的代理发 `https:`,有的框架 `nextUrl.protocol` 返回 `https`。结果某些 HTTPS 场景会**漏掉 `Secure` 标记**。

**修复**:归一化(lowercase + trim + 去尾冒号)后再比较,两种写法都判对。

**TDD**:补三例(`x-forwarded-proto: https:`、`protocol: https` 无冒号、`x-forwarded-proto: http:`)。isCookieSecure 9/9 绿,apps/web tsc 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)