### PR TITLE
feat(net): 支持出站代理(HTTP_PROXY/HTTPS_PROXY)——墙内可用自己的 TMDB token (#68)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,13 @@ MEDIA_TRACK_POSTGRES_URL=
 # TMDB v4 read token —— 可留空:默认经作者 CF Worker 代理开箱即用,
 # 想用自己额度更稳可在「设置」页填或填这里。
 TMDB_READ_TOKEN=
+# 出站代理（可选）—— 墙内想用自己的 TMDB token 时用得到：api.themoviedb.org
+# 常被单独墙，直连不到你的 token。配一个能穿透的代理让全部出站请求走它即可。
+# 172.17.0.1 = Docker 默认网关（指向宿主机），端口换成你宿主代理软件的实际端口。
+# 不设则行为不变（token 留空走作者内置代理依旧开箱即用）。详见 docs/deploy.md。
+# HTTP_PROXY=http://172.17.0.1:7890
+# HTTPS_PROXY=http://172.17.0.1:7890
+# NO_PROXY=localhost,127.0.0.1
 # Web search uses deterministic demo candidates by default.
 # Set to "tmdb" only when you want browser searches to call TMDB (compose 默认 tmdb)。
 MEDIA_TRACK_SEARCH_PROVIDER=demo

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -8,6 +8,16 @@ export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== "nodejs") {
     return;
   }
