### PR TITLE
docs(deploy): 代理文档补内置代理被墙场景与 WSL2 注记(#83)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -102,6 +102,8 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 
 - **自己的 TMDB key**(设置 → TMDB 元数据):直连你自己的额度,调不通自动回退作者代理。
 - **出站代理**(`.env` 设 `HTTP_PROXY` / `HTTPS_PROXY`):墙内想用**自己的 TMDB token / 额度**时用得到。TMDB 的 API 主机(`api.themoviedb.org`)在国内常被单独墙(官网能开 ≠ API 能通),直连不到你的 token 就用不上。给容器配一个能穿透的代理即可让全部出站请求(TMDB / PanSou / Prowlarr)走它:在仓库根 `.env` 里写 `HTTP_PROXY=http://172.17.0.1:7890` 和 `HTTPS_PROXY=http://172.17.0.1:7890`(`172.17.0.1` 是 Docker 默认网关,指向宿主机;端口换成你宿主上代理软件的实际端口,如 Clash 的 7890),再 `docker compose up -d`。`NO_PROXY` 可排除内网地址。**不设代理时行为不变**——TMDB token 留空走作者内置代理依旧开箱即用,这条只为「墙内 + 想用自己 token」准备。
+  - **内置代理也连不上时同样用此法**(#83 实例):内置 TMDB 代理托管在 Cloudflare Workers,`*.workers.dev` 域名在部分国内网络/运营商下也会被阻断——症状是搜索报 `All 1 TMDB access(es) failed: TimeoutError`。此时无论是否有自己的 token,都需要按上面配 `HTTPS_PROXY` 让容器出站走代理。
+  - **WSL2 部署注意**(#83 踩坑实录):容器内的 `127.0.0.1` 指容器自身,填 Windows 宿主上的代理要用 WSL2 虚拟网卡的宿主 IP;且 Windows 防火墙常拦截来自 WSL2 虚拟网卡的入站连接(即使代理软件开了「允许局域网连接」),需要放行防火墙或在 WSL2 内起一层转发(监听 0.0.0.0 转发到 127.0.0.1:代理端口),容器再指向 WSL2 自身 IP。
 - **Prowlarr**(设置 → 资源提供商):接入索引器聚合,磁力与 PanSou 结果合并,走 115 或光鸭的离线下载落盘(夸克无磁力 API)。
 - **换 PanSou 实例**(设置 → 资源提供商):默认用 compose 自带的;想指向别的实例/公共域名在此手填。
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -102,7 +102,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 
 - **自己的 TMDB key**(设置 → TMDB 元数据):直连你自己的额度,调不通自动回退作者代理。
 - **出站代理**(`.env` 设 `HTTP_PROXY` / `HTTPS_PROXY`):墙内想用**自己的 TMDB token / 额度**时用得到。TMDB 的 API 主机(`api.themoviedb.org`)在国内常被单独墙(官网能开 ≠ API 能通),直连不到你的 token 就用不上。给容器配一个能穿透的代理即可让全部出站请求(TMDB / PanSou / Prowlarr)走它:在仓库根 `.env` 里写 `HTTP_PROXY=http://172.17.0.1:7890` 和 `HTTPS_PROXY=http://172.17.0.1:7890`(`172.17.0.1` 是 Docker 默认网关,指向宿主机;端口换成你宿主上代理软件的实际端口,如 Clash 的 7890),再 `docker compose up -d`。`NO_PROXY` 可排除内网地址。**不设代理时行为不变**——TMDB token 留空走作者内置代理依旧开箱即用,这条只为「墙内 + 想用自己 token」准备。
-  - **内置代理也连不上时同样用此法**(#83 实例):内置 TMDB 代理托管在 Cloudflare Workers,`*.workers.dev` 域名在部分国内网络/运营商下也会被阻断——症状是搜索报 `All 1 TMDB access(es) failed: TimeoutError`。此时无论是否有自己的 token,都需要按上面配 `HTTPS_PROXY` 让容器出站走代理。
+  - **内置代理也连不上时同样用此法**(#83 实例):内置 TMDB 代理托管在 Cloudflare Workers,`*.workers.dev` 域名在部分国内网络/运营商下也会被阻断——症状是搜索报 `All N TMDB access(es) failed: TimeoutError`(N 为通道数,未配 token 时为 1)。此时无论是否有自己的 token,都需要按上面配 `HTTP_PROXY` / `HTTPS_PROXY` 让容器出站走代理。
   - **WSL2 部署注意**(#83 踩坑实录):容器内的 `127.0.0.1` 指容器自身,填 Windows 宿主上的代理要用 WSL2 虚拟网卡的宿主 IP;且 Windows 防火墙常拦截来自 WSL2 虚拟网卡的入站连接(即使代理软件开了「允许局域网连接」),需要放行防火墙或在 WSL2 内起一层转发(监听 0.0.0.0 转发到 127.0.0.1:代理端口),容器再指向 WSL2 自身 IP。
 - **Prowlarr**(设置 → 资源提供商):接入索引器聚合,磁力与 PanSou 结果合并,走 115 或光鸭的离线下载落盘(夸克无磁力 API)。
 - **换 PanSou 实例**(设置 → 资源提供商):默认用 compose 自带的;想指向别的实例/公共域名在此手填。


### PR DESCRIPTION
#83 的经验帖表明两件文档没讲透的事:①内置 TMDB 代理(CF Workers)在部分国内网络下自身也会被阻断,此时**必须**配出站代理(现文档只把代理定位为「想用自己 token」);②WSL2 下容器访问 Windows 宿主代理有防火墙/回环两重坑。在 docs/deploy.md 出站代理小节补两条实战注记,不改任何行为。

Thanks @wxz2672554287 的详细排查记录。

🤖 Generated with [Claude Code](https://claude.com/claude-code)