### PR TITLE
fix(tmdb): 死通道记忆按 baseURL+token 做键(#69 Copilot review)

### DIFF
--- a/packages/workflow/src/tmdb-provider.ts
+++ b/packages/workflow/src/tmdb-provider.ts
@@ -45,8 +45,11 @@ function normalizeAccess(access: TmdbAccess): TmdbAccess {
  *  Without it, a user TMDB token whose direct api.themoviedb.org hop is blocked
  *  makes EVERY call (a search fires ~11) re-time-out on that hop before falling
  *  back — the cumulative stall shows as "A server error occurred" (issue #68).
- *  Accesses are dropped from the dead set on no live attempt so a request that
- *  starts all-dead still probes once rather than throwing blind. */
+ *  Keyed by baseURL + token (accessKey), so two accesses sharing a host but
+ *  carrying different tokens (user key, then env token) are tracked independently
+ *  — a failing user key must not skip a still-working env-token access. When every
+ *  access is already marked dead the set is left untouched and all are retried
+ *  (the prior failures may have been transient) rather than throwing blind. */
 async function fetchViaAccessChain(
   accesses: TmdbAccess[],
   path: string,
@@ -55,9 +58,8 @@ async function fetchViaAccessChain(
   deadAccesses?: Set<string>,
 ): Promise<unknown> {
   let lastError: unknown = new Error("no TMDB access configured");
-  const live = deadAccesses ? accesses.filter((a) => !deadAccesses.has(a.baseURL)) : accesses;
-  // If every access is already marked dead, fall back to trying them all again
-  // (the prior failures may have been transient) rather than throwing blind.
+  const accessKey = (a: TmdbAccess) => `${a.baseURL}\n${a.readToken ?? ""}`;
+  const live = deadAccesses ? accesses.filter((a) => !deadAccesses.has(accessKey(a))) : accesses;
   const candidates = live.length > 0 ? live : accesses;
   for (const access of candidates) {
     const url = `${access.baseURL}/${path}?${new URLSearchParams(query).toString()}`;
@@ -69,7 +71,7 @@ async function fetchViaAccessChain(
       return await fetchJson(url, { method: "GET", headers });
     } catch (error) {
       lastError = error;
-      deadAccesses?.add(access.baseURL);
+      deadAccesses?.add(accessKey(access));
     }
   }
   throw new Error(`All ${candidates.length} TMDB access(es) failed: ${String(lastError)}`);

--- a/packages/workflow/tests/tmdb-provider.test.ts
+++ b/packages/workflow/tests/tmdb-provider.test.ts
@@ -473,6 +473,35 @@ describe("TmdbMetadataProvider multi-access fallback", () => {
     expect(proxyCalls).toHaveLength(3); // every call still resolves via the proxy
   });
 
+  it("keys the dead set by baseURL + token, so a failing user key does not poison a working env key on the same host (Copilot #69)", async () => {
+    // getTmdbAccesses produces two accesses with the SAME baseURL (TMDB direct)
+    // but different tokens: the user key, then the env token. A bad user key must
+    // not make later calls skip the env-token access (same host) — only the exact
+    // failing access should be remembered as dead.
+    const tokensTried: string[] = [];
+    const provider = new TmdbMetadataProvider({
+      accesses: [
+        { baseURL: "https://api.themoviedb.org/3", readToken: "bad-user-key" },
+        { baseURL: "https://api.themoviedb.org/3", readToken: "good-env-key" },
+        { baseURL: "https://proxy.example" },
+      ],
+      fetchJson: async (_url, init) => {
+        const auth = init.headers.Authorization ?? "(none)";
+        tokensTried.push(auth);
+        if (auth === "Bearer bad-user-key") throw new Error("HTTP 401");
+        return movieJson(278);
+      },
+    });
+    await provider.getMovieDetails(278);
+    await provider.getMovieDetails(550);
+    await provider.getMovieDetails(155);
+    // The good env key is used on every call; the proxy is never needed.
+    expect(tokensTried.filter((a) => a === "Bearer good-env-key")).toHaveLength(3);
+    expect(tokensTried.filter((a) => a === "(none)")).toHaveLength(0); // proxy never hit
+    // The bad user key is probed once, then remembered as dead (not retried).
+    expect(tokensTried.filter((a) => a === "Bearer bad-user-key")).toHaveLength(1);
+  });
+
   it("sends Authorization only when the access has a readToken", async () => {
     const seen: Array<Record<string, string>> = [];
     const provider = new TmdbMetadataProvider({


### PR DESCRIPTION
跟进 #69 的 Copilot review,两条都成立。

1. **真 bug**:`deadAccesses` 只按 `baseURL` 做键。`getTmdbAccesses` 会建两个**同 baseURL、不同 token** 的直连通道(用户 key + env token)。用户 key 失败一次 → 后续调用把 **env-token 直连也一起跳过**(同主机),即便它本可工作 → 退化到代理、或代理挂时直接失败。改按 `baseURL + token` 复合键,两通道独立记忆。
2. **文档 nit**:注释原说"全死时从 dead set 移除条目",实际是"全死时重试全部、不改 set"。注释已改正。

**TDD**:同 baseURL 的坏 user key + 好 env key,三次调用都走 env key、proxy 永不触发、坏 key 只探一次。836 workflow + build:workflow 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)