### PR TITLE
fix(search): 动漫热门榜改「近期」口径(修全职猎人1999顶榜)

### DIFF
--- a/apps/web/lib/trending.test.ts
+++ b/apps/web/lib/trending.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { animeFirstAirDateFloor, mapTrendingResults, TRENDING_KINDS, trendingFeedQuery } from "./trending";
 
-describe("trending feed contract (must match workers/tmdb-proxy TRENDING_FEEDS)", () => {
+describe("trending feed contract (must match workers/tmdb-proxy getTrendingFeeds)", () => {
   // The Worker Cron warms KV under cacheKeyFor(path + sorted query). The frontend
   // reads the SAME feed. cacheKeyFor sorts params, so what must match is the param
   // SET, captured here as the sorted querystring. If you edit one side, this fails.

--- a/apps/web/lib/trending.test.ts
+++ b/apps/web/lib/trending.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mapTrendingResults, TRENDING_KINDS } from "./trending";
+import { animeFirstAirDateFloor, mapTrendingResults, TRENDING_KINDS, trendingFeedQuery } from "./trending";
 
 describe("trending feed contract (must match workers/tmdb-proxy TRENDING_FEEDS)", () => {
   // The Worker Cron warms KV under cacheKeyFor(path + sorted query). The frontend
@@ -18,11 +18,23 @@ describe("trending feed contract (must match workers/tmdb-proxy TRENDING_FEEDS)"
     expect(sortedQuery(TRENDING_KINDS.tv.query)).toBe("language=zh-CN");
   });
 
-  it("anime feed carries the adult filter + vote floor (mainstream anime only)", () => {
+  it("anime feed = recent (first_air_date rolls to <year-1>-01-01) + mainstream (vote_count.gte=50) + no adult", () => {
     expect(TRENDING_KINDS.anime.path).toBe("discover/tv");
-    expect(sortedQuery(TRENDING_KINDS.anime.query)).toBe(
-      "include_adult=false&language=zh-CN&sort_by=popularity.desc&vote_count.gte=200&with_genres=16&with_original_language=ja",
+    const now = new Date("2026-07-04T00:00:00Z");
+    expect(sortedQuery(trendingFeedQuery("anime", now))).toBe(
+      "first_air_date.gte=2025-01-01&include_adult=false&language=zh-CN&sort_by=popularity.desc&vote_count.gte=50&with_genres=16&with_original_language=ja",
     );
+  });
+
+  it("movie/tv feed queries carry no dynamic date (unchanged)", () => {
+    const now = new Date("2026-07-04T00:00:00Z");
+    expect(sortedQuery(trendingFeedQuery("movie", now))).toBe("language=zh-CN");
+    expect(sortedQuery(trendingFeedQuery("tv", now))).toBe("language=zh-CN");
+  });
+
+  it("anime first-air-date floor rolls with the year (last calendar year onward)", () => {
+    expect(animeFirstAirDateFloor(new Date("2026-07-04T00:00:00Z"))).toBe("2025-01-01");
+    expect(animeFirstAirDateFloor(new Date("2027-01-01T00:00:00Z"))).toBe("2026-01-01");
   });
 });
 

--- a/apps/web/lib/trending.ts
+++ b/apps/web/lib/trending.ts
@@ -25,8 +25,8 @@ export const TRENDING_KINDS: Record<
     path: "discover/tv",
     // 静态参数;动态 first_air_date.gte 由 trendingFeedQuery 注入(见下)。
     // include_adult=false + vote_count.gte=50 挡成人/里番,只留主流;first_air_date
-    // 门槛保证「近期」而非史上最热老番。必须与 workers/tmdb-proxy getTrendingFeeds
-    // 的 anime feed 同 `now` 逐字一致(cacheKey 命中)。
+    // 门槛保证「近期」而非史上最热老番。契约=与 workers/tmdb-proxy getTrendingFeeds
+    // 的 anime feed 同 `now` **参数集(名+值)一致**即可,顺序无关(cacheKeyFor 两边都排序)。
     query: {
       include_adult: "false",
       language: "zh-CN",

--- a/apps/web/lib/trending.ts
+++ b/apps/web/lib/trending.ts
@@ -23,14 +23,15 @@ export const TRENDING_KINDS: Record<
   anime: {
     label: "热门动漫",
     path: "discover/tv",
-    // include_adult=false + vote_count.gte=200 是 NECESSARY:裸 popularity.desc 会
-    // 把成人/里番动画顶上首屏(popularity 被刷高、adult 标记不可靠),vote 门槛只留
-    // 主流。必须与 workers/tmdb-proxy TRENDING_FEEDS 的 anime feed 逐字一致(cacheKey)。
+    // 静态参数;动态 first_air_date.gte 由 trendingFeedQuery 注入(见下)。
+    // include_adult=false + vote_count.gte=50 挡成人/里番,只留主流;first_air_date
+    // 门槛保证「近期」而非史上最热老番。必须与 workers/tmdb-proxy getTrendingFeeds
+    // 的 anime feed 同 `now` 逐字一致(cacheKey 命中)。
     query: {
       include_adult: "false",
       language: "zh-CN",
       sort_by: "popularity.desc",
-      "vote_count.gte": "200",
+      "vote_count.gte": "50",
       with_genres: "16",
       with_original_language: "ja",
     },
@@ -39,6 +40,24 @@ export const TRENDING_KINDS: Record<
 };
 
 export const TRENDING_KIND_ORDER: TrendingKind[] = ["movie", "tv", "anime"];
+
+/** Last-calendar-year floor (rolls yearly): the anime feed shows RECENT seasons,
+ *  not TMDB's all-time-popularity classics (全职猎人1999/死神2004…). MUST match
+ *  workers/tmdb-proxy handler.ts animeFirstAirDateFloor. */
+export function animeFirstAirDateFloor(now: Date = new Date()): string {
+  return `${now.getUTCFullYear() - 1}-01-01`;
+}
+
+/** The query for a feed, with the rolling first_air_date.gte injected for anime.
+ *  MUST match workers/tmdb-proxy getTrendingFeeds for the same `now` — cacheKeyFor
+ *  sorts params, so the param SET (not order) is the contract. */
+export function trendingFeedQuery(kind: TrendingKind, now: Date = new Date()): Record<string, string> {
+  const query = { ...TRENDING_KINDS[kind].query };
+  if (kind === "anime") {
+    query["first_air_date.gte"] = animeFirstAirDateFloor(now);
+  }
+  return query;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -79,7 +98,7 @@ export function mapTrendingResults(raw: unknown, kind: TrendingKind): TrendingCa
 export async function getTrending(kind: TrendingKind): Promise<TrendingCard[]> {
   try {
     const accesses = await getTmdbAccesses(getAccountScopedSettings(await getCurrentAccountId()));
-    const raw = await fetchTmdbList(accesses, TRENDING_KINDS[kind].path, TRENDING_KINDS[kind].query);
+    const raw = await fetchTmdbList(accesses, TRENDING_KINDS[kind].path, trendingFeedQuery(kind));
     return mapTrendingResults(raw, kind).slice(0, 12);
   } catch {
     return [];

--- a/workers/tmdb-proxy/src/handler.test.ts
+++ b/workers/tmdb-proxy/src/handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { handleTmdbProxy, runScheduledRefresh, TRENDING_FEEDS, type KvLike } from "./handler";
+import { getTrendingFeeds, handleTmdbProxy, runScheduledRefresh, type KvLike } from "./handler";
 
 function fakeKv(initial: Record<string, string> = {}): KvLike & { puts: Array<{ key: string; ttl: number | undefined }> } {
   const store = new Map(Object.entries(initial));
@@ -125,6 +125,20 @@ describe("handleTmdbProxy — KV cache", () => {
 });
 
 describe("trending discovery", () => {
+  it("anime feed = recent (first_air_date rolls to <year-1>-01-01) + vote_count.gte=50, matching the frontend", () => {
+    const now = new Date("2026-07-04T00:00:00Z");
+    const feeds = getTrendingFeeds(now);
+    expect(feeds[0]).toBe("trending/movie/week?language=zh-CN");
+    expect(feeds[1]).toBe("trending/tv/week?language=zh-CN");
+    const animeParams = new URL(`https://x/${feeds[2]}`).searchParams;
+    expect(animeParams.get("first_air_date.gte")).toBe("2025-01-01");
+    expect(animeParams.get("vote_count.gte")).toBe("50");
+    expect(animeParams.get("include_adult")).toBe("false");
+    expect(animeParams.get("with_original_language")).toBe("ja");
+    expect(animeParams.get("with_genres")).toBe("16");
+    expect(animeParams.get("sort_by")).toBe("popularity.desc");
+  });
+
   it("allows the trending/ prefix (was 404)", async () => {
     const res = await handleTmdbProxy({
       request: new Request("https://w.example/trending/movie/week?language=zh-CN"),
@@ -142,7 +156,7 @@ describe("trending discovery", () => {
       token: "k",
       originFetch: async () => new Response(JSON.stringify({ results: [{ id: 1 }] }), { status: 200 }),
     });
-    expect(kv.puts).toHaveLength(TRENDING_FEEDS.length);
+    expect(kv.puts).toHaveLength(getTrendingFeeds().length);
     for (const put of kv.puts) {
       expect(put.ttl).toBe(25 * 60 * 60);
     }
@@ -151,7 +165,7 @@ describe("trending discovery", () => {
     // A subsequent frontend request for the same feed must serve the warmed KV
     // entry WITHOUT hitting origin — proving the Cron key === proxy key.
     const hit = await handleTmdbProxy({
-      request: new Request(`https://w.example/${TRENDING_FEEDS[0]}`),
+      request: new Request(`https://w.example/${getTrendingFeeds()[0]}`),
       kv,
       token: "k",
       originFetch: async () => new Response("SHOULD_NOT_FETCH", { status: 500 }),
@@ -165,7 +179,7 @@ describe("trending discovery", () => {
     // It must still get the daily-cadence TTL, else the proxy re-hits TMDB hourly.
     const kv = fakeKv();
     await handleTmdbProxy({
-      request: new Request(`https://w.example/${TRENDING_FEEDS[1]}`), // trending/tv/week
+      request: new Request(`https://w.example/${getTrendingFeeds()[1]}`), // trending/tv/week
       kv,
       token: "k",
       originFetch: async () => new Response(JSON.stringify({ results: [] }), { status: 200 }),

--- a/workers/tmdb-proxy/src/handler.test.ts
+++ b/workers/tmdb-proxy/src/handler.test.ts
@@ -186,6 +186,18 @@ describe("trending discovery", () => {
     });
     expect(kv.puts[0]?.ttl).toBe(25 * 60 * 60);
 
+    // The DYNAMIC anime feed (first_air_date.gte rolls yearly) must get the same
+    // daily TTL on a reactive MISS — isTrendingFeedRequest recomputes the feeds,
+    // so the rolling date must still be recognized as a trending feed.
+    const animeKv = fakeKv();
+    await handleTmdbProxy({
+      request: new Request(`https://w.example/${getTrendingFeeds()[2]}`), // discover/tv anime
+      kv: animeKv,
+      token: "k",
+      originFetch: async () => new Response(JSON.stringify({ results: [] }), { status: 200 }),
+    });
+    expect(animeKv.puts[0]?.ttl).toBe(25 * 60 * 60);
+
     // A non-feed discover/tv call keeps its ordinary short TTL (feed-specific, not
     // a blanket discover override).
     const other = fakeKv();

--- a/workers/tmdb-proxy/src/handler.ts
+++ b/workers/tmdb-proxy/src/handler.ts
@@ -24,24 +24,37 @@ function cacheKeyFor(request: Request): string {
 
 const TRENDING_TTL_SECONDS = 25 * 60 * 60; // > 24h 刷新间隔,断刷时兜底一小时
 
-/** The three discovery feeds the search page shows, aligned to the app's
- *  电影/剧集/动漫 library types. Single source of truth: the Cron refresh writes
- *  these and the frontend reads the SAME path+query, so cacheKeyFor matches. */
-export const TRENDING_FEEDS = [
-  "trending/movie/week?language=zh-CN",
-  "trending/tv/week?language=zh-CN",
-  // 动漫:日语动画按热度排。include_adult=false + vote_count.gte=200 是 NECESSARY,
-  // 不是可选 —— 裸 popularity.desc 会把大量成人/里番动画顶上来(其 popularity 被
-  // 刷高、adult 标记不可靠);vote_count 门槛把它们挡掉,只留主流(咒术/死神/JOJO)。
-  // 必须与 apps/web/lib/trending.ts TRENDING_KINDS.anime.query 逐字一致(cacheKey 命中)。
-  "discover/tv?include_adult=false&language=zh-CN&sort_by=popularity.desc&vote_count.gte=200&with_genres=16&with_original_language=ja",
-];
+/** Last-calendar-year floor (rolls yearly): the anime feed shows RECENT seasons,
+ *  not TMDB's all-time-popularity classics (全职猎人1999/死神2004…). MUST match
+ *  apps/web/lib/trending.ts animeFirstAirDateFloor. */
+export function animeFirstAirDateFloor(now: Date = new Date()): string {
+  return `${now.getUTCFullYear() - 1}-01-01`;
+}
 
-/** The cacheKeys of the daily-cadence feeds. A reactive MISS on one of these
- *  (cold KV / delayed Cron) must cache with the daily TTL — otherwise a feed that
- *  fell out of KV re-hits TMDB every hour (ttlForPath gives non-movie paths 1h).
- *  Feed-specific: an ordinary discover/tv call keeps its normal short TTL. */
-const TRENDING_FEED_KEYS = new Set(TRENDING_FEEDS.map((feed) => cacheKeyFor(new Request(`https://proxy/${feed}`))));
+/** The three discovery feeds the search page shows, aligned to 电影/剧集/动漫.
+ *  Movie/TV are TMDB weekly trending. Anime has no "trending" endpoint, so it's
+ *  discover/tv (日语动画) with a ROLLING first_air_date.gte (recent seasons only —
+ *  bare popularity.desc surfaces decade-old classics) + vote_count.gte=50 +
+ *  include_adult=false (mainstream, drops 里番/borderline). The Cron warms these
+ *  and the frontend reads the SAME feed — MUST stay byte-compatible with
+ *  apps/web/lib/trending.ts trendingFeedQuery for the same `now` (cacheKeyFor
+ *  sorts, so the param SET must match). */
+export function getTrendingFeeds(now: Date = new Date()): string[] {
+  const floor = animeFirstAirDateFloor(now);
+  return [
+    "trending/movie/week?language=zh-CN",
+    "trending/tv/week?language=zh-CN",
+    `discover/tv?first_air_date.gte=${floor}&include_adult=false&language=zh-CN&sort_by=popularity.desc&vote_count.gte=50&with_genres=16&with_original_language=ja`,
+  ];
+}
+
+/** Is this request one of the daily-cadence feeds? A reactive MISS on one must
+ *  cache with the daily TTL (else a feed that fell out of KV re-hits TMDB every
+ *  hour — ttlForPath gives non-movie paths 1h). Feed-specific: an ordinary
+ *  discover/tv call keeps its short TTL. Computed per-call (feeds roll by date). */
+function isTrendingFeedRequest(key: string, now: Date = new Date()): boolean {
+  return getTrendingFeeds(now).some((feed) => cacheKeyFor(new Request(`https://proxy/${feed}`)) === key);
+}
 
 export interface KvLike {
   get(key: string): Promise<string | null>;
@@ -96,7 +109,7 @@ export async function handleTmdbProxy(deps: HandleTmdbProxyDeps): Promise<Respon
   if (!originResponse.ok) {
     return new Response(body, { status: originResponse.status, headers: jsonHeaders("MISS") });
   }
-  const ttl = TRENDING_FEED_KEYS.has(key) ? TRENDING_TTL_SECONDS : ttlForPath(path);
+  const ttl = isTrendingFeedRequest(key) ? TRENDING_TTL_SECONDS : ttlForPath(path);
   await deps.kv.put(key, body, { expirationTtl: ttl });
   return new Response(body, { status: 200, headers: jsonHeaders("MISS") });
 }
@@ -114,7 +127,7 @@ export interface RunScheduledRefreshDeps {
  *  (if any) lives on under its TTL, and one bad feed never aborts the others. */
 export async function runScheduledRefresh(deps: RunScheduledRefreshDeps): Promise<void> {
   const originFetch = deps.originFetch ?? fetch;
-  for (const feed of TRENDING_FEEDS) {
+  for (const feed of getTrendingFeeds()) {
     const key = cacheKeyFor(new Request(`https://proxy/${feed}`));
     try {
       const originResponse = await originFetch(`${TMDB_ORIGIN}/${key}`, {

--- a/workers/tmdb-proxy/src/handler.ts
+++ b/workers/tmdb-proxy/src/handler.ts
@@ -36,9 +36,9 @@ export function animeFirstAirDateFloor(now: Date = new Date()): string {
  *  discover/tv (日语动画) with a ROLLING first_air_date.gte (recent seasons only —
  *  bare popularity.desc surfaces decade-old classics) + vote_count.gte=50 +
  *  include_adult=false (mainstream, drops 里番/borderline). The Cron warms these
- *  and the frontend reads the SAME feed — MUST stay byte-compatible with
- *  apps/web/lib/trending.ts trendingFeedQuery for the same `now` (cacheKeyFor
- *  sorts, so the param SET must match). */
+ *  and the frontend reads the SAME feed — the contract is that the PARAM SET
+ *  (names+values) matches apps/web/lib/trending.ts trendingFeedQuery for the same
+ *  `now`; ORDER does not matter (cacheKeyFor sorts both sides before keying). */
 export function getTrendingFeeds(now: Date = new Date()): string[] {
   const floor = animeFirstAirDateFloor(now);
   return [


### PR DESCRIPTION
## 现象(用户反馈)
「近期热门」的动漫 Tab 全是全职猎人(1999)/死神(2004)/钢炼(2009)这种老番,不像「近期」。

## 根因(我 #98 的设计锅)
- `sort_by=popularity.desc`:TMDB 的 popularity **不是本周热度,是常年累积人气**——国民级老番常年霸榜,跟在不在更新无关。
- `vote_count.gte=200`(为滤成人加的):老番攒了多年投票轻松过线,**本季新番投票没攒够反被挡掉**——我这刀专砍「新」。

## 修复(真数据对比 4 组候选后定 D')
`first_air_date.gte=<今年-1>-01-01` + `vote_count.gte=50` + `include_adult=false` + `popularity.desc`:
- 近1年首播 → 全 2025-26 新番,老番彻底消失
- vote≥50 挡掉边缘擦边(拔作岛 v31)+ include_adult=false 挡里番 → 零成人
- 实测前12:鹰峰同学/薰香花朵/尖帽子/刃牙道/坂本日常/金牌得主/咔嗒咔嗒… 全主流当季番
- **日期按年滚动**(`getUTCFullYear()-1`),不硬编码,明年自动前移

## 契约
worker `getTrendingFeeds(now)` 与前端 `trendingFeedQuery(kind, now)` 同 `now` 产生**逐字相同**的 cacheKey(node cross-check MATCH=true + 两侧 contract 测试各自钉死),Cron 预热的 KV 前端仍命中。movie/tv 榜不动。

## 测试
TDD:动漫 feed 近期口径 + 日期滚动 + movie/tv 不变 + 跨包契约。全量 1169 绿 + 双 tsc + build:web。

## 部署(合并后)
worker `wrangler deploy` + 实例 --no-cache 重建(见昨天部署事故教训)+ 真机 e2e 验动漫 Tab 是近番。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
