### PR TITLE
fix(agent-loop): 获取循环四病 — terminal no-coverage, search-loop vitality hints, audit trail

### DIFF
--- a/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
@@ -141,6 +141,35 @@ export function buildSystemicBlockStop<TOOLS extends ToolSet = ToolSet>(): StopC
 }
 
 /**
+ * 病1 fix (2026-07-06 GITS incident): reportNoCoverage was registered as an
+ * ordinary evidence tool, so an honest no-coverage report did NOT end the run —
+ * the model idled, re-read skills, and double-reported (2.5 min of dead tail).
+ * A SUCCESSFUL report (the sandbox's §9 evidence check passed — output carries
+ * no `error`) is a terminal declaration: stop the loop immediately. A REFUSED
+ * report ({error: SANDBOX_NO_PROVIDER_EVIDENCE...}) keeps the loop alive — that
+ * refusal is an infrastructure guard, not an honest result.
+ */
+export function hasSuccessfulNoCoverageReport(steps: ReadonlyArray<StepLike>): boolean {
+  for (const step of steps) {
+    if (!(step.toolCalls ?? []).some((c) => c.toolName === "reportNoCoverage")) {
+      continue;
+    }
+    for (const result of step.toolResults ?? []) {
+      const output = result.output as { error?: unknown; reason?: unknown } | undefined;
+      if (output && output.error === undefined && output.reason !== undefined) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** A StopCondition that ends the loop once the agent has successfully reported no coverage. */
+export function buildNoCoverageStop<TOOLS extends ToolSet = ToolSet>(): StopCondition<TOOLS> {
+  return ({ steps }) => hasSuccessfulNoCoverageReport(steps as ReadonlyArray<StepLike>);
+}
+
+/**
  * The reflection nudge, as a pure decision: within the last REMIND_WITHIN_STEPS
  * steps before the cap, return the base system text + reminder (to override the
  * step's system message); otherwise undefined (no override). Pure → unit-testable.

--- a/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop-guards.ts
@@ -155,7 +155,12 @@ export function hasSuccessfulNoCoverageReport(steps: ReadonlyArray<StepLike>): b
       continue;
     }
     for (const result of step.toolResults ?? []) {
-      const output = result.output as { error?: unknown; reason?: unknown } | undefined;
+      // NOTE: TransferToolResult carries systemicBlock.reason at a NESTED level;
+      // this shallow cast only sees top-level fields, so a systemic-block result
+      // can never trip the reason check.
+      const output = result.output as
+        | { error?: unknown; reason?: unknown; searchesPerformed?: number }
+        | undefined;
       if (output && output.error === undefined && output.reason !== undefined) {
         return true;
       }

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -292,6 +292,8 @@ export async function runAcquisitionAgent(
     // Four stops: step cap (cost/runaway), repetition (agent crazy), systemic
     // transfer block (account quota/auth — every candidate will fail, stop grinding),
     // and successful reportNoCoverage (terminal declaration — no second report).
+    // The stops are independent and OR'd — each fires under disjoint conditions,
+    // so their ordering in this array is not semantic.
     stopWhen: [stepCountIs(maxSteps), buildRepetitionStop(), buildSystemicBlockStop(), buildNoCoverageStop()],
     // Last ~10 steps before the cap: inject a calm "wrap up + clean staging" nudge
     // so a step-capped run doesn't leave the 一人之下-style half-done mess.

--- a/packages/workflow/src/acquisition-v2/agent-loop.ts
+++ b/packages/workflow/src/acquisition-v2/agent-loop.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_MAX_STEPS,
   buildRepetitionStop,
   buildSystemicBlockStop,
+  buildNoCoverageStop,
   prepareStepSystemOverride,
 } from "./agent-loop-guards.js";
 import { interpretTool, type AgentToolEvent } from "./activity.js";
@@ -185,7 +186,7 @@ export function buildSandboxToolSet(
     },
     reportNoCoverage: {
       description:
-        "Honestly report you cannot cover the target. Valid only after a real search ran; backs the report with real provider evidence.",
+        "Honestly report you cannot cover the target. Valid only after a real search ran; backs the report with real provider evidence. TERMINAL: a successful report ENDS the task immediately — do NOT call finish after it, and do NOT report twice.",
       inputSchema: z.object({ reason: z.string() }),
       execute: (args: { reason: string }) => asEvidence(() => sandbox.reportNoCoverage(args.reason)),
     },
@@ -234,7 +235,9 @@ export interface AcquisitionAgentRequest {
   model: LanguageModel;
   system: string;
   prompt: string;
-  /** Hard ceiling on tool-loop steps (the model still terminates earlier via finish/reportNoCoverage). */
+  /** Hard ceiling on tool-loop steps. The loop also ends earlier when the model
+   *  stops calling tools, or when a stop fires (repetition / systemic block /
+   *  successful reportNoCoverage — the terminal no-coverage declaration). */
   maxSteps?: number;
   /** Movie task → expose the movie-only transferUntilLanded tool. */
   movie?: boolean;
@@ -286,9 +289,10 @@ export async function runAcquisitionAgent(
     system: request.system,
     prompt: request.prompt,
     tools,
-    // Three stops: step cap (cost/runaway), repetition (agent crazy), and systemic
-    // transfer block (account quota/auth — every candidate will fail, stop grinding).
-    stopWhen: [stepCountIs(maxSteps), buildRepetitionStop(), buildSystemicBlockStop()],
+    // Four stops: step cap (cost/runaway), repetition (agent crazy), systemic
+    // transfer block (account quota/auth — every candidate will fail, stop grinding),
+    // and successful reportNoCoverage (terminal declaration — no second report).
+    stopWhen: [stepCountIs(maxSteps), buildRepetitionStop(), buildSystemicBlockStop(), buildNoCoverageStop()],
     // Last ~10 steps before the cap: inject a calm "wrap up + clean staging" nudge
     // so a step-capped run doesn't leave the 一人之下-style half-done mess.
     prepareStep: ({ stepNumber }) => {

--- a/packages/workflow/src/acquisition-v2/interrogation.ts
+++ b/packages/workflow/src/acquisition-v2/interrogation.ts
@@ -112,6 +112,35 @@ export const INTERROGATION_QUESTIONS: readonly InterrogationQuestion[] = [
     expectation:
       "need 只含第 3、5 季的缺集,只往第 3、5 季目录落;绝不碰第 1、2、4 季,绝不自作主张多获取用户没点的季。",
   },
+  // 2026-07-06 获取循环四病（攻壳事故 run 7bc9dbf3）——新工具语义的理解验收:
+  {
+    id: "terminal_no_coverage",
+    prompt:
+      "你认真搜索并核对后确认资源市场确无该作品的任何覆盖,于是调用 reportNoCoverage 上报,返回成功。接下来你还会做什么?还需要再 readSkill 复查、再上报一次、或调用 finish 吗?",
+    expectation:
+      "认得工具描述里的 TERMINAL 语义:上报成功=任务立即结束,不再有任何后续动作——绝不二次上报(攻壳事故的 2.5 分钟死尾巴)、不需要也不能再 finish。",
+  },
+  {
+    id: "repeat_search_notice",
+    prompt:
+      "你调用 searchResources 搜某关键词,返回里带着提示:「⚠️「莉可丽丝」已是第 2 次搜索(结果与上次相同,共 20 候选)。换实质不同的新词,或立即基于已有证据决策。」你接下来怎么做?",
+    expectation:
+      "明白重复同词只会拿到同一快照、白烧轮次;要么换【实质不同】的新词(繁体/英文/罗马音升级,不是加空格换标点),要么立即基于已有 20 候选做决策(转存或上报);绝不第三次搜同词。",
+  },
+  {
+    id: "taboo_warning_reaction",
+    prompt:
+      "动漫任务里,你搜「攻壳机动队 ARISE」和「攻壳机动队 2020」,返回里带 warnings:一条说关键词带了片名之外的附加词「ARISE」疑似另一部系列作品,一条说动漫忌 4 位年份。你怎么处理这两条警告?",
+    expectation:
+      "把警告当搜索纪律的校验信号:年份直接去掉重搜(动漫加年份召回归零或拉真人版);ARISE 先核对它是否属于本次目标作品——若是隔壁衍生系列就放弃该词(跨系列会把任务拉偏),若确认是本作官方别名/罗马音可说明理由继续。不无视警告,也不因警告就中止任务。",
+  },
+  {
+    id: "digest_hint_reaction",
+    prompt:
+      "你换了个新关键词搜索,返回里前置了一句:「提示:上一快照「攻殻機動隊」有 58 个候选尚未筛过(viewResourceSnapshot 免费);先消化再换词通常更快。」你接下来怎么做?",
+    expectation:
+      "先回头消化那 58 个候选(viewResourceSnapshot 免费、不耗预算),读标题判断里面有没有目标本体/全集包,消化完再决定是否需要继续换词——而不是继续换词穷搜(攻壳事故:58 候选没筛就连搜 19 次)。",
+  },
 ];
 
 export interface InterrogationEntry extends InterrogationQuestion {

--- a/packages/workflow/src/acquisition-v2/interrogation.ts
+++ b/packages/workflow/src/acquisition-v2/interrogation.ts
@@ -137,9 +137,9 @@ export const INTERROGATION_QUESTIONS: readonly InterrogationQuestion[] = [
   {
     id: "digest_hint_reaction",
     prompt:
-      "你换了个新关键词搜索,返回里前置了一句:「提示:上一快照「攻殻機動隊」有 58 个候选尚未筛过(viewResourceSnapshot 免费);先消化再换词通常更快。」你接下来怎么做?",
+      "你换了个新关键词搜索,返回里前置了一句:「提示:上一快照「攻殻機動隊」有 58 个候选尚未筛过——候选列表就在你此前那次 searchResources 的返回里,回读不花预算;先消化再换词通常更快。」你接下来怎么做?",
     expectation:
-      "先回头消化那 58 个候选(viewResourceSnapshot 免费、不耗预算),读标题判断里面有没有目标本体/全集包,消化完再决定是否需要继续换词——而不是继续换词穷搜(攻壳事故:58 候选没筛就连搜 19 次)。",
+      "先回头消化那 58 个候选(回读自己先前 searchResources 返回的候选列表,不花预算),读标题判断里面有没有目标本体/全集包,消化完再决定是否需要继续换词——而不是继续换词穷搜(攻壳事故:58 候选没筛就连搜 19 次)。",
   },
 ];
 

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -10,6 +10,7 @@ import { RealStorageV2 } from "./real-storage-adapter.js";
 import { budgetSoftThreshold } from "./agent-loop-guards.js";
 import { TaskSandbox } from "./sandbox.js";
 import { AssrtSubtitleProvider, type AssrtProviderPort } from "../subtitle-provider.js";
+import type { SearchProfile } from "./search-profile.js";
 import {
   needForMovie,
   needForTvTarget,
@@ -54,6 +55,9 @@ export interface RunAcquisitionV2Request {
   searchHints?: string;
   /** Rendered quality-preference guidance (召回后选片优先级), injected into the prompt. */
   qualityGuidance?: string;
+  /** The task's fine-grained search profile — enables the anime taboo-keyword
+   *  validator (warnings only, never blocking). 病2b。 */
+  searchProfile?: SearchProfile;
   /** The run's drive brand — selects the brand transfer model + dead-links section. */
   storageProvider?: string;
   /** Filters known-dead candidates from search results before the agent sees them,
@@ -116,6 +120,7 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
     // fallbacks ("2026 电影") at the tool boundary so they never burn a search.
     titleTerms: [request.target.title, ...request.target.aliases],
     ...(request.searchBudget === undefined ? {} : { searchBudget: request.searchBudget }),
+    ...(request.searchProfile === undefined ? {} : { searchProfile: request.searchProfile }),
   });
 
   // Pre-warm the raw snapshot (bare title) BEFORE building the system prompt, so the

--- a/packages/workflow/src/acquisition-v2/orchestrator.ts
+++ b/packages/workflow/src/acquisition-v2/orchestrator.ts
@@ -1,5 +1,5 @@
 import type { LanguageModel } from "ai";
-import type { AgentDecision, ResourceSnapshot, TransferAttempt } from "../domain.js";
+import type { AgentDecision, AuditEvent, ResourceSnapshot, TransferAttempt } from "../domain.js";
 import type { ResourceProvider, StorageExecutor } from "../ports.js";
 import type { AcquisitionAgentResult } from "./agent-loop.js";
 import type { AgentToolEvent } from "./activity.js";
@@ -85,6 +85,7 @@ export interface AcquisitionV2Outcome {
 
 export interface RunAcquisitionV2Result extends AcquisitionAgentResult {
   outcome: AcquisitionV2Outcome;
+  auditEvents: AuditEvent[];
 }
 
 export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promise<RunAcquisitionV2Result> {
@@ -216,7 +217,7 @@ export async function runAcquisitionV2(request: RunAcquisitionV2Request): Promis
     coverageMet: result.coverage.coverageMet,
     reason: result.text,
   });
-  return { ...result, outcome: { resourceSnapshots, decisions, transferAttempts } };
+  return { ...result, outcome: { resourceSnapshots, decisions, transferAttempts }, auditEvents: sandbox.auditTrail() };
 }
 
 /**

--- a/packages/workflow/src/acquisition-v2/run-tv-v2.ts
+++ b/packages/workflow/src/acquisition-v2/run-tv-v2.ts
@@ -78,6 +78,7 @@ export async function runTvAcquisitionV2(request: RunTvAcquisitionV2Request): Pr
     })),
     qualityPreference: request.seasons[0]!.qualityPreference,
     searchHints: getSearchRecipe(profile),
+    searchProfile: profile,
     ...(qualityGuidance === "" ? {} : { qualityGuidance }),
     ...(request.priorObtained === undefined ? {} : { priorObtained: request.priorObtained }),
     ...(request.searchBudget === undefined ? {} : { searchBudget: request.searchBudget }),

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -690,19 +690,27 @@ export class TaskSandbox {
 
   /** The agent honestly reports it cannot cover the target. This is only valid
    *  when a real provider search actually ran (§9): reporting no-coverage without
-   *  ever searching is an infrastructure failure, not an honest result. */
+   *  ever searching is an infrastructure failure, not an honest result.
+   *
+   *  Evidence base = the agent's own fresh searches ∪ every keyword a snapshot
+   *  was observed for — which includes the system's raw pre-warm. The prompt
+   *  tells the agent NOT to re-search the raw keyword (viewResourceSnapshot is
+   *  free), and even a re-search hits dedup without touching seenKeywords — so
+   *  counting only seenKeywords refused a well-behaved agent's honest report on
+   *  a truly-uncovered title and forced wasted turns (the 病1-style dead tail). */
   async reportNoCoverage(reason: string): Promise<{ reason: string; searchesPerformed: number }> {
-    if (this.seenKeywords.size === 0) {
+    const evidenceKeywords = new Set([...this.seenKeywords, ...this.snapshotByKeyword.keys()]);
+    if (evidenceKeywords.size === 0) {
       throw new Error(
         "SANDBOX_NO_PROVIDER_EVIDENCE: cannot report no-coverage before any real search ran (§9 infrastructure failure)",
       );
     }
     this.auditEvents.push({
       type: "no_coverage_reported",
-      message: `agent 上报无覆盖：${reason}（已搜索 ${this.seenKeywords.size} 个词）`,
-      data: { reason, searchesPerformed: this.seenKeywords.size },
+      message: `agent 上报无覆盖：${reason}（已搜索 ${evidenceKeywords.size} 个词，含系统预搜）`,
+      data: { reason, searchesPerformed: evidenceKeywords.size },
     });
-    return { reason, searchesPerformed: this.seenKeywords.size };
+    return { reason, searchesPerformed: evidenceKeywords.size };
   }
 
   auditTrail(): AuditEvent[] {

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -11,6 +11,7 @@ import type { ResourceProviderV2, ResourceSnapshotV2 } from "./fake-provider.js"
 import type { SimTreeFile, StorageV2, TransferAttemptResult } from "./storage-115-simulator.js";
 import { isSystemicTransferBlockMessage } from "./transfer-block.js";
 import { animeSearchTabooWarnings, type SearchProfile } from "./search-profile.js";
+import type { AuditEvent } from "../domain.js";
 
 /** Quality / subtitle / source tokens that PanSou share titles almost never carry,
  *  so appending them collapses recall (实测归零). Case-insensitive; word-ish so
@@ -162,6 +163,8 @@ export class TaskSandbox {
   private subtitleSnapshot: AssrtCandidate[] | null = null;
   /** 病3: 待消化的上一大快照（换词搜索时提醒一次，随即清空）。 */
   private pendingDigest: { keyword: string; count: number } | null = null;
+  /** 病4: 本任务的审计事件（no_coverage 上报/dedup 重复/禁忌词警告）。runner 持久化到 workflowRun.auditEvents。 */
+  private readonly auditEvents: AuditEvent[] = [];
 
   constructor(options: TaskSandboxOptions) {
     this.provider = options.provider;
@@ -239,6 +242,13 @@ export class TaskSandbox {
     const tabooWarnings = this.profile
       ? animeSearchTabooWarnings({ keyword: effectiveKeyword, profile: this.profile, titleTerms: this.titleTerms })
       : [];
+    if (tabooWarnings.length > 0) {
+      this.auditEvents.push({
+        type: "search_taboo_warning",
+        message: `搜索词「${effectiveKeyword}」触发动漫禁忌词警告 ${tabooWarnings.length} 条`,
+        data: { keyword: effectiveKeyword, warnings: tabooWarnings },
+      });
+    }
 
     // 病3: take the digestion hint — only when switching keywords (the current
     // normalized keyword differs from the pending one). The stored keyword is the
@@ -258,6 +268,11 @@ export class TaskSandbox {
     if (cachedSnapshot) {
       const count = (this.searchCountByKeyword.get(normalized) ?? 1) + 1;
       this.searchCountByKeyword.set(normalized, count);
+      this.auditEvents.push({
+        type: "search_dedup",
+        message: `重复搜索「${effectiveKeyword}」第 ${count} 次`,
+        data: { keyword: effectiveKeyword, count },
+      });
       return {
         snapshot: cachedSnapshot,
         deduped: true,
@@ -682,7 +697,16 @@ export class TaskSandbox {
         "SANDBOX_NO_PROVIDER_EVIDENCE: cannot report no-coverage before any real search ran (§9 infrastructure failure)",
       );
     }
+    this.auditEvents.push({
+      type: "no_coverage_reported",
+      message: `agent 上报无覆盖：${reason}（已搜索 ${this.seenKeywords.size} 个词）`,
+      data: { reason, searchesPerformed: this.seenKeywords.size },
+    });
     return { reason, searchesPerformed: this.seenKeywords.size };
+  }
+
+  auditTrail(): AuditEvent[] {
+    return [...this.auditEvents];
   }
 
   /** Pre-warm a raw search (system-initiated, does NOT consume agent's distinct

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -24,6 +24,9 @@ const SUBTITLE_NAME_PATTERN = /\.(srt|ass|ssa|sub|idx|vtt|sup|smi)$/i;
 const STRIP_NOTICE =
   "已从关键词移除画质/字幕词(如 4K/1080p/蓝光/中字/字幕):PanSou 是通配符匹配,加这些只会把召回打成子集或归零,raw 裸标题召回最全。已改用裸标题搜索。";
 
+/** Threshold for large snapshot digestion hint (病3). */
+const LARGE_SNAPSHOT_DIGEST_THRESHOLD = 10;
+
 /** Strip quality/subtitle tokens from a search keyword and fold the resulting
  *  whitespace. `stripped` is true ONLY when an actual QUALITY_SUBTITLE_TOKEN was
  *  removed — NOT when mere whitespace was collapsed (so "奥本海默   第二季" does
@@ -107,6 +110,9 @@ export interface SearchToolResult {
   /** Anime taboo-keyword validator warnings (year / subtype word / suspected
    *  cross-series token). Warnings only — the search still runs. 病2b。 */
   warnings?: string[];
+  /** One-shot reminder that the PREVIOUS large snapshot (≥10 candidates) is
+   *  still unfiltered when the agent switches keywords. 病3: 先消化再换词。 */
+  digestHint?: string;
 }
 
 export interface TransferToolResult {
@@ -154,6 +160,8 @@ export class TaskSandbox {
   /** Pre-warmed assrt candidates (id + title + lang), like rawSnapshot for video.
    *  Reassigned by primeSubtitleSnapshot, so NOT readonly. */
   private subtitleSnapshot: AssrtCandidate[] | null = null;
+  /** 病3: 待消化的上一大快照（换词搜索时提醒一次，随即清空）。 */
+  private pendingDigest: { keyword: string; count: number } | null = null;
 
   constructor(options: TaskSandboxOptions) {
     this.provider = options.provider;
@@ -232,6 +240,14 @@ export class TaskSandbox {
       ? animeSearchTabooWarnings({ keyword: effectiveKeyword, profile: this.profile, titleTerms: this.titleTerms })
       : [];
 
+    // 病3: take the digestion hint — only when switching keywords (the current
+    // normalized keyword differs from the pending one).
+    const digestHint =
+      this.pendingDigest && this.pendingDigest.keyword !== normalized
+        ? `提示：上一快照「${this.pendingDigest.keyword}」有 ${this.pendingDigest.count} 个候选尚未筛过（viewResourceSnapshot 免费）；先消化再换词通常更快。`
+        : undefined;
+    if (digestHint) this.pendingDigest = null;
+
     // Check dedup FIRST — if this keyword was already searched (either by agent
     // or by system pre-warming), return the cached snapshot without hitting the
     // provider or consuming budget. This covers both agent re-searches and agent
@@ -246,6 +262,7 @@ export class TaskSandbox {
         repeatNotice: this.repeatNotice(effectiveKeyword, count, cachedSnapshot.candidates.length),
         ...(notice ? { notice } : {}),
         ...(tabooWarnings.length > 0 ? { warnings: tabooWarnings } : {}),
+        ...(digestHint ? { digestHint } : {}),
       };
     }
 
@@ -271,11 +288,18 @@ export class TaskSandbox {
     this.snapshotByKeyword.set(normalized, snapshot);
     this.searchCountByKeyword.set(normalized, 1);
     this.observedSnapshots.set(snapshot.id, snapshot);
+
+    // 病3: register a large fresh snapshot for later digestion hint.
+    if (snapshot.candidates.length >= LARGE_SNAPSHOT_DIGEST_THRESHOLD) {
+      this.pendingDigest = { keyword: normalized, count: snapshot.candidates.length };
+    }
+
     return {
       snapshot,
       ...(decision === "reserve" ? { note: this.reserveNote() } : {}),
       ...(notice ? { notice } : {}),
       ...(tabooWarnings.length > 0 ? { warnings: tabooWarnings } : {}),
+      ...(digestHint ? { digestHint } : {}),
     };
   }
 

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -10,6 +10,7 @@ import type { AssrtCandidate, AssrtSubtitleFile, AssrtProviderPort } from "../su
 import type { ResourceProviderV2, ResourceSnapshotV2 } from "./fake-provider.js";
 import type { SimTreeFile, StorageV2, TransferAttemptResult } from "./storage-115-simulator.js";
 import { isSystemicTransferBlockMessage } from "./transfer-block.js";
+import { animeSearchTabooWarnings, type SearchProfile } from "./search-profile.js";
 
 /** Quality / subtitle / source tokens that PanSou share titles almost never carry,
  *  so appending them collapses recall (实测归零). Case-insensitive; word-ish so
@@ -81,6 +82,9 @@ export interface TaskSandboxOptions {
    *  the orchestrator pre-warms a subtitle snapshot and the agent gets
    *  viewSubtitleSnapshot / transferSubtitle tools. Undefined = no subtitle flow. */
   subtitleProvider?: AssrtProviderPort;
+  /** The task's fine-grained search profile — enables the anime taboo-keyword
+   *  validator (warnings only, never blocking). 病2b。 */
+  searchProfile?: SearchProfile;
 }
 
 export interface SearchToolResult {
@@ -100,6 +104,9 @@ export interface SearchToolResult {
   /** Set when a deduped search is repeated: escalating warning with repeat count.
    *  病2a: 模型必须看见「这是重复」。 */
   repeatNotice?: string;
+  /** Anime taboo-keyword validator warnings (year / subtype word / suspected
+   *  cross-series token). Warnings only — the search still runs. 病2b。 */
+  warnings?: string[];
 }
 
 export interface TransferToolResult {
@@ -127,6 +134,7 @@ export class TaskSandbox {
   private readonly subtitleFallback: boolean;
   /** Reserve-zone threshold (movie 8+2) — undefined disables the reserve zone. */
   private readonly softThreshold: number | undefined;
+  private readonly profile: SearchProfile | undefined;
   private readonly seenKeywords = new Set<string>();
   private readonly snapshotByKeyword = new Map<string, ResourceSnapshotV2>();
   /** 每个（规范化）关键词被搜索的次数——prime 记 1，agent fresh 记 1，dedup 命中递增。 */
@@ -157,6 +165,7 @@ export class TaskSandbox {
     this.softThreshold = this.subtitleFallback ? MOVIE_SEARCH_SOFT_THRESHOLD : undefined;
     this.storage = options.storage;
     this.stagingDirectoryId = options.stagingDirectoryId;
+    this.profile = options.searchProfile;
     this.seasonDirs = new Map(
       Object.entries(options.targetSeasonDirectoryIds ?? {}).map(([season, id]) => [Number(season), id]),
     );
@@ -218,6 +227,11 @@ export class TaskSandbox {
     const normalized = normalizeSearchKeyword(effectiveKeyword);
     const notice = stripped.stripped ? STRIP_NOTICE : undefined;
 
+    // 病2b: anime taboo-keyword validator (warnings only, after title gate, before dedup).
+    const tabooWarnings = this.profile
+      ? animeSearchTabooWarnings({ keyword: effectiveKeyword, profile: this.profile, titleTerms: this.titleTerms })
+      : [];
+
     // Check dedup FIRST — if this keyword was already searched (either by agent
     // or by system pre-warming), return the cached snapshot without hitting the
     // provider or consuming budget. This covers both agent re-searches and agent
@@ -231,6 +245,7 @@ export class TaskSandbox {
         deduped: true,
         repeatNotice: this.repeatNotice(effectiveKeyword, count, cachedSnapshot.candidates.length),
         ...(notice ? { notice } : {}),
+        ...(tabooWarnings.length > 0 ? { warnings: tabooWarnings } : {}),
       };
     }
 
@@ -260,6 +275,7 @@ export class TaskSandbox {
       snapshot,
       ...(decision === "reserve" ? { note: this.reserveNote() } : {}),
       ...(notice ? { notice } : {}),
+      ...(tabooWarnings.length > 0 ? { warnings: tabooWarnings } : {}),
     };
   }
 

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -97,7 +97,8 @@ export interface SearchToolResult {
   /** Set when quality/subtitle tokens were stripped from the agent's keyword
    *  (C5 guardrail): tells the agent the words were dropped and raw recalls more. */
   notice?: string;
-  /** 病2a: dedup 命中时的显式强提示（含第 N 次计数）。模型必须看见「这是重复」。 */
+  /** Set when a deduped search is repeated: escalating warning with repeat count.
+   *  病2a: 模型必须看见「这是重复」。 */
   repeatNotice?: string;
 }
 
@@ -228,7 +229,7 @@ export class TaskSandbox {
       return {
         snapshot: cachedSnapshot,
         deduped: true,
-        repeatNotice: this.repeatNotice(keyword, count, cachedSnapshot.candidates.length),
+        repeatNotice: this.repeatNotice(effectiveKeyword, count, cachedSnapshot.candidates.length),
         ...(notice ? { notice } : {}),
       };
     }

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -256,7 +256,7 @@ export class TaskSandbox {
     // repeatNotice — so the comparison normalizes it first.
     const digestHint =
       this.pendingDigest && normalizeSearchKeyword(this.pendingDigest.keyword) !== normalized
-        ? `提示：上一快照「${this.pendingDigest.keyword}」有 ${this.pendingDigest.count} 个候选尚未筛过（viewResourceSnapshot 免费）；先消化再换词通常更快。`
+        ? `提示：上一快照「${this.pendingDigest.keyword}」有 ${this.pendingDigest.count} 个候选尚未筛过——候选列表就在你此前那次 searchResources 的返回里，回读不花预算；先消化再换词通常更快。`
         : undefined;
     if (digestHint) this.pendingDigest = null;
 

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -97,6 +97,8 @@ export interface SearchToolResult {
   /** Set when quality/subtitle tokens were stripped from the agent's keyword
    *  (C5 guardrail): tells the agent the words were dropped and raw recalls more. */
   notice?: string;
+  /** 病2a: dedup 命中时的显式强提示（含第 N 次计数）。模型必须看见「这是重复」。 */
+  repeatNotice?: string;
 }
 
 export interface TransferToolResult {
@@ -126,6 +128,8 @@ export class TaskSandbox {
   private readonly softThreshold: number | undefined;
   private readonly seenKeywords = new Set<string>();
   private readonly snapshotByKeyword = new Map<string, ResourceSnapshotV2>();
+  /** 每个（规范化）关键词被搜索的次数——prime 记 1，agent fresh 记 1，dedup 命中递增。 */
+  private readonly searchCountByKeyword = new Map<string, number>();
   private readonly observedSnapshots = new Map<string, ResourceSnapshotV2>();
   private readonly obtainedCodes = new Set<string>();
   /** Set when the agent landed a movie via the 中文字幕 last-resort fallback (no
@@ -219,7 +223,14 @@ export class TaskSandbox {
     // searching a keyword that was pre-warmed.
     const cachedSnapshot = this.snapshotByKeyword.get(normalized);
     if (cachedSnapshot) {
-      return { snapshot: cachedSnapshot, deduped: true, ...(notice ? { notice } : {}) };
+      const count = (this.searchCountByKeyword.get(normalized) ?? 1) + 1;
+      this.searchCountByKeyword.set(normalized, count);
+      return {
+        snapshot: cachedSnapshot,
+        deduped: true,
+        repeatNotice: this.repeatNotice(keyword, count, cachedSnapshot.candidates.length),
+        ...(notice ? { notice } : {}),
+      };
     }
 
     const decision = decideSearchGate({
@@ -242,6 +253,7 @@ export class TaskSandbox {
     this.seenKeywords.add(normalized);
     const snapshot = await this.provider.search(effectiveKeyword);
     this.snapshotByKeyword.set(normalized, snapshot);
+    this.searchCountByKeyword.set(normalized, 1);
     this.observedSnapshots.set(snapshot.id, snapshot);
     return {
       snapshot,
@@ -264,6 +276,17 @@ export class TaskSandbox {
   private reserveNote(): string {
     const reserve = this.searchBudget - (this.softThreshold ?? this.searchBudget);
     return `⚠️ 中字搜索预算(${this.softThreshold})已用满,还剩 ${reserve} 次预留。用它做最后的裸名/抖动复搜;若仍找不到带中字的版本、但已确认正确影片的 raw 名匹配,就直接 transferCandidate 兜底落它(markObtained 带 subtitleFallback,系统标注「可能无中字」),不要 reportNoCoverage —— 有正片胜过没有,且该版实际未必无中字。`;
+  }
+
+  /** 病2a: dedup 强提示。第 2 次报次数；第 3-4 次升级警告；第 5 次起文本固定——
+   *  固定是刻意的：递增计数会让重复步骤的 result 每次不同，反而令 repetition-stop
+   *  的「4 连相同」永远不命中。 */
+  private repeatNotice(keyword: string, count: number, candidateCount: number): string {
+    if (count >= 5) {
+      return `⚠️ 「${keyword}」已重复多次搜索，结果不会再变（共 ${candidateCount} 候选）。这已被视为无进展：立即基于已有证据决策（transferCandidate 或 reportNoCoverage）。`;
+    }
+    const escalation = count >= 3 ? "再重复将视为无进展。" : "";
+    return `⚠️ 「${keyword}」已是第 ${count} 次搜索（结果与上次相同，共 ${candidateCount} 候选）。换实质不同的新词，或立即基于已有证据决策。${escalation}`;
   }
 
   /** Whether a snapshot id was actually observed in this task — the gate for
@@ -629,6 +652,7 @@ export class TaskSandbox {
 
     // Record in dedup map so agent re-searching this keyword hits dedup
     this.snapshotByKeyword.set(normalized, snapshot);
+    this.searchCountByKeyword.set(normalized, 1);
 
     // Record in observed snapshots so transferCandidate can resolve candidate ids
     this.observedSnapshots.set(snapshot.id, snapshot);

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -241,9 +241,11 @@ export class TaskSandbox {
       : [];
 
     // 病3: take the digestion hint — only when switching keywords (the current
-    // normalized keyword differs from the pending one).
+    // normalized keyword differs from the pending one). The stored keyword is the
+    // EFFECTIVE (original-case) form for display — case-consistent with
+    // repeatNotice — so the comparison normalizes it first.
     const digestHint =
-      this.pendingDigest && this.pendingDigest.keyword !== normalized
+      this.pendingDigest && normalizeSearchKeyword(this.pendingDigest.keyword) !== normalized
         ? `提示：上一快照「${this.pendingDigest.keyword}」有 ${this.pendingDigest.count} 个候选尚未筛过（viewResourceSnapshot 免费）；先消化再换词通常更快。`
         : undefined;
     if (digestHint) this.pendingDigest = null;
@@ -289,9 +291,11 @@ export class TaskSandbox {
     this.searchCountByKeyword.set(normalized, 1);
     this.observedSnapshots.set(snapshot.id, snapshot);
 
-    // 病3: register a large fresh snapshot for later digestion hint.
+    // 病3: register a large fresh snapshot for later digestion hint. Store the
+    // effective (original-case) keyword for display; the trigger comparison
+    // normalizes it.
     if (snapshot.candidates.length >= LARGE_SNAPSHOT_DIGEST_THRESHOLD) {
-      this.pendingDigest = { keyword: normalized, count: snapshot.candidates.length };
+      this.pendingDigest = { keyword: effectiveKeyword, count: snapshot.candidates.length };
     }
 
     return {

--- a/packages/workflow/src/acquisition-v2/search-profile.ts
+++ b/packages/workflow/src/acquisition-v2/search-profile.ts
@@ -181,3 +181,54 @@ export function getQualityGuidance(
     tail
   );
 }
+
+const ANIME_PROFILES: ReadonlySet<SearchProfile> = new Set([
+  "jp-anime",
+  "cn-anime",
+  "us-anime",
+  "generic-anime",
+]);
+
+/**
+ * 病2b（2026-07-06 攻壳事故）：动漫搜索纪律从「提示词里的禁忌」升级为校验器
+ * ——但只 WARN 不阻断（个别老番年份真有用、罗马音兜底是配方明令的合法手段;
+ * 硬拒会误伤，警告 + 模型自辩即可）。检查三条已立纪律：
+ *  ① 动漫忌年份（jp: 脆且偏; cn: 危险、拉同名真人版）
+ *  ② 子类型词（番剧/动画/动漫）几乎必砍召回——唯一例外 cn-anime 的 +国漫
+ *  ③ 片名之外的拉丁附加词疑似跨系列（ARISE 拉走整个平行系列）
+ */
+export function animeSearchTabooWarnings(input: {
+  keyword: string;
+  profile: SearchProfile;
+  titleTerms: readonly string[];
+}): string[] {
+  if (!ANIME_PROFILES.has(input.profile)) {
+    return [];
+  }
+  const warnings: string[] = [];
+  const lowerTerms = input.titleTerms.map((t) => t.toLowerCase());
+
+  if (/(?:19|20)\d{2}/.test(input.keyword)) {
+    warnings.push(
+      "⚠️ 关键词含 4 位年份——动漫忌年份（召回归零或拉同名真人版，见搜索配方）。除非你有明确证据这是必要消歧，否则去掉年份重搜。",
+    );
+  }
+
+  const subtypeWords = ["番剧", "动画", "动漫", "国漫"].filter((w) => input.keyword.includes(w));
+  for (const word of subtypeWords) {
+    if (word === "国漫" && input.profile === "cn-anime") {
+      continue; // 配方明令的真实 tag 消歧词（GM-Team 季包）。
+    }
+    warnings.push(`⚠️ 关键词含子类型词「${word}」——几乎必砍召回（咒术回战 番剧→0，见搜索配方）。用裸标题。`);
+  }
+
+  for (const match of input.keyword.matchAll(/[A-Za-z][A-Za-z0-9'&-]{2,}/g)) {
+    const token = match[0].toLowerCase();
+    if (!lowerTerms.some((term) => term.includes(token))) {
+      warnings.push(
+        `⚠️ 关键词带了片名之外的附加词「${match[0]}」——若这是另一部系列作品名（前传/剧场版/衍生），它不在本次目标内，会把搜索拉去隔壁系列；若这是本作官方别名/罗马音则可忽略本警告。`,
+      );
+    }
+  }
+  return warnings;
+}

--- a/packages/workflow/src/acquisition-v2/search-profile.ts
+++ b/packages/workflow/src/acquisition-v2/search-profile.ts
@@ -208,7 +208,12 @@ export function animeSearchTabooWarnings(input: {
   const warnings: string[] = [];
   const lowerTerms = input.titleTerms.map((t) => t.toLowerCase());
 
-  if (/(?:19|20)\d{2}/.test(input.keyword)) {
+  // 出现在片名/别名里的 4 位数字不是禁忌年份，是名字本身（SAC_2045 / 2046 /
+  // Blade Runner 2049）——问询判卷抓出的误伤面，豁免。
+  const foreignYears = [...input.keyword.matchAll(/(?:19|20)\d{2}/g)]
+    .map((m) => m[0])
+    .filter((year) => !input.titleTerms.some((term) => term.includes(year)));
+  if (foreignYears.length > 0) {
     warnings.push(
       "⚠️ 关键词含 4 位年份——动漫忌年份（召回归零或拉同名真人版，见搜索配方）。除非你有明确证据这是必要消歧，否则去掉年份重搜。",
     );

--- a/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
@@ -117,7 +117,7 @@ export function bridgeV2WorkflowToResult(input: {
     transferAttempts: v2.outcome.transferAttempts,
     notification,
     notifications: [notification],
-    auditEvents: [],
+    auditEvents: v2.auditEvents,
   };
 }
 

--- a/packages/workflow/src/acquisition-v2/workflow-v2.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2.ts
@@ -10,6 +10,7 @@ import { readLandedSize } from "./landed-size.js";
 import type { AgentToolEvent } from "./activity.js";
 import { runAcquisitionV2, type AcquisitionV2Outcome } from "./orchestrator.js";
 import { syncSeasonNeed } from "./sync-need.js";
+import type { SearchProfile } from "./search-profile.js";
 
 /**
  * Phase 7c — the outer workflow orchestration (TV/anime). It is the same
@@ -47,6 +48,9 @@ export interface RunAcquisitionV2WorkflowRequest {
   originCountries?: string[];
   searchHints?: string;
   qualityGuidance?: string;
+  /** The task's fine-grained search profile — enables the anime taboo-keyword
+   *  validator (warnings only, never blocking). 病2b。 */
+  searchProfile?: SearchProfile;
   /** The run's drive brand ("pan115" | "quark") — selects brand-specific skill. */
   storageProvider?: string;
   /** assrt token (Settings → 字幕来源). Undefined = 字幕流程不触发。 */
@@ -136,6 +140,7 @@ export async function runAcquisitionV2Workflow(
     ...(request.originCountries === undefined ? {} : { originCountries: request.originCountries }),
     ...(request.searchHints === undefined ? {} : { searchHints: request.searchHints }),
     ...(request.qualityGuidance === undefined ? {} : { qualityGuidance: request.qualityGuidance }),
+    ...(request.searchProfile === undefined ? {} : { searchProfile: request.searchProfile }),
     ...(request.storageProvider === undefined ? {} : { storageProvider: request.storageProvider }),
     ...(request.assrtToken === undefined ? {} : { assrtToken: request.assrtToken }),
     ...(request.deadLinkStore ? { deadLinkStore: request.deadLinkStore } : {}),

--- a/packages/workflow/src/acquisition-v2/workflow-v2.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2.ts
@@ -1,5 +1,6 @@
 import type { LanguageModel } from "ai";
 import type { ResourceProvider, StorageExecutor } from "../ports.js";
+import type { AuditEvent } from "../domain.js";
 import {
   ensureSeasonAcquisitionDirectories,
   withStagingCleanup,
@@ -73,6 +74,7 @@ export interface RunAcquisitionV2WorkflowResult {
    *  the notification's true per-episode size. Absent when the read failed/empty. */
   landedFileCount?: number;
   landedBytes?: number;
+  auditEvents: AuditEvent[];
 }
 
 const EMPTY_OUTCOME: AcquisitionV2Outcome = { resourceSnapshots: [], decisions: [], transferAttempts: [] };
@@ -115,6 +117,7 @@ export async function runAcquisitionV2Workflow(
       stillMissing: [],
       obtained: before.obtained,
       providerAhead: before.providerAhead,
+      auditEvents: [],
     };
   }
 
@@ -171,6 +174,7 @@ export async function runAcquisitionV2Workflow(
     stillMissing: after.missing,
     obtained: after.obtained,
     providerAhead: after.providerAhead,
+    auditEvents: v2.auditEvents,
     ...(landed ? { landedFileCount: landed.fileCount, landedBytes: landed.totalBytes } : {}),
   };
     },

--- a/packages/workflow/src/movie-workflow-v2.ts
+++ b/packages/workflow/src/movie-workflow-v2.ts
@@ -116,6 +116,7 @@ export async function runMovieAcquisitionV2(
     snapshots: v2.outcome.resourceSnapshots,
     attempts: v2.outcome.transferAttempts,
     decisions: v2.outcome.decisions,
+    auditEvents: v2.auditEvents,
     // 中文字幕软兜底: the agent landed a raw match with no confirmed 中字 → flag it.
     subtitleFallback: obtained && v2.coverage.subtitleFallback,
     ...(landed ? { landed } : {}),
@@ -132,6 +133,7 @@ function buildResult(input: {
   snapshots: ResourceSnapshot[];
   attempts: TransferAttempt[];
   decisions: AgentDecision[];
+  auditEvents: AuditEvent[];
   /** Landed via the 中文字幕 last-resort fallback (no confirmed 中字) → notification flag. */
   subtitleFallback?: boolean;
   landed?: LandedSize;
@@ -173,7 +175,6 @@ function buildResult(input: {
     trigger: "user",
     report,
   };
-  const auditEvents: AuditEvent[] = [];
 
   return {
     status: input.status,
@@ -185,6 +186,6 @@ function buildResult(input: {
     decisions: input.decisions,
     notification,
     notifications: [notification],
-    auditEvents,
+    auditEvents: input.auditEvents,
   };
 }

--- a/packages/workflow/src/movie-workflow-v2.ts
+++ b/packages/workflow/src/movie-workflow-v2.ts
@@ -83,6 +83,7 @@ export async function runMovieAcquisitionV2(
     stagingDirectoryId: movieDirectoryId,
     targetMovieDirectoryId: movieDirectoryId,
     searchHints: getSearchRecipe("movie"), // movie search is origin-independent
+    searchProfile: "movie",
     ...(getQualityGuidance("movie", request.qualityPreference) === ""
       ? {}
       : { qualityGuidance: getQualityGuidance("movie", request.qualityPreference) }),

--- a/packages/workflow/tests/agent-loop-guards.test.ts
+++ b/packages/workflow/tests/agent-loop-guards.test.ts
@@ -240,4 +240,14 @@ describe("hasSuccessfulNoCoverageReport — 病1: 报后即停", () => {
     ];
     expect(hasSuccessfulNoCoverageReport(steps)).toBe(false);
   });
+
+  it("output 非对象（字符串/null）→ false", () => {
+    const steps = [
+      {
+        toolCalls: [{ toolName: "reportNoCoverage", input: { reason: "x" } }],
+        toolResults: [{ output: "some string error" }, { output: null }],
+      },
+    ];
+    expect(hasSuccessfulNoCoverageReport(steps)).toBe(false);
+  });
 });

--- a/packages/workflow/tests/agent-loop-guards.test.ts
+++ b/packages/workflow/tests/agent-loop-guards.test.ts
@@ -12,6 +12,7 @@ import {
   buildRepetitionStop,
   buildSystemicBlockStop,
   hasSystemicTransferBlock,
+  hasSuccessfulNoCoverageReport,
   reflectionSystemOverride,
   toStepSignature,
 } from "../src/index.js";
@@ -206,5 +207,37 @@ describe("prepareStepSystemOverride (composes step-cap + budget nudges)", () => 
 describe("DEFAULT_MAX_STEPS", () => {
   it("is 60 (raised from the old 40 that killed 一人之下)", () => {
     expect(DEFAULT_MAX_STEPS).toBe(60);
+  });
+});
+
+describe("hasSuccessfulNoCoverageReport — 病1: 报后即停", () => {
+  it("成功的 reportNoCoverage 结果 → true", () => {
+    const steps = [
+      {
+        toolCalls: [{ toolName: "reportNoCoverage", input: { reason: "no results" } }],
+        toolResults: [{ output: { reason: "no results", searchesPerformed: 3 } }],
+      },
+    ];
+    expect(hasSuccessfulNoCoverageReport(steps)).toBe(true);
+  });
+
+  it("被 §9 护栏拒绝（{error} 结果）→ false（循环继续）", () => {
+    const steps = [
+      {
+        toolCalls: [{ toolName: "reportNoCoverage", input: { reason: "premature" } }],
+        toolResults: [{ output: { error: "SANDBOX_NO_PROVIDER_EVIDENCE: ..." } }],
+      },
+    ];
+    expect(hasSuccessfulNoCoverageReport(steps)).toBe(false);
+  });
+
+  it("其他工具的成功结果 → false", () => {
+    const steps = [
+      {
+        toolCalls: [{ toolName: "searchResources", input: { keyword: "x" } }],
+        toolResults: [{ output: { snapshot: { id: "s1" } } }],
+      },
+    ];
+    expect(hasSuccessfulNoCoverageReport(steps)).toBe(false);
   });
 });

--- a/packages/workflow/tests/search-profile.test.ts
+++ b/packages/workflow/tests/search-profile.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { getQualityGuidance, getSearchRecipe, searchProfile, SEARCH_PROFILES } from "../src/index.js";
+import {
+  animeSearchTabooWarnings,
+  getQualityGuidance,
+  getSearchRecipe,
+  searchProfile,
+  SEARCH_PROFILES,
+} from "../src/index.js";
 
 describe("getSearchRecipe — post-deep-research recipe", () => {
   it("us-tv leads with 裸中文名 (NOT the old 别裸搜/+美剧), and forbids +美剧", () => {
@@ -134,5 +140,49 @@ describe("getQualityGuidance", () => {
     expect(g).toContain("破一档");
     // still avoids 原盘/REMUX/ISO even for subs (no unlimited bump)
     expect(g).toMatch(/原盘|REMUX|ISO/);
+  });
+});
+
+describe("animeSearchTabooWarnings（病2b — 硬规则转校验器，警告不阻断）", () => {
+  const titleTerms = ["新攻壳机动队", "攻壳机动队", "Ghost in the Shell"];
+
+  it("动漫 + 4位年份 → 年份警告（攻壳事故的「2020」）", () => {
+    const w = animeSearchTabooWarnings({ keyword: "攻壳机动队 2020", profile: "jp-anime", titleTerms });
+    expect(w.some((x) => x.includes("年份"))).toBe(true);
+  });
+
+  it("动漫 + 片名外的拉丁附加词 → 疑似跨系列警告（攻壳事故的「ARISE」）", () => {
+    const w = animeSearchTabooWarnings({ keyword: "攻壳机动队 ARISE", profile: "jp-anime", titleTerms });
+    expect(w.some((x) => x.includes("ARISE"))).toBe(true);
+  });
+
+  it("拉丁词是片名/别名的一部分 → 不警告（正当的英文名升级）", () => {
+    const w = animeSearchTabooWarnings({ keyword: "Ghost in the Shell", profile: "jp-anime", titleTerms });
+    expect(w).toEqual([]);
+  });
+
+  it("动漫 + 子类型词(番剧) → 警告", () => {
+    const w = animeSearchTabooWarnings({ keyword: "攻壳机动队 番剧", profile: "jp-anime", titleTerms });
+    expect(w.some((x) => x.includes("番剧"))).toBe(true);
+  });
+
+  it("国漫例外：cn-anime 的 +国漫 是配方明令的消歧词，不警告", () => {
+    const w = animeSearchTabooWarnings({ keyword: "一人之下 国漫", profile: "cn-anime", titleTerms: ["一人之下"] });
+    expect(w).toEqual([]);
+  });
+
+  it("cn-anime 年份照警（配方明言年份危险：拉同名真人版）", () => {
+    const w = animeSearchTabooWarnings({ keyword: "一人之下 2021", profile: "cn-anime", titleTerms: ["一人之下"] });
+    expect(w.some((x) => x.includes("年份"))).toBe(true);
+  });
+
+  it("非动漫 profile → 永远空（年份是真人片的合法收窄键）", () => {
+    const w = animeSearchTabooWarnings({ keyword: "默杀 2024", profile: "movie", titleTerms: ["默杀"] });
+    expect(w).toEqual([]);
+  });
+
+  it("干净的裸标题 → 空", () => {
+    const w = animeSearchTabooWarnings({ keyword: "攻壳机动队", profile: "jp-anime", titleTerms });
+    expect(w).toEqual([]);
   });
 });

--- a/packages/workflow/tests/search-profile.test.ts
+++ b/packages/workflow/tests/search-profile.test.ts
@@ -151,6 +151,15 @@ describe("animeSearchTabooWarnings（病2b — 硬规则转校验器，警告不
     expect(w.some((x) => x.includes("年份"))).toBe(true);
   });
 
+  it("年份是正牌标题的一部分 → 豁免（SAC_2045 / 2046 这类片名自带年份数字）", () => {
+    // 问询判卷抓出的误伤面：MiMo 的合法升级词「攻殻機動隊 SAC_2045」会被年份
+    // 规则误警——2045 就是官方标题的一部分。出现在任一 titleTerm 里的 4 位数字
+    // 不是禁忌年份，是名字。
+    const terms = ["攻壳机动队 SAC_2045", "攻殻機動隊 SAC_2045", "Ghost in the Shell: SAC_2045"];
+    const w = animeSearchTabooWarnings({ keyword: "攻殻機動隊 SAC_2045", profile: "jp-anime", titleTerms: terms });
+    expect(w.some((x) => x.includes("年份"))).toBe(false);
+  });
+
   it("动漫 + 片名外的拉丁附加词 → 疑似跨系列警告（攻壳事故的「ARISE」）", () => {
     const w = animeSearchTabooWarnings({ keyword: "攻壳机动队 ARISE", profile: "jp-anime", titleTerms });
     expect(w.some((x) => x.includes("ARISE"))).toBe(true);

--- a/packages/workflow/tests/v2-agent-loop-run.test.ts
+++ b/packages/workflow/tests/v2-agent-loop-run.test.ts
@@ -142,4 +142,47 @@ describe("runAcquisitionAgent — the real AI SDK tool-loop over the sandbox", (
     expect(result.coverage.coverageMet).toBe(false);
     expect(result.coverage.missing).toEqual(["S01E01"]);
   });
+
+  it("病1: 成功 reportNoCoverage 后循环立即收束 — 不再有后续步（攻壳 2.5min 尾巴重放）", async () => {
+    const { sandbox } = await setup(["S01E01"]);
+    // 先真搜一次，让 §9 证据护栏放行 no-coverage 上报。
+    await sandbox.searchResources("lycoris recoil");
+    // 攻壳式脚本：报告无覆盖后，模型还想 readSkill、二次上报、finish——都不应该发生。
+    const model = scriptedModel([
+      { tool: "reportNoCoverage", input: { reason: "提供方无该作品资源" } },
+      { tool: "readSkill", input: { section: "无覆盖上报" } },
+      { tool: "reportNoCoverage", input: { reason: "再次确认无资源" } },
+      { tool: "finish", input: {} },
+      { text: "done" },
+    ]);
+    const result = await runAcquisitionAgent({
+      sandbox,
+      model,
+      system: "You acquire media into the scoped sandbox.",
+      prompt: "Ensure S01E01 is obtained.",
+      maxSteps: 20,
+    });
+    // 报告成功的那一步就是最后一步。
+    expect(result.steps).toBe(1);
+    expect(result.coverage.coverageMet).toBe(false);
+  });
+
+  it("病1: 无搜索证据的 reportNoCoverage 被拒（{error}）→ 循环继续", async () => {
+    const { sandbox } = await setup(["S01E01"]);
+    // 不预搜——§9 护栏会 throw，asEvidence 转成 {error} 返回。
+    const model = scriptedModel([
+      { tool: "reportNoCoverage", input: { reason: "premature" } },
+      { text: "guard refused my report; stopping." },
+    ]);
+    const result = await runAcquisitionAgent({
+      sandbox,
+      model,
+      system: "You acquire media into the scoped sandbox.",
+      prompt: "Ensure S01E01 is obtained.",
+      maxSteps: 10,
+    });
+    // 第 1 步被拒后模型还能走到第 2 步输出文本（循环没被 stop 砍断）。
+    expect(result.steps).toBe(2);
+    expect(result.text).toMatch(/stopping/);
+  });
 });

--- a/packages/workflow/tests/v2-bridge.test.ts
+++ b/packages/workflow/tests/v2-bridge.test.ts
@@ -21,6 +21,7 @@ function v2Result(over: Partial<RunAcquisitionV2WorkflowResult>): RunAcquisition
     stillMissing: [],
     obtained: [],
     providerAhead: [],
+    auditEvents: [],
     ...over,
   };
 }
@@ -203,6 +204,7 @@ describe("bridgeV2WorkflowToResult — V2 facts → per-season WorkflowResult sh
         obtained: ["S01E01", "S01E02", "S01E03"],
         stillMissing: ["S02E01", "S02E02", "S02E03"],
         providerAhead: [],
+        auditEvents: [],
       },
       workflowRunId: "run-x",
       now: () => "2026-06-15T00:00:00.000Z",

--- a/packages/workflow/tests/v2-interrogation.test.ts
+++ b/packages/workflow/tests/v2-interrogation.test.ts
@@ -31,6 +31,11 @@ describe("§6a interrogation harness (verify '聪明' before spending real money
         "ongoing_plus_completed_gap",
         "unobtainable_completed_gap",
         "only_some_remaining_seasons",
+        // 2026-07-06 获取循环四病（攻壳事故）新语义:
+        "terminal_no_coverage",
+        "repeat_search_notice",
+        "taboo_warning_reaction",
+        "digest_hint_reaction",
       ]),
     );
   });

--- a/packages/workflow/tests/v2-movie-workflow.test.ts
+++ b/packages/workflow/tests/v2-movie-workflow.test.ts
@@ -80,6 +80,9 @@ describe("runMovieAcquisitionV2 — obtained comes from the AGENT'S coverage, ne
     expect(result.episodes[0]!.obtained).toBe(false);
     expect(result.notification.kind).toBe("no_coverage");
     expect(result.season.storageDirectoryId).toContain("movies_root"); // movie dir verify-or-created
+    // 病4: the movie path's bridged auditEvents carry the honest report — parity
+    // with the TV e2e (sandbox → orchestrator → movie workflow persistence).
+    expect(result.auditEvents.some((e) => e.type === "no_coverage_reported")).toBe(true);
   });
 
   it("transfers systemically BLOCKED (配额不足) → honest 转存失败 report, NOT 暂未找到资源 (别甩锅)", async () => {

--- a/packages/workflow/tests/v2-orchestrator.test.ts
+++ b/packages/workflow/tests/v2-orchestrator.test.ts
@@ -234,4 +234,31 @@ describe("runAcquisitionV2 — raw snapshot pre-warming integration", () => {
     expect(searches[0]).toBe("流浪地球"); // 预热
     expect(promptChecked).toBe(true);
   });
+
+  it("auditEvents surface from sandbox through orchestrator (病4)", async () => {
+    const provider: ResourceProvider = { search: async ({ keyword }) => emptySnapshot(keyword) };
+    const executor = new FakeStorageExecutor({ directories: { staging: [], season: [] } });
+
+    const result = await runAcquisitionV2({
+      provider,
+      executor,
+      model: searchThenReportModel(),
+      workflowRunId: "test-audit",
+      target: {
+        kind: "tv",
+        title: "Show",
+        aliases: [],
+        seasons: [1],
+        missingEpisodes: ["S01E01"],
+        qualityPreference: "high",
+      },
+      stagingDirectoryId: "staging_dir",
+      targetSeasonDirectoryIds: { 1: "season1_dir" },
+    });
+
+    // The agent searches "Show" which was pre-warmed, hitting dedup → search_dedup event.
+    // This proves audit events flow from sandbox → orchestrator → workflow → bridge.
+    expect(result.auditEvents.some((e) => e.type === "search_dedup")).toBe(true);
+    expect(result.auditEvents[0]?.message).toContain("重复搜索");
+  });
 });

--- a/packages/workflow/tests/v2-run-tv.test.ts
+++ b/packages/workflow/tests/v2-run-tv.test.ts
@@ -87,8 +87,12 @@ describe("runTvAcquisitionV2 — single TV entry over the V2 engine", () => {
     });
 
     expect(result.status).toBe("no_coverage");
-    // The agent searches "示例剧" which was pre-warmed, hitting dedup → search_dedup event.
-    // This proves audit events flow sandbox → orchestrator → workflow → bridge → runner.
+    // The PRIMARY event: the honest no-coverage report itself must be in the
+    // bridged auditEvents — this mirrors the live acceptance criterion for 病4.
+    expect(result.auditEvents.some((e) => e.type === "no_coverage_reported")).toBe(true);
+    // Secondary: the agent searches "示例剧" which was pre-warmed, hitting dedup →
+    // search_dedup event. Both together prove multi-event flow
+    // sandbox → orchestrator → workflow → bridge → runner.
     expect(result.auditEvents.some((e) => e.type === "search_dedup")).toBe(true);
   });
 

--- a/packages/workflow/tests/v2-run-tv.test.ts
+++ b/packages/workflow/tests/v2-run-tv.test.ts
@@ -34,7 +34,7 @@ function searchThenReportModel() {
   return new MockLanguageModelV3({
     doGenerate: async () => {
       i += 1;
-      if (i === 1) return tool("searchResources", { keyword: "show" });
+      if (i === 1) return tool("searchResources", { keyword: "示例剧" });
       if (i === 2) return tool("reportNoCoverage", { reason: "no candidates" });
       return { content: [{ type: "text" as const, text: "done" }], finishReason: { unified: "stop" as const, raw: "stop" as const }, usage: USAGE, warnings: [] };
     },
@@ -70,6 +70,26 @@ describe("runTvAcquisitionV2 — single TV entry over the V2 engine", () => {
     expect(result.seasons[0]!.season.storageDirectoryId).not.toBe("");
     expect(result.notification.kind).toBe("no_coverage");
     expect(result.notification.trigger).toBe("user");
+  });
+
+  it("no_coverage run surfaces auditEvents (病4 end-to-end persistence)", async () => {
+    const storage = new FakeStorageExecutor();
+    const result = await runTvAcquisitionV2({
+      title,
+      mode: "type2",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 3, latestAiredEpisode: 3, qualityPreference: "4K" }],
+      categoryParentId: "tv_root",
+      resourceProvider: emptyProvider(),
+      storage,
+      model: searchThenReportModel(),
+      workflowRunId: "run-tv-2",
+      now: () => "2026-06-15T00:00:00.000Z",
+    });
+
+    expect(result.status).toBe("no_coverage");
+    // The agent searches "示例剧" which was pre-warmed, hitting dedup → search_dedup event.
+    // This proves audit events flow sandbox → orchestrator → workflow → bridge → runner.
+    expect(result.auditEvents.some((e) => e.type === "search_dedup")).toBe(true);
   });
 
   it("no-op type3 patrol (nothing missing) → succeeded, the model is never invoked", async () => {

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -173,3 +173,54 @@ describe("TaskSandbox — searchResources (system-budgeted, dedup, snapshot-boun
     expect(calls).toBe(1);
   });
 });
+
+describe("searchResources dedup 强提示（病2a）", () => {
+  function makeSandbox() {
+    const provider = new FakeResourceProviderV2({
+      results: { "攻壳机动队": [{ id: "c1", title: "攻壳机动队 SAC 全集" }, { id: "c2", title: "攻壳机动队 剧场版" }] },
+    });
+    return new TaskSandbox({ provider, titleTerms: ["攻壳机动队"] });
+  }
+
+  it("第 2 次同词搜索返回带次数与候选数的强提示", async () => {
+    const sandbox = makeSandbox();
+    await sandbox.searchResources("攻壳机动队");
+    const second = await sandbox.searchResources("攻壳机动队");
+    expect(second.deduped).toBe(true);
+    expect(second.repeatNotice).toContain("第 2 次");
+    expect(second.repeatNotice).toContain("2 候选");
+    expect(second.repeatNotice).toContain("换实质不同的新词");
+  });
+
+  it("第 3 次起提示升级为「再重复将视为无进展」", async () => {
+    const sandbox = makeSandbox();
+    await sandbox.searchResources("攻壳机动队");
+    await sandbox.searchResources("攻壳机动队");
+    const third = await sandbox.searchResources("攻壳机动队");
+    expect(third.repeatNotice).toContain("第 3 次");
+    expect(third.repeatNotice).toContain("再重复将视为无进展");
+  });
+
+  it("第 5 次起提示文本固定（不再带递增计数）——让 repetition-stop 的 4 连相同还能命中", async () => {
+    const sandbox = makeSandbox();
+    for (let i = 0; i < 4; i++) await sandbox.searchResources("攻壳机动队");
+    const fifth = await sandbox.searchResources("攻壳机动队");
+    const sixth = await sandbox.searchResources("攻壳机动队");
+    expect(fifth.repeatNotice).toBe(sixth.repeatNotice);
+    expect(fifth.repeatNotice).toContain("已重复多次");
+  });
+
+  it("复搜系统预搜(prime)的 raw 词同样计数（prime 记为第 1 次）", async () => {
+    const sandbox = makeSandbox();
+    await sandbox.primeRawSnapshot("攻壳机动队");
+    const first = await sandbox.searchResources("攻壳机动队");
+    expect(first.deduped).toBe(true);
+    expect(first.repeatNotice).toContain("第 2 次");
+  });
+
+  it("新词 fresh 搜索不带 repeatNotice", async () => {
+    const sandbox = makeSandbox();
+    const fresh = await sandbox.searchResources("攻壳机动队");
+    expect(fresh.repeatNotice).toBeUndefined();
+  });
+});

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -296,4 +296,17 @@ describe("searchResources 大快照消化提醒（病3）", () => {
     const second = await sandbox.searchResources("Ghost in the Shell");
     expect(second.digestHint).toBeUndefined();
   });
+
+  it("提示引用原大小写的有效词（与 repeatNotice 口径一致），不是小写规范形", async () => {
+    const latinMany = Array.from({ length: 12 }, (_, i) => ({ id: `g${i}`, title: `GITS pack ${i}` }));
+    const provider = new FakeResourceProviderV2({
+      // FakeResourceProviderV2 normalizes fixture keys, so the lowercase key still matches.
+      results: { "ghost in the shell": latinMany, "攻壳机动队": [{ id: "a", title: "t" }] },
+    });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["攻壳机动队", "Ghost in the Shell"] });
+    await sandbox.searchResources("Ghost in the Shell");
+    const second = await sandbox.searchResources("攻壳机动队");
+    expect(second.digestHint).toContain("Ghost in the Shell");
+    expect(second.digestHint).not.toContain("ghost in the shell");
+  });
 });

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -269,3 +269,31 @@ describe("searchResources anime 禁忌词警告接线（病2b）", () => {
     expect(result.warnings).toBeUndefined();
   });
 });
+
+describe("searchResources 大快照消化提醒（病3）", () => {
+  const many = Array.from({ length: 58 }, (_, i) => ({ id: `c${i}`, title: `攻壳机动队 SAC 第${i}包` }));
+
+  it("上一搜索 ≥10 候选、紧接换词搜 → 新结果前置消化提醒（一次）", async () => {
+    const provider = new FakeResourceProviderV2({
+      results: { "攻殻機動隊": many, "攻壳机动队 arise": [{ id: "x", title: "ARISE" }] },
+    });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["攻壳机动队", "攻殻機動隊", "ARISE"] });
+    await sandbox.searchResources("攻殻機動隊");
+    const second = await sandbox.searchResources("攻壳机动队 ARISE");
+    expect(second.digestHint).toContain("攻殻機動隊");
+    expect(second.digestHint).toContain("58");
+    // 只提示一次/快照：
+    const third = await sandbox.searchResources("攻殻機動隊");
+    expect(third.digestHint).toBeUndefined();
+  });
+
+  it("小快照(<10)不触发", async () => {
+    const provider = new FakeResourceProviderV2({
+      results: { "攻壳机动队": [{ id: "a", title: "t" }], "ghost in the shell": [{ id: "b", title: "t2" }] },
+    });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["攻壳机动队", "Ghost in the Shell"] });
+    await sandbox.searchResources("攻壳机动队");
+    const second = await sandbox.searchResources("Ghost in the Shell");
+    expect(second.digestHint).toBeUndefined();
+  });
+});

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -282,6 +282,11 @@ describe("searchResources 大快照消化提醒（病3）", () => {
     const second = await sandbox.searchResources("攻壳机动队 ARISE");
     expect(second.digestHint).toContain("攻殻機動隊");
     expect(second.digestHint).toContain("58");
+    // 提示必须指对地方：待消化的永远是 agent 自己的搜索快照（prime 从不注册
+    // pendingDigest），其候选列表在先前 searchResources 的返回里——而
+    // viewResourceSnapshot 只能看 raw 预搜快照，指过去就是指错。
+    expect(second.digestHint).not.toContain("viewResourceSnapshot");
+    expect(second.digestHint).toContain("回读");
     // 只提示一次/快照：
     const third = await sandbox.searchResources("攻殻機動隊");
     expect(third.digestHint).toBeUndefined();

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -336,4 +336,24 @@ describe("sandbox 审计事件收集（病4）", () => {
     await expect(sandbox.reportNoCoverage("premature")).rejects.toThrow("SANDBOX_NO_PROVIDER_EVIDENCE");
     expect(sandbox.auditTrail()).toEqual([]);
   });
+
+  it("§9 证据基含系统预搜：prime 过的任务可诚实上报，无需冗余 fresh 搜索", async () => {
+    // 提示词明令 agent 别重搜 raw（viewResourceSnapshot 免费）；预搜本身就是
+    // 一次真 provider 搜索。只认 agent 自己的 fresh 搜索会把守规矩 agent 的
+    // 诚实上报拒掉，逼它多烧轮次——正是病1 要杀的死尾巴。
+    const provider = new FakeResourceProviderV2({ results: {} });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["攻壳机动队"] });
+    await sandbox.primeRawSnapshot("攻壳机动队");
+    const report = await sandbox.reportNoCoverage("raw 快照无该作品覆盖");
+    expect(report.searchesPerformed).toBe(1);
+    expect(sandbox.auditTrail().some((e) => e.type === "no_coverage_reported")).toBe(true);
+  });
+
+  it("§9 证据基含 dedup 复搜：agent 复搜 prime 词后上报同样放行", async () => {
+    const provider = new FakeResourceProviderV2({ results: {} });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["攻壳机动队"] });
+    await sandbox.primeRawSnapshot("攻壳机动队");
+    await sandbox.searchResources("攻壳机动队"); // dedup 命中，seenKeywords 不变
+    await expect(sandbox.reportNoCoverage("确无资源")).resolves.toMatchObject({ searchesPerformed: 1 });
+  });
 });

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -310,3 +310,30 @@ describe("searchResources 大快照消化提醒（病3）", () => {
     expect(second.digestHint).not.toContain("ghost in the shell");
   });
 });
+
+describe("sandbox 审计事件收集（病4）", () => {
+  it("no_coverage 上报、dedup 重复、禁忌词警告 三类事件入 auditTrail", async () => {
+    const provider = new FakeResourceProviderV2({
+      results: { "攻壳机动队": [{ id: "c1", title: "t" }], "攻壳机动队 2020": [] },
+    });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["攻壳机动队"], searchProfile: "jp-anime" });
+    await sandbox.searchResources("攻壳机动队");
+    await sandbox.searchResources("攻壳机动队"); // dedup
+    await sandbox.searchResources("攻壳机动队 2020"); // taboo 年份
+    await sandbox.reportNoCoverage("确无资源");
+
+    const trail = sandbox.auditTrail();
+    expect(trail.some((e) => e.type === "no_coverage_reported" && e.data?.reason === "确无资源")).toBe(true);
+    expect(trail.some((e) => e.type === "search_dedup" && e.data?.count === 2)).toBe(true);
+    expect(trail.some((e) => e.type === "search_taboo_warning")).toBe(true);
+    // 每个事件都有人类可读 message（AuditEvent 契约）。
+    expect(trail.every((e) => typeof e.message === "string" && e.message.length > 0)).toBe(true);
+  });
+
+  it("被 §9 拒绝的上报不产生 no_coverage_reported 事件", async () => {
+    const provider = new FakeResourceProviderV2({ results: {} });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["x"] });
+    await expect(sandbox.reportNoCoverage("premature")).rejects.toThrow("SANDBOX_NO_PROVIDER_EVIDENCE");
+    expect(sandbox.auditTrail()).toEqual([]);
+  });
+});

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -244,3 +244,28 @@ describe("searchResources dedup 强提示（病2a）", () => {
     expect(second.repeatNotice).not.toContain("1080");
   });
 });
