### PR TITLE
feat(env): 自定义媒体库目录名(全盘通用 115/夸克/光鸭,仅名字、无写域脚枪)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,15 @@ TV_SHOWS_CID=
 # Parent for anime directories: 动漫名 (年份) -> Season N
 ANIME_CID=
 
+# Optional: 自定义媒体库目录名(对 115 / 夸克 / 光鸭 所有网盘统一生效)。不设则用默认
+# 「Mediary Scout / Movies / TV / Anime」。仅自定义"名字",不改结构——程序仍会建一个容器
+# 根目录,再在其下建三个分类目录(分类不会散落到账号根)。留空的项自动回落默认。
+# ⚠️ 在"连接网盘时"读取并据此建目录:改名只影响之后新连接的盘,已连接的盘需重连才生效。
+# MEDIA_TRACK_LIBRARY_ROOT_DIR=我的影音库
+# MEDIA_TRACK_LIBRARY_MOVIES_DIR=电影
+# MEDIA_TRACK_LIBRARY_TV_DIR=剧集
+# MEDIA_TRACK_LIBRARY_ANIME_DIR=番剧
+
 # 会话 cookie 的 Secure 标记。默认(不设)= 按请求协议自动判定:HTTPS 加 Secure、
 # 纯 HTTP(局域网/FRP) 不加,登录开箱即用。仅在反代未透传 x-forwarded-proto 时才需手动:
 #   MEDIA_TRACK_COOKIE_SECURE=1  强制开启(确有 HTTPS 但自动判成了 HTTP)

--- a/apps/web/lib/workflow-runtime.test.ts
+++ b/apps/web/lib/workflow-runtime.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   acquireLlmPreflightError,
+  customDirNamesFromEnv,
   isCookieSecure,
   getLlmConfig,
   getPanSouBaseUrl,
@@ -267,3 +268,32 @@ describe("isCookieSecure (the LAN/HTTP login-bounce fix, #60)", () => {
     expect(isCookieSecure(req({ xfp: "http:", protocol: "http:" }))).toBe(false);
   });
 });
+
+describe("customDirNamesFromEnv (brand-agnostic 自定义媒体库目录名)", () => {
+  const env = (m: Record<string, string>) => m as unknown as NodeJS.ProcessEnv;
+
+  it("nothing set → {} (defaults apply downstream)", () => {
+    expect(customDirNamesFromEnv(env({}))).toEqual({});
+  });
+
+  it("reads + trims the four generic vars (applies to every drive brand)", () => {
+    expect(
+      customDirNamesFromEnv(
+        env({
+          MEDIA_TRACK_LIBRARY_ROOT_DIR: " 我的影音库 ",
+          MEDIA_TRACK_LIBRARY_MOVIES_DIR: "电影",
+          MEDIA_TRACK_LIBRARY_TV_DIR: "剧集",
+          MEDIA_TRACK_LIBRARY_ANIME_DIR: "番剧",
+        }),
+      ),
+    ).toEqual({ rootName: "我的影音库", moviesName: "电影", tvName: "剧集", animeName: "番剧" });
+  });
+
+  it("blank / whitespace values are omitted (never an empty-string root → no write-scope footgun)", () => {
+    expect(
+      customDirNamesFromEnv(
+        env({ MEDIA_TRACK_LIBRARY_ROOT_DIR: "", MEDIA_TRACK_LIBRARY_MOVIES_DIR: "   ", MEDIA_TRACK_LIBRARY_TV_DIR: "剧集" }),
+      ),
+    ).toEqual({ tvName: "剧集" });
+  });
+})

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -338,6 +338,35 @@ export function isCookieSecure(request: {
   }
   return normalizeScheme(request.nextUrl?.protocol ?? "") === "https";
 }
