### PR TITLE
fix(search): Copilot 补评审(#76)的 2 条修复 — 正则 lastIndex 加固 + 拒绝消息更正

### DIFF
--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -25,6 +25,10 @@ const STRIP_NOTICE =
  *  removed — NOT when mere whitespace was collapsed (so "奥本海默   第二季" does
  *  not falsely trip the strip notice). */
 function stripQualitySubtitleTokens(keyword: string): { keyword: string; stripped: boolean } {
+  // QUALITY_SUBTITLE_TOKEN has the /g flag → RegExp.test() is stateful on lastIndex.
+  // Reset BEFORE and after the test so a non-zero lastIndex (from any prior/concurrent
+  // use of this shared regex) can never make `stripped` a false negative.
+  QUALITY_SUBTITLE_TOKEN.lastIndex = 0;
   const stripped = QUALITY_SUBTITLE_TOKEN.test(keyword);
   QUALITY_SUBTITLE_TOKEN.lastIndex = 0;
   const cleaned = keyword.replace(QUALITY_SUBTITLE_TOKEN, " ").replace(/\s+/g, " ").trim();
@@ -188,7 +192,7 @@ export class TaskSandbox {
     // real title. (asEvidence turns this throw into the {error} the agent reads.)
     if (!keywordReferencesTitle(effectiveKeyword, this.titleTerms)) {
       throw new Error(
-        `搜索关键词必须包含片名(片名/原名/别名)。"${keyword}" 不含片名,只会返回噪音,已拒绝。请用包含片名的关键词(裸标题召回最全;繁体/英文/原名 可作升级,别加画质/字幕/年份词——会被移除且只会减召回),不要用纯类型或纯年份(如 "电影"、"2026 电影")。`,
+        `搜索关键词必须包含片名(片名/原名/别名)。"${keyword}" 不含片名,只会返回噪音,已拒绝。请用包含片名的关键词(裸标题召回最全;繁体/英文/原名 可作升级。注意:画质/字幕词会被自动移除,年份/季 等词虽不移除但同样会减召回,别加),不要用纯类型或纯年份(如 "电影"、"2026 电影")。`,
       );
     }
     const normalized = normalizeSearchKeyword(effectiveKeyword);

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -142,6 +142,19 @@ describe("TaskSandbox — searchResources (system-budgeted, dedup, snapshot-boun
     expect(result.notice).toBeUndefined();
   });
 
+  it("emits the strip notice on EVERY quality-laden search (shared /g regex lastIndex never leaks)", async () => {
+    const provider = new FakeResourceProviderV2({
+      results: { 铁拳教育: [{ id: "c1", title: "铁拳教育 全集" }], 奥本海默: [{ id: "c2", title: "奥本海默 全集" }] },
+    });
+    const sandbox = new TaskSandbox({ provider, searchBudget: 8, titleTerms: ["铁拳教育", "奥本海默"] });
+
+    const first = await sandbox.searchResources("铁拳教育 1080p");
+    const second = await sandbox.searchResources("奥本海默 中字");
+
+    expect(first.notice).toMatch(/已移除|画质|raw/);
+    expect(second.notice).toMatch(/已移除|画质|raw/);
+  });
+
   it("rejects a keyword that does not reference the title (no provider hit, no budget spent)", async () => {
     let calls = 0;
     const sandbox = new TaskSandbox({


### PR DESCRIPTION
## 背景
#75 合并时,处理首轮 Copilot 4 条意见的修复提交 a4e92c0 **没再走一道 Copilot 评审**就进了 main。补开 review-only PR #76 专审那 4 处,Copilot 又发现 2 个真问题(首轮漏掉的)。本 PR 在 main 上修这 2 处。

## 修复
1. **stateful /g 正则 lastIndex 加固** — `stripQualitySubtitleTokens` 用了带 /g 的 `QUALITY_SUBTITLE_TOKEN.test()`(有状态),原来只在 test 后重置 lastIndex、依赖入口恒为 0(当前靠下方 .replace() 巧合归零),脆弱。改为 test 前后都重置,杜绝 `stripped` 假阴性。加回归测试:连续两次画质关键词搜索都必须触发 notice。
2. **拒绝消息更正** — 原称『画质/字幕/年份词会被移除』,但 strip 只移画质/字幕词、不移年份。改为『画质/字幕词会被自动移除,年份/季 不移除但同样减召回,别加』,不再 overclaim。

## 验证
lint 0 / typecheck 0 / apps-web tsc 0 / vitest 866 passed。

关联 #76(review-only)、#72、#75。