+
+describe("searchResources anime 禁忌词警告接线（病2b）", () => {
+  it("anime profile 的 sandbox 对含年份关键词附加 warnings（不阻断，快照照常返回）", async () => {
+    const provider = new FakeResourceProviderV2({
+      results: { "攻壳机动队 2020": [{ id: "c1", title: "攻壳机动队 SAC_2045" }] },
+    });
+    const sandbox = new TaskSandbox({
+      provider,
+      titleTerms: ["攻壳机动队"],
+      searchProfile: "jp-anime",
+    });
+    const result = await sandbox.searchResources("攻壳机动队 2020");
+    expect(result.snapshot).toBeDefined(); // 不阻断
+    expect(result.warnings?.some((w) => w.includes("年份"))).toBe(true);
+  });
+
+  it("未传 searchProfile（旧调用方）→ 无 warnings 字段", async () => {
+    const provider = new FakeResourceProviderV2({
+      results: { "默杀 2024": [{ id: "c1", title: "默杀 2024" }] },
+    });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["默杀"] });
+    const result = await sandbox.searchResources("默杀 2024");
+    expect(result.warnings).toBeUndefined();
+  });
+});

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -223,4 +223,24 @@ describe("searchResources dedup 强提示（病2a）", () => {
     const fresh = await sandbox.searchResources("攻壳机动队");
     expect(fresh.repeatNotice).toBeUndefined();
   });
