### PR TITLE
fix(ci): remove empty CSC_LINK causing 'not a file' error

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -77,7 +77,6 @@ jobs:
 
       - name: Package + sign + notarize DMG
         env:
-          CSC_LINK: ""
           CSC_NAME: "Developer ID Application: Qinghai Wu (P8GK36YA6D)"
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}


### PR DESCRIPTION
## Summary
- Remove `CSC_LINK: ""` from the packaging step env — electron-builder treats CSC_LINK as a file path, and an empty string makes it try to read the workspace dir as a p12, producing `⨯ …/apps/desktop not a file`
- With CSC_LINK removed, electron-builder falls back to CSC_NAME → resolves the identity from the imported keychain

## Context
Release workflow run #2 (28740436305) failed at the packaging step with this error after the certificate import succeeded.

## Test plan
- [ ] Merge → re-trigger release → packaging step passes → DMG signed + notarized
