### PR TITLE
fix(tracking): graduate finished fully-obtained seasons to completed (莫离 stuck-active bug)

### DIFF
--- a/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
@@ -130,20 +130,6 @@ function bridgeSeason(input: {
 }): BridgedSeasonResult {
   const { title, intent, v2, obtainedSet, providerAheadSet } = input;
   const trackedSeasonId = `${title.id}_s${intent.seasonNumber}`;
-  const status: SeasonStatus =
-    intent.status ??
-    (intent.totalEpisodes > 0 && intent.latestAiredEpisode >= intent.totalEpisodes ? "completed" : "active");
-  const season: TrackedSeason = {
-    id: trackedSeasonId,
-    mediaTitleId: title.id,
-    seasonNumber: intent.seasonNumber,
-    status,
-    qualityPreference: intent.qualityPreference,
-    storageDirectoryId: v2.directories.seasonDirectoryIds[intent.seasonNumber] ?? "",
-    totalEpisodes: intent.totalEpisodes,
-    latestAiredEpisode: intent.latestAiredEpisode,
-    latestAiredSource: "metadata",
-  };
 
   const base = createEpisodeStates({
     trackedSeasonId,
@@ -183,6 +169,33 @@ function bridgeSeason(input: {
       verifiedFileIds: [],
     });
   }
+
+  const fullyAired = intent.totalEpisodes > 0 && intent.latestAiredEpisode >= intent.totalEpisodes;
+  const baseStatus: SeasonStatus = intent.status ?? (fullyAired ? "completed" : "active");
+  // The finale graduation season-sync.ts promises ("only the finale — all
+  // obtained — graduates it to completed"). Callers pass the persisted status
+  // through, and this bridge is the only post-creation writer of it — so an
+  // active season that is now fully aired AND fully obtained must graduate
+  // HERE, or the patrol re-sweeps a finished show daily and the library keeps
+  // 追更中 while the notification claims 不再追踪. A season with real aired
+  // gaps stays active so the sweep keeps filling them; completed never reverts.
+  const fullyObtained =
+    fullyAired &&
+    episodes.filter((episode) => episode.airStatus === "aired").every((episode) => episode.obtained) &&
+    episodes.filter((episode) => episode.obtained).length >= intent.totalEpisodes;
+  const status: SeasonStatus = baseStatus === "active" && fullyObtained ? "completed" : baseStatus;
+
+  const season: TrackedSeason = {
+    id: trackedSeasonId,
+    mediaTitleId: title.id,
+    seasonNumber: intent.seasonNumber,
+    status,
+    qualityPreference: intent.qualityPreference,
+    storageDirectoryId: v2.directories.seasonDirectoryIds[intent.seasonNumber] ?? "",
+    totalEpisodes: intent.totalEpisodes,
+    latestAiredEpisode: intent.latestAiredEpisode,
+    latestAiredSource: "metadata",
+  };
 
   return { season, episodes };
 }

--- a/packages/workflow/tests/v2-bridge.test.ts
+++ b/packages/workflow/tests/v2-bridge.test.ts
@@ -125,6 +125,64 @@ describe("bridgeV2WorkflowToResult — V2 facts → per-season WorkflowResult sh
     expect(result.notification.trigger).toBe("scheduled");
   });
 
