### PR TITLE
feat: 外挂中文字幕自动补全（assrt.net，阶段一仅 115）

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -546,6 +546,32 @@ export async function clearTmdbApiKeyAction(): Promise<PushSettingsActionResult>
   }
 }
 
+export async function saveAssrtTokenAction(token: string): Promise<PushSettingsActionResult> {
+  assertNotDemo();
+  try {
+    const { getWorkflowRepository, getCurrentAccountId, ASSRT_TOKEN_SETTING_KEY } = await import("../lib/workflow-runtime");
+    const repository = getWorkflowRepository();
+    const trimmed = token.trim();
+    if (trimmed) {
+      await repository.setAccountSetting(await getCurrentAccountId(), ASSRT_TOKEN_SETTING_KEY, trimmed);
+    }
+    return { success: true };
+  } catch (error) {
+    return { success: false, message: `保存失败：${String(error)}` };
+  }
+}
+
+export async function clearAssrtTokenAction(): Promise<PushSettingsActionResult> {
+  assertNotDemo();
+  try {
+    const { getWorkflowRepository, getCurrentAccountId, ASSRT_TOKEN_SETTING_KEY } = await import("../lib/workflow-runtime");
+    await getWorkflowRepository().setAccountSetting(await getCurrentAccountId(), ASSRT_TOKEN_SETTING_KEY, "");
+    return { success: true };
+  } catch (error) {
+    return { success: false, message: `清除失败：${String(error)}` };
+  }
+}
+
 export async function savePanSouBaseUrlAction(baseURL: string): Promise<PushSettingsActionResult> {
   assertNotDemo();
   try {

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,6 +1,6 @@
 import { connection } from "next/server";
 import { Suspense } from "react";
-import { Bell, Bot, Cable, CalendarClock, Clapperboard, Gauge, KeyRound, Languages, Radio, ShieldCheck, TriangleAlert, Users } from "lucide-react";
+import { Bell, Bot, Cable, CalendarClock, Clapperboard, Gauge, KeyRound, Languages, Radio, ShieldCheck, Subtitles, TriangleAlert, Users } from "lucide-react";
 import { AppSidebar } from "../../components/app-sidebar";
 import { AddDriveBrandTabs } from "../../components/add-drive-brand-tabs";
 import { TestConnectionButton } from "../../components/test-connection-button";
@@ -10,6 +10,7 @@ import { PreferredLanguageForm } from "../../components/preferred-language-form"
 import { QualityPreferenceForm } from "../../components/quality-preference-form";
 import { LlmConfigForm } from "../../components/llm-config-form";
 import { TmdbApiKeyForm } from "../../components/tmdb-api-key-form";
+import { AssrtTokenForm } from "../../components/assrt-token-form";
 import { ProwlarrConfigForm } from "../../components/prowlarr-config-form";
 import { PanSouConfigForm } from "../../components/pansou-config-form";
 import { DailySweepForm } from "../../components/daily-sweep-form";
@@ -32,6 +33,7 @@ import {
   LLM_MODEL_ID_SETTING_KEY,
   LLM_API_KEY_SETTING_KEY,
   TMDB_API_KEY_SETTING_KEY,
+  ASSRT_TOKEN_SETTING_KEY,
   PROWLARR_BASE_URL_SETTING_KEY,
   PROWLARR_API_KEY_SETTING_KEY,
   PANSOU_BASE_URL_SETTING_KEY,
@@ -90,6 +92,9 @@ export default function SettingsPage({
             </Suspense>
             <Suspense fallback={<div className="skeleton skeleton-heading" />}>
               <ResourceProviderSection />
+            </Suspense>
+            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+              <SubtitleSourceSection />
             </Suspense>
             <Suspense fallback={<div className="skeleton skeleton-heading" />}>
               <DailySweepSection />
@@ -285,6 +290,27 @@ async function ResourceProviderSection() {
           </p>
         </>
       ) : null}
+    </section>
+  );
+}
+
+async function SubtitleSourceSection() {
+  await connection();
+  const repository = getAccountScopedSettings(await getCurrentAccountId());
+  const tokenSet = Boolean((await repository.getSetting(ASSRT_TOKEN_SETTING_KEY))?.trim());
+
+  return (
+    <section className="panel" style={{ maxWidth: 720, marginTop: 24 }}>
+      <div className="panel-header">
+        <div>
+          <h2 className="panel-title">
+            <Subtitles size={16} aria-hidden style={{ verticalAlign: "-2px", marginRight: 8 }} />
+            字幕来源
+          </h2>
+          <p className="panel-note">外挂中文字幕自动补全（assrt.net，免费）；仅对非国产内容 + 115 网盘生效</p>
+        </div>
+      </div>
+      <AssrtTokenForm tokenSet={tokenSet} />
     </section>
   );
 }

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -307,7 +307,7 @@ async function SubtitleSourceSection() {
             <Subtitles size={16} aria-hidden style={{ verticalAlign: "-2px", marginRight: 8 }} />
             字幕来源
           </h2>
-          <p className="panel-note">外挂中文字幕自动补全（assrt.net，免费）；仅对非国产内容 + 115 网盘生效</p>
+          <p className="panel-note">外挂中文字幕自动补全（assrt.net，免费）；仅对非国产内容生效，需网盘支持外链离线（目前：115）</p>
         </div>
       </div>
       <AssrtTokenForm tokenSet={tokenSet} />

--- a/apps/web/components/assrt-token-form.tsx
+++ b/apps/web/components/assrt-token-form.tsx
@@ -26,7 +26,10 @@ export function AssrtTokenForm({ tokenSet }: { tokenSet: boolean }) {
     startTransition(async () => {
       const res = await clearAssrtTokenAction();
       setResult(res.success ? "✅ 已清除，字幕补全功能关闭" : `❌ ${res.message ?? "清除失败"}`);
-      if (res.success) setHasToken(false);
+      if (res.success) {
+        setHasToken(false);
+        setToken("");
+      }
       setTimeout(() => setResult(null), 3000);
     });
   };

--- a/apps/web/components/assrt-token-form.tsx
+++ b/apps/web/components/assrt-token-form.tsx
@@ -37,7 +37,7 @@ export function AssrtTokenForm({ tokenSet }: { tokenSet: boolean }) {
   return (
     <div className="push-form">
       <p className="panel-note" style={{ marginBottom: 6 }}>
-        外挂中文字幕来源：assrt.net（伪射手）有免费官方 API，agent 获取非国产剧集/电影时会自动搜字幕候选并挑合适的落盘到视频旁（目前仅支持 115 网盘）。免费申请 Token，留空则该功能完全不启用。国产内容原生中文对白，不需要此功能。
+        外挂中文字幕来源：assrt.net（伪射手）有免费官方 API，agent 获取非国产剧集/电影时会自动搜字幕候选并挑合适的落盘到视频旁。需网盘支持外链离线落盘（目前 115 支持；夸克/光鸭暂不触发）。免费申请 Token，留空则该功能完全不启用。国产内容原生中文对白，不需要此功能。
       </p>
       <p className="push-help" style={{ marginBottom: 12 }}>
         了解 assrt.net{" "}

--- a/apps/web/components/assrt-token-form.tsx
+++ b/apps/web/components/assrt-token-form.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Check, ExternalLink, LoaderCircle, Trash2 } from "lucide-react";
+import { saveAssrtTokenAction, clearAssrtTokenAction } from "../app/actions";
+
+export function AssrtTokenForm({ tokenSet }: { tokenSet: boolean }) {
+  const [isPending, startTransition] = useTransition();
+  const [token, setToken] = useState("");
+  const [hasToken, setHasToken] = useState(tokenSet);
+  const [result, setResult] = useState<string | null>(null);
+
+  const handleSave = () => {
+    startTransition(async () => {
+      const res = await saveAssrtTokenAction(token);
+      setResult(res.success ? "✅ 保存成功" : `❌ ${res.message ?? "保存失败"}`);
+      if (res.success && token.trim()) {
+        setToken("");
+        setHasToken(true);
+      }
+      setTimeout(() => setResult(null), 3000);
+    });
+  };
+
+  const handleClear = () => {
+    startTransition(async () => {
+      const res = await clearAssrtTokenAction();
+      setResult(res.success ? "✅ 已清除，字幕补全功能关闭" : `❌ ${res.message ?? "清除失败"}`);
+      if (res.success) setHasToken(false);
+      setTimeout(() => setResult(null), 3000);
+    });
+  };
+
+  return (
+    <div className="push-form">
+      <p className="panel-note" style={{ marginBottom: 6 }}>
+        外挂中文字幕来源：assrt.net（伪射手）有免费官方 API，agent 获取非国产剧集/电影时会自动搜字幕候选并挑合适的落盘到视频旁（目前仅支持 115 网盘）。免费申请 Token，留空则该功能完全不启用。国产内容原生中文对白，不需要此功能。
+      </p>
+      <p className="push-help" style={{ marginBottom: 12 }}>
+        了解 assrt.net{" "}
+        <a href="https://assrt.net" target="_blank" rel="noopener noreferrer">
+          官网 <ExternalLink size={12} style={{ verticalAlign: "-1px" }} />
+        </a>
+        {" · 免费申请 Token "}
+        <a href="https://secure.assrt.net/user/register.xml" target="_blank" rel="noopener noreferrer">
+          注册页面 <ExternalLink size={12} style={{ verticalAlign: "-1px" }} />
+        </a>
+      </p>
+      <div className="setting-row">
+        <input
+          type="password"
+          className="setting-control"
+          value={token}
+          onChange={(event) => setToken(event.target.value)}
+          placeholder={hasToken ? "已设置(留空不改)" : "assrt Token"}
+          aria-label="assrt Token"
+          autoComplete="off"
+        />
+        <button type="button" className="primary-button" onClick={handleSave} disabled={isPending}>
+          {isPending ? <LoaderCircle size={14} className="spin" aria-hidden /> : <Check size={14} aria-hidden />}
+          保存
+        </button>
+        {hasToken ? (
+          <button type="button" className="secondary-button" onClick={handleClear} disabled={isPending}>
+            <Trash2 size={14} aria-hidden />
+            清除
+          </button>
+        ) : null}
+      </div>
+      {result ? (
+        <p className="panel-note" style={{ marginTop: 10 }}>
+          {result}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/assrt-token-form.tsx
+++ b/apps/web/components/assrt-token-form.tsx
@@ -11,6 +11,13 @@ export function AssrtTokenForm({ tokenSet }: { tokenSet: boolean }) {
   const [result, setResult] = useState<string | null>(null);
 
   const handleSave = () => {
+    // Blank input: the server action would no-op yet report success — guard here
+    // so first-time setup never sees a misleading "保存成功".
+    if (!token.trim()) {
+      setResult("❌ 请输入 Token 后再保存");
+      setTimeout(() => setResult(null), 3000);
+      return;
+    }
     startTransition(async () => {
       const res = await saveAssrtTokenAction(token);
       setResult(res.success ? "✅ 保存成功" : `❌ ${res.message ?? "保存失败"}`);

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -684,11 +684,13 @@ function buildAccountContextResolver(): ResolveAccountWorkerContext {
     // 115→PanSou+Prowlarr). null when no drive resolves → default 115 fallback.
     const driveProvider =
       (await getAccountStorageCredentials(accountId, connectedStorageId))?.provider ?? "pan115";
+    const assrtToken = await getAssrtToken(scoped);
     return {
       storage: await getWorkerStorageExecutor(accountId, connectedStorageId),
       resourceProvider: await getWorkerResourceProvider(scoped, driveProvider),
       storageProvider: driveProvider,
       model,
+      ...(assrtToken === undefined ? {} : { assrtToken }),
       ...(preferredLanguage === undefined ? {} : { preferredLanguage }),
       ...(qualityPreference === undefined ? {} : { qualityPreference }),
       storageParentDirectoryId: parents.tv,

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -816,6 +816,18 @@ export async function getLlmConfig(repository: {
 
 export const TMDB_API_KEY_SETTING_KEY = "tmdb_api_key";
 
+export const ASSRT_TOKEN_SETTING_KEY = "assrt_token";
+
+/** The user's assrt.net subtitle API token (Settings → 字幕来源). Undefined when
+ *  unset/blank → the orchestrator skips the subtitle flow entirely (the agent
+ *  never sees viewSubtitleSnapshot/transferSubtitle). Free registration, BYO-token. */
+export async function getAssrtToken(
+  repository: { getSetting(key: string): Promise<string | null> },
+): Promise<string | undefined> {
+  const value = (await repository.getSetting(ASSRT_TOKEN_SETTING_KEY))?.trim();
+  return value ? value : undefined;
+}
+
 /** Author-deployed CF Worker that proxies TMDB with the author's key (KV-cached).
  *  env TMDB_PROXY_BASE_URL overrides it (e.g. a user who self-hosts the worker). */
 export const DEFAULT_TMDB_PROXY_BASE_URL = "https://media-track-tmdb-proxy.fancydirty.workers.dev";

--- a/packages/workflow/src/acquisition-v2/activity.ts
+++ b/packages/workflow/src/acquisition-v2/activity.ts
@@ -82,6 +82,15 @@ export function interpretTool(toolName: string, args: Record<string, unknown> = 
       }
       return { activity: `已确认 ${codes.length} 集入库`, phase: "mark" };
     }
+    // Subtitle tools (assrt 活期文档 flow). They run AFTER the video landed, so
+    // they weigh in the pick/organize bands — the monotonic clamp keeps the bar
+    // honest either way; the ticker text is what the user actually reads.
+    case "viewSubtitleSnapshot":
+      return { activity: "正在浏览字幕候选…", phase: "pick" };
+    case "transferSubtitle":
+      return { activity: "正在下载字幕…", phase: "organize" };
+    case "renameSubtitle":
+      return { activity: "正在重命名字幕…", phase: "organize" };
     case "finish":
       return { activity: "正在收尾…", phase: "finalize" };
     case "reportNoCoverage":

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -90,7 +90,9 @@ export function buildSandboxToolSet(
     movie?: boolean;
     /** When true, register viewSubtitleSnapshot + transferSubtitle (the "tool
      *  exists = this run needs subtitles" signal). Set by the orchestrator only
-     *  when assrtToken is configured AND the title is non-CN AND the drive is 115. */
+     *  when assrtToken is configured AND the title is non-CN AND the executor
+     *  can land external subtitle urls (transferSubtitleUrl capability probe —
+     *  today 115; any brand lights up by implementing the method). */
     subtitle?: boolean;
     onToolCall?: (toolName: string, args: Record<string, unknown>) => void;
     /** The run's drive brand — selects the brand-specific dead-links section. */
@@ -206,7 +208,7 @@ export function buildSandboxToolSet(
         "Land a chosen assrt subtitle package's files into staging. Pass the candidateId from viewSubtitleSnapshot. The system resolves the package's filelist (per-episode .ass/.srt with SxxExx filenames) and lands each via the drive's offline-task path. Returns the filenames that landed. Then RENAME each landed subtitle to match its video (same prefix, different extension) — subtitles are the ONLY files you may rename (a documented exception to the keep-original-name rule) so the scraper auto-loads them. Subtitle miss/empty filelist is a SOFT fail — it does NOT block video coverage; just proceed without subtitles.",
       inputSchema: z.object({ candidateId: z.number().int().positive() }),
       execute: (args: { candidateId: number }) =>
-        asEvidence(() => sandbox.transferSubtitle({ candidateId: args.candidateId, workflowRunId: "agent" })),
+        asEvidence(() => sandbox.transferSubtitle({ candidateId: args.candidateId })),
     };
     tools["renameSubtitle"] = {
       description:

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -225,6 +225,9 @@ export interface AcquisitionAgentRequest {
   maxSteps?: number;
   /** Movie task → expose the movie-only transferUntilLanded tool. */
   movie?: boolean;
+  /** When true, register the subtitle tools (viewSubtitleSnapshot + transferSubtitle).
+   *  Set by the orchestrator only when the subtitle gates pass. */
+  subtitle?: boolean;
   /** The run's drive brand — selects the brand-specific dead-links skill section. */
   storageProvider?: string;
   /** Per-tool-call live progress for the activity page (cleaned activity + phase
@@ -255,6 +258,7 @@ export async function runAcquisitionAgent(
   const onProgress = request.onProgress;
   const tools = buildSandboxToolSet(request.sandbox, {
     movie: request.movie ?? false,
+    ...(request.subtitle ? { subtitle: true } : {}),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
     ...(onProgress
       ? {

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -208,6 +208,13 @@ export function buildSandboxToolSet(
       execute: (args: { candidateId: number }) =>
         asEvidence(() => sandbox.transferSubtitle({ candidateId: args.candidateId, workflowRunId: "agent" })),
     };
+    tools["renameSubtitle"] = {
+      description:
+        "Rename a landed subtitle file (from transferSubtitle) to match its video: same filename prefix as the video, keep the subtitle extension (e.g. video Show.S02E01.mkv → subtitle Show.S02E01.ass). Pass the subtitle's fileId (from inspectStaging) + the newName. Subtitles are the ONLY files you may rename (the documented exception) so the scraper auto-loads them beside the video. Then move it into the season with its video via moveToSeason.",
+      inputSchema: z.object({ fileId: z.string(), newName: z.string() }),
+      execute: (args: { fileId: string; newName: string }) =>
+        asEvidence(() => sandbox.renameSubtitle(args)),
+    };
   }
   const toolSet = tools as ToolSet;
   return wrapTools(toolSet, {

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -88,6 +88,10 @@ export function buildSandboxToolSet(
   sandbox: TaskSandbox,
   options: {
     movie?: boolean;
+    /** When true, register viewSubtitleSnapshot + transferSubtitle (the "tool
+     *  exists = this run needs subtitles" signal). Set by the orchestrator only
+     *  when assrtToken is configured AND the title is non-CN AND the drive is 115. */
+    subtitle?: boolean;
     onToolCall?: (toolName: string, args: Record<string, unknown>) => void;
     /** The run's drive brand — selects the brand-specific dead-links section. */
     storageProvider?: string;
@@ -188,6 +192,21 @@ export function buildSandboxToolSet(
         'Movie only. Transfer a PRIORITY-ORDERED list of candidates you judged to be the SAME target film (best resource first), stopping at the FIRST that 秒传-lands; the rest are abandoned. 115 SHARE LINKS ONLY — magnets do NOT fail loud, so for a magnet use transferCandidate and verify via inspectStaging. YOU pick the set (a keyword search returns same-named DIFFERENT works — never hand it everything); the system just burns through the dead links for you (链接已过期/分享已取消/错误的链接 are common). Returns {landed, transferredCandidateId, attempts}. Use this when several 115 shares for the one film may be dead/black-box; for a single obvious share, transferCandidate is fine.',
       inputSchema: z.object({ candidateIds: z.array(z.string()) }),
       execute: (args: { candidateIds: string[] }) => asEvidence(() => sandbox.transferUntilLanded(args)),
+    };
+  }
+  if (options.subtitle) {
+    tools["viewSubtitleSnapshot"] = {
+      description:
+        "View the system's pre-warmed assrt.net subtitle snapshot (活期文档). Read-only, free, repeatable. The system already searched assrt for this title's bare name; this returns the candidate subtitle packages (id + title + language tag). THIS TOOL APPEARING IN YOUR TOOLSET means this run needs external Chinese subtitles — read it and pick a package whose language covers your need (简/繁/双语), then transferSubtitle to land its files.",
+      inputSchema: z.object({}),
+      execute: () => Promise.resolve(sandbox.viewSubtitleSnapshot()),
+    };
+    tools["transferSubtitle"] = {
+      description:
+        "Land a chosen assrt subtitle package's files into staging. Pass the candidateId from viewSubtitleSnapshot. The system resolves the package's filelist (per-episode .ass/.srt with SxxExx filenames) and lands each via 115's offline-task path. Returns the filenames that landed. Then RENAME each landed subtitle to match its video (same prefix, different extension) — subtitles are the ONLY files you may rename (a documented exception to the keep-original-name rule) so the scraper auto-loads them. Subtitle miss/empty filelist is a SOFT fail — it does NOT block video coverage; just proceed without subtitles.",
+      inputSchema: z.object({ candidateId: z.number().int().positive() }),
+      execute: (args: { candidateId: number }) =>
+        asEvidence(() => sandbox.transferSubtitle({ candidateId: args.candidateId, workflowRunId: "agent" })),
     };
   }
   const toolSet = tools as ToolSet;

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -1,7 +1,7 @@
 import { generateText, stepCountIs, type LanguageModel, type ToolSet } from "ai";
 import { z } from "zod";
 import type { TaskSandbox } from "./sandbox.js";
-import { readSkillSection } from "./skill.js";
+import { readSkillSection, SKILL_SECTION_NAMES } from "./skill.js";
 import {
   DEFAULT_MAX_STEPS,
   buildRepetitionStop,
@@ -102,7 +102,9 @@ export function buildSandboxToolSet(
   const tools: Record<string, unknown> = {
     readSkill: {
       description:
-        "Read a section of your domain skill manual ON DEMAND — the hard-won playbook for HOW to act. Sections: protocol, dead-links-black-box, dedup, movie, tv, mistakes. Read your sections before you act, and re-read the relevant one the moment its situation arises. Acting from memory instead of the skill is how the old agent hammered the drive and corrupted libraries.",
+        // Section list derived from SKILL_SECTION_NAMES — the single source of
+        // truth — so adding a section can never leave this description stale.
+        `Read a section of your domain skill manual ON DEMAND — the hard-won playbook for HOW to act. Sections: ${SKILL_SECTION_NAMES.join(", ")}. Read your sections before you act, and re-read the relevant one the moment its situation arises. Acting from memory instead of the skill is how the old agent hammered the drive and corrupted libraries.`,
       inputSchema: z.object({ section: z.string() }),
       execute: (args: { section: string }) =>
         Promise.resolve({ section: args.section, body: readSkillSection(args.section, options.storageProvider) }),

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -197,13 +197,13 @@ export function buildSandboxToolSet(
   if (options.subtitle) {
     tools["viewSubtitleSnapshot"] = {
       description:
-        "View the system's pre-warmed assrt.net subtitle snapshot (活期文档). Read-only, free, repeatable. The system already searched assrt for this title's bare name; this returns the candidate subtitle packages (id + title + language tag). THIS TOOL APPEARING IN YOUR TOOLSET means this run needs external Chinese subtitles — read it and pick a package whose language covers your need (简/繁/双语), then transferSubtitle to land its files.",
+        "View the system's pre-warmed assrt.net subtitle snapshot (活期文档). Read-only, free, repeatable. The system already searched assrt for this title's bare name; this returns the candidate subtitle packages (id + title + language tag, plus community evidence when available: ★vote score / 字幕组 / upload time). THIS TOOL APPEARING IN YOUR TOOLSET means this run needs external Chinese subtitles — read it and pick a package whose language covers your need (简/繁/双语), weighing higher ★ and a known 字幕组 as community-validated quality, then transferSubtitle to land its files.",
       inputSchema: z.object({}),
       execute: () => Promise.resolve(sandbox.viewSubtitleSnapshot()),
     };
     tools["transferSubtitle"] = {
       description:
-        "Land a chosen assrt subtitle package's files into staging. Pass the candidateId from viewSubtitleSnapshot. The system resolves the package's filelist (per-episode .ass/.srt with SxxExx filenames) and lands each via 115's offline-task path. Returns the filenames that landed. Then RENAME each landed subtitle to match its video (same prefix, different extension) — subtitles are the ONLY files you may rename (a documented exception to the keep-original-name rule) so the scraper auto-loads them. Subtitle miss/empty filelist is a SOFT fail — it does NOT block video coverage; just proceed without subtitles.",
+        "Land a chosen assrt subtitle package's files into staging. Pass the candidateId from viewSubtitleSnapshot. The system resolves the package's filelist (per-episode .ass/.srt with SxxExx filenames) and lands each via the drive's offline-task path. Returns the filenames that landed. Then RENAME each landed subtitle to match its video (same prefix, different extension) — subtitles are the ONLY files you may rename (a documented exception to the keep-original-name rule) so the scraper auto-loads them. Subtitle miss/empty filelist is a SOFT fail — it does NOT block video coverage; just proceed without subtitles.",
       inputSchema: z.object({ candidateId: z.number().int().positive() }),
       execute: (args: { candidateId: number }) =>
         asEvidence(() => sandbox.transferSubtitle({ candidateId: args.candidateId, workflowRunId: "agent" })),

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -134,15 +134,19 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
 
   // Pre-warm the assrt subtitle snapshot when all three gates pass: token
   // configured, non-CN origin (国产内容 natively Chinese-spoken, no 中字 to find),
-  // and the drive is 115 (phase 1 only — quark/guangya have no subtitle landing
-  // path). Soft-fail: a flaky assrt / empty search sets an empty snapshot, never
-  // blocks the video task. When the gates don't pass, the subtitle tools are
-  // simply not registered (the agent never knows subtitles were an option).
+  // and the EXECUTOR can land external subtitle urls. The third gate is a
+  // CAPABILITY probe (transferSubtitleUrl presence), not a brand string — the
+  // day the 光鸭/夸克 executor implements the method, subtitles light up there
+  // automatically, and the gate can never disagree with what the executor can
+  // actually do (today only 115 implements it). Soft-fail: a flaky assrt /
+  // empty search sets an empty snapshot, never blocks the video task. When the
+  // gates don't pass, the subtitle tools are simply not registered (the agent
+  // never knows subtitles were an option).
   const subtitleActive =
     request.assrtToken !== undefined &&
     request.assrtToken.trim() !== "" &&
     (request.originCountries ?? []).every((c) => c !== "CN") &&
-    (request.storageProvider ?? "pan115") === "pan115";
+    typeof request.executor.transferSubtitleUrl === "function";
   if (subtitleActive) {
     const subtitleProvider: AssrtProviderPort =
       request.assrtProvider ?? new AssrtSubtitleProvider({ token: request.assrtToken! });

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -133,30 +133,36 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
   }
 
   // Pre-warm the assrt subtitle snapshot when all three gates pass: token
-  // configured, non-CN origin (国产内容 natively Chinese-spoken, no 中字 to find),
-  // and the EXECUTOR can land external subtitle urls. UNKNOWN origin (undefined/
-  // empty originCountries — missing TMDB metadata) deliberately counts as
-  // non-CN: the spec gate is "not known to be 国产", and the failure mode is
-  // soft-and-cheap (a CN title just gets an empty assrt snapshot + "proceed
-  // without subtitles"), whereas requiring KNOWN non-CN would silently drop
-  // subtitles for every foreign title with missing metadata. The third gate is a
-  // CAPABILITY probe (transferSubtitleUrl presence), not a brand string — the
-  // day the 光鸭/夸克 executor implements the method, subtitles light up there
-  // automatically, and the gate can never disagree with what the executor can
-  // actually do (today only 115 implements it). Soft-fail: a flaky assrt /
-  // empty search sets an empty snapshot, never blocks the video task. When the
-  // gates don't pass, the subtitle tools are simply not registered (the agent
-  // never knows subtitles were an option).
+  // configured, KNOWN non-CN origin, and the EXECUTOR can land external
+  // subtitle urls. UNKNOWN origin (undefined/empty originCountries — missing
+  // TMDB metadata) counts as NOT eligible: niche 国产短剧 are precisely the
+  // titles most likely to lack origin metadata, while mainstream foreign
+  // titles essentially always carry it — and a false positive here recurs on
+  // EVERY patrol tick, burning the shared assrt quota (20/min) and confusing
+  // the agent with subtitle tools on a natively-Chinese title. Requiring known
+  // non-CN loses almost nothing and matches the UI copy (仅对非国产内容生效).
+  // The third gate is a CAPABILITY probe (transferSubtitleUrl presence), not a
+  // brand string — the day the 光鸭/夸克 executor implements the method,
+  // subtitles light up there automatically, and the gate can never disagree
+  // with what the executor can actually do (today only 115 implements it).
+  // Soft-fail: a flaky assrt / empty search sets an empty snapshot, never
+  // blocks the video task. When the gates don't pass, the subtitle tools are
+  // simply not registered (the agent never knows subtitles were an option).
+  const origins = request.originCountries ?? [];
   const subtitleActive =
     request.assrtToken !== undefined &&
     request.assrtToken.trim() !== "" &&
-    (request.originCountries ?? []).every((c) => c !== "CN") &&
+    origins.length > 0 &&
+    origins.every((c) => c !== "CN") &&
     typeof request.executor.transferSubtitleUrl === "function";
+  let subtitleCandidateCount: number | undefined;
   if (subtitleActive) {
     const subtitleProvider: AssrtProviderPort =
       request.assrtProvider ?? new AssrtSubtitleProvider({ token: request.assrtToken! });
     try {
       await sandbox.primeSubtitleSnapshot(request.target.title, subtitleProvider);
+      // Feed the prompt pointer line (the 活期文档 twin of prefetchedCandidateCount).
+      subtitleCandidateCount = sandbox.viewSubtitleSnapshot().candidateCount;
     } catch {
       // assrt unavailable → empty snapshot; the subtitle tools still register
       // (viewSubtitleSnapshot will show "no snapshot"), agent decides from there.
@@ -173,6 +179,7 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
     ...(request.qualityGuidance === undefined ? {} : { qualityGuidance: request.qualityGuidance }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
     ...(subtitleActive ? { subtitle: true } : {}),
+    ...(subtitleCandidateCount ? { subtitleCandidateCount } : {}),
     ...(request.onProgress ? { onProgress: request.onProgress } : {}),
     // Real 115 exposes its cumulative call count → drives the budget soft-warning
     // in the agent loop; fakes/sim omit apiCallCount → no nudge.

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -9,6 +9,7 @@ import { RealResourceProviderV2 } from "./real-provider-adapter.js";
 import { RealStorageV2 } from "./real-storage-adapter.js";
 import { budgetSoftThreshold } from "./agent-loop-guards.js";
 import { TaskSandbox } from "./sandbox.js";
+import { AssrtSubtitleProvider, type AssrtProviderPort } from "../subtitle-provider.js";
 import {
   needForMovie,
   needForTvTarget,
@@ -58,6 +59,14 @@ export interface RunAcquisitionV2Request {
   /** Filters known-dead candidates from search results before the agent sees them,
    *  and records newly-proven-dead links from failed transfers (#15). */
   deadLinkStore?: DeadLinkStore;
+  /** assrt token (Settings → 字幕来源). When set AND origin is non-CN AND the
+   *  drive is 115, the orchestrator pre-warms a subtitle snapshot and the agent
+   *  gets viewSubtitleSnapshot/transferSubtitle tools. Undefined/empty = no
+   *  subtitle flow (the agent never sees those tools). */
+  assrtToken?: string;
+  /** Injectable assrt provider (tests pass a spy). When absent, the orchestrator
+   *  builds a real AssrtSubtitleProvider from assrtToken. */
+  assrtProvider?: AssrtProviderPort;
   /** Per-tool-call live progress for the activity page (best-effort). */
   onProgress?: (event: AgentToolEvent) => void;
 }
@@ -123,6 +132,28 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
     prefetchedCandidateCount = undefined;
   }
 
+  // Pre-warm the assrt subtitle snapshot when all three gates pass: token
+  // configured, non-CN origin (国产内容 natively Chinese-spoken, no 中字 to find),
+  // and the drive is 115 (phase 1 only — quark/guangya have no subtitle landing
+  // path). Soft-fail: a flaky assrt / empty search sets an empty snapshot, never
+  // blocks the video task. When the gates don't pass, the subtitle tools are
+  // simply not registered (the agent never knows subtitles were an option).
+  const subtitleActive =
+    request.assrtToken !== undefined &&
+    request.assrtToken.trim() !== "" &&
+    (request.originCountries ?? []).every((c) => c !== "CN") &&
+    (request.storageProvider ?? "pan115") === "pan115";
+  if (subtitleActive) {
+    const subtitleProvider: AssrtProviderPort =
+      request.assrtProvider ?? new AssrtSubtitleProvider({ token: request.assrtToken! });
+    try {
+      await sandbox.primeSubtitleSnapshot(request.target.title, subtitleProvider);
+    } catch {
+      // assrt unavailable → empty snapshot; the subtitle tools still register
+      // (viewSubtitleSnapshot will show "no snapshot"), agent decides from there.
+    }
+  }
+
   const common = {
     sandbox,
     model: request.model,
@@ -132,6 +163,7 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
     ...(request.searchHints === undefined ? {} : { searchHints: request.searchHints }),
     ...(request.qualityGuidance === undefined ? {} : { qualityGuidance: request.qualityGuidance }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
+    ...(subtitleActive ? { subtitle: true } : {}),
     ...(request.onProgress ? { onProgress: request.onProgress } : {}),
     // Real 115 exposes its cumulative call count → drives the budget soft-warning
     // in the agent loop; fakes/sim omit apiCallCount → no nudge.

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -134,7 +134,12 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
 
   // Pre-warm the assrt subtitle snapshot when all three gates pass: token
   // configured, non-CN origin (国产内容 natively Chinese-spoken, no 中字 to find),
-  // and the EXECUTOR can land external subtitle urls. The third gate is a
+  // and the EXECUTOR can land external subtitle urls. UNKNOWN origin (undefined/
+  // empty originCountries — missing TMDB metadata) deliberately counts as
+  // non-CN: the spec gate is "not known to be 国产", and the failure mode is
+  // soft-and-cheap (a CN title just gets an empty assrt snapshot + "proceed
+  // without subtitles"), whereas requiring KNOWN non-CN would silently drop
+  // subtitles for every foreign title with missing metadata. The third gate is a
   // CAPABILITY probe (transferSubtitleUrl presence), not a brand string — the
   // day the 光鸭/夸克 executor implements the method, subtitles light up there
   // automatically, and the gate can never disagree with what the executor can

--- a/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
+++ b/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
@@ -117,7 +117,6 @@ export class RealStorageV2 implements StorageV2 {
     url: string;
     filename: string;
     intoDirectoryId: string;
-    workflowRunId?: string;
   }): Promise<TransferAttemptResult> {
     if (!this.executor.transferSubtitleUrl) {
       throw new Error("REAL_STORAGE_NO_SUBTITLE_SUPPORT: this storage brand has no transferSubtitleUrl");
@@ -126,6 +125,8 @@ export class RealStorageV2 implements StorageV2 {
       url: input.url,
       filename: input.filename,
       directoryId: input.intoDirectoryId,
+      // Run identity comes from THIS adapter instance — StorageV2 callers can't
+      // (and shouldn't) override it, so the input carries no workflowRunId.
       workflowRunId: this.workflowRunId,
     });
     // Deliberately NOT recorded into recordedAttempts: those are the video-candidate

--- a/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
+++ b/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
@@ -128,7 +128,12 @@ export class RealStorageV2 implements StorageV2 {
       directoryId: input.intoDirectoryId,
       workflowRunId: this.workflowRunId,
     });
-    this.recordedAttempts.push(attempt);
+    // Deliberately NOT recorded into recordedAttempts: those are the video-candidate
+    // transfer trace, and validateWorkflowRunSnapshot requires every persisted
+    // transferAttempt.candidateId to belong to a resource snapshot. A subtitle
+    // attempt's synthetic `subtitle:<filename>` candidateId has no snapshot, so
+    // persisting it would abort the whole run's snapshot save AFTER the video already
+    // landed. Subtitles are a soft side-channel — kept out of the video trace.
     return {
       status: attempt.status === "succeeded" ? "succeeded" : "failed",
       materializedFileIds: attempt.materializedFileIds,

--- a/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
+++ b/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
@@ -117,6 +117,7 @@ export class RealStorageV2 implements StorageV2 {
     url: string;
     filename: string;
     intoDirectoryId: string;
+    workflowRunId?: string;
   }): Promise<TransferAttemptResult> {
     if (!this.executor.transferSubtitleUrl) {
       throw new Error("REAL_STORAGE_NO_SUBTITLE_SUPPORT: this storage brand has no transferSubtitleUrl");

--- a/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
+++ b/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
@@ -113,6 +113,28 @@ export class RealStorageV2 implements StorageV2 {
     };
   }
 
+  async transferSubtitleUrl(input: {
+    url: string;
+    filename: string;
+    intoDirectoryId: string;
+  }): Promise<TransferAttemptResult> {
+    if (!this.executor.transferSubtitleUrl) {
+      throw new Error("REAL_STORAGE_NO_SUBTITLE_SUPPORT: this storage brand has no transferSubtitleUrl");
+    }
+    const attempt = await this.executor.transferSubtitleUrl({
+      url: input.url,
+      filename: input.filename,
+      directoryId: input.intoDirectoryId,
+      workflowRunId: this.workflowRunId,
+    });
+    this.recordedAttempts.push(attempt);
+    return {
+      status: attempt.status === "succeeded" ? "succeeded" : "failed",
+      materializedFileIds: attempt.materializedFileIds,
+      ...(attempt.providerMessage ? { providerMessage: attempt.providerMessage } : {}),
+    };
+  }
+
   async listTree(input: { directoryId: string }): Promise<SimTreeFile[]> {
     const tree = await this.executor.listTree({ directoryId: input.directoryId });
     return tree.map((file) => ({

--- a/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
+++ b/packages/workflow/src/acquisition-v2/real-storage-adapter.ts
@@ -154,6 +154,10 @@ export class RealStorageV2 implements StorageV2 {
     return this.executor.moveFiles(input);
   }
 
+  async renameFile(input: { directoryId: string; fileId: string; newName: string }): Promise<void> {
+    return this.executor.renameFile(input);
+  }
+
   async deleteFiles(input: { directoryId: string; fileIds: string[] }): Promise<{ deleted: string[] }> {
     return this.executor.deleteFiles(input);
   }

--- a/packages/workflow/src/acquisition-v2/run-tv-v2.ts
+++ b/packages/workflow/src/acquisition-v2/run-tv-v2.ts
@@ -43,6 +43,8 @@ export interface RunTvAcquisitionV2Request {
   qualityPreference?: "high" | "medium";
   /** The run's drive brand ("pan115" | "quark") — selects brand-specific skill. */
   storageProvider?: string;
+  /** assrt token (Settings → 字幕来源). Undefined = 字幕流程不触发。 */
+  assrtToken?: string;
   deadLinkStore?: DeadLinkStore;
   onProgress?: (event: AgentToolEvent) => void;
   now?: () => string;
@@ -83,6 +85,7 @@ export async function runTvAcquisitionV2(request: RunTvAcquisitionV2Request): Pr
     ...(request.preferredLanguage === undefined ? {} : { preferredLanguage: request.preferredLanguage }),
     ...(request.title.originCountries === undefined ? {} : { originCountries: request.title.originCountries }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
+    ...(request.assrtToken === undefined ? {} : { assrtToken: request.assrtToken }),
     ...(request.deadLinkStore ? { deadLinkStore: request.deadLinkStore } : {}),
     ...(request.onProgress ? { onProgress: request.onProgress } : {}),
   });

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -6,6 +6,7 @@ import {
   keywordReferencesTitle,
   normalizeSearchKeyword,
 } from "../planning-search-gate.js";
+import type { AssrtCandidate, AssrtSubtitleFile } from "../subtitle-provider.js";
 import type { ResourceProviderV2, ResourceSnapshotV2 } from "./fake-provider.js";
 import type { SimTreeFile, StorageV2, TransferAttemptResult } from "./storage-115-simulator.js";
 import { isSystemicTransferBlockMessage } from "./transfer-block.js";
@@ -74,6 +75,13 @@ export interface TaskSandboxOptions {
    *  coverage (flagged 可能无中字) rather than reportNoCoverage. TV/anime leave
    *  this false so the 中文 floor stays HARD (no 生肉 dumping). */
   subtitleFallback?: boolean;
+  /** assrt subtitle provider — when present AND the run is non-CN on a 115 drive,
+   *  the orchestrator pre-warms a subtitle snapshot and the agent gets
+   *  viewSubtitleSnapshot / transferSubtitle tools. Undefined = no subtitle flow. */
+  subtitleProvider?: {
+    search(keyword: string): Promise<AssrtCandidate[]>;
+    detail(id: number): Promise<AssrtSubtitleFile[]>;
+  };
 }
 
 export interface SearchToolResult {
@@ -127,6 +135,13 @@ export class TaskSandbox {
   /** Raw snapshot from pre-warming (system-initiated search). Stored so
    *  viewResourceSnapshot can return it multiple times without cost. */
   private rawSnapshot: ResourceSnapshotV2 | null = null;
+  /** assrt provider remembered from primeSubtitleSnapshot so transferSubtitle can
+   *  later call detail() without the agent re-passing it. Reassigned on prime, so
+   *  NOT readonly — mirrors rawSnapshot. */
+  private subtitleProvider: TaskSandboxOptions["subtitleProvider"];
+  /** Pre-warmed assrt candidates (id + title + lang), like rawSnapshot for video.
+   *  Reassigned by primeSubtitleSnapshot, so NOT readonly. */
+  private subtitleSnapshot: AssrtCandidate[] | null = null;
 
   constructor(options: TaskSandboxOptions) {
     this.provider = options.provider;
@@ -144,6 +159,7 @@ export class TaskSandbox {
     this.movieDir = options.targetMovieDirectoryId;
     this.need = options.need ?? [];
     this.titleTerms = options.titleTerms ?? [];
+    this.subtitleProvider = options.subtitleProvider;
   }
 
   /** Every scoped target directory (all seasons + the movie) — the union used for
@@ -649,5 +665,98 @@ export class TaskSandbox {
     }
 
     return { document, candidateCount: total };
+  }
+
+  /** Pre-warm the assrt subtitle snapshot (system-initiated, like primeRawSnapshot).
+   *  Stores candidates so viewSubtitleSnapshot can render them repeatedly for free.
+   *  Soft-fails (empty snapshot) on any provider miss — never throws, so a flaky
+   *  assrt / a no-result search never blocks the video task. */
+  async primeSubtitleSnapshot(
+    keyword: string,
+    provider: { search(k: string): Promise<AssrtCandidate[]>; detail(id: number): Promise<AssrtSubtitleFile[]> },
+  ): Promise<void> {
+    try {
+      this.subtitleSnapshot = await provider.search(keyword);
+      this.subtitleProvider = provider; // remember detail() for transferSubtitle
+    } catch {
+      this.subtitleSnapshot = [];
+    }
+  }
+
+  /** Read-only view of the pre-warmed subtitle candidates as a structured doc.
+   *  Free, repeatable. The agent reads this to pick which subtitle package to land. */
+  viewSubtitleSnapshot(): { document: string; candidateCount: number } {
+    if (!this.subtitleSnapshot || this.subtitleSnapshot.length === 0) {
+      return {
+        document: "No subtitle snapshot available (未配置 assrt token / 国产内容 / 预搜无结果). Call primeSubtitleSnapshot first or skip subtitles.",
+        candidateCount: 0,
+      };
+    }
+    const candidates = this.subtitleSnapshot;
+    let document = `📋 Subtitle snapshot (${candidates.length} candidates from assrt.net):\n\n`;
+    for (const candidate of candidates) {
+      const lang = candidate.lang ? ` [${candidate.lang}]` : "";
+      document += `[${candidate.id}] ${candidate.title}${lang}\n`;
+    }
+    return { document, candidateCount: candidates.length };
+  }
+
+  /** Land a chosen subtitle package's files into staging via the 115 offline-task
+   *  path (transferSubtitleUrl). Resolves the package's filelist via detail(),
+   *  submits each file's url, returns the filenames that actually landed. The
+   *  agent then renames them (moveToSeason/flattenMovie) to ride beside the video.
+   *  Soft-fails: empty filelist → {status:"failed", landedFilenames:[]}. */
+  async transferSubtitle(input: {
+    candidateId: number;
+    workflowRunId?: string;
+  }): Promise<{ status: "succeeded" | "failed"; landedFilenames: string[]; error?: string }> {
+    if (!this.storage || !this.stagingDirectoryId) {
+      throw new Error("SANDBOX: no storage/staging handle configured for subtitle transfer");
+    }
+    if (!this.subtitleProvider) {
+      throw new Error("SANDBOX_NO_SUBTITLE_PROVIDER: subtitle flow was not primed");
+    }
+    if (!this.subtitleSnapshot || !this.subtitleSnapshot.some((c) => c.id === input.candidateId)) {
+      throw new Error(
+        `SANDBOX_SUBTITLE_NOT_IN_SNAPSHOT: candidate ${input.candidateId} was not in the pre-warmed subtitle snapshot`,
+      );
+    }
+    const workflowRunId = input.workflowRunId ?? "agent";
+    let files: AssrtSubtitleFile[];
+    try {
+      files = await this.subtitleProvider.detail(input.candidateId);
+    } catch {
+      return { status: "failed", landedFilenames: [] };
+    }
+    if (files.length === 0) {
+      return { status: "failed", landedFilenames: [] };
+    }
+    const landedFilenames: string[] = [];
+    let lastError: string | undefined;
+    for (const file of files) {
+      try {
+        const result = await this.storage.transferSubtitleUrl({
+          url: file.url,
+          filename: file.filename,
+          intoDirectoryId: this.stagingDirectoryId,
+          workflowRunId,
+        });
+        if (result.status === "succeeded") {
+          landedFilenames.push(file.filename);
+        } else if (result.providerMessage) {
+          lastError = result.providerMessage;
+        }
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      }
+    }
+    if (landedFilenames.length === 0 && lastError === undefined) {
+      lastError = "subtitle transfer failed (no files landed, no provider message)";
+    }
+    return {
+      status: landedFilenames.length > 0 ? "succeeded" : "failed",
+      landedFilenames,
+      ...(lastError ? { error: lastError } : {}),
+    };
   }
 }

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -756,4 +756,23 @@ export class TaskSandbox {
       ...(lastError ? { error: lastError } : {}),
     };
   }
+
+  /** Rename a landed subtitle file in staging (the ONE rename exception — subtitles
+   *  are renamed to match their video so scrapers auto-load them). Scope-guarded to
+   *  THIS task's staging: the fileId must currently be in staging. */
+  async renameSubtitle(input: { fileId: string; newName: string }): Promise<{ renamed: string }> {
+    if (!this.storage || !this.stagingDirectoryId) {
+      throw new Error("SANDBOX: no storage/staging handle configured for subtitle rename");
+    }
+    const staging = await this.storage.listTree({ directoryId: this.stagingDirectoryId });
+    if (!staging.some((file) => file.id === input.fileId)) {
+      throw new Error(`SANDBOX_FILE_NOT_IN_STAGING: ${input.fileId} is not in this task's staging`);
+    }
+    await this.storage.renameFile({
+      directoryId: this.stagingDirectoryId,
+      fileId: input.fileId,
+      newName: input.newName,
+    });
+    return { renamed: input.newName };
+  }
 }

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -714,7 +714,6 @@ export class TaskSandbox {
    *  Soft-fails: empty filelist → {status:"failed", landedFilenames:[]}. */
   async transferSubtitle(input: {
     candidateId: number;
-    workflowRunId?: string;
   }): Promise<{ status: "succeeded" | "failed"; landedFilenames: string[]; error?: string }> {
     if (!this.storage || !this.stagingDirectoryId) {
       throw new Error("SANDBOX: no storage/staging handle configured for subtitle transfer");
@@ -727,7 +726,6 @@ export class TaskSandbox {
         `SANDBOX_SUBTITLE_NOT_IN_SNAPSHOT: candidate ${input.candidateId} was not in the pre-warmed subtitle snapshot`,
       );
     }
-    const workflowRunId = input.workflowRunId ?? "agent";
     let files: AssrtSubtitleFile[];
     try {
       files = await this.subtitleProvider.detail(input.candidateId);
@@ -767,7 +765,6 @@ export class TaskSandbox {
           url: file.url,
           filename: file.filename,
           intoDirectoryId: this.stagingDirectoryId,
-          workflowRunId,
         });
         if (result.status === "succeeded") {
           landedFilenames.push(file.filename);

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -6,7 +6,7 @@ import {
   keywordReferencesTitle,
   normalizeSearchKeyword,
 } from "../planning-search-gate.js";
-import type { AssrtCandidate, AssrtSubtitleFile } from "../subtitle-provider.js";
+import type { AssrtCandidate, AssrtSubtitleFile, AssrtProviderPort } from "../subtitle-provider.js";
 import type { ResourceProviderV2, ResourceSnapshotV2 } from "./fake-provider.js";
 import type { SimTreeFile, StorageV2, TransferAttemptResult } from "./storage-115-simulator.js";
 import { isSystemicTransferBlockMessage } from "./transfer-block.js";
@@ -78,10 +78,7 @@ export interface TaskSandboxOptions {
   /** assrt subtitle provider — when present AND the run is non-CN on a 115 drive,
    *  the orchestrator pre-warms a subtitle snapshot and the agent gets
    *  viewSubtitleSnapshot / transferSubtitle tools. Undefined = no subtitle flow. */
-  subtitleProvider?: {
-    search(keyword: string): Promise<AssrtCandidate[]>;
-    detail(id: number): Promise<AssrtSubtitleFile[]>;
-  };
+  subtitleProvider?: AssrtProviderPort;
 }
 
 export interface SearchToolResult {
@@ -673,7 +670,7 @@ export class TaskSandbox {
    *  assrt / a no-result search never blocks the video task. */
   async primeSubtitleSnapshot(
     keyword: string,
-    provider: { search(k: string): Promise<AssrtCandidate[]>; detail(id: number): Promise<AssrtSubtitleFile[]> },
+    provider: AssrtProviderPort,
   ): Promise<void> {
     try {
       this.subtitleSnapshot = await provider.search(keyword);

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -737,6 +737,21 @@ export class TaskSandbox {
     if (files.length === 0) {
       return { status: "failed", landedFilenames: [] };
     }
+    // Boundary guard (same class as the rename guard): only subtitle-extension
+    // files may ride the landing pipeline. assrt's detail() can return a
+    // whole-package .zip fallback or stray readme/fonts entries — those would
+    // land as unusable junk in staging (renameSubtitle rejects them, cleanup has
+    // to sweep them) while burning real 115 API budget, and a zip-only landing
+    // would report a misleading "succeeded".
+    const subtitleFiles = files.filter((file) => SUBTITLE_NAME_PATTERN.test(file.filename));
+    if (subtitleFiles.length === 0) {
+      return {
+        status: "failed",
+        landedFilenames: [],
+        error:
+          "该字幕包没有可直接落盘的字幕文件(整包压缩包 zip/rar 落盘也无法使用)——换一个候选,或放弃字幕(软目标,不阻塞视频)。",
+      };
+    }
     const landedFilenames: string[] = [];
     let lastError: string | undefined;
     // Budget guard: each failed landing costs real 115 API calls (offline task +
@@ -745,8 +760,8 @@ export class TaskSandbox {
     // whole filelist (a success resets the counter: mixed flakiness still lands).
     const MAX_CONSECUTIVE_FAILURES = 3;
     let consecutiveFailures = 0;
-    for (let i = 0; i < files.length; i += 1) {
-      const file = files[i]!;
+    for (let i = 0; i < subtitleFiles.length; i += 1) {
+      const file = subtitleFiles[i]!;
       try {
         const result = await this.storage.transferSubtitleUrl({
           url: file.url,
@@ -768,7 +783,7 @@ export class TaskSandbox {
         lastError = error instanceof Error ? error.message : String(error);
       }
       if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-        lastError = `已连续 ${MAX_CONSECUTIVE_FAILURES} 个字幕文件落盘失败,提前中止(剩余 ${files.length - i - 1} 个未尝试)。字幕是软目标——不要重试,带着已落的继续,或直接只交付视频。${lastError ? ` 最后错误: ${lastError}` : ""}`;
+        lastError = `已连续 ${MAX_CONSECUTIVE_FAILURES} 个字幕文件落盘失败,提前中止(剩余 ${subtitleFiles.length - i - 1} 个未尝试)。字幕是软目标——不要重试,带着已落的继续,或直接只交付视频。${lastError ? ` 最后错误: ${lastError}` : ""}`;
         break;
       }
     }

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -18,6 +18,8 @@ import { isSystemicTransferBlockMessage } from "./transfer-block.js";
 const QUALITY_SUBTITLE_TOKEN =
   /\b(?:4k|2160p|1080p|720p|hdr|dv|remux|web-?dl|bluray|bdrip)\b|蓝光|中字|国语|双语|字幕/gi;
 
+const SUBTITLE_NAME_PATTERN = /\.(srt|ass|ssa|sub|idx|vtt|sup|smi)$/i;
+
 const STRIP_NOTICE =
   "已从关键词移除画质/字幕词(如 4K/1080p/蓝光/中字/字幕):PanSou 是通配符匹配,加这些只会把召回打成子集或归零,raw 裸标题召回最全。已改用裸标题搜索。";
 
@@ -765,8 +767,23 @@ export class TaskSandbox {
       throw new Error("SANDBOX: no storage/staging handle configured for subtitle rename");
     }
     const staging = await this.storage.listTree({ directoryId: this.stagingDirectoryId });
-    if (!staging.some((file) => file.id === input.fileId)) {
+    const target = staging.find((file) => file.id === input.fileId);
+    if (!target) {
       throw new Error(`SANDBOX_FILE_NOT_IN_STAGING: ${input.fileId} is not in this task's staging`);
+    }
+    // Enforce the "subtitles are the ONLY renameable files" rule at the tool boundary
+    // (the sandbox makes the documented mistake impossible, rather than trusting the
+    // agent): the SOURCE must be a subtitle, the NEW name must stay a subtitle (so a
+    // model slip can't disguise a video), and the new name must be a bare filename
+    // (no path separators — rename is not a move).
+    if (!target.isSubtitle) {
+      throw new Error(`SANDBOX_NOT_A_SUBTITLE: ${input.fileId} is not a subtitle file; only subtitles may be renamed`);
+    }
+    if (/[\\/]/.test(input.newName)) {
+      throw new Error(`SANDBOX_INVALID_SUBTITLE_NAME: newName must be a bare filename without path separators`);
+    }
+    if (!SUBTITLE_NAME_PATTERN.test(input.newName)) {
+      throw new Error(`SANDBOX_INVALID_SUBTITLE_NAME: newName must keep a subtitle extension (.srt/.ass/.ssa/.sub/.idx/.vtt/.sup/.smi)`);
     }
     await this.storage.renameFile({
       directoryId: this.stagingDirectoryId,

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -692,10 +692,17 @@ export class TaskSandbox {
       };
     }
     const candidates = this.subtitleSnapshot;
-    let document = `📋 Subtitle snapshot (${candidates.length} candidates from assrt.net):\n\n`;
+    let document = `📋 Subtitle snapshot (${candidates.length} candidates from assrt.net; ★=社区评分,组=字幕组 — 大家验证过的证据,语义权衡用):\n\n`;
     for (const candidate of candidates) {
       const lang = candidate.lang ? ` [${candidate.lang}]` : "";
-      document += `[${candidate.id}] ${candidate.title}${lang}\n`;
+      const evidence = [
+        candidate.voteScore === undefined ? "" : `★${candidate.voteScore}`,
+        candidate.releaseSite ? `组:${candidate.releaseSite}` : "",
+        candidate.uploadTime ?? "",
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      document += `[${candidate.id}] ${candidate.title}${lang}${evidence ? ` (${evidence})` : ""}\n`;
     }
     return { document, candidateCount: candidates.length };
   }
@@ -732,7 +739,14 @@ export class TaskSandbox {
     }
     const landedFilenames: string[] = [];
     let lastError: string | undefined;
-    for (const file of files) {
+    // Budget guard: each failed landing costs real 115 API calls (offline task +
+    // materialization polls + cleanup). A dead assrt package fails file after file
+    // the same way — abort after 3 CONSECUTIVE failures instead of hammering the
+    // whole filelist (a success resets the counter: mixed flakiness still lands).
+    const MAX_CONSECUTIVE_FAILURES = 3;
+    let consecutiveFailures = 0;
+    for (let i = 0; i < files.length; i += 1) {
+      const file = files[i]!;
       try {
         const result = await this.storage.transferSubtitleUrl({
           url: file.url,
@@ -742,11 +756,20 @@ export class TaskSandbox {
         });
         if (result.status === "succeeded") {
           landedFilenames.push(file.filename);
-        } else if (result.providerMessage) {
-          lastError = result.providerMessage;
+          consecutiveFailures = 0;
+        } else {
+          consecutiveFailures += 1;
+          if (result.providerMessage) {
+            lastError = result.providerMessage;
+          }
         }
       } catch (error) {
+        consecutiveFailures += 1;
         lastError = error instanceof Error ? error.message : String(error);
+      }
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        lastError = `已连续 ${MAX_CONSECUTIVE_FAILURES} 个字幕文件落盘失败,提前中止(剩余 ${files.length - i - 1} 个未尝试)。字幕是软目标——不要重试,带着已落的继续,或直接只交付视频。${lastError ? ` 最后错误: ${lastError}` : ""}`;
+        break;
       }
     }
     if (landedFilenames.length === 0 && lastError === undefined) {

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -672,9 +672,9 @@ export class TaskSandbox {
     keyword: string,
     provider: AssrtProviderPort,
   ): Promise<void> {
+    this.subtitleProvider = provider;
     try {
       this.subtitleSnapshot = await provider.search(keyword);
-      this.subtitleProvider = provider; // remember detail() for transferSubtitle
     } catch {
       this.subtitleSnapshot = [];
     }
@@ -685,7 +685,7 @@ export class TaskSandbox {
   viewSubtitleSnapshot(): { document: string; candidateCount: number } {
     if (!this.subtitleSnapshot || this.subtitleSnapshot.length === 0) {
       return {
-        document: "No subtitle snapshot available (未配置 assrt token / 国产内容 / 预搜无结果). Call primeSubtitleSnapshot first or skip subtitles.",
+        document: "No subtitle candidates were found for this title on assrt.net. Subtitles are optional — proceed with the video alone; do not block or retry on this.",
         candidateCount: 0,
       };
     }

--- a/packages/workflow/src/acquisition-v2/skill.ts
+++ b/packages/workflow/src/acquisition-v2/skill.ts
@@ -194,6 +194,20 @@ const MISTAKES = `# Worked right/wrong examples (the hard-won lessons)
 - Acting on a hunch: transferring / deleting / marking without first stating Evidence → Facts → Decision. WRONG. Right: state the evidence and the facts, then act.
 - Serial single transfers: transfer-one → re-search → transfer-one, repeated, hammering 115. WRONG. Right: decide the covering set, then transfer it back-to-back without re-searching.`;
 
+const SUBTITLE = `# External subtitle completion (assrt.net) — only when viewSubtitleSnapshot is in your tools
+
+## The signal
+\`viewSubtitleSnapshot\` appearing in your toolset means THIS run needs external Chinese subtitles — the system already searched assrt.net for this title's bare name and laid the candidate packages out as a read-only 活期文档. If the tool is NOT in your toolset, this whole section does not apply — skip it (国产内容 natively Chinese-spoken, or no assrt token configured, or the drive is not 115).
+
+## The flow (alongside, never blocking the video)
+1. viewSubtitleSnapshot() — read the candidate packages. Each shows id + title + language tag (e.g. [英 简 双语]). Pick ONE whose language covers your need (prefer 简体/双语 for a Chinese-subtitle user).
+2. transferSubtitle({ candidateId }) — land its files into staging. assrt's filelist is per-episode with SxxExx filenames already, so the landed files are named like "Breaking.Bad.S02E01.ass".
+3. RENAME each landed subtitle to match its video: same filename prefix, different extension (video.mkv → subtitle.ass). Subtitles are the ONLY files you may rename — a documented exception to the keep-original-name rule, because players auto-load a subtitle whose prefix matches the video. Everything else (videos, covers, nfos) still keeps its original name.
+4. Move the renamed subtitle with its video in the SAME moveToSeason call (its fileId rides in that season's fileIds), or let flattenMovie pull it up for a movie — exactly like a subtitle that came bundled inside the resource pack.
+
+## Soft-fail (never block the video)
+Subtitle miss / empty filelist / transferSubtitle returning failed / no matching SxxExx episode — all of these are SOFT. Video coverage is the only hard gate. If subtitles don't pan out, proceed with the video alone (markObtained on the video as normal); the user values an honest "video landed, no subtitle" over a blocked task. Never re-search assrt repeatedly — one viewSubtitleSnapshot read, one pick, one transfer attempt, move on.`;
+
 const SEARCH = `# Keyword strategy by media type (lived PanSou research)
 
 ## ⛳ 最重要:raw 已经预搜好了,就在你眼前的「活期文档」里
@@ -251,6 +265,7 @@ const SECTIONS = {
   movie: MOVIE,
   tv: TV,
   mistakes: MISTAKES,
+  subtitle: SUBTITLE,
 } as const;
 
 export type SkillSectionName = keyof typeof SECTIONS;
@@ -300,6 +315,6 @@ export function skillIndexForAgent(agent: "movie" | "tv"): string {
   const own = agent; // "movie" or "tv"
   return `You have a domain skill manual. Read a section on demand with readSkill({ section: "<name>" }) — do not act from memory when a section covers your situation.
 Read NOW, before you start: "protocol" (the Evidence→Facts→Decision + decide-the-covering-set-then-batch method) and "${own}" (your acquisition playbook).
-Re-read the moment you hit it: "search" (your first searches return junk / 0 / wrong works — the per-media-type keyword recipes), "dead-links-black-box" (a transfer fails, or every candidate title is opaque), "dedup" (the same episode lands more than once), "mistakes" (worked right/wrong examples).
-Available sections: protocol, ${own}, search, dead-links-black-box, dedup, mistakes.`;
+Re-read the moment you hit it: "search" (your first searches return junk / 0 / wrong works — the per-media-type keyword recipes), "dead-links-black-box" (a transfer fails, or every candidate title is opaque), "dedup" (the same episode lands more than once), "subtitle" (viewSubtitleSnapshot is in your toolset — external Chinese subtitles are available for this run), "mistakes" (worked right/wrong examples).
+Available sections: protocol, ${own}, search, dead-links-black-box, dedup, subtitle, mistakes.`;
 }

--- a/packages/workflow/src/acquisition-v2/skill.ts
+++ b/packages/workflow/src/acquisition-v2/skill.ts
@@ -202,7 +202,7 @@ const SUBTITLE = `# External subtitle completion (assrt.net) — only when viewS
 ## The flow (alongside, never blocking the video)
 1. viewSubtitleSnapshot() — read the candidate packages. Each shows id + title + language tag (e.g. [英 简 双语]). Pick ONE whose language covers your need (prefer 简体/双语 for a Chinese-subtitle user).
 2. transferSubtitle({ candidateId }) — land its files into staging. assrt's filelist is per-episode with SxxExx filenames already, so the landed files are named like "Breaking.Bad.S02E01.ass".
-3. RENAME each landed subtitle to match its video: same filename prefix, different extension (video.mkv → subtitle.ass). Subtitles are the ONLY files you may rename — a documented exception to the keep-original-name rule, because players auto-load a subtitle whose prefix matches the video. Everything else (videos, covers, nfos) still keeps its original name.
+3. renameSubtitle({ fileId, newName }) — rename each landed subtitle (get its fileId from inspectStaging) to match its video: same prefix as the video file, keep the subtitle extension (Show.S02E01.mkv → Show.S02E01.ass). Subtitles are the ONLY files you may rename — the documented exception — so the player auto-loads them. Everything else keeps its original name.
 4. Move the renamed subtitle with its video in the SAME moveToSeason call (its fileId rides in that season's fileIds), or let flattenMovie pull it up for a movie — exactly like a subtitle that came bundled inside the resource pack.
 
 ## Soft-fail (never block the video)

--- a/packages/workflow/src/acquisition-v2/skill.ts
+++ b/packages/workflow/src/acquisition-v2/skill.ts
@@ -316,5 +316,5 @@ export function skillIndexForAgent(agent: "movie" | "tv"): string {
   return `You have a domain skill manual. Read a section on demand with readSkill({ section: "<name>" }) — do not act from memory when a section covers your situation.
 Read NOW, before you start: "protocol" (the Evidence→Facts→Decision + decide-the-covering-set-then-batch method) and "${own}" (your acquisition playbook).
 Re-read the moment you hit it: "search" (your first searches return junk / 0 / wrong works — the per-media-type keyword recipes), "dead-links-black-box" (a transfer fails, or every candidate title is opaque), "dedup" (the same episode lands more than once), "subtitle" (viewSubtitleSnapshot is in your toolset — external Chinese subtitles are available for this run), "mistakes" (worked right/wrong examples).
-Available sections: protocol, ${own}, search, dead-links-black-box, dedup, subtitle, mistakes.`;
+Available sections: ${SKILL_SECTION_NAMES.filter((section) => section !== (own === "movie" ? "tv" : "movie")).join(", ")}.`;
 }

--- a/packages/workflow/src/acquisition-v2/skill.ts
+++ b/packages/workflow/src/acquisition-v2/skill.ts
@@ -197,10 +197,10 @@ const MISTAKES = `# Worked right/wrong examples (the hard-won lessons)
 const SUBTITLE = `# External subtitle completion (assrt.net) — only when viewSubtitleSnapshot is in your tools
 
 ## The signal
-\`viewSubtitleSnapshot\` appearing in your toolset means THIS run needs external Chinese subtitles — the system already searched assrt.net for this title's bare name and laid the candidate packages out as a read-only 活期文档. If the tool is NOT in your toolset, this whole section does not apply — skip it (国产内容 natively Chinese-spoken, or no assrt token configured, or the drive is not 115).
+\`viewSubtitleSnapshot\` appearing in your toolset means THIS run needs external Chinese subtitles — the system already searched assrt.net for this title's bare name and laid the candidate packages out as a read-only 活期文档. If the tool is NOT in your toolset, this whole section does not apply — skip it (国产内容 natively Chinese-spoken, or no assrt token configured, or this drive cannot land external subtitle files).
 
 ## The flow (alongside, never blocking the video)
-1. viewSubtitleSnapshot() — read the candidate packages. Each shows id + title + language tag (e.g. [英 简 双语]). Pick ONE whose language covers your need (prefer 简体/双语 for a Chinese-subtitle user).
+1. viewSubtitleSnapshot() — read the candidate packages. Each shows id + title + language tag (e.g. [英 简 双语]), plus community evidence when available (★social vote score · 字幕组 · upload time). Pick ONE whose language covers your need (prefer 简体/双语 for a Chinese-subtitle user); between language-equal candidates, a higher ★ and a known 字幕组 mean the community already validated it — weigh that semantically, it is evidence, not a rule.
 2. transferSubtitle({ candidateId }) — land its files into staging. assrt's filelist is per-episode with SxxExx filenames already, so the landed files are named like "Breaking.Bad.S02E01.ass".
 3. renameSubtitle({ fileId, newName }) — rename each landed subtitle (get its fileId from inspectStaging) to match its video: same prefix as the video file, keep the subtitle extension (Show.S02E01.mkv → Show.S02E01.ass). Subtitles are the ONLY files you may rename — the documented exception — so the player auto-loads them. Everything else keeps its original name.
 4. Move the renamed subtitle with its video in the SAME moveToSeason call (its fileId rides in that season's fileIds), or let flattenMovie pull it up for a movie — exactly like a subtitle that came bundled inside the resource pack.

--- a/packages/workflow/src/acquisition-v2/storage-115-simulator.ts
+++ b/packages/workflow/src/acquisition-v2/storage-115-simulator.ts
@@ -71,6 +71,14 @@ export interface StorageV2 {
   deleteFiles(input: { directoryId: string; fileIds: string[] }): Promise<{ deleted: string[] }>;
   /** Remove a directory and everything nested under it (the flatten peel-off). */
   removeDirectory(input: { directoryId: string }): Promise<{ removed: string[] }>;
+  /** Subtitle direct-link landing (test-double): drops a same-named file into the
+   *  target dir so sandbox/agent-loop tests work without a real 115 round-trip. */
+  transferSubtitleUrl(input: {
+    url: string;
+    filename: string;
+    intoDirectoryId: string;
+    workflowRunId: string;
+  }): Promise<TransferAttemptResult>;
 }
 
 export class Storage115Simulator implements StorageV2 {
@@ -165,6 +173,26 @@ export class Storage115Simulator implements StorageV2 {
       materializedFileIds.push(id);
     }
     return { status: "succeeded", materializedFileIds };
+  }
+
+  async transferSubtitleUrl(input: {
+    url: string;
+    filename: string;
+    intoDirectoryId: string;
+    workflowRunId: string;
+  }): Promise<TransferAttemptResult> {
+    if (!this.dirs.has(input.intoDirectoryId)) {
+      throw new Error(`SIM_DIR_NOT_FOUND: target ${input.intoDirectoryId}`);
+    }
+    this.spendBudget(1);
+    const id = this.nextId("file");
+    this.files.set(id, {
+      id,
+      name: input.filename,
+      parentId: input.intoDirectoryId,
+      sizeBytes: 1024, // test double; size irrelevant to subtitle logic
+    });
+    return { status: "succeeded", materializedFileIds: [id] };
   }
 
   /** Recursive, path-preserving snapshot of everything under a directory. */

--- a/packages/workflow/src/acquisition-v2/storage-115-simulator.ts
+++ b/packages/workflow/src/acquisition-v2/storage-115-simulator.ts
@@ -66,6 +66,8 @@ export interface StorageV2 {
    *  the source of the wrapper-dir handle flatten removes. */
   listSubdirectories(input: { directoryId: string }): Promise<Array<{ id: string; path: string }>>;
   moveFiles(input: { fileIds: string[]; targetDirectoryId: string }): Promise<{ moved: string[] }>;
+  /** Rename a single file in place (same directory) — the subtitle-rename exception. */
+  renameFile(input: { directoryId: string; fileId: string; newName: string }): Promise<void>;
   /** Delete files scoped to a directory — real 115 deletion is directory-scoped,
    *  so the caller names the dir the files live in. */
   deleteFiles(input: { directoryId: string; fileIds: string[] }): Promise<{ deleted: string[] }>;
@@ -243,6 +245,18 @@ export class Storage115Simulator implements StorageV2 {
       moved.push(fileId);
     }
     return { moved };
+  }
+
+  async renameFile(input: { directoryId: string; fileId: string; newName: string }): Promise<void> {
+    if (!this.dirs.has(input.directoryId)) {
+      throw new Error(`SIM_DIR_NOT_FOUND: ${input.directoryId}`);
+    }
+    this.spendBudget(1);
+    const file = this.files.get(input.fileId);
+    if (!file || file.parentId !== input.directoryId) {
+      throw new Error(`SIM_FILE_NOT_FOUND: ${input.fileId}`);
+    }
+    file.name = input.newName;
   }
 
   /** Recursive subdirectories of a directory, path-relative to it. */

--- a/packages/workflow/src/acquisition-v2/storage-115-simulator.ts
+++ b/packages/workflow/src/acquisition-v2/storage-115-simulator.ts
@@ -74,12 +74,13 @@ export interface StorageV2 {
   /** Remove a directory and everything nested under it (the flatten peel-off). */
   removeDirectory(input: { directoryId: string }): Promise<{ removed: string[] }>;
   /** Subtitle direct-link landing (test-double): drops a same-named file into the
-   *  target dir so sandbox/agent-loop tests work without a real 115 round-trip. */
+   *  target dir so sandbox/agent-loop tests work without a real 115 round-trip.
+   *  No workflowRunId here: run identity is the ADAPTER's business (RealStorageV2
+   *  scopes attempts to its own run) — callers must not pretend to control it. */
   transferSubtitleUrl(input: {
     url: string;
     filename: string;
     intoDirectoryId: string;
-    workflowRunId: string;
   }): Promise<TransferAttemptResult>;
 }
 
@@ -181,7 +182,6 @@ export class Storage115Simulator implements StorageV2 {
     url: string;
     filename: string;
     intoDirectoryId: string;
-    workflowRunId: string;
   }): Promise<TransferAttemptResult> {
     if (!this.dirs.has(input.intoDirectoryId)) {
       throw new Error(`SIM_DIR_NOT_FOUND: target ${input.intoDirectoryId}`);

--- a/packages/workflow/src/acquisition-v2/task-agents.ts
+++ b/packages/workflow/src/acquisition-v2/task-agents.ts
@@ -60,6 +60,9 @@ export interface TaskAgentPromptOptions {
   /** The run's drive brand ("pan115" | "quark") — selects the brand transfer model
    *  in the prompt and the brand-specific dead-links skill section. Default 115. */
   storageProvider?: string;
+  /** When true, the agent loop registers the subtitle tools (viewSubtitleSnapshot +
+   *  transferSubtitle). Set by orchestrator when the subtitle gates pass. */
+  subtitle?: boolean;
   /** Movie-only: soften the 中文 floor into a last-resort fallback (land a
    *  correct-film raw match when the search budget is exhausted and no 中字 is
    *  reachable, flagged 可能无中字) instead of the HARD reportNoCoverage. Set by
@@ -274,6 +277,7 @@ If one pack covers multiple seasons, distribute its files in ONE plan with a mov
     system: buildTvAnimeSystemPrompt(promptOptions),
     prompt,
     ...(promptOptions.storageProvider === undefined ? {} : { storageProvider: promptOptions.storageProvider }),
+    ...(promptOptions.subtitle ? { subtitle: true } : {}),
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(onProgress ? { onProgress } : {}),
     ...(apiCallCount ? { apiCallCount } : {}),
@@ -293,6 +297,7 @@ Find the one correct film, transfer it, keep the directory clean, mark it presen
     prompt,
     movie: true,
     ...(promptOptions.storageProvider === undefined ? {} : { storageProvider: promptOptions.storageProvider }),
+    ...(promptOptions.subtitle ? { subtitle: true } : {}),
     ...(maxSteps === undefined ? {} : { maxSteps }),
     ...(onProgress ? { onProgress } : {}),
     ...(apiCallCount ? { apiCallCount } : {}),

--- a/packages/workflow/src/acquisition-v2/task-agents.ts
+++ b/packages/workflow/src/acquisition-v2/task-agents.ts
@@ -63,6 +63,9 @@ export interface TaskAgentPromptOptions {
   /** When true, the agent loop registers the subtitle tools (viewSubtitleSnapshot +
    *  transferSubtitle). Set by orchestrator when the subtitle gates pass. */
   subtitle?: boolean;
+  /** How many subtitle packages the system's assrt pre-search found — renders the
+   *  subtitle pointer line (the 活期文档 twin of prefetchedCandidateCount). */
+  subtitleCandidateCount?: number;
   /** Movie-only: soften the 中文 floor into a last-resort fallback (land a
    *  correct-film raw match when the search budget is exhausted and no 中字 is
    *  reachable, flagged 可能无中字) instead of the HARD reportNoCoverage. Set by
@@ -153,11 +156,22 @@ function rawSnapshotPointer(options: TaskAgentPromptOptions): string {
   return `\n📋 RAW SNAPSHOT (活期文档): The system has already pre-searched the raw keyword (bare title) for you and found ${options.prefetchedCandidateCount} candidates. Your FIRST step: call viewResourceSnapshot() to view this live document — it's free, read-only, and contains all the raw candidates (id + title). Do NOT use searchResources to re-search the raw keyword; searchResources is ONLY for 繁体/英文/原名 upgrades when the raw snapshot is insufficient.\n`;
 }
 
+/** The subtitle twin of rawSnapshotPointer — rendered only when the subtitle flow
+ *  is active AND the pre-search found candidates, so the 活期文档 signal is
+ *  symmetric for video and subtitles (a low-end model shouldn't have to infer the
+ *  pre-search from the tool description alone). */
+function subtitleSnapshotPointer(options: TaskAgentPromptOptions): string {
+  if (!options.subtitle || !options.subtitleCandidateCount) {
+    return "";
+  }
+  return `\n📋 SUBTITLE SNAPSHOT (字幕活期文档): The system has already pre-searched assrt.net for this title and found ${options.subtitleCandidateCount} subtitle packages. After the video lands, call viewSubtitleSnapshot() (free, read-only) and follow the "subtitle" skill section — pick ONE package, transferSubtitle it, renameSubtitle to match the video. Subtitles are a SOFT goal: never let them block or delay the video.\n`;
+}
+
 export function buildTvAnimeSystemPrompt(options: TaskAgentPromptOptions): string {
   return `${SANDBOX_BOUNDARY}
 
 ${skillMandate("tv")}
-${rawSnapshotPointer(options)}
+${rawSnapshotPointer(options)}${subtitleSnapshotPointer(options)}
 You own the COMPLETE acquisition judgment for one OR MORE seasons of a TV/anime title in scope: keyword strategy, target matching, season/episode coverage, package recognition + normalization, provider-ahead reasoning, staging→season extraction, residue classification, same-episode dedup grouping, and marking. It is ONE deliberation, not separate filters. The need is simply "应有 vs 实有 = which episodes are still missing"; it may span several seasons.
 
 Target matching:
@@ -189,7 +203,7 @@ export function buildMovieSystemPrompt(options: TaskAgentPromptOptions): string 
   return `${SANDBOX_BOUNDARY}
 
 ${skillMandate("movie")}
-${rawSnapshotPointer(options)}
+${rawSnapshotPointer(options)}${subtitleSnapshotPointer(options)}
 You own the COMPLETE acquisition judgment for ONE movie: target正片 identification (guard against remakes/wrong films — cross-check BOTH title AND year), main-file selection, quality tradeoff, rejection of extras/trailers/foreign works, import cleanup, and marking. A movie is a SINGLE video file — there are no seasons or episodes; its one synthetic coverage token is "MOVIE".
 
 Identity (the hard part): the candidate must be THIS film, not a remake, sequel, prequel, or same-IP different film. Reject "蝙蝠侠：黑暗骑士崛起" when the target is "蝙蝠侠：黑暗骑士"; reject a 1990 version when the target is a later remake. When identity is unclear, do not transfer speculatively.

--- a/packages/workflow/src/acquisition-v2/workflow-v2.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2.ts
@@ -49,6 +49,8 @@ export interface RunAcquisitionV2WorkflowRequest {
   qualityGuidance?: string;
   /** The run's drive brand ("pan115" | "quark") — selects brand-specific skill. */
   storageProvider?: string;
+  /** assrt token (Settings → 字幕来源). Undefined = 字幕流程不触发。 */
+  assrtToken?: string;
   deadLinkStore?: DeadLinkStore;
   onProgress?: (event: AgentToolEvent) => void;
 }
@@ -135,6 +137,7 @@ export async function runAcquisitionV2Workflow(
     ...(request.searchHints === undefined ? {} : { searchHints: request.searchHints }),
     ...(request.qualityGuidance === undefined ? {} : { qualityGuidance: request.qualityGuidance }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
+    ...(request.assrtToken === undefined ? {} : { assrtToken: request.assrtToken }),
     ...(request.deadLinkStore ? { deadLinkStore: request.deadLinkStore } : {}),
     ...(request.onProgress ? { onProgress: request.onProgress } : {}),
   });

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -20,6 +20,7 @@ export * from "./pansou-provider.js";
 export * from "./prowlarr-provider.js";
 export * from "./composite-provider.js";
 export * from "./tmdb-provider.js";
+export * from "./subtitle-provider.js";
 export * from "./storage-115-executor.js";
 export * from "./pan115-cookie-client.js";
 export * from "./quark-cookie-client.js";

--- a/packages/workflow/src/movie-workflow-v2.ts
+++ b/packages/workflow/src/movie-workflow-v2.ts
@@ -47,6 +47,8 @@ export interface RunMovieAcquisitionV2Request {
   qualityPreference?: "high" | "medium";
   /** The run's drive brand ("pan115" | "quark") — selects brand-specific skill. */
   storageProvider?: string;
+  /** assrt token (Settings → 字幕来源). Undefined = 字幕流程不触发。 */
+  assrtToken?: string;
   deadLinkStore?: DeadLinkStore;
   onProgress?: (event: AgentToolEvent) => void;
   now?: () => string;
@@ -90,6 +92,7 @@ export async function runMovieAcquisitionV2(
     // 国产片(CN origin)→ 电影 prompt 跳过中文字幕 floor(原生中文对白,无中字可寻)。
     ...(request.title.originCountries === undefined ? {} : { originCountries: request.title.originCountries }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
+    ...(request.assrtToken === undefined ? {} : { assrtToken: request.assrtToken }),
     ...(request.deadLinkStore ? { deadLinkStore: request.deadLinkStore } : {}),
     ...(request.onProgress ? { onProgress: request.onProgress } : {}),
   });

--- a/packages/workflow/src/ports.ts
+++ b/packages/workflow/src/ports.ts
@@ -60,11 +60,12 @@ export interface StorageExecutor {
   /** The configured HARD 115 call budget — lets the agent loop derive its SOFT
    *  warning threshold from the real limit. Optional (real 115 executor only). */
   apiCallBudget?(): number;
-  /** Subtitle direct-link landing (115-only, phase 1). Submits the http url as a
-   *  115 offline task and confirms the named file landed via listTree (NOT
-   *  listVideoFiles — subtitle extensions are invisible to that path). Optional:
-   *  only the 115 executor implements it; the subtitle tool is registered only
-   *  for pan115, so a non-115 executor is never asked. */
+  /** Subtitle direct-link landing. Submits the http url as a drive offline task
+   *  and confirms the named file landed via listTree (NOT listVideoFiles —
+   *  subtitle extensions are invisible to that path). Optional AND the
+   *  capability gate: the orchestrator enables the whole subtitle flow iff this
+   *  method exists on the executor (today only 115 implements it; implementing
+   *  it on 光鸭/夸克 lights subtitles up there with zero other wiring). */
   transferSubtitleUrl?(input: {
     url: string;
     filename: string;

--- a/packages/workflow/src/ports.ts
+++ b/packages/workflow/src/ports.ts
@@ -60,4 +60,15 @@ export interface StorageExecutor {
   /** The configured HARD 115 call budget — lets the agent loop derive its SOFT
    *  warning threshold from the real limit. Optional (real 115 executor only). */
   apiCallBudget?(): number;
+  /** Subtitle direct-link landing (115-only, phase 1). Submits the http url as a
+   *  115 offline task and confirms the named file landed via listTree (NOT
+   *  listVideoFiles — subtitle extensions are invisible to that path). Optional:
+   *  only the 115 executor implements it; the subtitle tool is registered only
+   *  for pan115, so a non-115 executor is never asked. */
+  transferSubtitleUrl?(input: {
+    url: string;
+    filename: string;
+    directoryId: string;
+    workflowRunId: string;
+  }): Promise<TransferAttempt>;
 }

--- a/packages/workflow/src/runner-v2.ts
+++ b/packages/workflow/src/runner-v2.ts
@@ -46,6 +46,8 @@ interface TvV2Common {
   qualityPreference?: "high" | "medium";
   /** The run's drive brand ("pan115" | "quark") — selects brand-specific skill. */
   storageProvider?: string;
+  /** assrt token (Settings → 字幕来源). Undefined = 字幕流程不触发。 */
+  assrtToken?: string;
   /**
    * Wall clock for the run. Drives the engine's timestamps (including the
    * terminal notification's `createdAt`) AND the persisted `finishedAt`, which
@@ -67,6 +69,7 @@ function passthrough(input: TvV2Common): {
   preferredLanguage?: string;
   qualityPreference?: "high" | "medium";
   storageProvider?: string;
+  assrtToken?: string;
 } {
   return {
     ...(input.searchBudget === undefined ? {} : { searchBudget: input.searchBudget }),
@@ -74,6 +77,7 @@ function passthrough(input: TvV2Common): {
     ...(input.preferredLanguage === undefined ? {} : { preferredLanguage: input.preferredLanguage }),
     ...(input.qualityPreference === undefined ? {} : { qualityPreference: input.qualityPreference }),
     ...(input.storageProvider === undefined ? {} : { storageProvider: input.storageProvider }),
+    ...(input.assrtToken === undefined ? {} : { assrtToken: input.assrtToken }),
   };
 }
 
@@ -323,6 +327,8 @@ export async function runMovieAcquisitionV2AndPersist(input: {
   qualityPreference?: "high" | "medium";
   /** The run's drive brand ("pan115" | "quark") — selects brand-specific skill. */
   storageProvider?: string;
+  /** assrt token (Settings → 字幕来源). Undefined = 字幕流程不触发。 */
+  assrtToken?: string;
   /** See TvV2Common.now — finishedAt is stamped post-run from this clock. */
   now?: () => string;
 }): Promise<MovieWorkflowResult> {
@@ -347,6 +353,7 @@ export async function runMovieAcquisitionV2AndPersist(input: {
     ...(input.preferredLanguage === undefined ? {} : { preferredLanguage: input.preferredLanguage }),
     ...(input.qualityPreference === undefined ? {} : { qualityPreference: input.qualityPreference }),
     ...(input.storageProvider === undefined ? {} : { storageProvider: input.storageProvider }),
+    ...(input.assrtToken === undefined ? {} : { assrtToken: input.assrtToken }),
   });
 
   await input.repository.saveWorkflowRunSnapshot({

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -551,6 +551,27 @@ export class Storage115Executor implements StorageExecutor {
       if (remaining > 0) await this.sleep(this.offlineMaterializePollMs);
     }
 
+    // Nothing materialized in the window: 115 queued a real background download we
+    // will not wait for. Best-effort cancel it (task_del) so it can't drop the file
+    // into staging AFTER the workflow moves on, and so it doesn't tie up offline-task
+    // quota — mirroring transfer()'s non-秒传 cleanup. The HTTP subtitle url has no
+    // infoHash up front, so resolve the queued task by matching its url in the task
+    // list, then remove it by the infoHash 115 assigned. Never fail the attempt over
+    // cleanup.
+    if (materializedFileIds.length === 0) {
+      try {
+        const tasks = await this.callApi("listOfflineTasks", () => this.api.listOfflineTasks());
+        const queued = tasks.find((task) => task.url === input.url);
+        if (queued && queued.infoHash) {
+          await this.callApi("removeOfflineTask", () =>
+            this.api.removeOfflineTask({ infoHashes: [queued.infoHash] }),
+          );
+        }
+      } catch {
+        // best-effort cleanup — a failed cancel must never fail the subtitle attempt
+      }
+    }
+
     const status: TransferStatus =
       materializedFileIds.length > 0 ? "succeeded" : "no_target_change";
     return {

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -516,10 +516,15 @@ export class Storage115Executor implements StorageExecutor {
     // before spending any API call. Soft failure (attempt, not throw): the
     // sandbox counts it like any other landing failure.
     if (/[\\/]/.test(input.filename)) {
+      // Consume a number even for guard-rejected calls (same "one number per
+      // call" invariant as every other attempt) so ids stay unique; keep the
+      // raw filename OUT of the candidateId — it's exactly what pollutes ids.
+      const invalidAttemptNumber = this.nextTransferNumber;
+      this.nextTransferNumber += 1;
       return {
-        id: `${input.workflowRunId}_subtitle_invalid_name`,
+        id: `${input.workflowRunId}_subtitle_${invalidAttemptNumber}`,
         workflowRunId: input.workflowRunId,
-        candidateId: `subtitle:${input.filename}`,
+        candidateId: `subtitle:invalid_name_${invalidAttemptNumber}`,
         status: "failed",
         providerMessage:
           "SUBTITLE_INVALID_FILENAME: filename must be a bare name without path separators (路径分隔符)",
@@ -535,6 +540,20 @@ export class Storage115Executor implements StorageExecutor {
     const attemptNumber = this.nextTransferNumber;
     this.nextTransferNumber += 1;
     const candidateId = `subtitle:${input.filename}`;
+
+    // Landing detection is a BEFORE/AFTER diff (mirroring transfer()'s
+    // materialization diff): only a same-named file that APPEARS after the task
+    // was submitted counts. Matching a pre-existing file (an earlier attempt's
+    // leftover with the same name) would report success for a transfer that
+    // landed nothing. Match by exact basename — endsWith("/name") could be
+    // satisfied by a same-named file in any wrapper dir, which is intended, but
+    // exact basename keeps it unambiguous.
+    const basenameMatches = (path: string): boolean => path.split("/").pop() === input.filename;
+    const beforeIds = new Set(
+      (await this.listTree({ directoryId: safeDirectoryId, maxDepth: 2 }))
+        .filter((file) => basenameMatches(file.path))
+        .map((file) => file.providerFileId),
+    );
 
     const action = await this.callApi("addOfflineTask", () =>
       this.api.addOfflineTask({ url: input.url, directoryId: safeDirectoryId }),
@@ -559,7 +578,7 @@ export class Storage115Executor implements StorageExecutor {
       // down, so depth 2 catches both while staying cheap.
       const tree = await this.listTree({ directoryId: safeDirectoryId, maxDepth: 2 });
       const hit = tree.find(
-        (file) => file.path.endsWith(`/${input.filename}`) || file.path === input.filename,
+        (file) => basenameMatches(file.path) && !beforeIds.has(file.providerFileId),
       );
       if (hit) {
         materializedFileIds = [hit.providerFileId];

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -498,6 +498,70 @@ export class Storage115Executor implements StorageExecutor {
     return attempt;
   }
 
+  /** Subtitle direct-link landing: submit the http url as a 115 offline task
+   *  (115's lixianssp add_task_url accepts http/https/ftp/magnet/ed2k), then
+   *  confirm the named file landed by reading listTree (NOT listVideoFiles —
+   *  subtitle extensions are invisible to that path). Mirrors transfer()'s
+   *  offline-task materialization window, but matches by FILE NAME instead of
+   *  by video extension diff. */
+  async transferSubtitleUrl(input: {
+    url: string;
+    filename: string;
+    directoryId: string;
+    workflowRunId: string;
+  }): Promise<TransferAttempt> {
+    const safeDirectoryId = await this.assertWithinWriteScope(input.directoryId, "transfer subtitle");
+    // Mirror transfer(): one number consumed per call (first call = _subtitle_1),
+    // unconditionally — a failed subtitle attempt burns a slot just like a failed
+    // transfer does, so subsequent ids never collide.
+    const attemptNumber = this.nextTransferNumber;
+    this.nextTransferNumber += 1;
+    const candidateId = `subtitle:${input.filename}`;
+
+    const action = await this.callApi("addOfflineTask", () =>
+      this.api.addOfflineTask({ url: input.url, directoryId: safeDirectoryId }),
+    );
+    if (!action.ok) {
+      return {
+        id: `${input.workflowRunId}_subtitle_${attemptNumber}`,
+        workflowRunId: input.workflowRunId,
+        candidateId,
+        status: "failed",
+        providerMessage: action.message,
+        materializedFileIds: [],
+      };
+    }
+
+    let remaining = this.offlineMaterializeAttempts;
+    let materializedFileIds: string[] = [];
+    while (remaining > 0) {
+      const tree = await this.listTree({ directoryId: safeDirectoryId });
+      const hit = tree.find(
+        (file) => file.path.endsWith(`/${input.filename}`) || file.path === input.filename,
+      );
+      if (hit) {
+        materializedFileIds = [hit.providerFileId];
+        break;
+      }
+      remaining -= 1;
+      if (remaining > 0) await this.sleep(this.offlineMaterializePollMs);
+    }
+
+    const status: TransferStatus =
+      materializedFileIds.length > 0 ? "succeeded" : "no_target_change";
+    return {
+      id: `${input.workflowRunId}_subtitle_${this.nextTransferNumber}`,
+      workflowRunId: input.workflowRunId,
+      candidateId: `subtitle:${input.filename}`,
+      status,
+      providerMessage:
+        status === "succeeded"
+          ? ""
+          : "subtitle offline task accepted but file did not materialize in window",
+      materializedFileIds,
+    };
+  }
+
   async flattenDirectory(directoryId: string): Promise<{ moved: string[]; removed: string[] }> {
     const safeDirectoryId = await this.assertSafeFlattenTarget(directoryId);
     await this.assertWithinWriteScope(safeDirectoryId, "flatten directory");

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -511,9 +511,11 @@ export class Storage115Executor implements StorageExecutor {
     workflowRunId: string;
   }): Promise<TransferAttempt> {
     const safeDirectoryId = await this.assertWithinWriteScope(input.directoryId, "transfer subtitle");
-    // Mirror transfer(): one number consumed per call (first call = _subtitle_1),
-    // unconditionally — a failed subtitle attempt burns a slot just like a failed
-    // transfer does, so subsequent ids never collide.
+    // Mirror transfer(): one number consumed per call from the SHARED transfer
+    // counter (video transfers advance it too, so the suffix reflects the run's
+    // overall attempt order, not a subtitle-only sequence), unconditionally — a
+    // failed subtitle attempt burns a slot just like a failed transfer does, so
+    // subsequent ids never collide.
     const attemptNumber = this.nextTransferNumber;
     this.nextTransferNumber += 1;
     const candidateId = `subtitle:${input.filename}`;

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -510,6 +510,22 @@ export class Storage115Executor implements StorageExecutor {
     directoryId: string;
     workflowRunId: string;
   }): Promise<TransferAttempt> {
+    // Boundary validation: the filename comes from an EXTERNAL provider (assrt).
+    // A path-y name like "subdir/file.ass" would pollute the synthetic
+    // candidateId and make the listTree endsWith-match ambiguous — reject it
+    // before spending any API call. Soft failure (attempt, not throw): the
+    // sandbox counts it like any other landing failure.
+    if (/[\\/]/.test(input.filename)) {
+      return {
+        id: `${input.workflowRunId}_subtitle_invalid_name`,
+        workflowRunId: input.workflowRunId,
+        candidateId: `subtitle:${input.filename}`,
+        status: "failed",
+        providerMessage:
+          "SUBTITLE_INVALID_FILENAME: filename must be a bare name without path separators (路径分隔符)",
+        materializedFileIds: [],
+      };
+    }
     const safeDirectoryId = await this.assertWithinWriteScope(input.directoryId, "transfer subtitle");
     // Mirror transfer(): one number consumed per call from the SHARED transfer
     // counter (video transfers advance it too, so the suffix reflects the run's

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -556,15 +556,17 @@ export class Storage115Executor implements StorageExecutor {
     // into staging AFTER the workflow moves on, and so it doesn't tie up offline-task
     // quota — mirroring transfer()'s non-秒传 cleanup. The HTTP subtitle url has no
     // infoHash up front, so resolve the queued task by matching its url in the task
-    // list, then remove it by the infoHash 115 assigned. Never fail the attempt over
-    // cleanup.
+    // list, then remove it by the infoHash 115 assigned. Only cancel on an UNAMBIGUOUS
+    // single match — if the account-wide list has zero or multiple tasks for this url
+    // (e.g. a stale task from a prior run), skip rather than risk cancelling the wrong
+    // task. Never fail the attempt over cleanup.
     if (materializedFileIds.length === 0) {
       try {
         const tasks = await this.callApi("listOfflineTasks", () => this.api.listOfflineTasks());
-        const queued = tasks.find((task) => task.url === input.url);
-        if (queued && queued.infoHash) {
+        const matches = tasks.filter((task) => task.url === input.url && task.infoHash);
+        if (matches.length === 1) {
           await this.callApi("removeOfflineTask", () =>
-            this.api.removeOfflineTask({ infoHashes: [queued.infoHash] }),
+            this.api.removeOfflineTask({ infoHashes: [matches[0]!.infoHash] }),
           );
         }
       } catch {

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -535,7 +535,11 @@ export class Storage115Executor implements StorageExecutor {
     let remaining = this.offlineMaterializeAttempts;
     let materializedFileIds: string[] = [];
     while (remaining > 0) {
-      const tree = await this.listTree({ directoryId: safeDirectoryId });
+      // maxDepth: 2 bounds the per-poll API fan-out (listTree recurses + lists each
+      // subdir; the default depth-6 could explode calls on a big staging tree). A 115
+      // offline task lands the file directly under the target dir OR one wrapper level
+      // down, so depth 2 catches both while staying cheap.
+      const tree = await this.listTree({ directoryId: safeDirectoryId, maxDepth: 2 });
       const hit = tree.find(
         (file) => file.path.endsWith(`/${input.filename}`) || file.path === input.filename,
       );

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -550,9 +550,9 @@ export class Storage115Executor implements StorageExecutor {
     const status: TransferStatus =
       materializedFileIds.length > 0 ? "succeeded" : "no_target_change";
     return {
-      id: `${input.workflowRunId}_subtitle_${this.nextTransferNumber}`,
+      id: `${input.workflowRunId}_subtitle_${attemptNumber}`,
       workflowRunId: input.workflowRunId,
-      candidateId: `subtitle:${input.filename}`,
+      candidateId,
       status,
       providerMessage:
         status === "succeeded"

--- a/packages/workflow/src/subtitle-provider.ts
+++ b/packages/workflow/src/subtitle-provider.ts
@@ -16,6 +16,12 @@ export interface AssrtCandidate {
   title: string;
   /** 语言标签,如 "英 简 双语"。空串表示未知。 */
   lang: string;
+  /** 社区评分(vote_score)。API 无排序参数,这是给 agent 的"大家选择"证据。 */
+  voteScore?: number;
+  /** 字幕组/来源站(release_site),质量语义判断的证据。 */
+  releaseSite?: string;
+  /** 上传时间(upload_time),新旧判断证据。 */
+  uploadTime?: string;
 }
 
 export interface AssrtSubtitleFile {
@@ -76,7 +82,21 @@ export class AssrtSubtitleProvider {
       const videoName = str(entry["videoname"]).trim();
       const title = [nativeName, videoName].filter(Boolean).join(" · ") || `assrt #${id}`;
       const lang = isRecord(entry["lang"]) ? str(entry["lang"]["desc"]).trim() : "";
-      out.push({ id, title, lang });
+      // Community-pick evidence: the API can't sort by votes/downloads, so we
+      // surface what search already returns (vote_score/release_site/upload_time)
+      // and let the agent weigh it semantically. Keys omitted when absent.
+      const voteScoreRaw = entry["vote_score"];
+      const voteScore = typeof voteScoreRaw === "number" ? voteScoreRaw : undefined;
+      const releaseSite = str(entry["release_site"]).trim();
+      const uploadTime = str(entry["upload_time"]).trim();
+      out.push({
+        id,
+        title,
+        lang,
+        ...(voteScore === undefined ? {} : { voteScore }),
+        ...(releaseSite ? { releaseSite } : {}),
+        ...(uploadTime ? { uploadTime } : {}),
+      });
     }
     return out;
   }

--- a/packages/workflow/src/subtitle-provider.ts
+++ b/packages/workflow/src/subtitle-provider.ts
@@ -23,6 +23,14 @@ export interface AssrtSubtitleFile {
   url: string;
 }
 
+/** The subtitle-provider surface the orchestrator/sandbox depend on (search +
+ *  detail). AssrtSubtitleProvider implements it; tests inject a spy of the same
+ *  shape. Named so the shape isn't hand-duplicated across call sites. */
+export interface AssrtProviderPort {
+  search(keyword: string): Promise<AssrtCandidate[]>;
+  detail(id: number): Promise<AssrtSubtitleFile[]>;
+}
+
 export interface AssrtSubtitleProviderOptions {
   token: string;
   fetchJson?: AssrtFetchJson;

--- a/packages/workflow/src/subtitle-provider.ts
+++ b/packages/workflow/src/subtitle-provider.ts
@@ -1,0 +1,115 @@
+/**
+ * assrt.net(伪射手)字幕 API 客户端。免费官方 API,零反爬。两段式:
+ *   search(keyword) → sub/search → 候选降维成 {id, title, lang}(agent 只看这些)
+ *   detail(id)      → sub/detail → 该字幕包的 filelist(文件名 + 单集直链)
+ * 容错哲学(对齐 PanSou):任何非命中——空结果 / 配额超限(30900)/ invalid token
+ * (20001)/ HTTP 错误 / 网络异常——一律返回空,绝不抛错,让上层软评判。
+ */
+const ASSRT_BASE_URL = "https://api.assrt.net/v1";
+const ASSRT_FETCH_TIMEOUT_MS = 15000;
+
+export type AssrtFetchJson = (url: string) => Promise<unknown>;
+
+export interface AssrtCandidate {
+  id: number;
+  /** native_name(中文名)· videoname(发布名),给 agent 语义判断用。 */
+  title: string;
+  /** 语言标签,如 "英 简 双语"。空串表示未知。 */
+  lang: string;
+}
+
+export interface AssrtSubtitleFile {
+  filename: string;
+  url: string;
+}
+
+export interface AssrtSubtitleProviderOptions {
+  token: string;
+  fetchJson?: AssrtFetchJson;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+export class AssrtSubtitleProvider {
+  private readonly token: string;
+  private readonly fetchJson: AssrtFetchJson;
+
+  constructor(options: AssrtSubtitleProviderOptions) {
+    this.token = options.token;
+    this.fetchJson = options.fetchJson ?? defaultAssrtFetchJson;
+  }
+
+  /** Search assrt for a keyword. Returns [] on ANY miss/error (never throws). */
+  async search(keyword: string): Promise<AssrtCandidate[]> {
+    const url = `${ASSRT_BASE_URL}/sub/search?token=${encodeURIComponent(this.token)}&q=${encodeURIComponent(keyword)}&cnt=15`;
+    let body: unknown;
+    try {
+      body = await this.fetchJson(url);
+    } catch {
+      return [];
+    }
+    if (!isRecord(body) || body["status"] !== 0) return [];
+    const sub = body["sub"];
+    if (!isRecord(sub)) return [];
+    const subs = sub["subs"];
+    // No-result sends an empty OBJECT {}, a hit sends an ARRAY — so guard on Array.
+    if (!Array.isArray(subs)) return [];
+    const out: AssrtCandidate[] = [];
+    for (const entry of subs) {
+      if (!isRecord(entry)) continue;
+      const id = entry["id"];
+      if (typeof id !== "number") continue;
+      const nativeName = str(entry["native_name"]).trim();
+      const videoName = str(entry["videoname"]).trim();
+      const title = [nativeName, videoName].filter(Boolean).join(" · ") || `assrt #${id}`;
+      const lang = isRecord(entry["lang"]) ? str(entry["lang"]["desc"]).trim() : "";
+      out.push({ id, title, lang });
+    }
+    return out;
+  }
+
+  /** Fetch one subtitle package's downloadable files. Prefers the per-episode
+   *  filelist; falls back to the whole-package zip. [] on any miss/error. */
+  async detail(id: number): Promise<AssrtSubtitleFile[]> {
+    const url = `${ASSRT_BASE_URL}/sub/detail?token=${encodeURIComponent(this.token)}&id=${id}`;
+    let body: unknown;
+    try {
+      body = await this.fetchJson(url);
+    } catch {
+      return [];
+    }
+    if (!isRecord(body) || body["status"] !== 0) return [];
+    const sub = body["sub"];
+    if (!isRecord(sub) || !Array.isArray(sub["subs"]) || sub["subs"].length === 0) return [];
+    const record = sub["subs"][0];
+    if (!isRecord(record)) return [];
+    const filelist = record["filelist"];
+    if (Array.isArray(filelist) && filelist.length > 0) {
+      const files: AssrtSubtitleFile[] = [];
+      for (const item of filelist) {
+        if (!isRecord(item)) continue;
+        const filename = str(item["f"]).trim();
+        const fileUrl = str(item["url"]).trim();
+        if (filename && fileUrl) files.push({ filename, url: fileUrl });
+      }
+      if (files.length > 0) return files;
+    }
+    // Fallback: the whole-package zip.
+    const zipName = str(record["filename"]).trim();
+    const zipUrl = str(record["url"]).trim();
+    return zipName && zipUrl ? [{ filename: zipName, url: zipUrl }] : [];
+  }
+}
+
+async function defaultAssrtFetchJson(url: string): Promise<unknown> {
+  const response = await fetch(url, { method: "GET", signal: AbortSignal.timeout(ASSRT_FETCH_TIMEOUT_MS) });
+  if (!response.ok) {
+    throw new Error(`assrt request failed with HTTP ${response.status}`);
+  }
+  return response.json();
+}

--- a/packages/workflow/src/worker.ts
+++ b/packages/workflow/src/worker.ts
@@ -66,6 +66,7 @@ async function resolveWorkerDeps(
   preferredLanguage: string | undefined;
   qualityPreference: "high" | "medium" | undefined;
   storageProvider: string | undefined;
+  assrtToken: string | undefined;
   storageParentDirectoryId: string | undefined;
   animeStorageParentDirectoryId: string | undefined;
   moviesParentDirectoryId: string | undefined;
@@ -78,6 +79,7 @@ async function resolveWorkerDeps(
     preferredLanguage: ctx.preferredLanguage ?? base.preferredLanguage,
     qualityPreference: ctx.qualityPreference ?? base.qualityPreference,
     storageProvider: ctx.storageProvider ?? base.storageProvider,
+    assrtToken: ctx.assrtToken ?? base.assrtToken,
     storageParentDirectoryId:
       ctx.storageParentDirectoryId ?? base.storageParentDirectoryId,
     animeStorageParentDirectoryId:
@@ -113,6 +115,8 @@ export interface AccountWorkerContext {
   qualityPreference?: "high" | "medium";
   /** The run's drive brand ("pan115" | "quark") — selects brand-specific skill. */
   storageProvider?: string;
+  /** assrt token (Settings → 字幕来源). Undefined = 字幕流程不触发。 */
+  assrtToken?: string;
   storageParentDirectoryId?: string;
   animeStorageParentDirectoryId?: string;
   moviesParentDirectoryId?: string;
@@ -292,6 +296,9 @@ export async function runQueuedType2Workflow(input: {
       ...(deps.storageProvider === undefined
         ? {}
         : { storageProvider: deps.storageProvider }),
+      ...(deps.assrtToken === undefined
+        ? {}
+        : { assrtToken: deps.assrtToken }),
       // finishedAt is stamped post-run inside the persist step (see runner-v2),
       // so it reflects actual completion, not the claim time.
       workflowRun: {
@@ -486,6 +493,9 @@ export async function runScheduledType3Monitoring(input: {
         ...(deps.storageProvider === undefined
           ? {}
           : { storageProvider: deps.storageProvider }),
+        ...(deps.assrtToken === undefined
+          ? {}
+          : { assrtToken: deps.assrtToken }),
         workflowRun: { id: workflowRunId, startedAt, finishedAt: null },
         now,
       });
@@ -554,6 +564,7 @@ async function patrolMovie(args: {
     preferredLanguage: string | undefined;
     qualityPreference: "high" | "medium" | undefined;
     storageProvider: string | undefined;
+    assrtToken: string | undefined;
     moviesParentDirectoryId: string | undefined;
   };
   state: {
@@ -638,6 +649,9 @@ async function patrolMovie(args: {
       ...(deps.storageProvider === undefined
         ? {}
         : { storageProvider: deps.storageProvider }),
+      ...(deps.assrtToken === undefined
+        ? {}
+        : { assrtToken: deps.assrtToken }),
       workflowRun: { id: workflowRunId, startedAt, finishedAt: null },
       now,
     });
@@ -763,6 +777,9 @@ export async function runQueuedMovieAcquisition(input: {
       ...(deps.storageProvider === undefined
         ? {}
         : { storageProvider: deps.storageProvider }),
+      ...(deps.assrtToken === undefined
+        ? {}
+        : { assrtToken: deps.assrtToken }),
       workflowRun: {
         id: claimed.workflowRun.id,
         startedAt: claimed.workflowRun.startedAt,
@@ -856,6 +873,9 @@ export async function runQueuedSeriesInitialization(input: {
       ...(deps.storageProvider === undefined
         ? {}
         : { storageProvider: deps.storageProvider }),
+      ...(deps.assrtToken === undefined
+        ? {}
+        : { assrtToken: deps.assrtToken }),
       workflowRun: {
         id: claimed.workflowRun.id,
         startedAt: claimed.workflowRun.startedAt,

--- a/packages/workflow/tests/activity.test.ts
+++ b/packages/workflow/tests/activity.test.ts
@@ -114,3 +114,17 @@ it("phase order is the canonical 7-phase pipeline", () => {
     expect(percents[i]!).toBeGreaterThanOrEqual(percents[i - 1]!);
   }
 });
+
+describe("interpretTool — subtitle tools (mirror contract with buildSandboxToolSet)", () => {
+  it("viewSubtitleSnapshot → 浏览字幕候选 (pick, not the generic fallback)", () => {
+    expect(interpretTool("viewSubtitleSnapshot", {})).toEqual({ activity: "正在浏览字幕候选…", phase: "pick" });
+  });
+
+  it("transferSubtitle → 下载字幕 (organize band — post-video side work)", () => {
+    expect(interpretTool("transferSubtitle", { candidateId: 713570 })).toEqual({ activity: "正在下载字幕…", phase: "organize" });
+  });
+
+  it("renameSubtitle → 重命名字幕 (organize)", () => {
+    expect(interpretTool("renameSubtitle", { fileId: "f", newName: "Show.S01E01.ass" })).toEqual({ activity: "正在重命名字幕…", phase: "organize" });
+  });
+});

--- a/packages/workflow/tests/orchestrator-subtitle.test.ts
+++ b/packages/workflow/tests/orchestrator-subtitle.test.ts
@@ -139,3 +139,11 @@ describe("runAcquisitionV2 subtitle pre-warming gates (capability-based, no bran
     ).toBe(0);
   });
 });
+
+describe("unknown-origin gate (known non-CN required)", () => {
+  it("does NOT pre-warm when origin metadata is missing/empty — niche CN titles lacking TMDB metadata must not burn assrt quota on every patrol", async () => {
+    expect(
+      await runWithGates({ originCountries: [], storageProvider: "pan115", assrtToken: "fake-token", subtitleCapable: true }),
+    ).toBe(0);
+  });
+});

--- a/packages/workflow/tests/orchestrator-subtitle.test.ts
+++ b/packages/workflow/tests/orchestrator-subtitle.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { MockLanguageModelV3 } from "ai/test";
+import { runAcquisitionV2 } from "../src/acquisition-v2/orchestrator.js";
+import type { ResourceProvider } from "../src/ports.js";
+import type { ResourceSnapshot } from "../src/domain.js";
+import type { AssrtCandidate, AssrtSubtitleFile } from "../src/subtitle-provider.js";
+import { FakeStorageExecutor } from "../src/fakes.js";
+
+const USAGE = {
+  inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+} as const;
+
+/** A model that stops immediately — the subtitle PRE-WARM side effect we assert
+ *  happens BEFORE the loop runs, so the agent behavior itself doesn't matter. */
+function stopModel(): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    doGenerate: async () => ({
+      content: [{ type: "text" as const, text: "done" }],
+      finishReason: { unified: "stop" as const, raw: "stop" as const },
+      usage: USAGE,
+      warnings: [],
+    }),
+  });
+}
+
+function emptyProvider(): ResourceProvider {
+  return {
+    search: async ({ keyword }): Promise<ResourceSnapshot> => ({
+      id: "snap_empty",
+      provider: "pansou",
+      keyword,
+      candidates: [],
+      createdAt: "2026-07-01T00:00:00.000Z",
+    }),
+  };
+}
+
+/** An assrt provider that records how many times search() was called, so we can
+ *  assert the pre-warm gate: 1 call when all gates pass, 0 when any gate fails. */
+function spyingAssrtProvider(): {
+  provider: { search(k: string): Promise<AssrtCandidate[]>; detail(id: number): Promise<AssrtSubtitleFile[]> };
+  state: { searchCalls: number };
+} {
+  const state = { searchCalls: 0 };
+  const provider = {
+    search: async (_k: string): Promise<AssrtCandidate[]> => {
+      state.searchCalls += 1;
+      return [];
+    },
+    detail: async (_id: number): Promise<AssrtSubtitleFile[]> => [],
+  };
+  return { provider, state };
+}
+
+/** Run a movie acquisition with the given gate inputs; return how many times
+ *  assrt.search was called (the pre-warm indicator). */
+async function runWithGates(gates: {
+  originCountries: string[];
+  storageProvider: string;
+  assrtToken?: string;
+}): Promise<number> {
+  const { provider: assrtProvider, state } = spyingAssrtProvider();
+  await runAcquisitionV2({
+    provider: emptyProvider(),
+    executor: new FakeStorageExecutor({ directories: { staging: [], movie: [] } }),
+    model: stopModel(),
+    workflowRunId: "run-test",
+    target: { kind: "movie", title: "Inception", aliases: [], year: 2010, qualityPreference: "4K" },
+    stagingDirectoryId: "staging",
+    targetMovieDirectoryId: "movie",
+    originCountries: gates.originCountries,
+    storageProvider: gates.storageProvider,
+    ...(gates.assrtToken === undefined ? {} : { assrtToken: gates.assrtToken }),
+    assrtProvider,
+  });
+  return state.searchCalls;
+}
+
+describe("runAcquisitionV2 subtitle pre-warming gates", () => {
+  it("pre-warms when assrtToken set + origin non-CN + drive 115", async () => {
+    expect(await runWithGates({ originCountries: ["US"], storageProvider: "pan115", assrtToken: "fake-token" })).toBe(1);
+  });
+
+  it("does NOT pre-warm when origin includes CN", async () => {
+    expect(await runWithGates({ originCountries: ["CN"], storageProvider: "pan115", assrtToken: "fake-token" })).toBe(0);
+  });
+
+  it("does NOT pre-warm when assrtToken is undefined", async () => {
+    expect(await runWithGates({ originCountries: ["US"], storageProvider: "pan115" })).toBe(0);
+  });
+
+  it("does NOT pre-warm when drive is quark (phase 1 = 115-only)", async () => {
+    expect(await runWithGates({ originCountries: ["US"], storageProvider: "quark", assrtToken: "fake-token" })).toBe(0);
+  });
+
+  it("does NOT pre-warm when origins include CN alongside others (multi-origin)", async () => {
+    expect(await runWithGates({ originCountries: ["CN", "US"], storageProvider: "pan115", assrtToken: "fake-token" })).toBe(0);
+  });
+});

--- a/packages/workflow/tests/orchestrator-subtitle.test.ts
+++ b/packages/workflow/tests/orchestrator-subtitle.test.ts
@@ -55,15 +55,42 @@ function spyingAssrtProvider(): {
 
 /** Run a movie acquisition with the given gate inputs; return how many times
  *  assrt.search was called (the pre-warm indicator). */
+/** A FakeStorageExecutor that CAN land subtitle urls — the capability the
+ *  orchestrator gate probes for. Brand string is irrelevant; the optional
+ *  method's presence is the single source of truth. */
+class SubtitleCapableExecutor extends FakeStorageExecutor {
+  async transferSubtitleUrl(input: {
+    url: string;
+    filename: string;
+    directoryId: string;
+    workflowRunId: string;
+  }) {
+    return {
+      id: `${input.workflowRunId}_subtitle_1`,
+      workflowRunId: input.workflowRunId,
+      candidateId: `subtitle:${input.filename}`,
+      status: "succeeded" as const,
+      providerMessage: "",
+      materializedFileIds: [],
+    };
+  }
+}
+
 async function runWithGates(gates: {
   originCountries: string[];
   storageProvider: string;
   assrtToken?: string;
+  /** true → executor implements transferSubtitleUrl (e.g. 115); false → it
+   *  doesn't (e.g. quark today). */
+  subtitleCapable: boolean;
 }): Promise<number> {
   const { provider: assrtProvider, state } = spyingAssrtProvider();
+  const executorOptions = { directories: { staging: [], movie: [] } };
   await runAcquisitionV2({
     provider: emptyProvider(),
-    executor: new FakeStorageExecutor({ directories: { staging: [], movie: [] } }),
+    executor: gates.subtitleCapable
+      ? new SubtitleCapableExecutor(executorOptions)
+      : new FakeStorageExecutor(executorOptions),
     model: stopModel(),
     workflowRunId: "run-test",
     target: { kind: "movie", title: "Inception", aliases: [], year: 2010, qualityPreference: "4K" },
@@ -77,24 +104,38 @@ async function runWithGates(gates: {
   return state.searchCalls;
 }
 
-describe("runAcquisitionV2 subtitle pre-warming gates", () => {
-  it("pre-warms when assrtToken set + origin non-CN + drive 115", async () => {
-    expect(await runWithGates({ originCountries: ["US"], storageProvider: "pan115", assrtToken: "fake-token" })).toBe(1);
+describe("runAcquisitionV2 subtitle pre-warming gates (capability-based, no brand hardcode)", () => {
+  it("pre-warms when assrtToken set + origin non-CN + executor can land subtitle urls", async () => {
+    expect(
+      await runWithGates({ originCountries: ["US"], storageProvider: "pan115", assrtToken: "fake-token", subtitleCapable: true }),
+    ).toBe(1);
   });
 
   it("does NOT pre-warm when origin includes CN", async () => {
-    expect(await runWithGates({ originCountries: ["CN"], storageProvider: "pan115", assrtToken: "fake-token" })).toBe(0);
+    expect(
+      await runWithGates({ originCountries: ["CN"], storageProvider: "pan115", assrtToken: "fake-token", subtitleCapable: true }),
+    ).toBe(0);
   });
 
   it("does NOT pre-warm when assrtToken is undefined", async () => {
-    expect(await runWithGates({ originCountries: ["US"], storageProvider: "pan115" })).toBe(0);
+    expect(await runWithGates({ originCountries: ["US"], storageProvider: "pan115", subtitleCapable: true })).toBe(0);
   });
 
-  it("does NOT pre-warm when drive is quark (phase 1 = 115-only)", async () => {
-    expect(await runWithGates({ originCountries: ["US"], storageProvider: "quark", assrtToken: "fake-token" })).toBe(0);
+  it("does NOT pre-warm when the executor lacks transferSubtitleUrl (quark today) — the gate can never disagree with the executor", async () => {
+    expect(
+      await runWithGates({ originCountries: ["US"], storageProvider: "quark", assrtToken: "fake-token", subtitleCapable: false }),
+    ).toBe(0);
+  });
+
+  it("brand string is IRRELEVANT: a capable executor pre-warms even under another provider name (光鸭 lights up the day its executor implements the method)", async () => {
+    expect(
+      await runWithGates({ originCountries: ["US"], storageProvider: "guangya", assrtToken: "fake-token", subtitleCapable: true }),
+    ).toBe(1);
   });
 
   it("does NOT pre-warm when origins include CN alongside others (multi-origin)", async () => {
-    expect(await runWithGates({ originCountries: ["CN", "US"], storageProvider: "pan115", assrtToken: "fake-token" })).toBe(0);
+    expect(
+      await runWithGates({ originCountries: ["CN", "US"], storageProvider: "pan115", assrtToken: "fake-token", subtitleCapable: true }),
+    ).toBe(0);
   });
 });

--- a/packages/workflow/tests/skill-subtitle.test.ts
+++ b/packages/workflow/tests/skill-subtitle.test.ts
@@ -21,3 +21,23 @@ describe("subtitle skill section", () => {
     expect(tv).toContain("subtitle");
   });
 });
+
+describe("skillIndexForAgent — Available-sections line derives from the single source of truth", () => {
+  it("lists every registered section except the OTHER agent's playbook (cannot drift)", () => {
+    for (const agent of ["movie", "tv"] as const) {
+      const other = agent === "movie" ? "tv" : "movie";
+      const line = skillIndexForAgent(agent)
+        .split("\n")
+        .find((l) => l.startsWith("Available sections:"));
+      expect(line).toBeDefined();
+      const listed = line!
+        .replace("Available sections:", "")
+        .replace(/\.$/, "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .sort();
+      expect(listed).toEqual([...SKILL_SECTION_NAMES].filter((s) => s !== other).sort());
+    }
+  });
+});

--- a/packages/workflow/tests/skill-subtitle.test.ts
+++ b/packages/workflow/tests/skill-subtitle.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { readSkillSection, skillIndexForAgent, SKILL_SECTION_NAMES } from "../src/acquisition-v2/skill.js";
+
+describe("subtitle skill section", () => {
+  it("is a registered section", () => {
+    expect(SKILL_SECTION_NAMES).toContain("subtitle");
+  });
+
+  it("readSkillSection('subtitle') returns the subtitle playbook body", () => {
+    const body = readSkillSection("subtitle");
+    expect(body).toContain("viewSubtitleSnapshot");
+    expect(body).toContain("transferSubtitle");
+    expect(body).toMatch(/rename|重命名/); // the rename exception
+    expect(body).toMatch(/soft|不阻塞|does not block/i); // soft-fail philosophy
+  });
+
+  it("both movie and tv skill indexes point at the subtitle section", () => {
+    const movie = skillIndexForAgent("movie");
+    const tv = skillIndexForAgent("tv");
+    expect(movie).toContain("subtitle");
+    expect(tv).toContain("subtitle");
+  });
+});

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1004,6 +1004,72 @@ describe("Storage115Executor", () => {
   });
 });
 
+describe("Storage115Executor.transferSubtitleUrl", () => {
+  it("submits an offline task with the subtitle url, then confirms landing via listTree by filename", async () => {
+    const api = new FakePan115Api({
+      directories: { stage: [] },
+    });
+    const SUBTITLE_FILENAME = "Breaking.Bad.S02E01.ass";
+    api.addOfflineTask = async (input) => {
+      api.directories[input.directoryId] = [
+        ...(api.directories[input.directoryId] ?? []),
+        { fid: `sub_${input.url.slice(-6)}`, n: SUBTITLE_FILENAME, s: "718KB" },
+      ];
+      return { ok: true, message: "offline task accepted" };
+    };
+    const executor = new Storage115Executor({ api });
+
+    const attempt = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/onthefly/713570/-/1/Breaking.Bad.S02E01.ass?api=1",
+      filename: SUBTITLE_FILENAME,
+      directoryId: "stage",
+      workflowRunId: "run-test",
+    });
+
+    expect(attempt.status).toBe("succeeded");
+    expect(attempt.materializedFileIds.length).toBe(1);
+    expect(attempt.providerMessage).toBe("");
+  });
+
+  it("reports failed when addOfflineTask returns ok:false (e.g. dead link)", async () => {
+    const api = new FakePan115Api({ directories: { stage: [] } });
+    api.addOfflineTask = async () => ({ ok: false, message: "invalid url" });
+    const executor = new Storage115Executor({ api });
+
+    const attempt = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/dead.zip",
+      filename: "dead.ass",
+      directoryId: "stage",
+      workflowRunId: "run-test",
+    });
+
+    expect(attempt.status).toBe("failed");
+    expect(attempt.providerMessage).toContain("invalid url");
+    expect(attempt.materializedFileIds).toEqual([]);
+  });
+
+  it("reports no_target_change when the file never appears in listTree", async () => {
+    const api = new FakePan115Api({ directories: { stage: [] } });
+    api.addOfflineTask = async () => ({ ok: true, message: "accepted" });
+    const executor = new Storage115Executor({
+      api,
+      offlineMaterializeAttempts: 1,
+      offlineMaterializePollMs: 1,
+      sleep: async () => {},
+    });
+
+    const attempt = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/onthefly/slow.ass",
+      filename: "slow.ass",
+      directoryId: "stage",
+      workflowRunId: "run-test",
+    });
+
+    expect(attempt.status).toBe("no_target_change");
+    expect(attempt.materializedFileIds).toEqual([]);
+  });
+});
+
 class FakePan115Api implements Pan115StorageApi {
   readonly directories: Record<string, Pan115Item[]>;
   readonly shareFiles: Record<string, Pan115Item[]>;

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1068,6 +1068,45 @@ describe("Storage115Executor.transferSubtitleUrl", () => {
     expect(attempt.status).toBe("no_target_change");
     expect(attempt.materializedFileIds).toEqual([]);
   });
+
+  it("assigns DISTINCT attempt ids across a succeed-then-fail sequence on one executor (no transfer_attempts PK collision)", async () => {
+    // A multi-file subtitle package loops transferSubtitleUrl per file on the SAME
+    // executor instance. A succeeded call followed by a failed call must NOT reuse
+    // the same attempt id — otherwise both attempts collide on the transfer_attempts
+    // primary key and the run's single-transaction persist rolls back, losing the
+    // video's obtained marks (a subtitle failure blocking the video).
+    const api = new FakePan115Api({ directories: { stage: [] } });
+    let call = 0;
+    api.addOfflineTask = async (input) => {
+      call += 1;
+      if (call === 1) {
+        api.directories[input.directoryId] = [
+          ...(api.directories[input.directoryId] ?? []),
+          { fid: "sub_ok", n: "Show.S01E01.ass", s: "700KB" },
+        ];
+        return { ok: true, message: "offline task accepted" };
+      }
+      return { ok: false, message: "invalid url" };
+    };
+    const executor = new Storage115Executor({ api });
+
+    const first = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/onthefly/1/Show.S01E01.ass",
+      filename: "Show.S01E01.ass",
+      directoryId: "stage",
+      workflowRunId: "run-collide",
+    });
+    const second = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/dead.ass",
+      filename: "Show.S01E02.ass",
+      directoryId: "stage",
+      workflowRunId: "run-collide",
+    });
+
+    expect(first.status).toBe("succeeded");
+    expect(second.status).toBe("failed");
+    expect(first.id).not.toBe(second.id); // distinct ids — no PK collision
+  });
 });
 
 class FakePan115Api implements Pan115StorageApi {

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1069,6 +1069,33 @@ describe("Storage115Executor.transferSubtitleUrl", () => {
     expect(attempt.materializedFileIds).toEqual([]);
   });
 
+  it("best-effort cancels the in-flight offline task on no_target_change (frees quota, prevents late drop)", async () => {
+    const SUBTITLE_URL = "http://file0.assrt.net/onthefly/never-lands.ass";
+    const api = new FakePan115Api({
+      directories: { stage: [] },
+      offlineTaskList: [
+        { infoHash: "hash-abc", name: "never-lands.ass", percentDone: 0, status: 1, statusText: "downloading", url: SUBTITLE_URL },
+      ],
+    });
+    api.addOfflineTask = async () => ({ ok: true, message: "accepted" });
+    const executor = new Storage115Executor({
+      api,
+      offlineMaterializeAttempts: 1,
+      offlineMaterializePollMs: 1,
+      sleep: async () => {},
+    });
+
+    const attempt = await executor.transferSubtitleUrl!({
+      url: SUBTITLE_URL,
+      filename: "never-lands.ass",
+      directoryId: "stage",
+      workflowRunId: "run-test",
+    });
+
+    expect(attempt.status).toBe("no_target_change");
+    expect(api.removedOfflineHashes).toContain("hash-abc"); // the queued task was cancelled by its infoHash
+  });
+
   it("assigns DISTINCT attempt ids across a succeed-then-fail sequence on one executor (no transfer_attempts PK collision)", async () => {
     // A multi-file subtitle package loops transferSubtitleUrl per file on the SAME
     // executor instance. A succeeded call followed by a failed call must NOT reuse

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1005,6 +1005,43 @@ describe("Storage115Executor", () => {
 });
 
 describe("Storage115Executor.transferSubtitleUrl", () => {
+  it("does NOT claim a pre-existing same-named file — only a file that APPEARS after submission counts", async () => {
+    const api = new FakePan115Api({
+      directories: { stage: [{ fid: "old_leftover", n: "Show.S01E01.ass", s: "1KB" }] },
+    });
+    api.addOfflineTask = async () => ({ ok: true, message: "accepted" }); // lands nothing new
+    const executor = new Storage115Executor({
+      api,
+      offlineMaterializeAttempts: 1,
+      offlineMaterializePollMs: 1,
+      sleep: async () => {},
+    });
+
+    const attempt = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/onthefly/1/Show.S01E01.ass",
+      filename: "Show.S01E01.ass",
+      directoryId: "stage",
+      workflowRunId: "run-test",
+    });
+
+    expect(attempt.status).toBe("no_target_change");
+    expect(attempt.materializedFileIds).toEqual([]);
+  });
+
+  it("guard-rejected invalid filenames consume attempt numbers — ids never collide", async () => {
+    const api = new FakePan115Api({ directories: { stage: [] } });
+    const executor = new Storage115Executor({ api });
+
+    const a = await executor.transferSubtitleUrl!({ url: "http://x/a.ass", filename: "a/b.ass", directoryId: "stage", workflowRunId: "run-test" });
+    const b = await executor.transferSubtitleUrl!({ url: "http://x/c.ass", filename: "c\\d.ass", directoryId: "stage", workflowRunId: "run-test" });
+
+    expect(a.status).toBe("failed");
+    expect(b.status).toBe("failed");
+    expect(a.id).not.toBe(b.id);
+    expect(a.candidateId).not.toBe(b.candidateId);
+    expect(a.candidateId).not.toContain("/"); // raw filename kept OUT of the id
+  });
+
   it("rejects a filename containing path separators at the boundary (zero API calls)", async () => {
     const api = new FakePan115Api({ directories: { stage: [] } });
     let offlineCalls = 0;

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1005,6 +1005,28 @@ describe("Storage115Executor", () => {
 });
 
 describe("Storage115Executor.transferSubtitleUrl", () => {
+  it("rejects a filename containing path separators at the boundary (zero API calls)", async () => {
+    const api = new FakePan115Api({ directories: { stage: [] } });
+    let offlineCalls = 0;
+    api.addOfflineTask = async () => {
+      offlineCalls += 1;
+      return { ok: true, message: "accepted" };
+    };
+    const executor = new Storage115Executor({ api });
+
+    const attempt = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/onthefly/1/evil.ass",
+      filename: "subdir/evil.ass",
+      directoryId: "stage",
+      workflowRunId: "run-test",
+    });
+
+    expect(attempt.status).toBe("failed");
+    expect(attempt.providerMessage).toMatch(/path separator|路径分隔/i);
+    expect(attempt.materializedFileIds).toEqual([]);
+    expect(offlineCalls).toBe(0);
+  });
+
   it("submits an offline task with the subtitle url, then confirms landing via listTree by filename", async () => {
     const api = new FakePan115Api({
       directories: { stage: [] },

--- a/packages/workflow/tests/subtitle-provider.test.ts
+++ b/packages/workflow/tests/subtitle-provider.test.ts
@@ -106,3 +106,37 @@ describe("AssrtSubtitleProvider.detail", () => {
     expect(await provider.detail(1)).toEqual([]);
   });
 });
+
+describe("AssrtSubtitleProvider.search — community-pick evidence fields", () => {
+  it("carries vote_score / release_site / upload_time when the API sends them", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: fakeFetch({
+        "sub/search": {
+          status: 0,
+          sub: {
+            subs: [
+              {
+                id: 5, videoname: "V", native_name: "N", lang: { desc: "简" },
+                vote_score: 50, release_site: "YYeTs", upload_time: "2023-05-01 12:00:00",
+              },
+            ],
+          },
+        },
+      }),
+    });
+    const out = await provider.search("k");
+    expect(out[0]).toMatchObject({ voteScore: 50, releaseSite: "YYeTs", uploadTime: "2023-05-01 12:00:00" });
+  });
+
+  it("omits the evidence keys entirely when absent (keeps the lean shape)", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: fakeFetch({
+        "sub/search": { status: 0, sub: { subs: [{ id: 6, videoname: "V", native_name: "", lang: { desc: "" } }] } },
+      }),
+    });
+    const out = await provider.search("k");
+    expect(Object.keys(out[0]!).sort()).toEqual(["id", "lang", "title"]);
+  });
+});

--- a/packages/workflow/tests/subtitle-provider.test.ts
+++ b/packages/workflow/tests/subtitle-provider.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { AssrtSubtitleProvider, type AssrtFetchJson } from "../src/subtitle-provider.js";
+
+function fakeFetch(byUrl: Record<string, unknown>): AssrtFetchJson {
+  return async (url: string) => {
+    for (const [needle, body] of Object.entries(byUrl)) {
+      if (url.includes(needle)) return body;
+    }
+    throw new Error(`unexpected url ${url}`);
+  };
+}
+
+describe("AssrtSubtitleProvider.search", () => {
+  it("maps a hit's sub.subs[] to {id,title,lang} candidates", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: fakeFetch({
+        "sub/search": {
+          status: 0,
+          sub: {
+            subs: [
+              { id: 713570, videoname: "Breaking.Bad.S02", native_name: "绝命毒师 第二季", lang: { desc: "英 简 双语" } },
+            ],
+          },
+        },
+      }),
+    });
+    const out = await provider.search("绝命毒师");
+    expect(out).toEqual([{ id: 713570, title: "绝命毒师 第二季 · Breaking.Bad.S02", lang: "英 简 双语" }]);
+  });
+
+  it("returns [] when sub.subs is the empty OBJECT the API sends for no results", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: fakeFetch({ "sub/search": { status: 0, sub: { subs: {}, result: "succeed" } } }),
+    });
+    expect(await provider.search("庆余年")).toEqual([]);
+  });
+
+  it("returns [] on quota-exceeded (status 30900) without throwing", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: fakeFetch({ "sub/search": { status: 30900, errmsg: "exceeding request limits" } }),
+    });
+    expect(await provider.search("x")).toEqual([]);
+  });
+
+  it("returns [] when the fetch itself throws (network / timeout)", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: async () => { throw new Error("network down"); },
+    });
+    expect(await provider.search("x")).toEqual([]);
+  });
+});
+
+describe("AssrtSubtitleProvider.detail", () => {
+  it("maps sub.subs[0].filelist to {filename,url} entries", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: fakeFetch({
+        "sub/detail": {
+          status: 0,
+          sub: {
+            subs: [
+              {
+                filename: "Breaking.Bad.S02.zip",
+                url: "http://file0.assrt.net/download/713570/x.zip?api=1",
+                filelist: [
+                  { f: "Breaking.Bad.S02E01.ass", s: "718KB", url: "http://file0.assrt.net/onthefly/713570/-/1/x.ass?api=1" },
+                  { f: "Breaking.Bad.S02E02.ass", s: "708KB", url: "http://file0.assrt.net/onthefly/713570/-/2/y.ass?api=1" },
+                ],
+              },
+            ],
+          },
+        },
+      }),
+    });
+    const out = await provider.detail(713570);
+    expect(out).toEqual([
+      { filename: "Breaking.Bad.S02E01.ass", url: "http://file0.assrt.net/onthefly/713570/-/1/x.ass?api=1" },
+      { filename: "Breaking.Bad.S02E02.ass", url: "http://file0.assrt.net/onthefly/713570/-/2/y.ass?api=1" },
+    ]);
+  });
+
+  it("falls back to the whole-package zip when filelist is absent", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: fakeFetch({
+        "sub/detail": {
+          status: 0,
+          sub: { subs: [{ filename: "pack.zip", url: "http://file0.assrt.net/download/1/pack.zip?api=1" }] },
+        },
+      }),
+    });
+    expect(await provider.detail(1)).toEqual([
+      { filename: "pack.zip", url: "http://file0.assrt.net/download/1/pack.zip?api=1" },
+    ]);
+  });
+
+  it("returns [] on a malformed / error detail response", async () => {
+    const provider = new AssrtSubtitleProvider({
+      token: "T",
+      fetchJson: fakeFetch({ "sub/detail": { status: 20001, errmsg: "invalid token" } }),
+    });
+    expect(await provider.detail(1)).toEqual([]);
+  });
+});

--- a/packages/workflow/tests/v2-agent-loop-tools.test.ts
+++ b/packages/workflow/tests/v2-agent-loop-tools.test.ts
@@ -105,3 +105,15 @@ describe("buildSandboxToolSet — the agent's tool surface over the cage", () =>
     expect(summary.missing).toEqual(["S01E02"]);
   });
 });
+
+describe("readSkill description — section list derived from the single source of truth", () => {
+  it("lists EVERY registered skill section (cannot drift when sections are added)", async () => {
+    const { SKILL_SECTION_NAMES } = await import("../src/acquisition-v2/skill.js");
+    const { sandbox } = await setup();
+    const tools = buildSandboxToolSet(sandbox);
+    const description = (tools["readSkill"] as { description?: string }).description ?? "";
+    for (const section of SKILL_SECTION_NAMES) {
+      expect(description).toContain(section);
+    }
+  });
+});

--- a/packages/workflow/tests/v2-raw-snapshot.test.ts
+++ b/packages/workflow/tests/v2-raw-snapshot.test.ts
@@ -147,3 +147,23 @@ describe("system prompt carries raw snapshot pointer", () => {
     expect(moviePrompt).not.toContain("viewResourceSnapshot");
   });
 });
+
+describe("system prompt carries subtitle snapshot pointer (symmetric with raw pointer)", () => {
+  it("TV/movie prompts include the subtitle pointer when the run is subtitle-active with candidates", () => {
+    for (const build of [buildTvAnimeSystemPrompt, buildMovieSystemPrompt]) {
+      const prompt = build({ subtitle: true, subtitleCandidateCount: 12 });
+      expect(prompt).toContain("12");
+      expect(prompt).toContain("viewSubtitleSnapshot");
+      expect(prompt).toMatch(/字幕|subtitle/i);
+    }
+  });
+
+  it("no subtitle pointer when the flow is inactive or the snapshot is empty", () => {
+    // The skill INDEX may mention viewSubtitleSnapshot (it tells the agent when to
+    // read the subtitle section) — what must NOT render is the POINTER header.
+    expect(buildTvAnimeSystemPrompt({})).not.toContain("SUBTITLE SNAPSHOT");
+    expect(buildTvAnimeSystemPrompt({ subtitle: true, subtitleCandidateCount: 0 })).not.toContain(
+      "SUBTITLE SNAPSHOT",
+    );
+  });
+});

--- a/packages/workflow/tests/v2-real-storage-adapter.test.ts
+++ b/packages/workflow/tests/v2-real-storage-adapter.test.ts
@@ -64,6 +64,16 @@ class RecordingExecutor implements StorageExecutor {
     return [];
   }
   async renameFile(): Promise<void> {}
+  async transferSubtitleUrl(input: { url: string; filename: string; directoryId: string; workflowRunId: string }): Promise<TransferAttempt> {
+    return {
+      id: `${input.workflowRunId}_subtitle_1`,
+      workflowRunId: input.workflowRunId,
+      candidateId: `subtitle:${input.filename}`,
+      status: "succeeded",
+      providerMessage: "",
+      materializedFileIds: ["sub_f1"],
+    };
+  }
   async flattenDirectory(): Promise<{ moved: string[]; removed: string[] }> {
     return { moved: [], removed: [] };
   }
@@ -156,6 +166,29 @@ describe("RealStorageV2 — StorageExecutor → StorageV2 adapter", () => {
     const { storage } = adapter(executor);
     await storage.deleteFiles({ directoryId: "season", fileIds: ["f1"] });
     expect(executor.deletes).toEqual([{ directoryId: "season", fileIds: ["f1"] }]);
+  });
+
+  it("keeps subtitle transfers OUT of attempts() so they can't fail snapshot persistence validation", async () => {
+    // A subtitle transfer's synthetic `subtitle:<filename>` candidateId belongs to no
+    // resource snapshot; validateWorkflowRunSnapshot rejects any persisted transferAttempt
+    // whose candidateId is not in a snapshot. So subtitle attempts must NOT enter attempts()
+    // (the persisted video-candidate trace) — otherwise a subtitle would abort the whole
+    // run's save after the video already landed.
+    const executor = new RecordingExecutor();
+    const { storage, registry } = adapter(executor);
+    registry.record(candidate("cand"));
+
+    await storage.transferCandidate({ candidateId: "cand", intoDirectoryId: "staging" });
+    await storage.transferSubtitleUrl({
+      url: "http://file0.assrt.net/onthefly/1/Show.S01E01.ass",
+      filename: "Show.S01E01.ass",
+      intoDirectoryId: "staging",
+    });
+
+    const attempts = storage.attempts();
+    expect(attempts).toHaveLength(1); // only the video transfer, not the subtitle
+    expect(attempts[0]!.candidateId).toBe("cand");
+    expect(attempts.some((a) => a.candidateId.startsWith("subtitle:"))).toBe(false);
   });
 
   it("classifies candidate link kind from the recorded url (115 share / magnet / unknown)", async () => {

--- a/packages/workflow/tests/v2-sandbox-subtitle.test.ts
+++ b/packages/workflow/tests/v2-sandbox-subtitle.test.ts
@@ -154,6 +154,45 @@ describe("transferSubtitle", () => {
   });
 });
 
+describe("renameSubtitle", () => {
+  it("renames a landed subtitle file in staging to a new name", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const file = { filename: "Breaking.Bad.S02E01.SOMEGROUP.ass", url: "http://file0.assrt.net/onthefly/1/a.ass?api=1" };
+    const provider = makeAssrtProvider([{ id: 500, title: "BB", lang: "英 简 双语" }], { 500: [file] });
+    await sandbox.primeSubtitleSnapshot("BB", provider);
+    const res = await sandbox.transferSubtitle({ candidateId: 500 });
+    expect(res.status).toBe("succeeded");
+
+    // Find the landed file's id via inspectStaging, then rename it.
+    const staging = await sandbox.inspectStaging();
+    const landed = staging.find((f) => f.path.endsWith("Breaking.Bad.S02E01.SOMEGROUP.ass"));
+    expect(landed).toBeDefined();
+
+    const out = await sandbox.renameSubtitle({ fileId: landed!.id, newName: "The.Video.S02E01.ass" });
+    expect(out.renamed).toBe("The.Video.S02E01.ass");
+
+    const after = await sandbox.inspectStaging();
+    expect(after.some((f) => f.path.endsWith("The.Video.S02E01.ass"))).toBe(true);
+    expect(after.some((f) => f.path.endsWith("Breaking.Bad.S02E01.SOMEGROUP.ass"))).toBe(false);
+  });
+
+  it("throws when the fileId is not in staging (scope guard)", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    await expect(sandbox.renameSubtitle({ fileId: "not-in-staging", newName: "x.ass" }))
+      .rejects.toThrow(/not in.*staging|SANDBOX_FILE_NOT_IN_STAGING|未.*staging/i);
+  });
+});
+
+describe("buildSandboxToolSet renameSubtitle registration", () => {
+  it("registers renameSubtitle only when options.subtitle is true", () => {
+    const provider = new FakeResourceProviderV2({ results: { title: [] } });
+    const storage = new Storage115Simulator({ packs: {} });
+    const sandbox = new TaskSandbox({ provider, storage, stagingDirectoryId: "s", need: ["S01E01"] });
+    expect("renameSubtitle" in buildSandboxToolSet(sandbox)).toBe(false);
+    expect("renameSubtitle" in buildSandboxToolSet(sandbox, { subtitle: true })).toBe(true);
+  });
+});
+
 describe("buildSandboxToolSet subtitle tool registration", () => {
   it("does NOT include viewSubtitleSnapshot/transferSubtitle by default", () => {
     const provider = new FakeResourceProviderV2({ results: { title: [] } });

--- a/packages/workflow/tests/v2-sandbox-subtitle.test.ts
+++ b/packages/workflow/tests/v2-sandbox-subtitle.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { TaskSandbox } from "../src/acquisition-v2/sandbox.js";
+import { FakeResourceProviderV2 } from "../src/acquisition-v2/fake-provider.js";
+import { Storage115Simulator, type TransferAttemptResult } from "../src/acquisition-v2/storage-115-simulator.js";
+import type { AssrtCandidate, AssrtSubtitleFile } from "../src/subtitle-provider.js";
+
+/** The provider object shape primeSubtitleSnapshot takes. */
+type FakeAssrtProvider = {
+  search(keyword: string): Promise<AssrtCandidate[]>;
+  detail(id: number): Promise<AssrtSubtitleFile[]>;
+};
+
+function makeAssrtProvider(
+  searchResults: AssrtCandidate[],
+  detailByCandidate: Record<number, AssrtSubtitleFile[]>,
+  spy?: { searchCalls?: number; detailCalls?: number },
+): FakeAssrtProvider {
+  return {
+    search: async (_keyword: string) => {
+      spy?.searchCalls !== undefined && (spy.searchCalls += 1);
+      return searchResults;
+    },
+    detail: async (id: number) => {
+      spy?.detailCalls !== undefined && (spy.detailCalls += 1);
+      return detailByCandidate[id] ?? [];
+    },
+  };
+}
+
+/** Build a TaskSandbox wired to a fake video provider + sim storage. assrt is NOT
+ *  passed at construction — it goes to primeSubtitleSnapshot per-test. */
+async function createSubtitleSandbox() {
+  const provider = new FakeResourceProviderV2({ results: { title: [] } });
+  const storage = new Storage115Simulator({ packs: {} });
+  const stagingDirectoryId = await storage.createDirectory({ name: "staging", parentId: "root" });
+  const targetSeasonDirectoryId = await storage.createDirectory({ name: "Season 1", parentId: "root" });
+  const sandbox = new TaskSandbox({
+    provider,
+    storage,
+    stagingDirectoryId,
+    targetSeasonDirectoryIds: { 1: targetSeasonDirectoryId },
+    need: ["S01E01"],
+  });
+  return { sandbox, stagingDirectoryId, targetSeasonDirectoryId };
+}
+
+describe("subtitle snapshot pre-warming + view", () => {
+  it("primeSubtitleSnapshot pre-warms assrt candidates, viewSubtitleSnapshot renders them", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const provider = makeAssrtProvider(
+      [{ id: 713570, title: "绝命毒师 第二季 · Breaking.Bad.S02", lang: "英 简 双语" }],
+      {},
+    );
+
+    await sandbox.primeSubtitleSnapshot("绝命毒师", provider);
+
+    const snap = sandbox.viewSubtitleSnapshot();
+    expect(snap.document).toContain("713570");
+    expect(snap.document).toContain("绝命毒师 第二季");
+    expect(snap.candidateCount).toBe(1);
+  });
+
+  it("viewSubtitleSnapshot before any pre-warm returns an empty doc", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const snap = sandbox.viewSubtitleSnapshot();
+    expect(snap.candidateCount).toBe(0);
+    expect(snap.document).toMatch(/no subtitle|无字幕|empty|未预热/i);
+  });
+
+  it("viewSubtitleSnapshot is free + repeatable (no provider re-hit)", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const spy = { searchCalls: 0, detailCalls: 0 };
+    const provider = makeAssrtProvider([{ id: 1, title: "x", lang: "" }], {}, spy);
+
+    await sandbox.primeSubtitleSnapshot("k", provider);
+    const searchCallsAfterPrime = spy.searchCalls;
+
+    sandbox.viewSubtitleSnapshot();
+    sandbox.viewSubtitleSnapshot();
+    expect(spy.searchCalls).toBe(searchCallsAfterPrime); // view never re-hits search
+  });
+});
+
+describe("transferSubtitle", () => {
+  it("resolves the candidate's detail filelist and lands each file via storage.transferSubtitleUrl", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const file = { filename: "Breaking.Bad.S02E01.ass", url: "http://file0.assrt.net/onthefly/713570/-/1/a.ass?api=1" };
+    const provider = makeAssrtProvider(
+      [{ id: 713570, title: "BB S02", lang: "英 简 双语" }],
+      { 713570: [file] },
+    );
+    await sandbox.primeSubtitleSnapshot("BB", provider);
+
+    const result = await sandbox.transferSubtitle({ candidateId: 713570 });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.landedFilenames).toEqual(["Breaking.Bad.S02E01.ass"]);
+  });
+
+  it("throws when the candidate was not in the pre-warmed snapshot (no stale ids)", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const provider = makeAssrtProvider([{ id: 1, title: "x", lang: "" }], {});
+    await sandbox.primeSubtitleSnapshot("k", provider);
+
+    await expect(sandbox.transferSubtitle({ candidateId: 999 })).rejects.toThrow(
+      /not in.*subtitle.*snapshot|未.*预热/i,
+    );
+  });
+
+  it("returns failed when the filelist is empty (detail miss)", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const provider = makeAssrtProvider([{ id: 1, title: "x", lang: "" }], {}); // detail(1) -> []
+    await sandbox.primeSubtitleSnapshot("k", provider);
+
+    const result = await sandbox.transferSubtitle({ candidateId: 1 });
+    expect(result.status).toBe("failed");
+    expect(result.landedFilenames).toEqual([]);
+  });
+
+  it("partial success: lands the files that succeed, reports succeeded, surfaces the failure error", async () => {
+    const provider = new FakeResourceProviderV2({ results: { title: [] } });
+    const storage = new Storage115Simulator({ packs: {} });
+    const stagingDirectoryId = await storage.createDirectory({ name: "staging", parentId: "root" });
+    const targetSeasonDirectoryId = await storage.createDirectory({ name: "Season 1", parentId: "root" });
+    const sandbox = new TaskSandbox({
+      provider,
+      storage,
+      stagingDirectoryId,
+      targetSeasonDirectoryIds: { 1: targetSeasonDirectoryId },
+      need: ["S01E01"],
+    });
+    // Override the sim's subtitle landing: 1st file succeeds, 2nd fails.
+    let call = 0;
+    storage.transferSubtitleUrl = async (
+      input: { url: string; filename: string; intoDirectoryId: string; workflowRunId: string },
+    ): Promise<TransferAttemptResult> => {
+      call += 1;
+      if (call === 1) return { status: "succeeded", materializedFileIds: ["f1"] };
+      return { status: "failed", materializedFileIds: [], providerMessage: "dead link" };
+    };
+    const files = [
+      { filename: "Show.S01E01.ass", url: "http://file0.assrt.net/onthefly/1/-/1/a.ass?api=1" },
+      { filename: "Show.S01E02.ass", url: "http://file0.assrt.net/onthefly/1/-/2/b.ass?api=1" },
+    ];
+    const assrtProvider = makeAssrtProvider([{ id: 500, title: "Show", lang: "简体" }], { 500: files });
+    await sandbox.primeSubtitleSnapshot("Show", assrtProvider);
+
+    const result = await sandbox.transferSubtitle({ candidateId: 500 });
+
+    expect(result.status).toBe("succeeded"); // at least one landed
+    expect(result.landedFilenames).toEqual(["Show.S01E01.ass"]); // only the one that landed
+    expect(result.error).toBe("dead link"); // the failure's message surfaced
+  });
+});

--- a/packages/workflow/tests/v2-sandbox-subtitle.test.ts
+++ b/packages/workflow/tests/v2-sandbox-subtitle.test.ts
@@ -334,3 +334,49 @@ describe("subtitle snapshot evidence + failure bounding", () => {
     expect(result.landedFilenames).toEqual(["E2.ass", "E5.ass"]);
   });
 });
+
+describe("transferSubtitle — non-subtitle files are filtered at the boundary", () => {
+  it("lands only subtitle-extension files from a mixed filelist (readme/fonts skipped, no budget waste)", async () => {
+    const provider = new FakeResourceProviderV2({ results: { title: [] } });
+    class CountingStorage extends Storage115Simulator {
+      calls: string[] = [];
+      override async transferSubtitleUrl(input: { url: string; filename: string; intoDirectoryId: string; workflowRunId: string }): Promise<TransferAttemptResult> {
+        this.calls.push(input.filename);
+        return super.transferSubtitleUrl(input);
+      }
+    }
+    const storage = new CountingStorage({ packs: {} });
+    const stagingDirectoryId = await storage.createDirectory({ name: "staging", parentId: "root" });
+    const sandbox = new TaskSandbox({ provider, storage, stagingDirectoryId, targetSeasonDirectoryIds: {}, need: [] });
+    const assrt = makeAssrtProvider(
+      [{ id: 9, title: "t", lang: "简" }],
+      { 9: [
+        { filename: "Show.S01E01.ass", url: "http://x/1.ass" },
+        { filename: "readme.txt", url: "http://x/readme.txt" },
+        { filename: "fonts.zip", url: "http://x/fonts.zip" },
+      ] },
+    );
+    await sandbox.primeSubtitleSnapshot("t", assrt);
+
+    const result = await sandbox.transferSubtitle({ candidateId: 9 });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.landedFilenames).toEqual(["Show.S01E01.ass"]);
+    expect(storage.calls).toEqual(["Show.S01E01.ass"]); // txt/zip never hit 115
+  });
+
+  it("whole-package zip fallback → failed WITHOUT any storage call (a zip in staging is unusable junk)", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const assrt = makeAssrtProvider(
+      [{ id: 10, title: "t", lang: "简" }],
+      { 10: [{ filename: "pack.zip", url: "http://x/pack.zip" }] },
+    );
+    await sandbox.primeSubtitleSnapshot("t", assrt);
+
+    const result = await sandbox.transferSubtitle({ candidateId: 10 });
+
+    expect(result.status).toBe("failed");
+    expect(result.landedFilenames).toEqual([]);
+    expect(result.error).toMatch(/压缩包|zip|字幕文件/i);
+  });
+});

--- a/packages/workflow/tests/v2-sandbox-subtitle.test.ts
+++ b/packages/workflow/tests/v2-sandbox-subtitle.test.ts
@@ -3,6 +3,7 @@ import { TaskSandbox } from "../src/acquisition-v2/sandbox.js";
 import { FakeResourceProviderV2 } from "../src/acquisition-v2/fake-provider.js";
 import { Storage115Simulator, type TransferAttemptResult } from "../src/acquisition-v2/storage-115-simulator.js";
 import type { AssrtCandidate, AssrtSubtitleFile } from "../src/subtitle-provider.js";
+import { buildSandboxToolSet } from "../src/acquisition-v2/agent-loop.js";
 
 /** The provider object shape primeSubtitleSnapshot takes. */
 type FakeAssrtProvider = {
@@ -150,5 +151,35 @@ describe("transferSubtitle", () => {
     expect(result.status).toBe("succeeded"); // at least one landed
     expect(result.landedFilenames).toEqual(["Show.S01E01.ass"]); // only the one that landed
     expect(result.error).toBe("dead link"); // the failure's message surfaced
+  });
+});
+
+describe("buildSandboxToolSet subtitle tool registration", () => {
+  it("does NOT include viewSubtitleSnapshot/transferSubtitle by default", () => {
+    const provider = new FakeResourceProviderV2({ results: { title: [] } });
+    const storage = new Storage115Simulator({ packs: {} });
+    const sandbox = new TaskSandbox({
+      provider,
+      storage,
+      stagingDirectoryId: "s",
+      need: ["S01E01"],
+    });
+    const tools = buildSandboxToolSet(sandbox);
+    expect("viewSubtitleSnapshot" in tools).toBe(false);
+    expect("transferSubtitle" in tools).toBe(false);
+  });
+
+  it("includes viewSubtitleSnapshot/transferSubtitle when options.subtitle is true", () => {
+    const provider = new FakeResourceProviderV2({ results: { title: [] } });
+    const storage = new Storage115Simulator({ packs: {} });
+    const sandbox = new TaskSandbox({
+      provider,
+      storage,
+      stagingDirectoryId: "s",
+      need: ["S01E01"],
+    });
+    const tools = buildSandboxToolSet(sandbox, { subtitle: true });
+    expect("viewSubtitleSnapshot" in tools).toBe(true);
+    expect("transferSubtitle" in tools).toBe(true);
   });
 });

--- a/packages/workflow/tests/v2-sandbox-subtitle.test.ts
+++ b/packages/workflow/tests/v2-sandbox-subtitle.test.ts
@@ -272,3 +272,65 @@ describe("buildSandboxToolSet subtitle tool registration", () => {
     expect("transferSubtitle" in tools).toBe(true);
   });
 });
+
+describe("subtitle snapshot evidence + failure bounding", () => {
+  it("viewSubtitleSnapshot renders vote score + release site so the agent can pick the community favorite", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const provider = makeAssrtProvider(
+      [{ id: 2, title: "BB S02", lang: "简", voteScore: 50, releaseSite: "YYeTs", uploadTime: "2023-05-01 12:00:00" }],
+      {},
+    );
+    await sandbox.primeSubtitleSnapshot("BB", provider);
+    const snap = sandbox.viewSubtitleSnapshot();
+    expect(snap.document).toContain("★50");
+    expect(snap.document).toContain("YYeTs");
+  });
+
+  it("aborts after 3 consecutive landing failures instead of hammering the whole filelist (115 budget guard)", async () => {
+    const provider = new FakeResourceProviderV2({ results: { title: [] } });
+    class AlwaysFailingStorage extends Storage115Simulator {
+      calls = 0;
+      override async transferSubtitleUrl(): Promise<TransferAttemptResult> {
+        this.calls += 1;
+        return { status: "failed", materializedFileIds: [], providerMessage: "dead link" };
+      }
+    }
+    const storage = new AlwaysFailingStorage({ packs: {} });
+    const stagingDirectoryId = await storage.createDirectory({ name: "staging", parentId: "root" });
+    const sandbox = new TaskSandbox({ provider, storage, stagingDirectoryId, targetSeasonDirectoryIds: {}, need: [] });
+    const files = Array.from({ length: 10 }, (_, i) => ({ filename: `E${i}.ass`, url: `http://x/${i}.ass` }));
+    const assrt = makeAssrtProvider([{ id: 7, title: "t", lang: "" }], { 7: files });
+    await sandbox.primeSubtitleSnapshot("t", assrt);
+
+    const result = await sandbox.transferSubtitle({ candidateId: 7 });
+
+    expect(result.status).toBe("failed");
+    expect(storage.calls).toBe(3);
+    expect(result.error).toMatch(/连续|consecutive/i);
+  });
+
+  it("a success in between resets the consecutive-failure counter", async () => {
+    const provider = new FakeResourceProviderV2({ results: { title: [] } });
+    class FlakyStorage extends Storage115Simulator {
+      calls = 0;
+      override async transferSubtitleUrl(input: { url: string; filename: string; intoDirectoryId: string; workflowRunId: string }): Promise<TransferAttemptResult> {
+        this.calls += 1;
+        // fail, fail, succeed, fail, fail, succeed, ... — never 3 in a row
+        if (this.calls % 3 === 0) return super.transferSubtitleUrl(input);
+        return { status: "failed", materializedFileIds: [], providerMessage: "flaky" };
+      }
+    }
+    const storage = new FlakyStorage({ packs: {} });
+    const stagingDirectoryId = await storage.createDirectory({ name: "staging", parentId: "root" });
+    const sandbox = new TaskSandbox({ provider, storage, stagingDirectoryId, targetSeasonDirectoryIds: {}, need: [] });
+    const files = Array.from({ length: 6 }, (_, i) => ({ filename: `E${i}.ass`, url: `http://x/${i}.ass` }));
+    const assrt = makeAssrtProvider([{ id: 8, title: "t", lang: "" }], { 8: files });
+    await sandbox.primeSubtitleSnapshot("t", assrt);
+
+    const result = await sandbox.transferSubtitle({ candidateId: 8 });
+
+    expect(result.status).toBe("succeeded");
+    expect(storage.calls).toBe(6); // all 6 attempted — counter reset by the successes
+    expect(result.landedFilenames).toEqual(["E2.ass", "E5.ass"]);
+  });
+});

--- a/packages/workflow/tests/v2-sandbox-subtitle.test.ts
+++ b/packages/workflow/tests/v2-sandbox-subtitle.test.ts
@@ -181,6 +181,56 @@ describe("renameSubtitle", () => {
     await expect(sandbox.renameSubtitle({ fileId: "not-in-staging", newName: "x.ass" }))
       .rejects.toThrow(/not in.*staging|SANDBOX_FILE_NOT_IN_STAGING|未.*staging/i);
   });
+
+  it("rejects a newName with path separators (rename is not a move)", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const file = { filename: "Show.S01E01.ass", url: "http://file0.assrt.net/onthefly/1/a.ass?api=1" };
+    const provider = makeAssrtProvider([{ id: 7, title: "Show", lang: "简体" }], { 7: [file] });
+    await sandbox.primeSubtitleSnapshot("Show", provider);
+    await sandbox.transferSubtitle({ candidateId: 7 });
+    const landed = (await sandbox.inspectStaging()).find((f) => f.path.endsWith("Show.S01E01.ass"));
+
+    await expect(sandbox.renameSubtitle({ fileId: landed!.id, newName: "sub/Show.S01E01.ass" }))
+      .rejects.toThrow(/SANDBOX_INVALID_SUBTITLE_NAME|path separator/i);
+  });
+
+  it("rejects a newName that is not a subtitle extension (can't disguise a subtitle as a video)", async () => {
+    const { sandbox } = await createSubtitleSandbox();
+    const file = { filename: "Show.S01E01.ass", url: "http://file0.assrt.net/onthefly/1/a.ass?api=1" };
+    const provider = makeAssrtProvider([{ id: 8, title: "Show", lang: "简体" }], { 8: [file] });
+    await sandbox.primeSubtitleSnapshot("Show", provider);
+    await sandbox.transferSubtitle({ candidateId: 8 });
+    const landed = (await sandbox.inspectStaging()).find((f) => f.path.endsWith("Show.S01E01.ass"));
+
+    await expect(sandbox.renameSubtitle({ fileId: landed!.id, newName: "Show.S01E01.mkv" }))
+      .rejects.toThrow(/SANDBOX_INVALID_SUBTITLE_NAME|subtitle extension/i);
+  });
+
+  it("rejects renaming a non-subtitle file (only subtitles may be renamed)", async () => {
+    const provider = new FakeResourceProviderV2({
+      results: { title: [{ id: "vid", title: "Show S01E01" }] },
+    });
+    const storage = new Storage115Simulator({
+      packs: { vid: { files: [{ path: "Show.S01E01.mkv", sizeBytes: 900_000_000 }] } },
+      linkKinds: { vid: "pan115" },
+    });
+    const stagingDirectoryId = await storage.createDirectory({ name: "staging", parentId: "root" });
+    const targetSeasonDirectoryId = await storage.createDirectory({ name: "Season 1", parentId: "root" });
+    const sandbox = new TaskSandbox({
+      provider,
+      storage,
+      stagingDirectoryId,
+      targetSeasonDirectoryIds: { 1: targetSeasonDirectoryId },
+      need: ["S01E01"],
+    });
+    const snap = await sandbox.searchResources("title");
+    await sandbox.transferCandidate({ snapshotId: snap.snapshot!.id, candidateId: "vid" });
+    const video = (await sandbox.inspectStaging()).find((f) => f.path.endsWith("Show.S01E01.mkv"));
+    expect(video).toBeDefined();
+
+    await expect(sandbox.renameSubtitle({ fileId: video!.id, newName: "Show.S01E01.ass" }))
+      .rejects.toThrow(/SANDBOX_NOT_A_SUBTITLE|not a subtitle/i);
+  });
 });
 
 describe("buildSandboxToolSet renameSubtitle registration", () => {

--- a/packages/workflow/tests/v2-sandbox-subtitle.test.ts
+++ b/packages/workflow/tests/v2-sandbox-subtitle.test.ts
@@ -133,7 +133,7 @@ describe("transferSubtitle", () => {
     // Override the sim's subtitle landing: 1st file succeeds, 2nd fails.
     let call = 0;
     storage.transferSubtitleUrl = async (
-      input: { url: string; filename: string; intoDirectoryId: string; workflowRunId: string },
+      _input: { url: string; filename: string; intoDirectoryId: string },
     ): Promise<TransferAttemptResult> => {
       call += 1;
       if (call === 1) return { status: "succeeded", materializedFileIds: ["f1"] };
@@ -313,7 +313,7 @@ describe("subtitle snapshot evidence + failure bounding", () => {
     const provider = new FakeResourceProviderV2({ results: { title: [] } });
     class FlakyStorage extends Storage115Simulator {
       calls = 0;
-      override async transferSubtitleUrl(input: { url: string; filename: string; intoDirectoryId: string; workflowRunId: string }): Promise<TransferAttemptResult> {
+      override async transferSubtitleUrl(input: { url: string; filename: string; intoDirectoryId: string }): Promise<TransferAttemptResult> {
         this.calls += 1;
         // fail, fail, succeed, fail, fail, succeed, ... — never 3 in a row
         if (this.calls % 3 === 0) return super.transferSubtitleUrl(input);
@@ -340,7 +340,7 @@ describe("transferSubtitle — non-subtitle files are filtered at the boundary",
     const provider = new FakeResourceProviderV2({ results: { title: [] } });
     class CountingStorage extends Storage115Simulator {
       calls: string[] = [];
-      override async transferSubtitleUrl(input: { url: string; filename: string; intoDirectoryId: string; workflowRunId: string }): Promise<TransferAttemptResult> {
+      override async transferSubtitleUrl(input: { url: string; filename: string; intoDirectoryId: string }): Promise<TransferAttemptResult> {
         this.calls.push(input.filename);
         return super.transferSubtitleUrl(input);
       }


### PR DESCRIPTION
## What

接 issue #82：非国产剧集/电影获取时，自动从 [assrt.net](https://assrt.net)（伪射手，免费官方 API）预搜外挂中文字幕候选，agent 语义挑选后落盘到视频旁。

设计哲学沿用刚完成的搜索重构（#72）：「系统预搜 + 活期文档 + agent 语义挑选」，**不做机械化健康检查**。**阶段一仅支持 115 网盘**（115 离线下载底层支持 http 直链，可零新协议落盘）；夸克/光鸭后续单独立项（夸克无磁力 web API，光鸭待验证）。

## How（10 commits，分层实现）

1. `AssrtSubtitleProvider`（search + detail，容错对齐 PanSou——任何非命中都返回空、绝不抛错）
2. 115 `transferSubtitleUrl`——字幕直链走 115 离线下载，落地检测用 `listTree` 按文件名匹配（**不复用** `transferCandidate`，因它用 `listVideoFiles` 会漏检字幕）
3. sandbox `primeSubtitleSnapshot`/`viewSubtitleSnapshot`/`transferSubtitle`（独立活期文档）
4. agent-loop 条件注册字幕工具
5. skill `subtitle` 章节（工具存在即信号 + 重命名例外 + 软评判）
6. orchestrator 三重门控（`assrtToken && 非国产 && 115`）+ `subtitle` 旗标贯通 + `AssrtProviderPort` 类型
7. Settings 页「字幕来源」section（仿 TMDB 单字段表单 + assrt 官网/注册页链接）
8. `assrtToken` 从 Settings DB 贯通 worker → runner → workflow → orchestrator
9. **fix**：`transferSubtitleUrl` id off-by-one（成功/失败路径撞 `transfer_attempts` 主键 → 整个 run 持久化回滚 → 丢视频记录，即字幕失败阻塞视频）——已修 + 回归测试
10. `renameSubtitle` 工具——接通 `renameFile` 存储链，让 agent 能把落盘字幕重命名成与视频同名（honoring「唯一重命名例外」设计）

## 「工具存在即信号」激活

`viewSubtitleSnapshot`/`transferSubtitle`/`renameSubtitle` **仅当**三重门控全过时才注册进 agent 工具表；不满足时 key 压根不存在（不是存在但返回空）。未配 token / 国产内容 / 非 115 品牌时对 agent 完全无感。

## 安全铁律

字幕失败**绝不阻塞视频**：provider 返回空、`primeSubtitleSnapshot` 内部+orchestrator 双层 try/catch、`transferSubtitle` 软失败、非 115 品牌工具压根不注册。final review 已逐路径核实（含修复的 id 冲突路径）。

## Test plan

- [x] unit：subtitle-provider（容错）、storage transferSubtitleUrl（离线任务+落地检测+id 不冲突回归）、sandbox（预热/view/transfer/rename）、agent-loop（条件注册）、skill（章节+index）、orchestrator（4 门控组合+多来源）
- [x] 全量门：lint / build:workflow / build:web / vitest（1097 passed）
- [ ] **live e2e（部署后）**：非国产剧集/电影 → agent 看到字幕工具、挑候选、落盘、重命名、归位到视频同目录；国产/未配 token/夸克盘 → 字幕工具压根不出现

🤖 Generated with subagent-driven development (per-task spec + code-quality review + final whole-feature review)