### PR TITLE
fix(activity): 映射 viewResourceSnapshot,不再回退「处理中…」

### DIFF
--- a/packages/workflow/src/acquisition-v2/activity.ts
+++ b/packages/workflow/src/acquisition-v2/activity.ts
@@ -34,6 +34,12 @@ export function interpretTool(toolName: string, args: Record<string, unknown> = 
   switch (toolName) {
     case "readSkill":
       return { activity: "正在查阅操作手册…", phase: "search" };
+    case "viewResourceSnapshot":
+      // The pre-warmed 活期文档 review: the agent is browsing the system's
+      // already-searched raw candidates (free, read-only) before deciding. It is
+      // search-phase work (orient the candidate set, no transfer yet), so it stays
+      // in the low band — never the generic "处理中…" fallback.
+      return { activity: "正在浏览候选资源…", phase: "search" };
     case "searchResources": {
       const keyword = String(args.keyword ?? "").trim();
       return { activity: keyword ? `正在搜索资源:${keyword}` : "正在搜索资源…", phase: "search" };

--- a/packages/workflow/tests/activity.test.ts
+++ b/packages/workflow/tests/activity.test.ts
@@ -72,8 +72,8 @@ describe("interpretTool — real agent tool names → cleaned 中文 + phase", (
     expect(r.phase).toBe("search");
   });
 
-  it("searchResources with a raw keyword echoes it (so the system pre-warm search shows its keyword on the activity page)", () => {
-    expect(interpretTool("searchResources", { keyword: "庆余年" })).toEqual({
+  it("searchResources trims leading/trailing whitespace from the displayed keyword (no stray-space echo)", () => {
+    expect(interpretTool("searchResources", { keyword: "  庆余年  " })).toEqual({
       activity: "正在搜索资源:庆余年",
       phase: "search",
     });

--- a/packages/workflow/tests/activity.test.ts
+++ b/packages/workflow/tests/activity.test.ts
@@ -65,6 +65,20 @@ describe("interpretTool — real agent tool names → cleaned 中文 + phase", (
     expect(interpretTool("readSkill", { section: "protocol" }).activity).toBe("正在查阅操作手册…");
   });
 
+  it("viewResourceSnapshot is the pre-warmed 活期文档 review → mapped (not the generic 处理中 fallback)", () => {
+    const r = interpretTool("viewResourceSnapshot", {});
+    expect(r.activity).not.toBe("处理中…");
+    expect(r.activity).toMatch(/候选|预搜|活期文档|浏览/);
+    expect(r.phase).toBe("search");
+  });
+
+  it("searchResources with a raw keyword echoes it (so the system pre-warm search shows its keyword on the activity page)", () => {
+    expect(interpretTool("searchResources", { keyword: "庆余年" })).toEqual({
+      activity: "正在搜索资源:庆余年",
+      phase: "search",
+    });
+  });
+
   it("never leaks ids/paths and falls back for an unknown tool", () => {
     expect(interpretTool("weirdTool", { cid: "33988", path: "/x" })).toEqual({ activity: "处理中…", phase: "search" });
   });


### PR DESCRIPTION
## 问题
Task 2 加了只读活期文档工具 `viewResourceSnapshot`,但 `activity.ts` 的 `interpretTool` switch **漏了这个 case**,导致 agent 读活期文档这一步在 `/activity` 页回退成无意义的 **「处理中…」**。

实测三次真实获取(庆余年 S1 / 新蝙蝠侠 / 复仇者联盟),`viewResourceSnapshot` 这步的 `agent_steps.activity` 全都是 `处理中…`:
```
2 | viewResourceSnapshot | 处理中…
```
其余每一步都有有意义文案(正在查阅操作手册 / 正在转存 / 正在核对…),唯独读活期文档这一步掉了。

## 修复
补 `viewResourceSnapshot` case:
- `activity = "正在浏览候选资源…"`
- `phase = "search"`(读活期文档是搜索阶段的取向工作——不进 transfer,落在低权重区,和它的语义一致;与现有 `inspectTargetDir` 同理,都是 EARLY orientation)

## 验证
- TDD:新增 2 测试(① `viewResourceSnapshot` 不再回退「处理中…」且文案含 候选/浏览;② `searchResources` raw keyword 仍正确回显)
- Gate 全绿:lint 0 / typecheck 0 / apps-web tsc 0 / vitest 868 passed
- 实测:部署前三次获取的 viewResourceSnapshot 都是「处理中…」,本次部署后会变成「正在浏览候选资源…」

这是个 Task 2 的遗漏收尾,纯加法(1 个 case + 2 测试),无行为风险。