+
+/** Brand-agnostic custom media-library directory NAMES, read from env and applied
+ *  to every drive's connect-time provisioning (115 / 夸克 / 光鸭 all funnel through
+ *  provisionCategoryDirs). Names only — never CIDs, and a blank value is omitted so
+ *  it falls back to the brand default downstream. The root therefore can never
+ *  collapse to the account root, so a drive's write scope stays bounded to its own
+ *  container. Read at connect time: changing a name only affects newly-connected drives. */
+export function customDirNamesFromEnv(env: NodeJS.ProcessEnv): {
+  rootName?: string;
+  moviesName?: string;
+  tvName?: string;
+  animeName?: string;
+} {
+  const opts: { rootName?: string; moviesName?: string; tvName?: string; animeName?: string } = {};
+  const pick = (raw: string | undefined): string | undefined => {
+    const trimmed = raw?.trim();
+    return trimmed ? trimmed : undefined;
+  };
+  const root = pick(env.MEDIA_TRACK_LIBRARY_ROOT_DIR);
+  if (root) opts.rootName = root;
+  const movies = pick(env.MEDIA_TRACK_LIBRARY_MOVIES_DIR);
+  if (movies) opts.moviesName = movies;
+  const tv = pick(env.MEDIA_TRACK_LIBRARY_TV_DIR);
+  if (tv) opts.tvName = tv;
+  const anime = pick(env.MEDIA_TRACK_LIBRARY_ANIME_DIR);
+  if (anime) opts.animeName = anime;
+  return opts;
+}
+
 const SESSION_SECRET_SETTING_KEY = "session_secret";
 /** Sentinel account that owns no data — returned in multi-user mode when there
  *  is no valid session, so reads fail CLOSED (empty) instead of leaking the
@@ -1400,6 +1429,7 @@ async function provisionDriveCategoryDirs(
     const executor = createExecutorForBrand({ provider: "guangya", credential: credential ?? {}, scopeCids: [] });
     return provisionCategoryDirs({
       baseParentId: "", // 光鸭 account root
+      ...customDirNamesFromEnv(process.env),
       storage: {
         listChildDirs: (parentId: string) => executor.listChildDirectories(parentId),
         createDirectory: (dir) => executor.createDirectory(dir),
@@ -1412,6 +1442,7 @@ async function provisionDriveCategoryDirs(
       : createBootstrapPan115CookieStorageExecutor({ cookie });
   return provisionCategoryDirs({
     baseParentId: "0",
+    ...customDirNamesFromEnv(process.env),
     storage: {
       listChildDirs: (parentId: string) => executor.listChildDirectories(parentId),
       createDirectory: (dir) => executor.createDirectory(dir),
@@ -2121,6 +2152,7 @@ async function bindPan115ConnectedStorage(input: {
       const executor = createBootstrapPan115CookieStorageExecutor({ cookie: input.cookie });
       const provisioned = await provisionCategoryDirs({
         baseParentId: "0", // 115 account root
+        ...customDirNamesFromEnv(process.env),
         storage: {
           // listChildDirectories = single-level, root-safe (find-or-create reads
           // the account root's children; recursive listSubdirectories is guarded).
@@ -2248,6 +2280,7 @@ export async function connectQuarkCookie(rawCookie: string): Promise<{ providerU
     const executor = createExecutorForBrand({ provider: "quark", cookie, scopeCids: [] });
     cids = await provisionCategoryDirs({
       baseParentId: "0", // 夸克 account root
+      ...customDirNamesFromEnv(process.env),
       storage: {
         listChildDirs: (parentId: string) => executor.listChildDirectories(parentId),
         createDirectory: (dir) => executor.createDirectory(dir),
@@ -2354,6 +2387,7 @@ export async function connectGuangYa(rawAccessToken: string, rawRefreshToken: st
     });
     cids = await provisionCategoryDirs({
       baseParentId: "", // 光鸭 account root
+      ...customDirNamesFromEnv(process.env),
       storage: {
         listChildDirs: (parentId: string) => executor.listChildDirectories(parentId),
         createDirectory: (dir) => executor.createDirectory(dir),

--- a/packages/workflow/src/account-credentials.ts
+++ b/packages/workflow/src/account-credentials.ts
@@ -113,21 +113,33 @@ export interface ProvisionedCids {
  * Idempotent: reuse a same-named directory if one already exists under the
  * parent, else create it. Safe to re-run on an already-provisioned 网盘 (the
  * second run finds every dir and creates nothing).
+ *
+ * Directory names are customisable (rootName / moviesName / tvName / animeName).
+ * A blank or whitespace-only name falls back to its brand default — in
+ * particular the root ALWAYS resolves to a real container folder, never to the
+ * account root, so the drive's write scope can never widen to the whole account.
  */
 export async function provisionCategoryDirs(input: {
   storage: DirProvisionStorage;
   baseParentId: string;
   rootName?: string;
+  moviesName?: string;
+  tvName?: string;
+  animeName?: string;
 }): Promise<ProvisionedCids> {
-  const rootName = input.rootName ?? "Mediary Scout";
+  const named = (value: string | undefined, fallback: string) => value?.trim() || fallback;
+  const rootName = named(input.rootName, "Mediary Scout");
+  const moviesName = named(input.moviesName, "Movies");
+  const tvName = named(input.tvName, "TV");
+  const animeName = named(input.animeName, "Anime");
   const findOrCreate = async (name: string, parentId: string): Promise<string> => {
     const existing = (await input.storage.listChildDirs(parentId)).find((dir) => dir.name === name);
     return existing ? existing.id : input.storage.createDirectory({ name, parentId });
   };
   const rootCid = await findOrCreate(rootName, input.baseParentId);
-  const moviesCid = await findOrCreate("Movies", rootCid);
-  const tvCid = await findOrCreate("TV", rootCid);
-  const animeCid = await findOrCreate("Anime", rootCid);
+  const moviesCid = await findOrCreate(moviesName, rootCid);
+  const tvCid = await findOrCreate(tvName, rootCid);
+  const animeCid = await findOrCreate(animeName, rootCid);
   return { rootCid, moviesCid, tvCid, animeCid };
 }
 

