### PR TITLE
fix(subtitle): 字幕落地检测窗与秒传确认窗分离(真机实测 20~60s)

### DIFF
--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -359,8 +359,9 @@ export class Storage115Executor implements StorageExecutor {
     // Subtitles are NOT 秒传 confirmations — they are real server-side HTTP
     // fetches with queue latency. Live e2e (The Matrix, 2026-07-02) measured
     // one landing at ~20s and one at ~60s (the 8s video window mis-judged it
-    // no_target_change and the file dropped in late). 8 × 6s ≈ 48s covers the
-    // common case while bounding poll cost (each poll = one depth-2 listTree).
+    // no_target_change and the file dropped in late). 8 attempts sleep only
+    // BETWEEN polls (7 gaps × 6s ≈ 42s + listing time) — covers the common
+    // case while bounding poll cost (each poll = one depth-2 listTree).
     this.subtitleMaterializeAttempts = options.subtitleMaterializeAttempts ?? 8;
     this.subtitleMaterializePollMs = options.subtitleMaterializePollMs ?? 6000;
     this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -119,7 +119,11 @@ export interface Storage115ExecutorOptions {
   /** Subtitle-landing window (transferSubtitleUrl). Separate from the video
    *  window: that one only confirms a 秒传 cache hit (~8s), while a subtitle is
    *  a REAL server-side HTTP fetch whose queue latency varies — live e2e
-   *  (2026-07-02, The Matrix) measured landings at ~20s and ~60s. */
+   *  (2026-07-02, The Matrix) measured landings at ~20s and ~60s.
+   *  Timing semantics: the first poll is immediate; sleeps happen only BETWEEN
+   *  polls, so the effective wait ≈ (attempts - 1) × pollMs plus listTree time
+   *  (defaults 8 & 6000ms → ~42s of sleeps). Each poll costs one depth-2
+   *  listTree, so attempts also bounds the 115 API spend per file. */
   subtitleMaterializeAttempts?: number;
   subtitleMaterializePollMs?: number;
   /** Injectable sleep (tests pass a fast/no-op). */

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -116,6 +116,12 @@ export interface Storage115ExecutorOptions {
   offlineMaterializeAttempts?: number;
   /** Delay between offline-task materialization checks (ms). */
   offlineMaterializePollMs?: number;
+  /** Subtitle-landing window (transferSubtitleUrl). Separate from the video
+   *  window: that one only confirms a 秒传 cache hit (~8s), while a subtitle is
+   *  a REAL server-side HTTP fetch whose queue latency varies — live e2e
+   *  (2026-07-02, The Matrix) measured landings at ~20s and ~60s. */
+  subtitleMaterializeAttempts?: number;
+  subtitleMaterializePollMs?: number;
   /** Injectable sleep (tests pass a fast/no-op). */
   sleep?: (ms: number) => Promise<void>;
 }
@@ -129,6 +135,8 @@ export interface ProtectedStorage115ExecutorOptions {
   videoExtensions?: string[];
   offlineMaterializeAttempts?: number;
   offlineMaterializePollMs?: number;
+  subtitleMaterializeAttempts?: number;
+  subtitleMaterializePollMs?: number;
   sleep?: (ms: number) => Promise<void>;
 }
 
@@ -325,6 +333,8 @@ export class Storage115Executor implements StorageExecutor {
   private readonly apiGuard: Pan115ApiGuard;
   private readonly offlineMaterializeAttempts: number;
   private readonly offlineMaterializePollMs: number;
+  private readonly subtitleMaterializeAttempts: number;
+  private readonly subtitleMaterializePollMs: number;
   private readonly sleep: (ms: number) => Promise<void>;
   private nextTransferNumber = 1;
 
@@ -346,6 +356,13 @@ export class Storage115Executor implements StorageExecutor {
     // span, 115 has no cached copy and the caller switches candidates.
     this.offlineMaterializeAttempts = options.offlineMaterializeAttempts ?? 4;
     this.offlineMaterializePollMs = options.offlineMaterializePollMs ?? 2000;
+    // Subtitles are NOT 秒传 confirmations — they are real server-side HTTP
+    // fetches with queue latency. Live e2e (The Matrix, 2026-07-02) measured
+    // one landing at ~20s and one at ~60s (the 8s video window mis-judged it
+    // no_target_change and the file dropped in late). 8 × 6s ≈ 48s covers the
+    // common case while bounding poll cost (each poll = one depth-2 listTree).
+    this.subtitleMaterializeAttempts = options.subtitleMaterializeAttempts ?? 8;
+    this.subtitleMaterializePollMs = options.subtitleMaterializePollMs ?? 6000;
     this.sleep = options.sleep ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
   }
 
@@ -569,7 +586,7 @@ export class Storage115Executor implements StorageExecutor {
       };
     }
 
-    let remaining = this.offlineMaterializeAttempts;
+    let remaining = this.subtitleMaterializeAttempts;
     let materializedFileIds: string[] = [];
     while (remaining > 0) {
       // maxDepth: 2 bounds the per-poll API fan-out (listTree recurses + lists each
@@ -585,7 +602,7 @@ export class Storage115Executor implements StorageExecutor {
         break;
       }
       remaining -= 1;
-      if (remaining > 0) await this.sleep(this.offlineMaterializePollMs);
+      if (remaining > 0) await this.sleep(this.subtitleMaterializePollMs);
     }
 
     // Nothing materialized in the window: 115 queued a real background download we

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -122,8 +122,9 @@ export interface Storage115ExecutorOptions {
    *  (2026-07-02, The Matrix) measured landings at ~20s and ~60s.
    *  Timing semantics: the first poll is immediate; sleeps happen only BETWEEN
    *  polls, so the effective wait ≈ (attempts - 1) × pollMs plus listTree time
-   *  (defaults 8 & 6000ms → ~42s of sleeps). Each poll costs one depth-2
-   *  listTree, so attempts also bounds the 115 API spend per file. */
+   *  (defaults 8 & 6000ms → ~42s of sleeps). Worst-case listTree count is
+   *  1 + attempts (the before/after-diff snapshot + each poll), so attempts
+   *  bounds the 115 API spend per file. */
   subtitleMaterializeAttempts?: number;
   subtitleMaterializePollMs?: number;
   /** Injectable sleep (tests pass a fast/no-op). */

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -1118,6 +1118,12 @@ function optionalExecutorOptions(
   if (options.offlineMaterializePollMs !== undefined) {
     executorOptions.offlineMaterializePollMs = options.offlineMaterializePollMs;
   }
+  if (options.subtitleMaterializeAttempts !== undefined) {
+    executorOptions.subtitleMaterializeAttempts = options.subtitleMaterializeAttempts;
+  }
+  if (options.subtitleMaterializePollMs !== undefined) {
+    executorOptions.subtitleMaterializePollMs = options.subtitleMaterializePollMs;
+  }
   if (options.sleep !== undefined) {
     executorOptions.sleep = options.sleep;
   }

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1078,8 +1078,8 @@ describe("Storage115Executor.transferSubtitleUrl", () => {
     api.addOfflineTask = async () => ({ ok: true, message: "accepted" }); // lands nothing new
     const executor = new Storage115Executor({
       api,
-      offlineMaterializeAttempts: 1,
-      offlineMaterializePollMs: 1,
+      subtitleMaterializeAttempts: 1,
+      subtitleMaterializePollMs: 1,
       sleep: async () => {},
     });
 
@@ -1178,8 +1178,8 @@ describe("Storage115Executor.transferSubtitleUrl", () => {
     api.addOfflineTask = async () => ({ ok: true, message: "accepted" });
     const executor = new Storage115Executor({
       api,
-      offlineMaterializeAttempts: 1,
-      offlineMaterializePollMs: 1,
+      subtitleMaterializeAttempts: 1,
+      subtitleMaterializePollMs: 1,
       sleep: async () => {},
     });
 
@@ -1205,8 +1205,8 @@ describe("Storage115Executor.transferSubtitleUrl", () => {
     api.addOfflineTask = async () => ({ ok: true, message: "accepted" });
     const executor = new Storage115Executor({
       api,
-      offlineMaterializeAttempts: 1,
-      offlineMaterializePollMs: 1,
+      subtitleMaterializeAttempts: 1,
+      subtitleMaterializePollMs: 1,
       sleep: async () => {},
     });
 

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1005,6 +1005,39 @@ describe("Storage115Executor", () => {
 });
 
 describe("Storage115Executor.transferSubtitleUrl", () => {
+  it("createProtectedStorage115Executor passes the subtitle window options through (tuning must not be silently ignored)", async () => {
+    const api = new FakePan115Api({ directories: { stage: [] } });
+    let listCalls = 0;
+    api.addOfflineTask = async () => ({ ok: true, message: "accepted" });
+    const origList = api.listItems.bind(api);
+    api.listItems = async (input) => {
+      listCalls += 1;
+      // Lands on the 2nd listing — inside the DEFAULT window (8) but outside the
+      // TUNED window (1). If the factory drops the tuning, this test sees succeeded.
+      if (listCalls === 2) {
+        api.directories["stage"] = [{ fid: "late_sub", n: "Tuned.S01E01.ass", s: "40KB" }];
+      }
+      return origList(input);
+    };
+    const executor = createProtectedStorage115Executor({
+      api,
+      env: { MEDIA_TRACK_115_TEST_ROOT_CID: "stage" },
+      apiGuardOptions: { minDelayMs: 0 },
+      subtitleMaterializeAttempts: 1,
+      subtitleMaterializePollMs: 1,
+      sleep: async () => {},
+    });
+
+    const attempt = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/onthefly/1/Tuned.S01E01.ass",
+      filename: "Tuned.S01E01.ass",
+      directoryId: "stage",
+      workflowRunId: "run-test",
+    });
+
+    expect(attempt.status).toBe("no_target_change");
+  });
+
   it("uses a subtitle-specific materialization window wider than the video default (live e2e: real assrt landings took ~60s, video window is 4x2s)", async () => {
     const api = new FakePan115Api({ directories: { stage: [] } });
     let listCalls = 0;

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1005,6 +1005,33 @@ describe("Storage115Executor", () => {
 });
 
 describe("Storage115Executor.transferSubtitleUrl", () => {
+  it("uses a subtitle-specific materialization window wider than the video default (live e2e: real assrt landings took ~60s, video window is 4x2s)", async () => {
+    const api = new FakePan115Api({ directories: { stage: [] } });
+    let listCalls = 0;
+    api.addOfflineTask = async () => ({ ok: true, message: "accepted" });
+    const origList = api.listItems.bind(api);
+    api.listItems = async (input) => {
+      listCalls += 1;
+      // The file materializes only on the 6th listing — beyond the video window
+      // (4 attempts) but inside the subtitle window.
+      if (listCalls === 6) {
+        api.directories["stage"] = [{ fid: "late_sub", n: "Late.S01E01.ass", s: "40KB" }];
+      }
+      return origList(input);
+    };
+    const executor = new Storage115Executor({ api, sleep: async () => {} });
+
+    const attempt = await executor.transferSubtitleUrl!({
+      url: "http://file0.assrt.net/onthefly/1/Late.S01E01.ass",
+      filename: "Late.S01E01.ass",
+      directoryId: "stage",
+      workflowRunId: "run-test",
+    });
+
+    expect(attempt.status).toBe("succeeded");
+    expect(attempt.materializedFileIds).toEqual(["late_sub"]);
+  });
+
   it("does NOT claim a pre-existing same-named file — only a file that APPEARS after submission counts", async () => {
     const api = new FakePan115Api({
       directories: { stage: [{ fid: "old_leftover", n: "Show.S01E01.ass", s: "1KB" }] },

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -1006,22 +1006,28 @@ describe("Storage115Executor", () => {
 
 describe("Storage115Executor.transferSubtitleUrl", () => {
   it("createProtectedStorage115Executor passes the subtitle window options through (tuning must not be silently ignored)", async () => {
-    const api = new FakePan115Api({ directories: { stage: [] } });
+    // Target a staging SUBDIR inside the write scope — the scope root itself is
+    // (correctly) protected from recursive listing.
+    const api = new FakePan115Api({
+      directories: { sub_stage: [] },
+      directoryInfo: { sub_stage: seasonPathInfo("test_root", "sub_stage") },
+    });
     let listCalls = 0;
     api.addOfflineTask = async () => ({ ok: true, message: "accepted" });
     const origList = api.listItems.bind(api);
     api.listItems = async (input) => {
       listCalls += 1;
-      // Lands on the 2nd listing — inside the DEFAULT window (8) but outside the
-      // TUNED window (1). If the factory drops the tuning, this test sees succeeded.
-      if (listCalls === 2) {
-        api.directories["stage"] = [{ fid: "late_sub", n: "Tuned.S01E01.ass", s: "40KB" }];
+      // Listing #1 is the BEFORE-snapshot; the tuned window (1) polls exactly once
+      // (listing #2). Landing on listing #3 is inside the DEFAULT window (8) but
+      // outside the tuned one — if the factory drops the tuning, this sees succeeded.
+      if (listCalls === 3) {
+        api.directories["sub_stage"] = [{ fid: "late_sub", n: "Tuned.S01E01.ass", s: "40KB" }];
       }
       return origList(input);
     };
     const executor = createProtectedStorage115Executor({
       api,
-      env: { MEDIA_TRACK_115_TEST_ROOT_CID: "stage" },
+      env: { MEDIA_TRACK_115_TEST_ROOT_CID: "test_root" },
       apiGuardOptions: { minDelayMs: 0 },
       subtitleMaterializeAttempts: 1,
       subtitleMaterializePollMs: 1,
@@ -1031,7 +1037,7 @@ describe("Storage115Executor.transferSubtitleUrl", () => {
     const attempt = await executor.transferSubtitleUrl!({
       url: "http://file0.assrt.net/onthefly/1/Tuned.S01E01.ass",
       filename: "Tuned.S01E01.ass",
-      directoryId: "stage",
+      directoryId: "sub_stage",
       workflowRunId: "run-test",
     });
 


### PR DESCRIPTION
## What
#84 合并部署后的真机 e2e(The Matrix @ 115)发现:assrt 字幕经 115 离线抓取的真实落地耗时 **~20s 与 ~60s**,而字幕落地检测复用的 4×2s 窗本是给**秒传缓存确认**调的——第二个字幕被误判 `no_target_change`,文件迟到落进 staging,靠 flattenMovie 才侥幸收编(农历上算成功,机制上是漏)。

## How
- `Storage115Executor` 新增 `subtitleMaterializeAttempts`/`subtitleMaterializePollMs`(默认 **8×6s ≈48s**),`transferSubtitleUrl` 轮询改走专用窗
- 视频秒传窗(4×2s)保持不动——两个窗语义不同:秒传=缓存反射,字幕=真服务端 HTTP 抓取(队列延迟主导)
- 预算成本有界:每轮询一次 depth-2 listTree;连续 3 文件失败熔断不变

## Test plan
- [x] TDD:新增「文件第 6 次列举才出现(超视频窗、within 字幕窗)→ succeeded」单测,红验证过(旧代码 4 次窗内必失败)
- [x] 全量 924 单测 + tsc 绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)