### PR TITLE
fix(test): actions.demo.test 重 import 挪 beforeAll,消除全量负载下偶发超时

### DIFF
--- a/apps/web/app/actions.demo.test.ts
+++ b/apps/web/app/actions.demo.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeAll, beforeEach, afterEach } from "vitest";
 import { DemoReadOnlyError } from "../lib/demo-mode";
 
 // Defense-in-depth: even if the UI is bypassed, side-effectful server actions must
 // reject in demo mode. Smoke-checks the gate is wired (one representative action).
 describe("server actions honor demo read-only", () => {
+  // Importing ./actions pulls in the whole workflow-runtime dependency graph
+  // (~5s cold, worse under full-suite load). Load once here with its own wide
+  // budget so the tests keep the default 5s timeout without flaking. Safe to
+  // import before env is set: the demo gate reads process.env at call time.
+  let actions: typeof import("./actions");
+  beforeAll(async () => {
+    actions = await import("./actions");
+  }, 30_000);
+
   beforeEach(() => {
     process.env.MEDIA_TRACK_DEMO_MODE = "1";
   });
@@ -12,12 +21,14 @@ describe("server actions honor demo read-only", () => {
   });
 
   it("testStorageConnectionAction rejects in demo mode", async () => {
-    const { testStorageConnectionAction } = await import("./actions");
-    await expect(testStorageConnectionAction("cs_x")).rejects.toBeInstanceOf(DemoReadOnlyError);
+    await expect(actions.testStorageConnectionAction("cs_x")).rejects.toBeInstanceOf(
+      DemoReadOnlyError,
+    );
   });
 
   it("savePushSettingsAction rejects in demo mode", async () => {
-    const { savePushSettingsAction } = await import("./actions");
-    await expect(savePushSettingsAction({ bark: "x" })).rejects.toBeInstanceOf(DemoReadOnlyError);
+    await expect(actions.savePushSettingsAction({ bark: "x" })).rejects.toBeInstanceOf(
+      DemoReadOnlyError,
+    );
   });
 });


### PR DESCRIPTION
## 问题
`apps/web/app/actions.demo.test.ts` 的 "testStorageConnectionAction rejects in demo mode" 在测试体内 `await import("./actions")`,拉起整个 workflow-runtime 依赖图,单跑就要 ~4.8s,贴着 vitest 默认 5s testTimeout——全量套件负载下偶发超时(2026-07-02 全量实录超时、单跑通过)。第二条测试吃模块缓存所以从不超时,flake 只落在第一条。

## 修复
把重 import 挪到 `beforeAll` 一次性加载,并给该 hook 单独 30s 预算;两条测试本体保持默认 5s 超时。demo 门禁(`isDemoMode`)是调用时读 `process.env`(apps/web/lib/demo-mode.ts:23-24),不是导入时快照,所以提前 import 不改变测试语义(现状里第二条测试早已复用第一条导入的模块实例,行为一致)。

## 验证
- `npx vitest run apps/web/app/actions.demo.test.ts` 绿(985ms)
- `npx vitest run --no-cache`(冷路径)绿(844ms)
- 全量 `npx vitest run`:143 files / 1132 tests 全绿(跑两遍,环境修复前后各一)
- `tsc -p apps/web/tsconfig.json --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)