### PR TITLE
chore(site): 下载兜底 JSON 刷到 v1.2.0

### DIFF
--- a/site/data/release-fallback.json
+++ b/site/data/release-fallback.json
@@ -1,13 +1,13 @@
 {
-  "tag_name": "v1.1.0",
+  "tag_name": "v1.2.0",
   "assets": [
     {
-      "name": "Mediary.Scout-1.1.0-arm64.dmg",
-      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.1.0/Mediary.Scout-1.1.0-arm64.dmg"
+      "name": "Mediary.Scout-1.2.0-arm64.dmg",
+      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.2.0/Mediary.Scout-1.2.0-arm64.dmg"
     },
     {
-      "name": "Mediary.Scout.Setup.1.1.0.exe",
-      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.1.0/Mediary.Scout.Setup.1.1.0.exe"
+      "name": "Mediary.Scout.Setup.1.2.0.exe",
+      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.2.0/Mediary.Scout.Setup.1.2.0.exe"
     }
   ]
 }


### PR DESCRIPTION
v1.2.0 桌面版已发布（含获取循环四病修复 #123），双平台资产真实可下载（dmg 117MB / exe 94MB，均 HTTP 200 验证）。

站点下载按钮优先走 GitHub API 实时拿最新 release；`site/data/release-fallback.json` 是 API 不可用时的兜底，之前停在 v1.1.0——降级用户会下到旧版。此 PR 把兜底同步到 v1.2.0。

## 验证
- JSON 合法（node require 通过）
- 两个资产 URL 真实 `curl -IL` 返回 HTTP 200
- site 测试套件 19/19 绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)