### PR TITLE
chore: bump desktop to 1.1.0; README notes machine-verified releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You ask for a movie, show, or anime; an LLM agent scouts resources across your i
 
 No Docker, no Postgres, no terminal. The app bundles its own SQLite data layer and runs the full engine inside an Electron shell.
 
-Every release is machine-verified before it ships: CI installs the freshly-built package on a clean Windows runner, boots the real app, and requires it to answer HTTP 200 — a broken build can't reach the Releases page.
+The Windows installer is machine-verified before it's published: CI installs it on a clean runner, boots the real app, and requires an HTTP 200 health response — a broken installer can't reach the Releases page. macOS builds get the same native-ABI verification at build time, plus signing and notarization.
 
 ### Docker (power users — always-on server)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ You ask for a movie, show, or anime; an LLM agent scouts resources across your i
 
 No Docker, no Postgres, no terminal. The app bundles its own SQLite data layer and runs the full engine inside an Electron shell.
 
+Every release is machine-verified before it ships: CI installs the freshly-built package on a clean Windows runner, boots the real app, and requires it to answer HTTP 200 — a broken build can't reach the Releases page.
+
 ### Docker (power users — always-on server)
 
 ```bash

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@media-track/desktop",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "commonjs",
   "main": "dist/main.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
     },
     "apps/desktop": {
       "name": "@media-track/desktop",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "better-sqlite3": "^12.11.1"
       },


### PR DESCRIPTION
Windows 桌面版已在真实用户机器上确认可用（#115 修复后的 v1.1.0 重建包）。按约定：

- `apps/desktop/package.json` 1.0.0 → **1.1.0**（与 release tag 对齐，产物文件名不再错位；package-lock 同步）
- README 桌面段落加一句底气：每个 release 发布前都在干净 Windows runner 上真装包、真启动、真探活（HTTP 200）——坏包上不了 Releases 页

合并后重打 v1.1.0 tag，产物将变为 `Mediary.Scout-1.1.0-arm64.dmg` / `Mediary.Scout.Setup.1.1.0.exe`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)