--- a/packages/workflow/tests/account-credentials.test.ts
+++ b/packages/workflow/tests/account-credentials.test.ts
@@ -64,6 +64,57 @@ describe("provisionCategoryDirs (find-or-create, idempotent)", () => {
     await provisionCategoryDirs({ storage: fakeStorage, baseParentId: "ROOT", rootName: "media-track-test" });
     expect(created[0]).toBe("media-track-test"); // explicit value still wins
   });
+
+  it("honors custom root + category names (all four), creating them under the custom root", async () => {
+    const created: string[] = [];
+    const fakeStorage = {
+      async listChildDirs() {
+        return [] as Array<{ name: string; id: string }>;
+      },
+      async createDirectory({ name, parentId }: { name: string; parentId: string }) {
+        created.push(`${name}@${parentId}`);
+        return `new_${name}`;
+      },
+    };
+    const cids = await provisionCategoryDirs({
+      storage: fakeStorage,
+      baseParentId: "ROOT",
+      rootName: "我的影音库",
+      moviesName: "电影",
+      tvName: "剧集",
+      animeName: "番剧",
+    });
+    expect(created[0]).toBe("我的影音库@ROOT");
+    expect(created.slice(1)).toEqual(["电影@new_我的影音库", "剧集@new_我的影音库", "番剧@new_我的影音库"]);
+    expect(cids.moviesCid).toBe("new_电影");
+  });
+
+  it("treats empty / whitespace names as unset → falls back to defaults (root never collapses to the account root)", async () => {
+    const created: string[] = [];
+    const fakeStorage = {
+      async listChildDirs() {
+        return [] as Array<{ name: string; id: string }>;
+      },
+      async createDirectory({ name, parentId }: { name: string; parentId: string }) {
+        created.push(`${name}@${parentId}`);
+        return `new_${name}`;
+      },
+    };
+    const cids = await provisionCategoryDirs({
+      storage: fakeStorage,
+      baseParentId: "0", // account root
+      rootName: "",
+      moviesName: "   ",
+      tvName: "",
+      animeName: "",
+    });
+    // Safety: an empty rootName must NOT place categories at the account root.
+    // It falls back to the brand default and creates a real container folder.
+    expect(created[0]).toBe("Mediary Scout@0");
+    expect(cids.rootCid).toBe("new_Mediary Scout");
+    expect(cids.rootCid).not.toBe("0");
+    expect(created.slice(1)).toEqual(["Movies@new_Mediary Scout", "TV@new_Mediary Scout", "Anime@new_Mediary Scout"]);
+  });
 });
 
 describe("parsePan115Uid", () => {


### PR DESCRIPTION
承接 @TastSong #63 的需求(自定义网盘目录名),做成**全盘通用**版本取代之。

## 为什么不直接合 #63
#63 只给夸克接了 env,但 115 / 夸克 / 光鸭**三盘都走同一个 `provisionCategoryDirs`**,单给夸克开口子会导致三盘不一致。本 PR 在共享路径统一接入,三盘行为一致。

## 写域脚枪(#63 review 发现,本版从构造上堵死)
#63 的 `QUARK_ROOT_DIR=""` 会让 `rootCid="0"`(账号根)流进 `scopeCids` → agent 的写/删域**扩到整个网盘**,击穿写域护栏。本版**只做"自定义名字",没有空根选项**:每个名 `trim() || 默认`,空串自动回落默认 → `rootName` 永不为空 → `rootCid` 永远是真实容器目录,绝不退化成账号根。

## 改动
- `provisionCategoryDirs`:加 `moviesName/tvName/animeName`(`rootName` 已有),空名安全回落
- `customDirNamesFromEnv(env)`:读通用 `MEDIA_TRACK_LIBRARY_{ROOT,MOVIES,TV,ANIME}_DIR`,空/未设省略;接进**全部 5 个** `provisionCategoryDirs` 调用点(光鸭×2、夸克、115 auto/connect)
- `.env.example`:通用文档,注明"仅名字""连接时读取、改名需重连"

## 测试(TDD)
- `provisionCategoryDirs`:自定义四名创建于自定义根下 / **空·空白名回落默认且 rootCid≠账号根**(安全断言)
- `customDirNamesFromEnv`:trim、空值省略
- **834 workflow + 185 apps/web + root/apps-web/build:workflow 三 tsc 全绿**

连接时读取,只影响新连接的盘(已连盘存了 CID,改名需重连)。

Closes #63
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)