### PR TITLE
fix(storage): 删除校验只认视频→改验全量 listTree(三盘同修,光鸭 e2e 抓到的老 bug)

### DIFF
--- a/packages/workflow/src/guangya-storage-executor.test.ts
+++ b/packages/workflow/src/guangya-storage-executor.test.ts
@@ -525,3 +525,32 @@ describe("GuangYaStorageExecutor.transferSubtitleUrl", () => {
     expect(subtitle.id).toBe("run-1_subtitle_2");
   });
 });
+
+describe("GuangYaStorageExecutor.deleteFiles — non-video cleanup (真机 e2e 2026-07-02 黑客帝国3)", () => {
+  it("deletes a subtitle (non-video) file that the directory tree contains", async () => {
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async () => [
+      { fileId: "sub1", parentId: SCOPE, fileName: "多余字幕.srt", fileSize: 77944, resType: 1 },
+    ]);
+    const deleteFiles = vi.fn<GuangYaStorageClient["deleteFiles"]>(async () => {});
+    const client = fakeClient({ listFiles, deleteFiles });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+
+    await expect(executor.deleteFiles({ directoryId: SCOPE, fileIds: ["sub1"] })).resolves.toEqual({
+      deleted: ["sub1"],
+    });
+    expect(deleteFiles).toHaveBeenCalledWith(["sub1"]);
+  });
+
+  it("still refuses ids that are nowhere in the directory tree", async () => {
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async () => [
+      { fileId: "sub1", parentId: SCOPE, fileName: "多余字幕.srt", fileSize: 77944, resType: 1 },
+    ]);
+    const client = fakeClient({ listFiles });
+    const executor = new GuangYaStorageExecutor({ client, writeScopeDirectoryIds: [SCOPE] });
+
+    await expect(executor.deleteFiles({ directoryId: SCOPE, fileIds: ["ghost"] })).rejects.toThrow(
+      /SAFETY_VIOLATION/,
+    );
+    expect(client.deleteFiles).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -546,8 +546,13 @@ export class GuangYaStorageExecutor implements StorageExecutor {
     return unparsed;
   }
 
+  /** Verify against the FULL tree (listTree), not listVideoFiles: the agent's
+   *  eyes (inspectStaging/inspectTargetDir) see every file, and cleanup targets
+   *  are mostly NON-video (extra subtitles, ads, nfo). Verifying videos-only made
+   *  deleting a subtitle impossible on every drive — caught live 2026-07-02 when
+   *  the 黑客帝国3@光鸭 run's cleanup was refused twice (SAFETY_VIOLATION). */
   private async assertFilesBelongToDirectory(directoryId: string, fileIds: string[]): Promise<void> {
-    const verified = new Set((await this.listVideoFiles(directoryId)).map((f) => f.providerFileId));
+    const verified = new Set((await this.listTree({ directoryId })).map((f) => f.providerFileId));
     const unverified = fileIds.filter((id) => !verified.has(id));
     if (unverified.length === 0) {
       return;

--- a/packages/workflow/src/quark-storage-executor.ts
+++ b/packages/workflow/src/quark-storage-executor.ts
@@ -363,8 +363,13 @@ export class QuarkStorageExecutor implements StorageExecutor {
     return unparsed;
   }
 
+  /** Verify against the FULL tree (listTree), not listVideoFiles: the agent's
+   *  eyes (inspectStaging/inspectTargetDir) see every file, and cleanup targets
+   *  are mostly NON-video (extra subtitles, ads, nfo). Verifying videos-only made
+   *  deleting a subtitle impossible on every drive — caught live 2026-07-02 on
+   *  光鸭 (黑客帝国3 cleanup refused twice). */
   private async assertFilesBelongToDirectory(directoryId: string, fileIds: string[]): Promise<void> {
-    const verified = new Set((await this.listVideoFiles(directoryId)).map((f) => f.providerFileId));
+    const verified = new Set((await this.listTree({ directoryId })).map((f) => f.providerFileId));
     const unverified = fileIds.filter((id) => !verified.has(id));
     if (unverified.length === 0) {
       return;

--- a/packages/workflow/src/storage-115-executor.ts
+++ b/packages/workflow/src/storage-115-executor.ts
@@ -932,8 +932,14 @@ export class Storage115Executor implements StorageExecutor {
     return normalized;
   }
 
+  /** Verify against the FULL tree (listTree), not listVideoFiles: the agent's
+   *  eyes (inspectStaging/inspectTargetDir) see every file, and cleanup targets
+   *  are mostly NON-video (extra subtitles, ads, nfo). Verifying videos-only made
+   *  deleting a subtitle impossible on every drive — caught live 2026-07-02 on
+   *  光鸭, and explains the `._*.ass` AppleDouble leftover from the 黑客帝国2@115
+   *  stress test. */
   private async assertFilesBelongToDirectory(directoryId: string, fileIds: string[]): Promise<void> {
-    const verifiedFileIds = new Set((await this.listVideoFiles(directoryId)).map((file) => file.providerFileId));
+    const verifiedFileIds = new Set((await this.listTree({ directoryId })).map((file) => file.providerFileId));
     const unverifiedFileIds = fileIds.filter((fileId) => !verifiedFileIds.has(fileId));
     if (unverifiedFileIds.length === 0) {
       return;

--- a/packages/workflow/tests/quark-storage-executor.test.ts
+++ b/packages/workflow/tests/quark-storage-executor.test.ts
@@ -211,4 +211,13 @@ describe("QuarkStorageExecutor", () => {
     });
     expect(calls).toContain("moveFiles:f9->STAGE");
   });
+  it("deleteFiles deletes a subtitle (non-video) file inside the staging dir", async () => {
+    const { client, files, calls } = makeFakeClient();
+    files.set("sub1", { fid: "sub1", file_name: "多余字幕.srt", dir: false, size: 77944, pdir_fid: "STAGE" });
+    const exec = quarkExecutor(client);
+    await expect(exec.deleteFiles({ directoryId: "STAGE", fileIds: ["sub1"] })).resolves.toEqual({
+      deleted: ["sub1"],
+    });
+    expect(calls).toContain("deleteFiles:sub1");
+  });
 });

--- a/packages/workflow/tests/quark-storage-executor.test.ts
+++ b/packages/workflow/tests/quark-storage-executor.test.ts
@@ -220,4 +220,14 @@ describe("QuarkStorageExecutor", () => {
     });
     expect(calls).toContain("deleteFiles:sub1");
   });
+
+  it("deleteFiles still refuses ids that are nowhere in the directory tree", async () => {
+    const { client, files, calls } = makeFakeClient();
+    files.set("sub1", { fid: "sub1", file_name: "多余字幕.srt", dir: false, size: 77944, pdir_fid: "STAGE" });
+    const exec = quarkExecutor(client);
+    await expect(exec.deleteFiles({ directoryId: "STAGE", fileIds: ["ghost"] })).rejects.toThrow(
+      /SAFETY_VIOLATION/,
+    );
+    expect(calls.filter((c) => c.startsWith("deleteFiles:"))).toEqual([]);
+  });
 });