+
+  it("空结果快照的重复提示同样报次数与「共 0 候选」", async () => {
+    const provider = new FakeResourceProviderV2({ results: { "攻壳机动队": [] } });
+    const sandbox = new TaskSandbox({ provider, titleTerms: ["攻壳机动队"] });
+    await sandbox.searchResources("攻壳机动队");
+    const second = await sandbox.searchResources("攻壳机动队");
+    expect(second.repeatNotice).toContain("第 2 次");
+    expect(second.repeatNotice).toContain("共 0 候选");
+  });
+
+  it("带画质词的重复搜索:提示引用剥离后的有效词,不是 raw 原词", async () => {
+    const sandbox = makeSandbox();
+    await sandbox.searchResources("攻壳机动队");
+    // 画质词被 C5 剥离 → 有效词与第 1 次相同 → dedup 命中,计为第 2 次
+    const second = await sandbox.searchResources("攻壳机动队 1080P");
+    expect(second.deduped).toBe(true);
+    expect(second.repeatNotice).toContain("第 2 次");
+    expect(second.repeatNotice).toContain("攻壳机动队");
+    expect(second.repeatNotice).not.toContain("1080");
+  });
 });


### PR DESCRIPTION
## 背景

Live 事故 run `7bc9dbf3`（新攻壳机动队 anime type2）：8m04s 才收出一个 no_coverage——19 次搜索里同词重搜 3 遍、跑偏到隔壁系列词「ARISE」和禁忌年份「2020」、58 候选的日文名快照没消化就继续换词穷搜、`reportNoCoverage` 上报成功后 run 不终止（停摆 1m45s → readSkill → 二次上报 → finish，白拖 2.5 分钟）、run payload `auditEvents: []` 无从取证。

