### PR TITLE
fix(ci): CSC_NAME without cert-type prefix

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Package + sign + notarize DMG
         env:
-          CSC_NAME: "Developer ID Application: Qinghai Wu (P8GK36YA6D)"
+          CSC_NAME: "Qinghai Wu (P8GK36YA6D)"
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -84,7 +84,8 @@ From your Apple Developer account, export before packaging:
 export CSC_LINK="/absolute/path/to/DeveloperIDApplication.p12"   # base64 or file path
 export CSC_KEY_PASSWORD="<p12 password>"
 # …or reference an identity already in the login keychain:
-# export CSC_NAME="Developer ID Application: Your Name (TEAMID)"
+# export CSC_NAME="Your Name (TEAMID)"
+# (electron-builder auto-selects "Developer ID Application:" — do NOT include that prefix)
 
 # Notarization (electron-builder v25 `mac.notarize: true` reads these):
 export APPLE_ID="you@example.com"


### PR DESCRIPTION
electron-builder asks to remove the 'Developer ID Application:' prefix — it auto-selects the cert type from the signer name.