### PR TITLE
ci: atomic release gate — publish DMG + EXE together from a single job

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -327,7 +327,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          target_commitish: ${{ github.sha }}
           files: |
             dist/*.dmg
             dist/*.exe

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,4 +1,4 @@
-name: Release macOS Desktop
+name: Release Desktop
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   ELECTRON_VERSION: "33.4.11"
@@ -127,22 +127,13 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run dist --workspace @media-track/desktop
 
-      - name: Determine release tag
-        id: tag
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Upload DMG to GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          target_commitish: ${{ github.sha }}
-          files: apps/desktop/dist-app/*.dmg
-          generate_release_notes: true
+          name: macos-dmg
+          path: apps/desktop/dist-app/*.dmg
+          if-no-files-found: error
+          retention-days: 7
 
   build-windows:
     runs-on: windows-latest
@@ -298,9 +289,27 @@ jobs:
           if (-not $healthy) { throw "installed app never answered 200 on its baseUrl within 120s" }
           Write-Host "SMOKE OK: $baseUrl answered 200"
 
+      - name: Upload installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: apps/desktop/dist-app/*.exe
+          if-no-files-found: error
+          retention-days: 7
+
+  # Atomic release gate: nothing reaches the Releases page unless BOTH
+  # platform builds (including the Windows install-and-boot smoke test)
+  # succeeded. Publishing from a single job prevents the mixed-version
+  # state where a fresh DMG sits next to a stale EXE because one
+  # platform's gate failed after the other had already uploaded.
+  release:
+    needs: [build-macos, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
       - name: Determine release tag
         id: tag
-        shell: bash
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
@@ -308,9 +317,19 @@ jobs:
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload Windows installer to GitHub Release
+      - name: Download platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Upload DMG + installer to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
-          files: apps/desktop/dist-app/*.exe
+          target_commitish: ${{ github.sha }}
+          files: |
+            dist/*.dmg
+            dist/*.exe
+          fail_on_unmatched_files: true
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You ask for a movie, show, or anime; an LLM agent scouts resources across your i
 
 No Docker, no Postgres, no terminal. The app bundles its own SQLite data layer and runs the full engine inside an Electron shell.
 
-The Windows installer is machine-verified before it's published: CI installs it on a clean runner, boots the real app, and requires an HTTP 200 health response — a broken installer can't reach the Releases page. macOS builds get the same native-ABI verification at build time, plus signing and notarization.
+Every release is machine-verified before it ships: CI installs the freshly-built Windows package on a clean runner, boots the real app, and requires an HTTP 200 health response, while the macOS build must pass native-ABI verification, signing, and notarization. Both platforms are published together in a single final step — if either gate fails, neither asset is uploaded, so a broken build can't reach the Releases page.
 
 ### Docker (power users — always-on server)
 


### PR DESCRIPTION
## Problem

Copilot flagged in #116: `build-macos` and `build-windows` each uploaded their own asset to the GitHub Release independently. If the Windows install-and-boot smoke gate failed, the macOS DMG had often already landed — leaving a mixed **"new DMG + old EXE"** release on the Releases page.

## Change

- Both build jobs now emit their installer as a **workflow artifact** (`actions/upload-artifact@v4`, `if-no-files-found: error`, 7-day retention) instead of uploading to the release directly.
- A new **`release` job** with `needs: [build-macos, build-windows]` downloads both artifacts and uploads DMG + EXE to the release **in a single step** (`fail_on_unmatched_files: true`). If either platform's gate fails, the release is not touched at all.
- Top-level `permissions` dropped from `contents: write` to `read`; only the `release` job gets `write` (least privilege).
- Workflow display name `Release macOS Desktop` → `Release Desktop` (it has built both platforms since #114).
- README: restores the strong claim — *"a broken build can't reach the Releases page"* — which #116 had to soften to per-platform wording precisely because of this gap. With the atomic gate it is now literally true, for both platforms.

## Verification

- YAML validated (`js-yaml`) + `actionlint` clean.
- End-to-end: after merge, re-push the `v1.1.0` tag and watch the run — expect both build jobs to pass, then the single `release` job to publish DMG + EXE together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