+  // The finale graduation promised by season-sync.ts ("only the finale — all
+  // obtained — graduates it to completed"). Callers pass the persisted status
+  // through, so without graduating HERE an active season stays active forever:
+  // the patrol re-sweeps a finished, fully-obtained show daily and the library
+  // keeps its 追更中 badge while the notification says 不再追踪 (莫离 bug).
+  it("type3 patrol: active season now fully aired AND fully obtained → persisted status graduates to completed", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type3",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 3, latestAiredEpisode: 3, qualityPreference: "4K", status: "active" }],
+      v2: v2Result({
+        missingBefore: [],
+        obtained: ["S01E01", "S01E02", "S01E03"],
+        stillMissing: [],
+      }),
+      workflowRunId: "run-x",
+      now: () => "2026-06-15T00:00:00.000Z",
+    });
+
+    expect(result.seasons[0]!.season.status).toBe("completed");
+    // The user-facing report agrees — persisted state and 不再追踪 wording can't diverge.
+    expect(result.notification.report?.status).toBe("complete");
+  });
+
+  it("type3 patrol: fully aired but a real gap remains → stays active so the sweep keeps filling", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type3",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 3, latestAiredEpisode: 3, qualityPreference: "4K", status: "active" }],
+      v2: v2Result({
+        missingBefore: ["S01E02"],
+        obtained: ["S01E01", "S01E03"],
+        stillMissing: ["S01E02"],
+      }),
+      workflowRunId: "run-x",
+      now: () => "2026-06-15T00:00:00.000Z",
+    });
+
+    expect(result.seasons[0]!.season.status).toBe("active");
+  });
+
+  it("type3 patrol: still airing (latestAired < total) with everything aired obtained → stays active", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type3",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 12, latestAiredEpisode: 2, qualityPreference: "4K", status: "active" }],
+      v2: v2Result({
+        missingBefore: [],
+        obtained: ["S01E01", "S01E02"],
+        stillMissing: [],
+      }),
+      workflowRunId: "run-x",
+      now: () => "2026-06-15T00:00:00.000Z",
+    });
+
+    expect(result.seasons[0]!.season.status).toBe("active");
+  });
+
   it("multi-season series, partial coverage → status partial, series-level rollup notification", () => {
     const result = bridgeV2WorkflowToResult({
       title,


### PR DESCRIPTION
## 现象(用户报告)
莫离(40 集,追更期入库)全部集数已获取、每日巡检通知已显示「已完结 · 全 40 集已完整获取,不再追踪」,但:
- 媒体库仍显示 **追更中** 徽章
- 每日巡检仍然天天带上它重复宣布自己完结

实例 DB 取证:`tmdb_tv_292696_s1` status=`active`,latestAired=40/total=40,episode_states 40/40 obtained。同病还有 `tmdb_tv_230311_s1`(36/36)。

## 根因
「大结局毕业」从未被实现:
- 建季时(commands.ts)正确地按「已播完→completed」落状态;追更剧自然是 `active` ✔
- 巡检的 `syncSeasonAgainstMetadata` 刻意不动 status,注释承诺 **“only the finale (all obtained) graduates it to completed”** ✔(设计意图)
- 但 bridgeSeason 里唯一的毕业默认(`intent.status ?? 播完→completed`)对 type2/type3 是**死代码**——runner-v2 始终显式传 `status: input.season.status`,把 DB 里的 `active` 永久透传回去
- 通知侧的「complete/不再追踪」是每次 run 从 seasonFacts 现算的,从不落库
- 巡检门(worker.ts:400 `status !== "active"` skip)与前端徽章(title-aggregate `aggregateAiring`)都读持久化 status → 永远追踪

即:任何**追更期开始跟踪**的剧,完结收齐后永远卡 active。全剧集一次性入库(series init/建季即完结)不受影响——这也是为什么浴血黑帮/后翼弃兵看起来正常。

## 修复
在 bridgeSeason(建季后唯一的持久化 status 写入点)实现承诺的毕业:active 季在「全部播完 **且** 全部获取」时落 `completed`;有真实缺集保持 active 让巡检继续补;completed 永不回退。通知的 complete 与持久化状态由同一份 episodes 派生,不会再打架。

**卡住的两部剧无需手工修库**:部署后下一次每日巡检仍会带上它们(还是 active),经 bridge 持久化时自动毕业,此后退出巡检。

## 测试
- 新增 3 个 bridge 测试:毕业(RED→GREEN)、播完但有缺集保持 active、在更保持 active
- 全量 vitest 1132 passed(exit 0)、根 tsc + apps/web tsc 均 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)