### PR TITLE
fix(ci): remove invalid target_commitish from Windows release upload

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -162,6 +162,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          target_commitish: refs/tags/${{ steps.tag.outputs.tag }}
           files: apps/desktop/dist-app/*.exe
           generate_release_notes: true

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -158,7 +158,7 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload installer to GitHub Release
+      - name: Upload Windows installer to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
## Root cause
Windows build job failed at upload step with HTTP 422: `target_commitish` set to `refs/tags/v1.1.0` which GitHub API rejects (expects commit SHA or branch name, not a refs path).

## Fix
Remove `target_commitish` from the Windows upload step. When the tag already exists (push event), the release action attaches to the existing tag without needing this field.

## Context
v1.1.0 CI run: macOS build succeeded (DMG uploaded), Windows build succeeded (exe built) but upload failed with this error.