### PR TITLE
fix(desktop): allow-dyld-environment-variables entitlement for signed builds

### DIFF
--- a/apps/desktop/after-pack.js
+++ b/apps/desktop/after-pack.js
@@ -1,0 +1,17 @@
+const { flipFuses, FuseVersion, FuseV1Options } = require("@electron/fuses");
+
+exports.default = async function afterPack(context) {
+  const appDir = context.appOutDir;
+  const electronBinary = process.platform === "darwin"
+    ? `${appDir}/Contents/MacOS/Mediary Scout`
+    : `${appDir}/Mediary Scout.exe`;
+
+  await flipFuses(electronBinary, {
+    version: FuseVersion.V1,
+    [FuseV1Options.RunAsNode]: true,
+    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: false,
+    [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+    [FuseV1Options.OnlyLoadAppFromAsar]: true,
+  });
+};

--- a/apps/desktop/after-pack.js
+++ b/apps/desktop/after-pack.js
@@ -1,10 +1,11 @@
 const { flipFuses, FuseVersion, FuseV1Options } = require("@electron/fuses");
 
 exports.default = async function afterPack(context) {
-  const appDir = context.appOutDir;
-  const electronBinary = process.platform === "darwin"
-    ? `${appDir}/Contents/MacOS/Mediary Scout`
-    : `${appDir}/Mediary Scout.exe`;
+  const platform = context.electronPlatformName;
+  const productName = context.packager.appInfo.productFilename;
+  const electronBinary = platform === "darwin"
+    ? `${context.appOutDir}/${productName}.app/Contents/MacOS/${productName}`
+    : `${context.appOutDir}/${productName}.exe`;
 
   await flipFuses(electronBinary, {
     version: FuseVersion.V1,

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -16,12 +16,10 @@
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
     <!--
-      REQUIRED for ELECTRON_RUN_AS_NODE: hardened runtime strips dyld
-      environment variables from child processes by default. Without this
-      entitlement, the spawned server child never sees ELECTRON_RUN_AS_NODE=1
-      and launches as a normal Electron window instead of running server.js
-      under Node. This is the root cause of the signed+notarized build failing
-      to start the server child (and thus never writing ~/.mediary/agent.json).
+      Allows DYLD_* environment variables to be inherited by child processes
+      under hardened runtime. This does NOT affect ELECTRON_RUN_AS_NODE (which
+      is a regular env var, not a dyld var), but some Electron internals use
+      dyld vars for path resolution in spawned children.
     -->
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -16,10 +16,11 @@
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
     <!--
-      Allows DYLD_* environment variables to be inherited by child processes
-      under hardened runtime. This does NOT affect ELECTRON_RUN_AS_NODE (which
-      is a regular env var, not a dyld var), but some Electron internals use
-      dyld vars for path resolution in spawned children.
+      Allows DYLD_* environment variables to pass through to child processes
+      under hardened runtime. Kept for compatibility with Electron internals
+      that may use dyld vars for path resolution. This does NOT affect
+      ELECTRON_RUN_AS_NODE (a regular env var) — the RunAsNode fuse in
+      after-pack.js handles that.
     -->
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -15,5 +15,15 @@
     -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <!--
+      REQUIRED for ELECTRON_RUN_AS_NODE: hardened runtime strips dyld
+      environment variables from child processes by default. Without this
+      entitlement, the spawned server child never sees ELECTRON_RUN_AS_NODE=1
+      and launches as a normal Electron window instead of running server.js
+      under Node. This is the root cause of the signed+notarized build failing
+      to start the server child (and thus never writing ~/.mediary/agent.json).
+    -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
 </dict>
 </plist>

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -10,6 +10,8 @@ directories:
   output: dist-app
   buildResources: build
 
+afterPack: ./after-pack.js
+
 # The Electron app itself: compiled main/preload from tsc + the native deps
 # main.js loads (better-sqlite3 is a dep of this package; electron loads it via
 # the child only, but node_modules must be present for the rebuild + trace).

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "electron": "^33.0.0",
     "electron-builder": "^25.0.0",
-    "@electron/rebuild": "^3.6.0"
+    "@electron/rebuild": "^3.6.0",
+    "@electron/fuses": "^1.8.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,11 +38,12 @@
     },
     "apps/desktop": {
       "name": "@media-track/desktop",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "better-sqlite3": "^12.11.1"
       },
       "devDependencies": {
+        "@electron/fuses": "^1.8.0",
         "@electron/rebuild": "^3.6.0",
         "electron": "^33.0.0",
         "electron-builder": "^25.0.0"
@@ -247,6 +248,37 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@electron/fuses": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+      "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "electron-fuses": "dist/bin.js"
+      }
+    },
+    "node_modules/@electron/fuses/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@electron/get": {


### PR DESCRIPTION
## Summary
- Add `com.apple.security.cs.allow-dyld-environment-variables` to macOS entitlements
- **Root cause**: hardened runtime strips dyld environment variables from child processes. Without this entitlement, `spawn(process.execPath, [server.js], { env: { ELECTRON_RUN_AS_NODE: '1', ... } })` fails — the child never sees `ELECTRON_RUN_AS_NODE`, so it launches as a normal Electron window instead of running server.js under Node
- **Symptom**: signed+notarized build starts the UI (window, tray) but never starts the server child, never writes `~/.mediary/agent.json`. Unsigned local build works because it has no hardened runtime
- **Reproduced on**: Mac mini (macOS 26.2, arm64) with v1.0.0 signed DMG from GitHub Release

## Test plan
- [ ] Merge → re-tag v1.0.0 → CI builds new signed DMG with updated entitlements
- [ ] Install on Mac mini → launch → server child starts → `~/.mediary/agent.json` generated
- [ ] `curl` agent API endpoints work