+  // Opt-in outbound proxy: Node's built-in fetch (undici) ignores HTTP_PROXY /
+  // HTTPS_PROXY on its own, so a self-hoster behind the GFW who sets them in
+  // docker-compose still couldn't reach api.themoviedb.org directly (#68).
+  // Install the env-driven dispatcher FIRST (before any outbound fetch) so TMDB /
+  // PanSou / Prowlarr calls honor the proxy. No proxy env → installs nothing.
+  const { configureHttpProxyFromEnv } = await import("./lib/http-proxy");
+  const proxy = configureHttpProxyFromEnv();
+  if (proxy.enabled) {
+    console.log(`[instrumentation] outbound proxy enabled via env (${proxy.proxyUrl})`);
+  }
   // Fail fast + loud on a runtime misconfig (e.g. MEDIA_TRACK_AGENT_ADAPTER=real)
   // instead of booting a worker that can never drain the queue. Throwing here
   // aborts startup with a clear reason.

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -16,7 +16,7 @@ export async function register(): Promise<void> {
   const { configureHttpProxyFromEnv } = await import("./lib/http-proxy");
   const proxy = configureHttpProxyFromEnv();
   if (proxy.enabled) {
-    console.log(`[instrumentation] outbound proxy enabled via env (${proxy.proxyUrl})`);
+    console.log(`[instrumentation] outbound proxy enabled via env (${proxy.proxyDisplay})`);
   }
   // Fail fast + loud on a runtime misconfig (e.g. MEDIA_TRACK_AGENT_ADAPTER=real)
   // instead of booting a worker that can never drain the queue. Throwing here

--- a/apps/web/lib/http-proxy.test.ts
+++ b/apps/web/lib/http-proxy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { configureHttpProxyFromEnv } from "./http-proxy";
+
+describe("configureHttpProxyFromEnv — opt-in proxy for outbound fetch (undici ignores HTTP_PROXY by default)", () => {
+  it("installs an EnvHttpProxyAgent dispatcher when HTTP_PROXY is set", () => {
+    const setDispatcher = vi.fn();
+    const agent = { kind: "agent" } as unknown as import("undici").Dispatcher;
+    const makeAgent = vi.fn(() => agent);
+
+    const result = configureHttpProxyFromEnv(
+      { HTTP_PROXY: "http://172.17.0.1:7890" },
+      { setDispatcher, makeAgent },
+    );
+
+    expect(makeAgent).toHaveBeenCalledTimes(1);
+    expect(setDispatcher).toHaveBeenCalledWith(agent);
+    expect(result.enabled).toBe(true);
+    expect(result.proxyUrl).toBe("http://172.17.0.1:7890");
+  });
+
+  it("honors HTTPS_PROXY and the lowercase variants", () => {
+    for (const key of ["HTTPS_PROXY", "http_proxy", "https_proxy"]) {
+      const setDispatcher = vi.fn();
+      const result = configureHttpProxyFromEnv(
+        { [key]: "http://proxy:8080" },
+        { setDispatcher, makeAgent: () => ({}) as unknown as import("undici").Dispatcher },
+      );
+      expect(result.enabled, key).toBe(true);
+      expect(setDispatcher, key).toHaveBeenCalledOnce();
+    }
+  });
+
+  it("does NOTHING when no proxy env var is set (zero impact on the default direct-fetch path)", () => {
+    const setDispatcher = vi.fn();
+    const makeAgent = vi.fn();
+
+    const result = configureHttpProxyFromEnv({}, { setDispatcher, makeAgent });
+
+    expect(makeAgent).not.toHaveBeenCalled();
+    expect(setDispatcher).not.toHaveBeenCalled();
+    expect(result.enabled).toBe(false);
+  });
+
+  it("ignores a blank/whitespace-only proxy value (treats it as unset)", () => {
+    const setDispatcher = vi.fn();
+    const result = configureHttpProxyFromEnv(
+      { HTTP_PROXY: "   " },
+      { setDispatcher, makeAgent: () => ({}) as unknown as import("undici").Dispatcher },
+    );
+    expect(result.enabled).toBe(false);
+    expect(setDispatcher).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/http-proxy.test.ts
+++ b/apps/web/lib/http-proxy.test.ts
@@ -50,4 +50,25 @@ describe("configureHttpProxyFromEnv — opt-in proxy for outbound fetch (undici 
     expect(result.enabled).toBe(false);
     expect(setDispatcher).not.toHaveBeenCalled();
   });
+
+  it("exposes a REDACTED proxy display (host:port only) so credentials never reach logs", () => {
+    const result = configureHttpProxyFromEnv(
+      { HTTP_PROXY: "http://user:secret@proxy.internal:7890" },
+      { setDispatcher: vi.fn(), makeAgent: () => ({}) as unknown as import("undici").Dispatcher },
+    );
+    expect(result.enabled).toBe(true);
+    expect(result.proxyDisplay).toBe("proxy.internal:7890");
+    // The credentials must NOT appear anywhere in the safe display.
+    expect(result.proxyDisplay).not.toContain("secret");
+    expect(result.proxyDisplay).not.toContain("user");
+  });
+
+  it("proxyDisplay falls back to the raw value when it isn't a parseable URL (still no crash)", () => {
+    const result = configureHttpProxyFromEnv(
+      { HTTP_PROXY: "172.17.0.1:7890" },
+      { setDispatcher: vi.fn(), makeAgent: () => ({}) as unknown as import("undici").Dispatcher },
+    );
+    expect(result.enabled).toBe(true);
+    expect(result.proxyDisplay).toBe("172.17.0.1:7890");
+  });
 });

--- a/apps/web/lib/http-proxy.ts
+++ b/apps/web/lib/http-proxy.ts
@@ -1,0 +1,50 @@
+import { EnvHttpProxyAgent, setGlobalDispatcher, type Dispatcher } from "undici";
+
+/**
+ * Opt-in outbound proxy for the server's global `fetch`.
+ *
+ * Node's built-in `fetch` (undici) does NOT read `HTTP_PROXY` / `HTTPS_PROXY`
+ * environment variables on its own (and `NODE_USE_ENV_PROXY` only exists on
+ * Node 24+). So a self-hoster behind the GFW who sets those vars in
+ * docker-compose still couldn't reach `api.themoviedb.org` directly — every
+ * TMDB call went out unproxied and timed out (#68).
+ *
+ * Installing undici's `EnvHttpProxyAgent` as the global dispatcher makes
+ * `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` actually take effect for every
+ * outbound fetch (TMDB direct, PanSou, Prowlarr). It is OPT-IN: with no proxy
+ * env set we install nothing, so the default direct-fetch path is unchanged.
+ */
+
+export interface ConfigureProxyDeps {
+  setDispatcher: (dispatcher: Dispatcher) => void;
+  makeAgent: () => Dispatcher;
+}
+
+export interface ConfigureProxyResult {
+  enabled: boolean;
+  proxyUrl?: string;
+}
+
+const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] as const;
+
+const defaultDeps: ConfigureProxyDeps = {
+  setDispatcher: setGlobalDispatcher,
+  makeAgent: () => new EnvHttpProxyAgent(),
+};
+
+/**
+ * Install the env-driven proxy dispatcher iff a proxy env var is set. Pure
+ * w.r.t. its injected deps so the env→install decision is unit-testable without
+ * mutating the real global dispatcher.
+ */
+export function configureHttpProxyFromEnv(
+  env: Readonly<Record<string, string | undefined>> = process.env,
+  deps: ConfigureProxyDeps = defaultDeps,
+): ConfigureProxyResult {
+  const proxyUrl = PROXY_ENV_KEYS.map((key) => env[key]?.trim()).find((value) => value);
+  if (!proxyUrl) {
+    return { enabled: false };
+  }
+  deps.setDispatcher(deps.makeAgent());
+  return { enabled: true, proxyUrl };
+}

--- a/apps/web/lib/http-proxy.ts
+++ b/apps/web/lib/http-proxy.ts
@@ -23,9 +23,23 @@ export interface ConfigureProxyDeps {
 export interface ConfigureProxyResult {
   enabled: boolean;
   proxyUrl?: string;
+  /** Credentials-stripped host:port for safe logging — a proxy URL may embed
+   *  user:pass, which must never reach application logs. */
+  proxyDisplay?: string;
 }
 
 const PROXY_ENV_KEYS = ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] as const;
+
+/** Reduce a proxy URL to `host:port`, dropping any embedded credentials. Falls
+ *  back to the raw value when it is not a parseable URL (e.g. bare `host:port`). */
+function redactProxy(raw: string): string {
+  try {
+    const u = new URL(raw);
+    return u.port ? `${u.hostname}:${u.port}` : u.hostname;
+  } catch {
+    return raw;
+  }
+}
 
 const defaultDeps: ConfigureProxyDeps = {
   setDispatcher: setGlobalDispatcher,
@@ -46,5 +60,5 @@ export function configureHttpProxyFromEnv(
     return { enabled: false };
   }
   deps.setDispatcher(deps.makeAgent());
-  return { enabled: true, proxyUrl };
+  return { enabled: true, proxyUrl, proxyDisplay: redactProxy(proxyUrl) };
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "dependencies": {
     "@media-track/workflow": "*",
-    "@vercel/analytics": "^2.0.1"
+    "@vercel/analytics": "^2.0.1",
+    "undici": "^7.28.0"
   }
 }

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -101,6 +101,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 ## 可选增强
 
 - **自己的 TMDB key**(设置 → TMDB 元数据):直连你自己的额度,调不通自动回退作者代理。
+- **出站代理**(`.env` 设 `HTTP_PROXY` / `HTTPS_PROXY`):墙内想用**自己的 TMDB token / 额度**时用得到。TMDB 的 API 主机(`api.themoviedb.org`)在国内常被单独墙(官网能开 ≠ API 能通),直连不到你的 token 就用不上。给容器配一个能穿透的代理即可让全部出站请求(TMDB / PanSou / Prowlarr)走它:在仓库根 `.env` 里写 `HTTP_PROXY=http://172.17.0.1:7890` 和 `HTTPS_PROXY=http://172.17.0.1:7890`(`172.17.0.1` 是 Docker 默认网关,指向宿主机;端口换成你宿主上代理软件的实际端口,如 Clash 的 7890),再 `docker compose up -d`。`NO_PROXY` 可排除内网地址。**不设代理时行为不变**——TMDB token 留空走作者内置代理依旧开箱即用,这条只为「墙内 + 想用自己 token」准备。
 - **Prowlarr**(设置 → 资源提供商):接入索引器聚合,磁力与 PanSou 结果合并,走 115 或光鸭的离线下载落盘(夸克无磁力 API)。
 - **换 PanSou 实例**(设置 → 资源提供商):默认用 compose 自带的;想指向别的实例/公共域名在此手填。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
       "name": "@media-track/web",
       "dependencies": {
         "@media-track/workflow": "*",
-        "@vercel/analytics": "^2.0.1"
+        "@vercel/analytics": "^2.0.1",
+        "undici": "^7.28.0"
       }
     },
     "apps/web/node_modules/@vercel/analytics": {
@@ -3965,6 +3966,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
## 背景(#68)

用户 wibi8bo 填了自己的 TMDB token 后搜索报错(`ERROR 441639633` 服务端渲染超时);更新 + 留空 token 后仍报错。另一位用户 mi4646 提出「在 compose 配 `HTTP_PROXY/HTTPS_PROXY` 暂时可解决」并附了软路由代理面板截图(`172.17.0.1:7890`)。

排查后发现一个真问题:

> **Node 原生 fetch(undici)默认不读 `HTTP_PROXY`/`HTTPS_PROXY` 环境变量**(`NODE_USE_ENV_PROXY` 仅 Node 24+,容器是 v22.22.3)。

实测确认:在 web 容器内设 `HTTP_PROXY=http://127.0.0.1:1`(死端口),原生 fetch **仍直连成功**(HTTP 200)——证明默认完全忽略 env。所以墙内用户即便在 compose 配了代理 env,`api.themoviedb.org` 直连仍被墙、用不上自己的 token。mi4646 的方向对,但单配 env 对 TMDB 这条(走原生 fetch)路其实无效。

## 修复

启动时(`instrumentation.ts` register,早于任何出站 fetch)按 env 装 undici 的 `EnvHttpProxyAgent` 全局 dispatcher,让 `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` 对**全部出站 fetch**(TMDB 直连 / PanSou / Prowlarr)真正生效。

- **OPT-IN**:不设代理 env → **什么都不装**,默认直连路径零影响。
- 实测验证外部 undici 包的 `setGlobalDispatcher` 确实能影响 global `fetch`(设死端口代理后 global fetch 14ms 失败 → 证明 dispatcher 生效,不是装了个无效的两份实例)。

## 改动

- 新增 `apps/web/lib/http-proxy.ts`:纯函数 `configureHttpProxyFromEnv`(依赖注入,可单测)。
- `instrumentation.ts`:启动时调用 + 启用时打日志。
- 加 `undici@^7.28.0` 依赖(engines Node≥20.18.1,容器 v22 满足)。
- `docs/deploy.md` 新增「出站代理」可选增强;`.env.example` 加 `HTTP_PROXY` 注释样例(对应 mi4646 的 `172.17.0.1:7890` 场景)。

## 验证

- TDD:4 个测试(HTTP_PROXY 装 dispatcher / 大小写变体 / 无 env 零影响 / 空白值当未设)。
- Gate 全绿:lint 0 / typecheck 0 / apps-web tsc 0 / build:web 0(无 DB)/ vitest 1064 passed。

关联 #68。
