### PR TITLE
feat(env): MEDIA_TRACK_ALLOWED_ORIGINS 反代跨源支持(承接 #63 + Copilot review)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,10 @@ ANIME_CID=
 #   MEDIA_TRACK_COOKIE_SECURE=1  强制开启(确有 HTTPS 但自动判成了 HTTP)
 #   MEDIA_TRACK_COOKIE_SECURE=0  强制关闭(纯 HTTP 部署)
 # MEDIA_TRACK_COOKIE_SECURE=
-# Server Actions 允许的域名(逗号分隔),用于反代穿透时绕过 x-forwarded-host 校验，解决跨域问题，当然你也可以使用反向代理的方式来解决跨域问题。
+# Server Actions 允许的来源域名(逗号分隔)。反代/隧道下,若访问域名与 x-forwarded-host
+# 不一致,Next.js 会按 CSRF 规则拒掉 Server Action(表单/按钮点了没反应、报 Invalid
+# Server Action)。把你的对外域名加进来即可放行。优先在反代正确透传 x-forwarded-host;
+# 实在不行再用本项。⚠️ 此值在镜像**构建时**烘焙进 next 产物,改后需重建:
+#   docker compose up -d --build
 # 例:MEDIA_TRACK_ALLOWED_ORIGINS=mediary-scout.example1.com,mediary-scout.example2.com
 # MEDIA_TRACK_ALLOWED_ORIGINS=

--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,6 @@ ANIME_CID=
 #   MEDIA_TRACK_COOKIE_SECURE=1  强制开启(确有 HTTPS 但自动判成了 HTTP)
 #   MEDIA_TRACK_COOKIE_SECURE=0  强制关闭(纯 HTTP 部署)
 # MEDIA_TRACK_COOKIE_SECURE=
+# Server Actions 允许的域名(逗号分隔),用于反代穿透时绕过 x-forwarded-host 校验，解决跨域问题，当然你也可以使用反向代理的方式来解决跨域问题。
+# 例:MEDIA_TRACK_ALLOWED_ORIGINS=mediary-scout.example1.com,mediary-scout.example2.com
+# MEDIA_TRACK_ALLOWED_ORIGINS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,10 @@ WORKDIR /app
 # Override for faster installs behind slow/blocked registries, e.g.
 #   docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com
 ARG NPM_REGISTRY=https://registry.npmjs.org
+# next.config.ts reads .env at build time, but .env is in .dockerignore (secrets).
+# Pass the public-only config values that next.config.ts needs as build args.
+ARG MEDIA_TRACK_ALLOWED_ORIGINS
+ENV MEDIA_TRACK_ALLOWED_ORIGINS=${MEDIA_TRACK_ALLOWED_ORIGINS}
 # Install deps first (cached unless the manifests change), then copy source.
 COPY package.json package-lock.json ./
 COPY apps/web/package.json apps/web/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,20 @@ WORKDIR /app
 # Override for faster installs behind slow/blocked registries, e.g.
 #   docker compose build --build-arg NPM_REGISTRY=https://registry.npmmirror.com
 ARG NPM_REGISTRY=https://registry.npmjs.org
-# next.config.ts reads .env at build time, but .env is in .dockerignore (secrets).
-# Pass the public-only config values that next.config.ts needs as build args.
+# next.config.ts bakes serverActions.allowedOrigins at BUILD time, but .env is in
+# .dockerignore (secrets) so it isn't readable then. Pass this public-only value as a
+# build arg. Declared here; exported to ENV only just before the build step (below) so
+# changing it doesn't bust the cached npm ci / dependency layers.
 ARG MEDIA_TRACK_ALLOWED_ORIGINS
-ENV MEDIA_TRACK_ALLOWED_ORIGINS=${MEDIA_TRACK_ALLOWED_ORIGINS}
 # Install deps first (cached unless the manifests change), then copy source.
 COPY package.json package-lock.json ./
 COPY apps/web/package.json apps/web/
 COPY packages/workflow/package.json packages/workflow/
 RUN npm config set registry "$NPM_REGISTRY" && npm ci
 COPY . .
-# build:web = build:workflow (tsc) + next build apps/web (output: standalone)
+# build:web = build:workflow (tsc) + next build apps/web (output: standalone).
+# allowedOrigins is baked here — change it ⇒ rebuild (docker compose up -d --build).
+ENV MEDIA_TRACK_ALLOWED_ORIGINS=${MEDIA_TRACK_ALLOWED_ORIGINS}
 RUN npm run build:web
 
 FROM node:22-slim AS runner

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -45,6 +45,12 @@ const nextConfig: NextConfig = {
   // mid-acquisition regardless).
   experimental: {
     staleTimes: { dynamic: 60, static: 300 },
+    serverActions: {
+      allowedOrigins: (process.env.MEDIA_TRACK_ALLOWED_ORIGINS ?? "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    },
   },
   // Legacy per-season URL → the canonical one-page-per-show route. Handled at
   // the routing layer (not a render-time redirect page, which can't prerender

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,10 @@ services:
     restart: unless-stopped
 
   web:
-    build: .
+    build:
+      context: .
+      args:
+        MEDIA_TRACK_ALLOWED_ORIGINS: ${MEDIA_TRACK_ALLOWED_ORIGINS:-}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
承接 @TastSong #63,cherry-pick 保留其提交与署名,叠加改进。

## 修的问题
反代 / 隧道部署下,访问域名与 `x-forwarded-host` 不一致时,Next.js 按 CSRF 规则拒掉 Server Action(表单/按钮点了没反应、报 *Invalid Server Action*)。正是当前自部署用户会踩的坑。

## 取证(整个 PR 根基)
`serverActions.allowedOrigins` 在**构建时**烘焙进 standalone 产物(`next.config.ts` build 阶段求值 → 序列化进 `required-server-files.json`,运行时加载),运行时再设 env **无效**。而 `.env` 在 `.dockerignore`(含密钥),构建时读不到 → 白名单空。所以 @TastSong 的 **build-arg** 方案是正确且必要的。来源:[Next.js serverActions 文档](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverActions)。

## 我的改进(在 TastSong 提交之上)
- **Dockerfile**(按 Copilot review):`ENV MEDIA_TRACK_ALLOWED_ORIGINS` 从 `npm ci` 之前**下移**到 `npm run build:web` 之前(`ARG` 声明保留原位)。原位置会把该 build-arg 纳入 `npm ci` 层缓存键,改 origin 触发全量重装依赖;下移后依赖层保持可缓存。
- **.env.example**:说清触发场景、优先反代透传 `x-forwarded-host`、⚠️构建时烘焙改后需 `docker compose up -d --build`;补结尾换行。

## 验证
apps/web tsc 绿;CI 构建镜像即覆盖 Dockerfile 有效性;另在生产实例真构建 + grep 烘焙产物确认 origin 落入 `required-server-files.json`(见 PR 评论)。

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)