### PR TITLE
ci: macOS desktop release workflow

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -5,6 +5,16 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Version tag to publish (e.g. v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  ELECTRON_VERSION: "33.4.11"
 
 jobs:
   build-macos:
@@ -27,7 +37,16 @@ jobs:
 
       - name: Swap better-sqlite3 to Electron ABI
         working-directory: apps/web/.next/standalone/node_modules/better-sqlite3
-        run: npx prebuild-install -r electron -t 33.4.11
+        run: npx prebuild-install -r electron -t ${{ env.ELECTRON_VERSION }}
+
+      - name: Verify ABI swap actually happened
+        run: |
+          cat > /tmp/abi-check.js <<'SCRIPT'
+          const Database = require(process.env.GITHUB_WORKSPACE + '/apps/web/.next/standalone/node_modules/better-sqlite3');
+          new Database(':memory:').exec('CREATE TABLE t(x)');
+          console.log('ABI_OK modules=' + process.versions.modules);
+          SCRIPT
+          ELECTRON_RUN_AS_NODE=1 "$(npm root)/electron/dist/Electron.app/Contents/MacOS/Electron" /tmp/abi-check.js
 
       - name: Import signing certificate
         env:
@@ -36,6 +55,7 @@ jobs:
         run: |
           echo "$MAC_CERT_P12_BASE64" | base64 --decode > /tmp/cert.p12
           security create-keychain -p build-keychain build.keychain
+          security unlock-keychain -p build-keychain build.keychain
           security import /tmp/cert.p12 -k build.keychain -P "$MAC_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           security list-keychains -s build.keychain
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k build-keychain build.keychain
@@ -50,9 +70,20 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run dist --workspace @media-track/desktop
 
+      - name: Determine release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload DMG to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           files: apps/desktop/dist-app/*.dmg
           draft: true
           generate_release_notes: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,58 @@
+name: Release macOS Desktop
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build Next standalone server
+        run: npm run build:web
+
+      - name: Build desktop TypeScript
+        run: npm run build --workspace @media-track/desktop
+
+      - name: Swap better-sqlite3 to Electron ABI
+        working-directory: apps/web/.next/standalone/node_modules/better-sqlite3
+        run: npx prebuild-install -r electron -t 33.4.11
+
+      - name: Import signing certificate
+        env:
+          MAC_CERT_P12_BASE64: ${{ secrets.MAC_CERT_P12_BASE64 }}
+          MAC_CERT_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
+        run: |
+          echo "$MAC_CERT_P12_BASE64" | base64 --decode > /tmp/cert.p12
+          security create-keychain -p build-keychain build.keychain
+          security import /tmp/cert.p12 -k build.keychain -P "$MAC_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security list-keychains -s build.keychain
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k build-keychain build.keychain
+          rm /tmp/cert.p12
+
+      - name: Package + sign + notarize DMG
+        env:
+          CSC_LINK: ""
+          CSC_NAME: "Developer ID Application: Qinghai Wu (P8GK36YA6D)"
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: npm run dist --workspace @media-track/desktop
+
+      - name: Upload DMG to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: apps/desktop/dist-app/*.dmg
+          draft: true
+          generate_release_notes: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -22,6 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout tag commit (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git fetch --tags
+          if git rev-parse "refs/tags/${{ inputs.tag }}" >/dev/null 2>&1; then
+            git checkout "${{ inputs.tag }}"
+          else
+            echo "::error::Tag ${{ inputs.tag }} does not exist. Create it first: git tag ${{ inputs.tag }} && git push origin ${{ inputs.tag }}"
+            exit 1
+          fi
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -53,12 +64,15 @@ jobs:
           MAC_CERT_P12_BASE64: ${{ secrets.MAC_CERT_P12_BASE64 }}
           MAC_CERT_PASSWORD: ${{ secrets.MAC_CERT_PASSWORD }}
         run: |
-          echo "$MAC_CERT_P12_BASE64" | base64 --decode > /tmp/cert.p12
-          security create-keychain -p build-keychain build.keychain
-          security unlock-keychain -p build-keychain build.keychain
-          security import /tmp/cert.p12 -k build.keychain -P "$MAC_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security list-keychains -s build.keychain
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k build-keychain build.keychain
+          KC="$RUNNER_TEMP/build.keychain-db"
+          KC_PASS=$(uuidgen)
+          echo "$MAC_CERT_P12_BASE64" | base64 -D -o /tmp/cert.p12
+          security create-keychain -p "$KC_PASS" "$KC"
+          security unlock-keychain -p "$KC_PASS" "$KC"
+          security set-keychain-settings -t 3600 -u "$KC"
+          security import /tmp/cert.p12 -k "$KC" -P "$MAC_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security list-keychains -s "$KC"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PASS" "$KC"
           rm /tmp/cert.p12
 
       - name: Package + sign + notarize DMG


### PR DESCRIPTION
## Summary
- Tag-triggered (`v*`) GitHub Actions workflow that builds, signs, notarizes, and publishes the macOS desktop DMG
- Runs on `macos-14` runner (Apple Silicon)
- Steps: `npm ci` → `build:web` → desktop tsc → better-sqlite3 Electron ABI swap → import Developer ID cert → electron-builder sign+notarize → upload DMG as draft Release
- Reads 5 GitHub Secrets: `MAC_CERT_P12_BASE64`, `MAC_CERT_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`
- Also supports `workflow_dispatch` for manual trigger without a tag

## Test plan
- [ ] Merge → tag `v0.1.0` → workflow runs → draft Release appears with signed DMG
- [ ] DMG opens on a clean Mac without Gatekeeper warning (signature + notarization valid)
