### PR TITLE
chore: move Vercel build config from root vercel.json into project settings

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "framework": "nextjs",
-  "buildCommand": "npm run build:web",
-  "outputDirectory": "apps/web/.next"
-}


### PR DESCRIPTION
根 vercel.json 是 demo 项目（mediary-scout）的构建配置，但会泄漏进同仓库的其他 Vercel 项目——新建的静态官网项目（mediary-site，rootDirectory=site）被它强制走 Next.js 构建而失败。配置已迁入两个项目各自的 Vercel 项目设置（API 写入并回读验证）：demo = nextjs/build:web/apps/web/.next，官网 = 零构建纯静态。仓库从此不携带宿主特定配置。

🤖 Generated with [Claude Code](https://claude.com/claude-code)