### PR TITLE
fix(settings): 网盘连接徽章按全部盘派生(closes #93)+ 文案补光鸭

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,3 +1,4 @@
+import { driveConnectionBadge } from "../../lib/settings-badge";
 import { connection } from "next/server";
 import { Suspense } from "react";
 import { Bell, Bot, Cable, CalendarClock, Clapperboard, Gauge, KeyRound, Languages, Radio, ShieldCheck, Subtitles, TriangleAlert, Users } from "lucide-react";
@@ -328,19 +329,23 @@ async function Pan115Section() {
             <Cable size={16} aria-hidden style={{ verticalAlign: "-2px", marginRight: 8 }} />
             网盘连接
           </h2>
-          <p className="panel-note">连接 115（扫码）或夸克（粘贴 cookie）；凭证持久化到数据库，自动用于后续转存。每块盘是独立工作区</p>
+          <p className="panel-note">连接 115（扫码）、夸克（粘贴 cookie）或光鸭（粘贴 token）；凭证持久化到数据库，自动用于后续转存。每块盘是独立工作区</p>
         </div>
-        {status.connected ? (
-          <span className="hub-badge tone-green">
-            <ShieldCheck size={12} aria-hidden />
-            {status.source === "qr" ? "已扫码连接" : "已连接（.env）"}
-          </span>
-        ) : (
-          <span className="hub-badge tone-amber">
-            <TriangleAlert size={12} aria-hidden />
-            未连接
-          </span>
-        )}
+        {(() => {
+          // #93: derive the header badge from ALL drives — 115-only status made
+          // a 光鸭/夸克-only user read a permanent misleading 未连接.
+          const badge = driveConnectionBadge({ envConnected: status.connected, drives });
+          return (
+            <span className={`hub-badge tone-${badge.tone}`}>
+              {badge.tone === "green" ? (
+                <ShieldCheck size={12} aria-hidden />
+              ) : (
+                <TriangleAlert size={12} aria-hidden />
+              )}
+              {badge.label}
+            </span>
+          );
+        })()}
       </div>
 
       {drives.length === 0 ? (
@@ -387,7 +392,7 @@ async function Pan115Section() {
 
       <p className="panel-note" style={{ marginBottom: 8 }}>
         {drives.length > 0
-          ? "添加另一块网盘（115 或夸克）——不同账号即新增一块独立工作区；绑到已连的同一账号会自动刷新登录"
+          ? "添加另一块网盘（115／夸克／光鸭）——不同账号即新增一块独立工作区；绑到已连的同一账号会自动刷新登录"
           : "添加你的第一块网盘"}
       </p>
       <AddDriveBrandTabs />

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -334,7 +334,7 @@ async function Pan115Section() {
         {(() => {
           // #93: derive the header badge from ALL drives — 115-only status made
           // a 光鸭/夸克-only user read a permanent misleading 未连接.
-          const badge = driveConnectionBadge({ envConnected: status.connected, drives });
+          const badge = driveConnectionBadge({ envConnected: status.connected && status.source === "env", drives });
           return (
             <span className={`hub-badge tone-${badge.tone}`}>
               {badge.tone === "green" ? (

--- a/apps/web/lib/settings-badge.test.ts
+++ b/apps/web/lib/settings-badge.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { driveConnectionBadge } from "./settings-badge";
+
+// Issue #93: the 网盘连接 section header badge read ONLY the 115 status, so a
+// user whose only drive is 光鸭/夸克 saw a permanent misleading 未连接 while the
+// per-drive rows below were correct. The badge must derive from ALL drives.
+describe("driveConnectionBadge", () => {
+  it("shows 已连接 with the drive count when any non-frozen drive exists (non-115 included)", () => {
+    expect(
+      driveConnectionBadge({ envConnected: false, drives: [{ status: "active" }] }),
+    ).toEqual({ tone: "green", label: "已连接 1 块盘" });
+    expect(
+      driveConnectionBadge({
+        envConnected: false,
+        drives: [{ status: "active" }, { status: "active" }, { status: "frozen" }],
+      }),
+    ).toEqual({ tone: "green", label: "已连接 2 块盘" });
+  });
+
+  it("all drives frozen → amber 全部掉线 (rows below carry the detail)", () => {
+    expect(
+      driveConnectionBadge({ envConnected: false, drives: [{ status: "frozen" }] }),
+    ).toEqual({ tone: "amber", label: "已连接但掉线" });
+  });
+
+  it("no drives but legacy .env 115 cookie → 已连接（.env）", () => {
+    expect(driveConnectionBadge({ envConnected: true, drives: [] })).toEqual({
+      tone: "green",
+      label: "已连接（.env）",
+    });
+  });
+
+  it("nothing connected → 未连接", () => {
+    expect(driveConnectionBadge({ envConnected: false, drives: [] })).toEqual({
+      tone: "amber",
+      label: "未连接",
+    });
+  });
+});

--- a/apps/web/lib/settings-badge.ts
+++ b/apps/web/lib/settings-badge.ts
@@ -1,0 +1,29 @@
+/**
+ * The 网盘连接 section-header badge, derived from ALL connected drives — not just
+ * 115. Issue #93: the header used getPan115ConnectionStatus() alone, so a user
+ * whose only drive is 光鸭/夸克 saw a permanent misleading 未连接 while the
+ * per-drive rows right below showed their drive as fine. Pure so it's testable;
+ * the page feeds it the drives list plus the legacy .env-115 flag (an env cookie
+ * predates connected_storages rows and deserves its distinct label).
+ */
+export interface DriveConnectionBadge {
+  tone: "green" | "amber";
+  label: string;
+}
+
+export function driveConnectionBadge(input: {
+  envConnected: boolean;
+  drives: Array<{ status: string }>;
+}): DriveConnectionBadge {
+  const active = input.drives.filter((drive) => drive.status !== "frozen").length;
+  if (active > 0) {
+    return { tone: "green", label: `已连接 ${active} 块盘` };
+  }
+  if (input.drives.length > 0) {
+    return { tone: "amber", label: "已连接但掉线" };
+  }
+  if (input.envConnected) {
+    return { tone: "green", label: "已连接（.env）" };
+  }
+  return { tone: "amber", label: "未连接" };
+}

--- a/apps/web/lib/settings-badge.ts
+++ b/apps/web/lib/settings-badge.ts
@@ -13,9 +13,9 @@ export interface DriveConnectionBadge {
 
 export function driveConnectionBadge(input: {
   envConnected: boolean;
-  drives: Array<{ status: string }>;
+  drives: Array<{ status: "active" | "frozen" }>;
 }): DriveConnectionBadge {
-  const active = input.drives.filter((drive) => drive.status !== "frozen").length;
+  const active = input.drives.filter((drive) => drive.status === "active").length;
   if (active > 0) {
     return { tone: "green", label: `已连接 ${active} 块盘` };
   }


### PR DESCRIPTION
## 现象(#93,报告的根因诊断属实)
设置页「网盘连接」区块**头部徽章**只读 `getPan115ConnectionStatus()`——只连光鸭/夸克的用户永远看到「未连接」,与下方(正确的)每盘状态行自相矛盾。

## 修复
- 新增纯函数 `driveConnectionBadge`(TDD 4 测):有活跃盘→「已连接 N 块盘」;全部掉线→「已连接但掉线」;无盘但有 .env 115 cookie→「已连接(.env)」;什么都没有→「未连接」
- 顺带修两处过时文案:面板说明与「添加另一块网盘」仍只提 115/夸克,补上光鸭(v0.3.0 起支持)

## 验证
全量 vitest 绿 + 根/web 双 tsc + `npm run build:web` 绿。

closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)