--- a/packages/workflow/tests/storage-115-executor.test.ts
+++ b/packages/workflow/tests/storage-115-executor.test.ts
@@ -790,6 +790,32 @@ describe("Storage115Executor", () => {
     expect(api.deletes).toEqual([{ fileIds: ["file_1"] }]);
   });
 
+  it("deletes a subtitle (non-video) file — cleanup must verify against ALL files, not just videos (光鸭 e2e 2026-07-02 暴露的跨盘缺陷)", async () => {
+    const api = new FakePan115Api({
+      directories: {
+        season_1: [
+          {
+            fid: "sub_1",
+            n: "多余字幕.srt",
+            s: "88753",
+          },
+        ],
+      },
+      directoryInfo: {
+        season_1: seasonPathInfo("test_root", "season_1"),
+      },
+    });
+    const executor = new Storage115Executor({ api, writeScopeDirectoryIds: ["test_root"] });
+
+    await expect(
+      executor.deleteFiles({
+        directoryId: "season_1",
+        fileIds: ["sub_1"],
+      }),
+    ).resolves.toEqual({ deleted: ["sub_1"] });
+    expect(api.deletes).toEqual([{ fileIds: ["sub_1"] }]);
+  });
+
   it("rejects delete file ids that were not verified in the target directory", async () => {
     const api = new FakePan115Api({
       directories: {


### PR DESCRIPTION
## 现象(黑客帝国3@光鸭 live e2e,2026-07-02)
字幕主链路完美(视频+同名字幕落盘),但 agent 清理 3 个多余字幕变体(英文/上英下中/上中下英)时被拒两次:
```
SAFETY_VIOLATION: refusing to delete unverified file ids from target directory
```
3 个文件至今物理留在目录里。

## 根因(跨盘,历史悠久)
115/夸克/光鸭三个 executor 的 `assertFilesBelongToDirectory` **逐字相同**地用 `listVideoFiles`(只看视频)做删除目标归属校验 → **任何非视频文件(多余字幕/广告txt/nfo)在所有盘上都永远删不掉**。agent 的眼睛(inspectStaging/inspectTargetDir)走 listTree 看得见它们,伸手删却被自家安全门拦住。压测时 黑客帝国2@115 留下的 `._*.ass` AppleDouble「装饰性灰尘」其实就是这个 bug,当时误判为无害小尾巴。

## 修复
三盘的归属校验统一改验 `listTree`(与 agent 视野同源的全量文件视图)。安全语义不变:不在目录树里的 id 照样 SAFETY_VIOLATION(既有守卫回归测试保留);listTree 与 listVideoFiles 挂同一个 protected-dir 递归列举守卫,防护面等价。

## 测试
- TDD:三盘各一个「删字幕文件」测试先 RED(SAFETY_VIOLATION)后 GREEN;「树外 id 仍拒」守卫保留
- 全量 vitest 1144 passed + 根/apps-web 双 tsc 绿

## 后续
合并部署后用真光鸭盘对黑客帝国3 目录里那 3 个遗留字幕跑一次真删除,作为修复的 live 验证(顺带清掉测试垃圾)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)