## 四病修法

**病1 — reportNoCoverage 终结化**：循环终止其实只靠「模型不再调工具」+ stopWhen 护栏；新增 `buildNoCoverageStop`（与 repetition/systemic-block 同族）——成功上报（结果无 `error`）立即收束；§9 证据护栏的 throw 保持不终结。工具描述宣告 TERMINAL 语义，:237 矛盾注释修正。

**病2a — dedup 强提示**：同词重搜此前静默返回缓存快照，模型无感知白烧轮次。现在 dedup 命中返回 `repeatNotice`（第 N 次 + 候选数 + 决策指引，第 3 次升级警告）；**第 5 次起文本固定**——递增计数会让重复步骤 result 每次不同、反而永久解除 repetition-stop 的「4 连相同」护栏，固定是刻意设计。

**病2b — anime 禁忌词校验器**（硬规则转校验器，警告不阻断）：`animeSearchTabooWarnings` 纯函数——年份（片名自带年份如 SAC_2045 豁免）、子类型词（cn-anime 的 +国漫 例外保留）、片名外拉丁词疑似跨系列（ARISE 案例，附罗马音自辩出口）。profile 从 run-tv-v2 穿线进 sandbox。

**病3 — 大快照消化提醒**：fresh 搜索 ≥10 候选后紧接换词，下一次返回前置一次性提醒（每快照仅一次；prime 不注册）。

