### PR TITLE
fix(subtitle): 光鸭字幕轮询窗独立(48s),不再复用视频 180s 窗

### DIFF
--- a/packages/workflow/src/guangya-storage-executor.test.ts
+++ b/packages/workflow/src/guangya-storage-executor.test.ts
@@ -408,8 +408,8 @@ describe("GuangYaStorageExecutor.transferSubtitleUrl", () => {
     const executor = new GuangYaStorageExecutor({
       client,
       writeScopeDirectoryIds: [SCOPE],
-      taskPollMaxPolls: 2,
-      taskPollIntervalMs: 0,
+      subtitleTaskPollMaxPolls: 2,
+      subtitleTaskPollIntervalMs: 0,
     });
 
     const attempt = await executor.transferSubtitleUrl({
@@ -552,5 +552,77 @@ describe("GuangYaStorageExecutor.deleteFiles — non-video cleanup (真机 e2e 2
       /SAFETY_VIOLATION/,
     );
     expect(client.deleteFiles).not.toHaveBeenCalled();
+  });
+});
+
+describe("GuangYaStorageExecutor.transferSubtitleUrl poll window (真机 2026-07-02 搏击俱乐部: 视频级 60×3s 窗让 3 个卡死字幕任务静默烧 9 分钟)", () => {
+  const SUB_URL = "http://file1.assrt.net/download/715078/The.Matrix.1999.srt?_=1&-=abc&api=1";
+  const SUB_NAME = "The.Matrix.1999.srt";
+
+  it("uses the SUBTITLE poll cap, not the video task cap", async () => {
+    const listTask = vi.fn<GuangYaStorageClient["listTask"]>(async () => [
+      { taskId: "task-1", status: 1, progress: 10, fileId: "" },
+    ]);
+    const client = fakeClient({ listTask });
+    const executor = new GuangYaStorageExecutor({
+      client,
+      writeScopeDirectoryIds: [SCOPE],
+      taskPollMaxPolls: 60,
+      taskPollIntervalMs: 0,
+      subtitleTaskPollMaxPolls: 2,
+      subtitleTaskPollIntervalMs: 0,
+    });
+
+    const attempt = await executor.transferSubtitleUrl({
+      url: SUB_URL,
+      filename: SUB_NAME,
+      directoryId: SCOPE,
+      workflowRunId: "run-1",
+    });
+
+    expect(attempt.status).toBe("no_target_change");
+    expect(listTask).toHaveBeenCalledTimes(2);
+  });
+
+  it("subtitle poll cap defaults to 16 (≈48s at 3s interval, mirroring the 115 subtitle window)", async () => {
+    const listTask = vi.fn<GuangYaStorageClient["listTask"]>(async () => [
+      { taskId: "task-1", status: 1, progress: 10, fileId: "" },
+    ]);
+    const client = fakeClient({ listTask });
+    const executor = new GuangYaStorageExecutor({
+      client,
+      writeScopeDirectoryIds: [SCOPE],
+      subtitleTaskPollIntervalMs: 0,
+    });
+
+    await executor.transferSubtitleUrl({
+      url: SUB_URL,
+      filename: SUB_NAME,
+      directoryId: SCOPE,
+      workflowRunId: "run-1",
+    });
+
+    expect(listTask).toHaveBeenCalledTimes(16);
+  });
+
+  it("video transfer() keeps its own (wider) poll cap untouched", async () => {
+    const createTask = vi.fn<GuangYaStorageClient["createTask"]>(async () => "task-9");
+    const listTask = vi.fn<GuangYaStorageClient["listTask"]>(async () => [
+      { taskId: "task-9", status: 1, progress: 10, fileId: "" },
+    ]);
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async () => []);
+    const client = fakeClient({ createTask, listTask, listFiles });
+    const executor = new GuangYaStorageExecutor({
+      client,
+      writeScopeDirectoryIds: [SCOPE],
+      taskPollMaxPolls: 5,
+      taskPollIntervalMs: 0,
+      subtitleTaskPollMaxPolls: 2,
+      subtitleTaskPollIntervalMs: 0,
+    });
+
+    await executor.transfer({ workflowRunId: "run-1", directoryId: SCOPE, candidate: candidate() });
+
+    expect(listTask).toHaveBeenCalledTimes(5);
   });
 });

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -481,9 +481,12 @@ export class GuangYaStorageExecutor implements StorageExecutor {
    *  with the materialized dir/file id). The sequence seen was 1 → 2, with the file
    *  landing the same instant status flipped to 2. We treat status >= 2 as terminal
    *  AND break the moment a non-empty fileId materializes (the strongest "file landed"
-   *  signal — it appears exactly at completion). No distinct failed code was observed
-   *  in this run (a later probe's statusCounts hints codes up to 5 exist); status >= 2
-   *  already breaks on any of them, so the caller's own landing check judges:
+   *  signal — it appears exactly at completion). 3 = FAILED ("云添加失败" in the
+   *  光鸭 client; observed live 2026-07-02 — three stuck subtitle fetches sat at
+   *  status 1 for 9+ minutes before the provider gave up and flipped them 1 → 3,
+   *  so a task can be terminally dead while still reading as in-progress; codes up
+   *  to 5 exist per statusCounts). status >= 2 breaks on all of them, so the
+   *  caller's own landing check judges:
    *  transfer() diffs listVideoFiles before/after, transferSubtitleUrl verifies the
    *  returned fileId is present in the target directory. */
   private async pollTaskForFileId(taskId: string, maxPolls: number, intervalMs: number): Promise<string> {

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -90,6 +90,14 @@ export interface GuangYaStorageExecutorOptions {
   /** Poll caps for an offline task (overridable so tests don't sleep). */
   taskPollMaxPolls?: number;
   taskPollIntervalMs?: number;
+  /** Subtitle-landing poll caps (transferSubtitleUrl), SEPARATE from the video
+   *  task caps above — the #85 lesson, relearned live on 光鸭 2026-07-02: a
+   *  subtitle is ~100KB and lands in seconds or effectively never, so polling it
+   *  on the video window (60×3s=180s) lets a few stuck assrt fetches silently
+   *  burn ~9 minutes inside one transferSubtitle call (搏击俱乐部). Default
+   *  16×3s≈48s, mirroring the 115 subtitle window budget. */
+  subtitleTaskPollMaxPolls?: number;
+  subtitleTaskPollIntervalMs?: number;
 }
 
 interface VideoFact {
@@ -110,6 +118,8 @@ export class GuangYaStorageExecutor implements StorageExecutor {
   private readonly videoExtensions: Set<string>;
   private readonly taskPollMaxPolls: number;
   private readonly taskPollIntervalMs: number;
+  private readonly subtitleTaskPollMaxPolls: number;
+  private readonly subtitleTaskPollIntervalMs: number;
   private nextTransferNumber = 1;
 
   constructor(options: GuangYaStorageExecutorOptions) {
@@ -122,6 +132,8 @@ export class GuangYaStorageExecutor implements StorageExecutor {
     );
     this.taskPollMaxPolls = options.taskPollMaxPolls ?? 60;
     this.taskPollIntervalMs = options.taskPollIntervalMs ?? 3000;
+    this.subtitleTaskPollMaxPolls = options.subtitleTaskPollMaxPolls ?? 16;
+    this.subtitleTaskPollIntervalMs = options.subtitleTaskPollIntervalMs ?? 3000;
   }
 
   async createDirectory(input: { name: string; parentId: string }): Promise<string> {
@@ -283,7 +295,11 @@ export class GuangYaStorageExecutor implements StorageExecutor {
         parentId: safe,
         newName: input.filename,
       });
-      const landedFileId = await this.pollTaskForFileId(taskId);
+      const landedFileId = await this.pollTaskForFileId(
+        taskId,
+        this.subtitleTaskPollMaxPolls,
+        this.subtitleTaskPollIntervalMs,
+      );
       if (!landedFileId) {
         softMissMessage = "SUBTITLE_NOT_LANDED: 离线任务在轮询窗口内未落盘(任务可能迟到,不等)";
       } else if ((await this.client.listFiles(safe)).some((item) => idOf(item) === landedFileId)) {
@@ -470,8 +486,8 @@ export class GuangYaStorageExecutor implements StorageExecutor {
    *  already breaks on any of them, so the caller's own landing check judges:
    *  transfer() diffs listVideoFiles before/after, transferSubtitleUrl verifies the
    *  returned fileId is present in the target directory. */
-  private async pollTaskForFileId(taskId: string): Promise<string> {
-    for (let i = 0; i < this.taskPollMaxPolls; i++) {
+  private async pollTaskForFileId(taskId: string, maxPolls: number, intervalMs: number): Promise<string> {
+    for (let i = 0; i < maxPolls; i++) {
       const tasks = await this.client.listTask([taskId]);
       const t = tasks.find((x) => x.taskId === taskId);
       if (!t) {
@@ -483,13 +499,13 @@ export class GuangYaStorageExecutor implements StorageExecutor {
       if (t.status >= 2) {
         return "";
       }
-      await new Promise((r) => setTimeout(r, this.taskPollIntervalMs));
+      await new Promise((r) => setTimeout(r, intervalMs));
     }
     return "";
   }
 
   private async pollTask(taskId: string): Promise<void> {
-    await this.pollTaskForFileId(taskId);
+    await this.pollTaskForFileId(taskId, this.taskPollMaxPolls, this.taskPollIntervalMs);
   }
 
   private async directoryContainsLargeVideo(directoryId: string): Promise<boolean> {


### PR DESCRIPTION
## 现象(用户报障,搏击俱乐部@光鸭 live)
run 在 transferSubtitle 里**静默 ~9 分钟**,容器日志零输出、UI 进度冻结,像卡死。

## 取证链
- 字幕包 8 文件:前 3 个真落成(ass+srt+srt),后 3 个光鸭离线任务**服务端卡 status 1**(光鸭拉不动那几个 assrt 文件;assrt 本身从软路由 0.88s 可达)
- 每个卡死任务按**视频级轮询参数**(60×3s=180s)烧满才计入熔断 → 3 连败 = 9 分钟静默
- 熔断触发后 run 诚实恢复(「带着已落的继续」),最终 **succeeded**(17.8GB 视频+3 字幕交付)——不是死锁,是病理性延迟

## 根因
**#85 的教训在光鸭重演**:115 当时就把字幕窗(8×6s=48s)从视频秒传窗分离;#89 给光鸭实现 transferSubtitleUrl 时复用了视频任务的 60×3s 轮询参数。字幕 ~100KB,秒级落或基本不落,180s/文件的耐心毫无意义。

## 修复
`subtitleTaskPollMaxPolls/subtitleTaskPollIntervalMs`(默认 16×3s≈48s,对齐 115 字幕窗预算),仅 transferSubtitleUrl 使用;视频 transfer() 宽窗不动。最坏 3 连败 9min→2.4min。TDD 3 测 RED→GREEN(字幕用独立窗/默认 16/视频窗不受影响),全量 1148 绿 + 双 tsc。

## 已知残留(非本 PR 范围)
光鸭 client 无取消任务端点 → 3 个卡死任务可能迟到落盘到影片目录(软语义,#91 后 agent 有能力清理)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)