### PR TITLE
feat(env): 添加 MEDIA_TRACK_ALLOWED_ORIGINS 以在服务器操作中支持跨源

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,6 @@ ANIME_CID=
 #   MEDIA_TRACK_COOKIE_SECURE=1  强制开启(确有 HTTPS 但自动判成了 HTTP)
 #   MEDIA_TRACK_COOKIE_SECURE=0  强制关闭(纯 HTTP 部署)
 # MEDIA_TRACK_COOKIE_SECURE=
+# Server Actions 允许的域名(逗号分隔),用于反代穿透时绕过 x-forwarded-host 校验，解决跨域问题，当然你也可以使用反向代理的方式来解决跨域问题。
+# 例:MEDIA_TRACK_ALLOWED_ORIGINS=mediary-scout.example1.com,mediary-scout.example2.com
+# MEDIA_TRACK_ALLOWED_ORIGINS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ WORKDIR /app
 # Override for faster installs behind slow/blocked registries, e.g.
 #   docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com
 ARG NPM_REGISTRY=https://registry.npmjs.org
+# next.config.ts reads .env at build time, but .env is in .dockerignore (secrets).
+# Pass the public-only config values that next.config.ts needs as build args.
+ARG MEDIA_TRACK_ALLOWED_ORIGINS
+ENV MEDIA_TRACK_ALLOWED_ORIGINS=${MEDIA_TRACK_ALLOWED_ORIGINS}
 # Install deps first (cached unless the manifests change), then copy source.
 COPY package.json package-lock.json ./
 COPY apps/web/package.json apps/web/

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -45,6 +45,12 @@ const nextConfig: NextConfig = {
   // mid-acquisition regardless).
   experimental: {
     staleTimes: { dynamic: 60, static: 300 },
+    serverActions: {
+      allowedOrigins: (process.env.MEDIA_TRACK_ALLOWED_ORIGINS ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    },
   },
   // Legacy per-season URL → the canonical one-page-per-show route. Handled at
   // the routing layer (not a render-time redirect page, which can't prerender

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
     restart: unless-stopped
 
   web:
-    build: .
+    build:
+      context: .
+      args:
+        MEDIA_TRACK_ALLOWED_ORIGINS: ${MEDIA_TRACK_ALLOWED_ORIGINS:-}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
1.  原理：Next.js 的 action-handler.js 在比对 X-Forwarded-Host 与 Origin 不匹配时，会 fallback serverActions.allowedOrigins 白名单。你的域名在白名单中，Server Action 请求就不再被拒绝。
2.  .env 在 .dockerignore 里（里面有 token/cookie 等密钥，不该打进镜像）。所以 Dockerfile 构建时 next.config.ts 读不到
  .env 文件，MEDIA_TRACK_ALLOWED_ORIGINS 为空，allowedOrigins 白名单是空数组。