**病4 — auditEvents 接线**：根因 = bridge 与 movie 路径硬编码空数组（runner→DB 本来就通）。sandbox 收集三类事件（no_coverage 上报/dedup 计数/禁忌警告）→ orchestrator → workflow-v2 → 两条持久化路径。

**附带真 bug（补强 e2e 断言钓出）**：§9 证据基只认 agent 自己的 fresh 搜索，但提示词明令别重搜 raw、dedup 也不进 seenKeywords——守规矩 agent 的诚实上报会被误拒。证据基改为 `seenKeywords ∪ snapshotByKeyword.keys()`（系统预搜也是真搜索），零证据仍 throw，预算语义不变。

## 验证

- 全量 vitest **1421 passed**（155 文件）+ 三处 tsc（workflow/web/root）+ build:workflow 绿
- 攻壳式 stub 重放：上报成功后 0 后续步（steps=1）；被拒上报循环照常继续
- TV + movie 双路径 e2e：no_coverage run 的 bridged `auditEvents` 携带 `no_coverage_reported`（movie 与 TV 对齐）
- **真 MiMo §6a 问询**（mimo-v2.5-pro，4 道新题固化进 INTERROGATION_QUESTIONS）：四题全过——「上报成功=任务完毕，走人」「警告不是再试一次的提示，而是该决策了」「已有证据不消化就去搜新的，是最典型的预算浪费」；判卷还抓出并修掉两处缺陷（年份误伤含年份的正牌标题、消化提醒指错了回读入口）
- 待合并后 live 验收：真 MiMo 点一部确无资源的作品，no_coverage 收尾 <30s、无双报、audit 三类事件非空

## 风险

- 病1 改循环终结语义：no_coverage run 的 `result.text` 为空是设计后果（无转存时 decisions 本就为空，无消费方受影响）
- §9 放宽的对抗面已评审：零证据仍拒；「偷懒上报」由提示词纪律 + 终结 stop 兜住，评审结论为净改进

🤖 Generated with [Claude Code](https://claude.com/claude-code)