### PR TITLE
review-only: Copilot 评审 a4e92c0(已并入 main 的 4 条修复)

### DIFF
--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -21,10 +21,14 @@ const STRIP_NOTICE =
   "已从关键词移除画质/字幕词(如 4K/1080p/蓝光/中字/字幕):PanSou 是通配符匹配,加这些只会把召回打成子集或归零,raw 裸标题召回最全。已改用裸标题搜索。";
 
 /** Strip quality/subtitle tokens from a search keyword and fold the resulting
- *  whitespace. Returns whether anything was removed (drives the agent notice). */
+ *  whitespace. `stripped` is true ONLY when an actual QUALITY_SUBTITLE_TOKEN was
+ *  removed — NOT when mere whitespace was collapsed (so "奥本海默   第二季" does
+ *  not falsely trip the strip notice). */
 function stripQualitySubtitleTokens(keyword: string): { keyword: string; stripped: boolean } {
+  const stripped = QUALITY_SUBTITLE_TOKEN.test(keyword);
+  QUALITY_SUBTITLE_TOKEN.lastIndex = 0;
   const cleaned = keyword.replace(QUALITY_SUBTITLE_TOKEN, " ").replace(/\s+/g, " ").trim();
-  return { keyword: cleaned, stripped: cleaned !== keyword.trim() };
+  return { keyword: cleaned, stripped };
 }
 
 /**
@@ -184,7 +188,7 @@ export class TaskSandbox {
     // real title. (asEvidence turns this throw into the {error} the agent reads.)
     if (!keywordReferencesTitle(effectiveKeyword, this.titleTerms)) {
       throw new Error(
-        `搜索关键词必须包含片名(片名/原名/别名)。"${keyword}" 不含片名,只会返回噪音,已拒绝。请用包含片名的关键词(可附加年份/原名/4K/全集 等),不要用纯类型或纯年份(如 "电影"、"2026 电影")。`,
+        `搜索关键词必须包含片名(片名/原名/别名)。"${keyword}" 不含片名,只会返回噪音,已拒绝。请用包含片名的关键词(裸标题召回最全;繁体/英文/原名 可作升级,别加画质/字幕/年份词——会被移除且只会减召回),不要用纯类型或纯年份(如 "电影"、"2026 电影")。`,
       );
     }
     const normalized = normalizeSearchKeyword(effectiveKeyword);

--- a/packages/workflow/tests/v2-raw-snapshot.test.ts
+++ b/packages/workflow/tests/v2-raw-snapshot.test.ts
@@ -45,17 +45,18 @@ describe("raw snapshot pre-warming", () => {
   it("pre-warmed search does NOT consume the agent's distinct search budget", async () => {
     const sandbox = await createTestSandbox(["Resource A", "Resource B"]);
 
-    // 预热
     await sandbox.primeRawSnapshot("test-title");
 
-    // agent 之后搜索仍有完整预算(默认 8 次)
-    const result1 = await sandbox.searchResources("keyword1");
-    expect(result1.refused).toBeUndefined();
-
-    const result2 = await sandbox.searchResources("keyword2");
-    expect(result2.refused).toBeUndefined();
-
-    // ... 继续搜索直到预算耗尽(8 次,不包括预热)
+    // The agent still has the FULL budget of 8 distinct searches: 8 fresh keywords
+    // all run (none refused), and only the 9th distinct agent search is refused —
+    // proving the system pre-warm took none of the agent's slots.
+    for (let i = 0; i < 8; i++) {
+      const r = await sandbox.searchResources(`agent-kw-${i}`);
+      expect(r.refused, `agent search #${i + 1} should run`).toBeUndefined();
+    }
+    const ninth = await sandbox.searchResources("agent-kw-8");
+    expect(ninth.refused).toBeTruthy();
+    expect(ninth.snapshot).toBeUndefined();
   });
 
   it("agent re-searching the same raw keyword hits dedup and does NOT re-hit the provider", async () => {
@@ -145,14 +146,5 @@ describe("system prompt carries raw snapshot pointer", () => {
 
     expect(tvPrompt).not.toContain("viewResourceSnapshot");
     expect(moviePrompt).not.toContain("viewResourceSnapshot");
-  });
-});
-
-describe("viewResourceSnapshot tool registration", () => {
-  it("agent-loop tools table includes viewResourceSnapshot as read-only", async () => {
-    // 这个测试需要检查 agent-loop.ts 中的工具表
-    // 由于工具表是在 runAcquisitionAgent 内部构造的,我们通过集成测试验证
-    // 这里先占位,实际实现后可能需要调整测试策略
-    expect(true).toBe(true); // placeholder
   });
 });

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -131,6 +131,17 @@ describe("TaskSandbox — searchResources (system-budgeted, dedup, snapshot-boun
     expect(result.notice).toBeUndefined();
   });
 
+  it("does NOT emit the strip notice when only whitespace changed (no quality token removed)", async () => {
+    const provider = new FakeResourceProviderV2({
+      results: { "奥本海默 第二季": [{ id: "c1", title: "奥本海默 第二季 全集" }] },
+    });
+    const sandbox = new TaskSandbox({ provider, searchBudget: 8, titleTerms: ["奥本海默"] });
+
+    const result = await sandbox.searchResources("奥本海默   第二季");
+
+    expect(result.notice).toBeUndefined();
+  });
+
   it("rejects a keyword that does not reference the title (no provider hit, no budget spent)", async () => {
     let calls = 0;
     const sandbox = new TaskSandbox({


### PR DESCRIPTION
## 补评审说明

a4e92c0 已经并入 main(PR #75 squash 时一起进去了),但这 4 处修复在合并前**没有单独再走一道 Copilot 评审**。本 PR 把这 4 处改动隔离出来(base=2913735 即 a4e92c0 的父提交)专门让 Copilot 复审。

**review-only:不会合并**——内容已在 main。Copilot 若发现真问题,我会在 main 上开后续 PR 修。

### 4 处修复(对应 #75 Copilot 的 4 条意见)
1. `stripQualitySubtitleTokens` 的 `stripped` 标志改为只在真正移除画质/字幕词时为 true,不再因纯空格折叠误报 notice(+回归测试)
2. 片名 gate 拒绝消息去掉过时的「可附加 4K」建议
3. 强化预热预算测试:跑满 8 次再断言第 9 次 refuse,真正证明预热不占 agent 预算
4. 删除占位测试 `expect(true).toBe(true)`