### PR TITLE
fix(tmdb): 自带 token 时直连被墙→搜索报错(超时 + 死通道记忆)#68

### DIFF
--- a/packages/workflow/src/tmdb-provider.ts
+++ b/packages/workflow/src/tmdb-provider.ts
@@ -38,15 +38,28 @@ function normalizeAccess(access: TmdbAccess): TmdbAccess {
 }
 
 /** Try each access in order; first success wins, all-fail throws. This is the
- *  one chokepoint where user-key → proxy fallback lives. */
+ *  one chokepoint where user-key → proxy fallback lives.
+ *
+ *  `deadAccesses` (shared across a provider's lifetime) memoizes which accesses
+ *  have already failed so later calls skip them instead of re-paying the cost.
+ *  Without it, a user TMDB token whose direct api.themoviedb.org hop is blocked
+ *  makes EVERY call (a search fires ~11) re-time-out on that hop before falling
+ *  back — the cumulative stall shows as "A server error occurred" (issue #68).
+ *  Accesses are dropped from the dead set on no live attempt so a request that
+ *  starts all-dead still probes once rather than throwing blind. */
 async function fetchViaAccessChain(
   accesses: TmdbAccess[],
   path: string,
   query: Record<string, string>,
   fetchJson: TmdbFetchJson,
+  deadAccesses?: Set<string>,
 ): Promise<unknown> {
   let lastError: unknown = new Error("no TMDB access configured");
-  for (const access of accesses) {
+  const live = deadAccesses ? accesses.filter((a) => !deadAccesses.has(a.baseURL)) : accesses;
+  // If every access is already marked dead, fall back to trying them all again
+  // (the prior failures may have been transient) rather than throwing blind.
+  const candidates = live.length > 0 ? live : accesses;
+  for (const access of candidates) {
     const url = `${access.baseURL}/${path}?${new URLSearchParams(query).toString()}`;
     const headers: Record<string, string> = { "Content-Type": "application/json;charset=utf-8" };
     if (access.readToken !== undefined) {
@@ -56,9 +69,10 @@ async function fetchViaAccessChain(
       return await fetchJson(url, { method: "GET", headers });
     } catch (error) {
       lastError = error;
+      deadAccesses?.add(access.baseURL);
     }
   }
-  throw new Error(`All ${accesses.length} TMDB access(es) failed: ${String(lastError)}`);
+  throw new Error(`All ${candidates.length} TMDB access(es) failed: ${String(lastError)}`);
 }
 
 /** Build the access list from either the new `accesses` or the legacy single
@@ -150,6 +164,9 @@ export class TmdbMetadataProvider {
   private readonly accesses: TmdbAccess[];
   private readonly language: string;
   private readonly fetchJson: TmdbFetchJson;
+  /** Per-instance memo of accesses that already failed (issue #68): skip them on
+   *  later calls so a blocked direct hop isn't re-probed once per TMDB request. */
+  private readonly deadAccesses = new Set<string>();
 
   constructor(options: TmdbMetadataProviderOptions) {
     this.accesses = resolveAccesses(options);
@@ -178,7 +195,7 @@ export class TmdbMetadataProvider {
   }
 
   private async get(path: string, query: Record<string, string>): Promise<unknown> {
-    return fetchViaAccessChain(this.accesses, path, query, this.fetchJson);
+    return fetchViaAccessChain(this.accesses, path, query, this.fetchJson, this.deadAccesses);
   }
 }
 
@@ -186,6 +203,9 @@ export class TmdbSearchProvider implements MediaSearchProvider {
   private readonly accesses: TmdbAccess[];
   private readonly language: string;
   private readonly fetchJson: TmdbFetchJson;
+  /** Per-instance memo of accesses that already failed (issue #68): skip them on
+   *  later calls so a blocked direct hop isn't re-probed once per TMDB request. */
+  private readonly deadAccesses = new Set<string>();
   private readonly maxResults: number;
   private readonly tvDetailsLimit: number;
 
@@ -238,7 +258,7 @@ export class TmdbSearchProvider implements MediaSearchProvider {
   }
 
   private async get(path: string, query: Record<string, string>): Promise<unknown> {
-    return fetchViaAccessChain(this.accesses, path, query, this.fetchJson);
+    return fetchViaAccessChain(this.accesses, path, query, this.fetchJson, this.deadAccesses);
   }
 }
 
@@ -425,10 +445,18 @@ export async function prepareSeriesTarget(input: {
   };
 }
 
+/** Per-request timeout for a single TMDB hop. A blocked direct api.themoviedb.org
+ *  connection otherwise hangs on the platform default (~10s+), and a search fires
+ *  many hops in series — the cumulative stall is what surfaced as a server error
+ *  in issue #68. Bounding each hop lets the access chain fail over to the proxy
+ *  well within the page's render budget. TMDB itself answers in well under a second. */
+const TMDB_FETCH_TIMEOUT_MS = 4500;
+
 async function defaultFetchJson(url: string, init: TmdbFetchInit): Promise<unknown> {
   const response = await fetch(url, {
     method: init.method,
     headers: init.headers,
+    signal: AbortSignal.timeout(TMDB_FETCH_TIMEOUT_MS),
   });
   if (!response.ok) {
     throw new Error(`TMDB request failed with HTTP ${response.status}`);

--- a/packages/workflow/tests/tmdb-provider.test.ts
+++ b/packages/workflow/tests/tmdb-provider.test.ts
@@ -446,6 +446,33 @@ describe("TmdbMetadataProvider multi-access fallback", () => {
     await expect(provider.getMovieDetails(278)).rejects.toThrow(/access/i);
   });
 
+  it("remembers a dead access and skips it on later calls within the same provider (issue #68)", async () => {
+    // The #68 repro: a user TMDB token makes api.themoviedb.org the first access.
+    // When that endpoint is unreachable (blocked network) it fails per call. A
+    // search fires ~11 TMDB calls; without memo, EVERY call re-pays the dead
+    // direct hop → cumulative timeout → "A server error occurred". The provider
+    // must probe the dead access once, then go straight to the working proxy.
+    const calls: string[] = [];
+    const provider = new TmdbMetadataProvider({
+      accesses: [
+        { baseURL: "https://primary.example/3", readToken: "userkey" },
+        { baseURL: "https://proxy.example" },
+      ],
+      fetchJson: async (url) => {
+        calls.push(url);
+        if (url.startsWith("https://primary.example")) throw new Error("ETIMEDOUT");
+        return movieJson(278);
+      },
+    });
+    await provider.getMovieDetails(278);
+    await provider.getMovieDetails(550);
+    await provider.getMovieDetails(155);
+    const primaryCalls = calls.filter((u) => u.startsWith("https://primary.example"));
+    const proxyCalls = calls.filter((u) => u.startsWith("https://proxy.example"));
+    expect(primaryCalls).toHaveLength(1); // probed once, then remembered as dead
+    expect(proxyCalls).toHaveLength(3); // every call still resolves via the proxy
+  });
+
   it("sends Authorization only when the access has a readToken", async () => {
     const seen: Array<Record<string, string>> = [];
     const provider = new TmdbMetadataProvider({


### PR DESCRIPTION
## 现象(issue #68)
用户填了自己的 TMDB token + 默认资源商,搜索约 10s 后跳「This page couldn't load / A server error occurred」。

## 根因(取证)
`getTmdbAccesses` 在用户填 token 时把直连 `api.themoviedb.org` 排第一通道。该域名在用户网络被墙时,`defaultFetchJson` 用裸 `fetch` **无超时** → TCP 连接挂起(~10s 平台默认)。而一次搜索串行打**最多 11 个** TMDB 请求(`search/multi` + 每个 TV 结果一次 `tv/{id}` details),每个都先白等直连超时 → 累积拖垮服务端渲染 → 报错页。默认(无 token)走 CF Worker 代理、不碰直连,所以正常 —— 这就是作者说的"撞到 cf workers"。

> 注:作者软路由网络能到 TMDB(`401 in 1.3s`),所以挂起是**用户本地网络封锁**特有,与 token 是否有效无关。

## 修复(access chain 唯一收口,两层)
1. `defaultFetchJson` 加 `AbortSignal.timeout(4500ms)`:被墙 hop 4.5s 内快速失败回退,不再挂到平台默认;合法 TMDB 响应 <2s,余量足。
2. `fetchViaAccessChain` 加 `deadAccesses` 记忆(provider 实例级):某通道失败后本次搜索后续请求直接跳过,把「11×挂起」降为「探一次即记住」。

## 验证
- 单元 TDD:死通道只探一次、后续走代理(#68 回归)。
- **真复现**(黑洞 IP 模拟被墙直连 + 真作者代理):修后 `call#1=6.2s`(被超时钳住)、`call#2+#3=0.7s`(记忆生效);修前会逐个累积挂起。
- 835 workflow + 185 apps/web + root/apps-web/build:workflow 三 tsc 全绿。

## 已知残留
被墙用户每次**新**搜索仍探一次直连(~4.5s);要彻底消除可加跨请求 dead-access 缓存,本次保持聚焦、不引入全局可变状态。

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)