### PR TITLE
feat(site): 专业冷峻文案 + Win CTA 按钮 + TMDB 归属修清晰 + FAQ 顺滑动画

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -265,7 +265,8 @@
     </div>
   </section>
 
-  <!-- FAQ accordion: exclusivity + smooth grid-rows animation driven by JS (.is-open) -->
+  <!-- FAQ accordion: JS-driven exclusivity + smooth max-height animation (.is-open);
+       collapse CSS is .js-scoped so native <details> toggle works without JS -->
   <section id="faq">
     <div class="container">
       <h2>你可能想问</h2>

--- a/site/index.html
+++ b/site/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mediary Scout — 追剧，只剩点一下</title>
-  <meta name="description" content="开源免费的网盘追剧工具：搜到你想看的，点一下，agent 替你找资源、存进你自己的 115/夸克网盘、核对无误。macOS / Windows 桌面版，双击就能用。">
+  <title>Mediary Scout — 自建网盘的媒体获取 agent</title>
+  <meta name="description" content="指定一部影视，agent 跨源检索、择优转存进你自己的 115/夸克/光鸭网盘、回读核对，并持续追踪缺集。macOS / Windows 桌面版，AGPL 开源、自部署。">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Mediary Scout — 追剧，只剩点一下">
-  <meta property="og:description" content="开源免费的网盘追剧工具：搜到你想看的，点一下，agent 替你找资源、存进你自己的 115/夸克网盘、核对无误。macOS / Windows 桌面版，双击就能用。">
+  <meta property="og:title" content="Mediary Scout — 自建网盘的媒体获取 agent">
+  <meta property="og:description" content="指定一部影视，agent 跨源检索、择优转存进你自己的 115/夸克/光鸭网盘、回读核对，并持续追踪缺集。macOS / Windows 桌面版，AGPL 开源、自部署。">
   <meta property="og:image" content="https://mediaryscout.app/assets/og.png">
   <meta property="og:url" content="https://mediaryscout.app/">
   <meta property="og:type" content="website">

--- a/site/index.html
+++ b/site/index.html
@@ -267,7 +267,8 @@
 
   <!-- FAQ accordion: native <details name="faq"> for exclusivity + a11y; smooth
        open/close via CSS ::details-content + interpolate-size (instant fallback on
-       engines without them). Zero JS — semantics stay fully native. -->
+       engines without them). initFAQ() adds only a toggle-listener exclusivity
+       fallback for engines without details[name] grouping — semantics stay native. -->
   <section id="faq">
     <div class="container">
       <h2>你可能想问</h2>

--- a/site/index.html
+++ b/site/index.html
@@ -63,8 +63,8 @@
   <!-- Hero section: title, CTAs, ticker window -->
   <section id="hero">
     <div class="container">
-      <h1>追剧，只剩<em>点一下</em></h1>
-      <p class="hero-sub">搜到你想看的，点一下——剩下的交给 agent：找资源、存网盘、回读核对。</p>
+      <h1>自建网盘的媒体获取 <em>agent</em></h1>
+      <p class="hero-sub">指定一部影视，agent 跨源检索、择优转存进你的网盘、回读核对，并持续追踪缺集。凭证据，不凭感觉。</p>
 
       <div class="cta-row">
         <a class="pill cta-main" data-dl href="https://github.com/fancydirty/mediary-scout/releases/latest">
@@ -79,10 +79,10 @@
           </svg>
           <span data-dl-label>Windows</span> <span data-dl-ver hidden></span>
         </a>
-        <a class="pill cta-outline" href="https://demo.mediaryscout.app">▶ 在线试玩</a>
+        <a class="pill cta-outline" href="https://demo.mediaryscout.app">在线 Demo</a>
       </div>
 
-      <p class="hero-note">免费开源 · 也可 docker 自部署 ↓</p>
+      <p class="hero-note">AGPL 开源 · 桌面版双击即用 · 也可 docker 自部署</p>
 
       <div class="ticker-window">
         <div class="ticker-dots">
@@ -91,11 +91,11 @@
           <div class="dot dot-green"></div>
         </div>
         <div class="ticker-content">
-          <div class="tk-line">▸ 正在搜罗全网资源…找到 37 个候选</div>
-          <div class="tk-line">▸ 挑中 2160p · 中文字幕 · 体积正常的那个</div>
-          <div class="tk-line">▸ 正在存进你的网盘…（不经过你的电脑）</div>
-          <div class="tk-line">▸ 回头打开网盘核对：真的到了，没缺没坏</div>
-          <div class="tk-line done">✓ 已入库 · 打开网盘直接看</div>
+          <div class="tk-line">▸ 跨源检索 · 命中 37 个候选</div>
+          <div class="tk-line">▸ 择优 · 2160p · 中文字幕 · 体积合理</div>
+          <div class="tk-line">▸ 转存至你的网盘 · 不经本地</div>
+          <div class="tk-line">▸ 回读核对 · 完整无损</div>
+          <div class="tk-line done">✓ 已入库</div>
         </div>
       </div>
     </div>
@@ -111,7 +111,7 @@
   <!-- Scrollytelling "它正在工作": 4-act sticky window + intersection observer -->
   <section id="how">
     <div class="container">
-      <h2>agent 是怎么干活的</h2>
+      <h2>agent 如何完成一次获取</h2>
       <div class="how-wrap">
         <div class="how-marker" data-scene="0"></div>
         <div class="how-marker" data-scene="1"></div>
@@ -127,10 +127,10 @@
             </div>
             <div class="how-search"><svg width="13" height="13" viewBox="0 0 18 18" fill="none" aria-hidden="true" style="vertical-align: middle; display: inline-block;"><circle cx="9" cy="9" r="5.5" stroke="currentColor" stroke-width="1.8"/><line x1="13" y1="13" x2="16.5" y2="16.5" stroke="currentColor" stroke-width="1.8"/></svg> 闪灵<span class="how-cursor">▏</span></div>
             <div class="how-ticker">
-              <div class="how-line" data-need="1">▸ 搜罗全网资源找到 37 个候选</div>
-              <div class="how-line" data-need="1">▸ 挑中 2160p·中文字幕</div>
-              <div class="how-line" data-need="2">▸ 存进你的网盘不经过你的电脑</div>
-              <div class="how-line" data-need="2">▸ 回头核对真的到了</div>
+              <div class="how-line" data-need="1">▸ 跨源检索 · 命中 37 个候选</div>
+              <div class="how-line" data-need="1">▸ 择优 · 2160p · 中文字幕</div>
+              <div class="how-line" data-need="2">▸ 转存至你的网盘 · 不经本地</div>
+              <div class="how-line" data-need="2">▸ 回读核对 · 完整无损</div>
               <div class="how-line" data-need="3">✓ 已入库</div>
             </div>
             <div class="how-eps">
@@ -142,20 +142,20 @@
           </div>
           <div class="how-captions">
             <div class="how-caption" data-cap="0">
-              <b>搜到，点一下</b>
-              <span>搜到你想看的，点一下获取。完事，该干嘛干嘛去。</span>
+              <b>检索与指定</b>
+              <span>搜到目标，点获取。agent 接管，你无需值守。</span>
             </div>
             <div class="how-caption" data-cap="1">
-              <b>它去找、去挑</b>
-              <span>画质、中文字幕、假资源，都替你把过关——挑不到合格的就直说，不塞垃圾给你。</span>
+              <b>择优</b>
+              <span>按画质、中文字幕、去重与真伪逐一筛选；无合格资源则如实报告，不塞垃圾。</span>
             </div>
             <div class="how-caption" data-cap="2">
-              <b>存进你自己的网盘</b>
-              <span>不下载到电脑、不占硬盘。存完还回头核对一遍，真到了才算数。</span>
+              <b>转存与核对</b>
+              <span>秒传 / 离线转存进你的网盘，不经本地磁盘；转存后回读真实文件，确认完整无损。</span>
             </div>
             <div class="how-caption" data-cap="3">
-              <b>追更的剧，缺的集自己回来</b>
-              <span>它记得你每部剧缺哪几集，出了新集自动补上。</span>
+              <b>持续追踪</b>
+              <span>季级状态机记录每部剧的缺集；定时巡检只在有新集时唤起 agent 补齐。</span>
             </div>
           </div>
         </div>
@@ -166,7 +166,7 @@
   <!-- Features v4: poster wall solo block + flat editorial column + label-voice trust line -->
   <section id="features">
     <div class="container">
-      <h2>不只是下载，是一个正经媒体库</h2>
+      <h2>不止获取，更是媒体库的状态管理</h2>
       <div class="feat-split">
         <div class="feat-glow" aria-hidden="true"></div>
 
@@ -176,8 +176,8 @@
             <div class="poster-wall"></div>
             <div class="poster-overlay">
               <div class="feat-eyebrow">LIBRARY</div>
-              <h3>你的网盘，长出一个正经媒体库</h3>
-              <p>真海报、真元数据，来自 TMDB · 本周热映</p>
+              <h3>你的网盘之上，一个结构化媒体库</h3>
+              <p>海报与元数据来自 TMDB</p>
             </div>
           </div>
         </div>
@@ -186,8 +186,8 @@
         <div class="feat-list">
           <div class="feat-item">
             <div class="feat-num">01</div>
-            <b>追更交给 agent</b>
-            <span>剧更新了，agent 自己去找、自己存进网盘。缺哪几集它记着，补齐为止。</span>
+            <b>追更</b>
+            <span>季级状态机跟踪缺集；剧集更新后 agent 自动检索、转存，直至补齐。</span>
             <div class="episode-grid">
               <i class="ep got"></i><i class="ep got"></i><i class="ep got"></i><i class="ep got"></i><i class="ep got"></i><i class="ep got"></i><i class="ep got"></i><i class="ep got"></i><i class="ep"></i><i class="ep"></i><i class="ep"></i><i class="ep"></i>
             </div>
@@ -195,18 +195,18 @@
           </div>
           <div class="feat-item">
             <div class="feat-num">02</div>
-            <b>找资源的活它来干</b>
-            <span>agent 全网搜罗，挑画质、挑中字、避开假资源。挑不到合格的会直说。</span>
+            <b>择优检索</b>
+            <span>跨源检索，按画质、中文字幕、去重与真伪筛选；无合格资源如实报告。</span>
           </div>
           <div class="feat-item">
             <div class="feat-num">03</div>
-            <b>存在你自己的网盘</b>
-            <span>115 / 夸克 / 光鸭，转存不下载，不占硬盘。缺字幕的它自动配。</span>
+            <b>转存进你的网盘</b>
+            <span>115 / 夸克 / 光鸭，秒传 / 离线转存，不占本地磁盘；缺字幕自动补配。</span>
           </div>
           <div class="feat-item">
             <div class="feat-num">04</div>
-            <b>全家可以分开用</b>
-            <span>一个实例各自注册，各绑各的网盘、各看各的库。</span>
+            <b>多账户隔离</b>
+            <span>同一实例，各自注册、各绑网盘、各看各库。</span>
           </div>
         </div>
       </div>
@@ -215,10 +215,10 @@
       <div class="feat-trust">
         <div class="feat-hairline" aria-hidden="true"></div>
         <div class="trust-row">
-          <span class="trust-green">开源免费</span>
-          <span>凭证只存你自己电脑</span>
-          <span>不下载不占硬盘</span>
-          <span>挑不到合格资源就直说</span>
+          <span class="trust-green">AGPL 开源</span>
+          <span>凭证仅存于你的实例</span>
+          <span>转存不落本地</span>
+          <span>无合格资源即如实报告</span>
         </div>
       </div>
     </div>
@@ -227,8 +227,8 @@
   <!-- Demo section: GIF + CTA to demo.mediaryscout.app -->
   <section id="demo">
     <div class="container">
-      <h2>不装也能玩</h2>
-      <p class="demo-sub">只读回放，不用注册不用装，点开就看。</p>
+      <h2>只读演示，无需安装</h2>
+      <p class="demo-sub">脚本化回放：真实 TMDB 检索，mock 网盘，不写入任何数据。</p>
       <div class="demo-window">
         <div class="demo-dots">
           <div class="dot dot-red"></div>
@@ -238,7 +238,7 @@
         <img loading="lazy" src="assets/demo.gif" alt="Mediary Scout 在线 demo 回放：搜索到入库全流程">
       </div>
       <div class="demo-cta">
-        <a class="pill cta-outline" href="https://demo.mediaryscout.app">打开在线 Demo，看它跑一单</a>
+        <a class="pill cta-outline" href="https://demo.mediaryscout.app">打开在线 Demo</a>
       </div>
     </div>
   </section>
@@ -246,12 +246,12 @@
   <!-- Desktop vs Docker comparison cards -->
   <section id="deploy">
     <div class="container">
-      <h2>装在电脑，或装在服务器</h2>
+      <h2>桌面，或服务器</h2>
       <div class="deploy-split">
         <div class="deploy-col">
           <div class="deploy-eyebrow deploy-eyebrow-green">DESKTOP</div>
-          <b>双击就能用（推荐）</b>
-          <p>macOS 签名公证 / Windows 安装向导 · 数据存你自己电脑</p>
+          <b>桌面版（推荐）</b>
+          <p>macOS 签名公证 / Windows 安装向导 · 数据存于本机</p>
         </div>
         <div class="deploy-divider"></div>
         <div class="deploy-col">
@@ -265,11 +265,11 @@
     </div>
   </section>
 
-  <!-- FAQ accordion with <details name="faq"> -->
+  <!-- FAQ accordion: exclusivity + smooth grid-rows animation driven by JS (.is-open) -->
   <section id="faq">
     <div class="container">
       <h2>你可能想问</h2>
-      <details name="faq" class="faq">
+      <details class="faq">
         <summary>
           它会乱动我的网盘吗？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -280,7 +280,7 @@
           <p>只做你手动也能做的转存和整理，全程每一步可见，凭证只在你自己的实例里。</p>
         </div>
       </details>
-      <details name="faq" class="faq">
+      <details class="faq">
         <summary>
           账号密码存在哪？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -291,7 +291,7 @@
           <p>你自己电脑（桌面版）或你自己的服务器，作者碰不到。</p>
         </div>
       </details>
-      <details name="faq" class="faq">
+      <details class="faq">
         <summary>
           要花钱吗？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -302,7 +302,7 @@
           <p>软件免费开源；你需要自己的网盘账号和一个 AI 服务的 key（任意 OpenAI 兼容接口）。</p>
         </div>
       </details>
-      <details name="faq" class="faq">
+      <details class="faq">
         <summary>
           支持哪些网盘？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -313,7 +313,7 @@
           <p>115、夸克、光鸭；网盘层是插件化接口，欢迎 PR 加新品牌。</p>
         </div>
       </details>
-      <details name="faq" class="faq">
+      <details class="faq">
         <summary>
           Windows 提示「已保护你的电脑」？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -330,13 +330,19 @@
   <!-- Final CTA -->
   <section id="cta">
     <div class="container">
-      <h2>觉得有用就试试</h2>
+      <h2>开始使用</h2>
       <div class="cta-final-row">
         <a class="pill cta-main cta-big" data-dl-cta href="https://github.com/fancydirty/mediary-scout/releases/latest">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="20" height="20">
             <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
           </svg>
-          <span data-dl-label>下载 Mediary Scout（macOS）</span>
+          <span data-dl-cta-label>下载 macOS 版</span>
+        </a>
+        <a class="pill cta-dark cta-big" data-dl-cta href="https://github.com/fancydirty/mediary-scout/releases/latest">
+          <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="20" height="20">
+            <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/>
+          </svg>
+          <span data-dl-cta-label>下载 Windows 版</span>
         </a>
         <a class="pill cta-outline cta-github" href="https://github.com/fancydirty/mediary-scout">
           <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" width="20" height="20">

--- a/site/index.html
+++ b/site/index.html
@@ -67,13 +67,13 @@
       <p class="hero-sub">指定一部影视，agent 跨源检索、择优转存进你的网盘、回读核对，并持续追踪缺集。凭证据，不凭感觉。</p>
 
       <div class="cta-row">
-        <a class="pill cta-main" data-dl href="https://github.com/fancydirty/mediary-scout/releases/latest">
+        <a class="pill cta-main" data-dl data-dl-platform="mac" href="https://github.com/fancydirty/mediary-scout/releases/latest">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="18" height="18">
             <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
           </svg>
           <span data-dl-label>macOS</span> <span data-dl-ver></span>
         </a>
-        <a class="pill cta-dark" data-dl href="https://github.com/fancydirty/mediary-scout/releases/latest">
+        <a class="pill cta-dark" data-dl data-dl-platform="win" href="https://github.com/fancydirty/mediary-scout/releases/latest">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="18" height="18">
             <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/>
           </svg>
@@ -335,13 +335,13 @@
     <div class="container">
       <h2>开始使用</h2>
       <div class="cta-final-row">
-        <a class="pill cta-main cta-big" data-dl-cta href="https://github.com/fancydirty/mediary-scout/releases/latest">
+        <a class="pill cta-main cta-big" data-dl-cta data-dl-platform="mac" href="https://github.com/fancydirty/mediary-scout/releases/latest">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="20" height="20">
             <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
           </svg>
           <span data-dl-cta-label>下载 macOS 版</span>
         </a>
-        <a class="pill cta-dark cta-big" data-dl-cta href="https://github.com/fancydirty/mediary-scout/releases/latest">
+        <a class="pill cta-dark cta-big" data-dl-cta data-dl-platform="win" href="https://github.com/fancydirty/mediary-scout/releases/latest">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="20" height="20">
             <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/>
           </svg>

--- a/site/index.html
+++ b/site/index.html
@@ -339,13 +339,13 @@
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="20" height="20">
             <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
           </svg>
-          <span data-dl-cta-label>下载 macOS 版</span>
+          <span>下载 macOS 版</span>
         </a>
         <a class="pill cta-dark cta-big" data-dl-cta data-dl-platform="win" href="https://github.com/fancydirty/mediary-scout/releases/latest">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" width="20" height="20">
             <path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/>
           </svg>
-          <span data-dl-cta-label>下载 Windows 版</span>
+          <span>下载 Windows 版</span>
         </a>
         <a class="pill cta-outline cta-github" href="https://github.com/fancydirty/mediary-scout">
           <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" width="20" height="20">

--- a/site/index.html
+++ b/site/index.html
@@ -265,12 +265,13 @@
     </div>
   </section>
 
-  <!-- FAQ accordion: JS-driven exclusivity + smooth max-height animation (.is-open);
-       collapse CSS is .js-scoped so native <details> toggle works without JS -->
+  <!-- FAQ accordion: native <details name="faq"> for exclusivity + a11y; smooth
+       open/close via CSS ::details-content + interpolate-size (instant fallback on
+       engines without them). Zero JS — semantics stay fully native. -->
   <section id="faq">
     <div class="container">
       <h2>你可能想问</h2>
-      <details class="faq">
+      <details name="faq" class="faq">
         <summary>
           它会乱动我的网盘吗？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -281,7 +282,7 @@
           <p>只做你手动也能做的转存和整理，全程每一步可见，凭证只在你自己的实例里。</p>
         </div>
       </details>
-      <details class="faq">
+      <details name="faq" class="faq">
         <summary>
           账号密码存在哪？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -292,7 +293,7 @@
           <p>你自己电脑（桌面版）或你自己的服务器，作者碰不到。</p>
         </div>
       </details>
-      <details class="faq">
+      <details name="faq" class="faq">
         <summary>
           要花钱吗？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -303,7 +304,7 @@
           <p>软件免费开源；你需要自己的网盘账号和一个 AI 服务的 key（任意 OpenAI 兼容接口）。</p>
         </div>
       </details>
-      <details class="faq">
+      <details name="faq" class="faq">
         <summary>
           支持哪些网盘？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -314,7 +315,7 @@
           <p>115、夸克、光鸭；网盘层是插件化接口，欢迎 PR 加新品牌。</p>
         </div>
       </details>
-      <details class="faq">
+      <details name="faq" class="faq">
         <summary>
           Windows 提示「已保护你的电脑」？
           <svg class="chev" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">

--- a/site/main.js
+++ b/site/main.js
@@ -36,15 +36,15 @@ async function wireDownloads() {
     if (i === 0) a.querySelector("[data-dl-ver]").textContent = version;
   });
 
-  // Wire the final CTA button
-  const cta = document.querySelector("[data-dl-cta]");
-  if (cta && items[0]) {
-    cta.href = items[0].url;
-    const label = cta.querySelector("[data-dl-label]");
-    if (label) {
-      label.textContent = `下载 Mediary Scout（${items[0].label}）`;
-    }
-  }
+  // Wire the two final-CTA download buttons. Order is FIXED (mac, win) with static
+  // labels — match each button to its platform's url by name, not by items order
+  // (items flips for win visitors). Falls back to the releases page per orderDownloads.
+  const urlByPlatform = Object.fromEntries(items.map((it) => [it.platform, it.url]));
+  const ctaOrder = ["mac", "win"]; // matches the HTML button order
+  document.querySelectorAll("[data-dl-cta]").forEach((btn, i) => {
+    const url = urlByPlatform[ctaOrder[i]];
+    if (url) btn.href = url;
+  });
 }
 
 async function wireStars() {
@@ -185,17 +185,26 @@ function initHowScrolly() {
 }
 
 function initFAQ() {
-  const faqs = document.querySelectorAll("details.faq");
+  const faqs = [...document.querySelectorAll("details.faq")];
   if (faqs.length === 0) return;
 
-  // Ensure exclusive accordion behavior (fallback for browsers without name attribute support)
+  // Keep native [open] set permanently so the content is always laid out (native
+  // <details> stops laying out closed content, which breaks any height/grid-rows
+  // transition). Visibility is driven by the .is-open class + a CSS grid-rows
+  // transition (0fr↔1fr auto-animates both ways). preventDefault takes over the
+  // native instant toggle; exclusivity closes the others.
+  // No-JS degradation: [open] is never set, so native click-to-toggle still works.
+  faqs.forEach((d) => { d.open = true; });
+
   faqs.forEach((d) => {
-    d.addEventListener("toggle", () => {
-      if (d.open) {
-        faqs.forEach((o) => {
-          if (o !== d) o.open = false;
-        });
-      }
+    d.querySelector("summary").addEventListener("click", (e) => {
+      e.preventDefault();
+      const willOpen = !d.classList.contains("is-open");
+      faqs.forEach((o) => o.classList.remove("is-open")); // exclusivity
+      if (willOpen) d.classList.add("is-open");
+      // Belt-and-suspenders: keep [open] set so content stays laid out even if a
+      // browser let the native toggle through — visibility is the .is-open class's job.
+      faqs.forEach((o) => { o.open = true; });
     });
   });
 }

--- a/site/main.js
+++ b/site/main.js
@@ -188,8 +188,20 @@ function initHowScrolly() {
   setScene(0);
 }
 
-// FAQ needs no JS: native <details name="faq"> gives exclusivity + correct a11y,
-// and the smooth open/close is pure CSS (::details-content + interpolate-size).
+function initFAQ() {
+  const faqs = [...document.querySelectorAll("details.faq")];
+  if (faqs.length === 0) return;
+  // Exclusivity is native via <details name="faq"> (Chrome 120+ / FF 130+ / Safari
+  // 17.2+). This toggle listener is a progressive-enhancement FALLBACK for older
+  // engines without name-grouping: when one opens, close the others. It drives the
+  // native [open], so a11y semantics and the CSS ::details-content animation stay
+  // fully native/correct. No effect where name-grouping already handles it.
+  faqs.forEach((d) => {
+    d.addEventListener("toggle", () => {
+      if (d.open) faqs.forEach((o) => { if (o !== d) o.open = false; });
+    });
+  });
+}
 
 function initNavScroll() {
   const nav = document.querySelector("nav");
@@ -219,4 +231,5 @@ wireStars();
 wirePosters();
 initHowScrolly();
 initFeatureReveal();
+initFAQ();
 initNavScroll();

--- a/site/main.js
+++ b/site/main.js
@@ -29,21 +29,25 @@ async function wireDownloads() {
     }
   }
   const { version, items } = orderDownloads(release, detectPlatform(navigator.userAgent));
+  // Map by platform NAME, not items order: orderDownloads reverses items for Windows
+  // visitors, but every button's icon + label is platform-fixed in the HTML (order
+  // [mac, win] in both the hero and the final CTA). Indexing by items would swap
+  // the href under the wrong icon on Windows.
+  const byPlatform = Object.fromEntries(items.map((it) => [it.platform, it]));
+  const fixedOrder = ["mac", "win"];
+
+  // Hero buttons (macOS shows the version).
   document.querySelectorAll("[data-dl]").forEach((a, i) => {
-    const it = items[i]; if (!it) return;
+    const it = byPlatform[fixedOrder[i]]; if (!it) return;
     a.href = it.url;
-    a.querySelector("[data-dl-label]").textContent = it.label;
-    if (i === 0) a.querySelector("[data-dl-ver]").textContent = version;
+    const label = a.querySelector("[data-dl-label]"); if (label) label.textContent = it.label;
+    const ver = a.querySelector("[data-dl-ver]"); if (ver && i === 0) ver.textContent = version;
   });
 
-  // Wire the two final-CTA download buttons. Order is FIXED (mac, win) with static
-  // labels — match each button to its platform's url by name, not by items order
-  // (items flips for win visitors). Falls back to the releases page per orderDownloads.
-  const urlByPlatform = Object.fromEntries(items.map((it) => [it.platform, it.url]));
-  const ctaOrder = ["mac", "win"]; // matches the HTML button order
+  // Final-CTA buttons (static labels, same fixed [mac, win] order).
   document.querySelectorAll("[data-dl-cta]").forEach((btn, i) => {
-    const url = urlByPlatform[ctaOrder[i]];
-    if (url) btn.href = url;
+    const it = byPlatform[fixedOrder[i]];
+    if (it) btn.href = it.url;
   });
 }
 
@@ -199,15 +203,32 @@ function initFAQ() {
   // CSS max-height transition; collapsed bodies are visibility:hidden so screen
   // readers don't read "closed" answers. preventDefault takes over the native
   // instant toggle; exclusivity closes the others.
-  faqs.forEach((d) => { d.open = true; });
+  faqs.forEach((d) => {
+    const summary = d.querySelector("summary");
+    if (!summary) return; // malformed markup — leave this one to native behavior
+    d.open = true;
+    summary.setAttribute("aria-expanded", "false"); // real state lives here, not [open]
+  });
+
+  // Sync the a11y disclosure state to the .is-open class (not the always-true
+  // [open]) so assistive tech announces the correct expanded/collapsed item.
+  function syncAria() {
+    faqs.forEach((o) => {
+      const s = o.querySelector("summary");
+      if (s) s.setAttribute("aria-expanded", o.classList.contains("is-open") ? "true" : "false");
+    });
+  }
 
   faqs.forEach((d) => {
-    d.querySelector("summary").addEventListener("click", (e) => {
+    const summary = d.querySelector("summary");
+    if (!summary) return;
+    summary.addEventListener("click", (e) => {
       e.preventDefault();
       const willOpen = !d.classList.contains("is-open");
       faqs.forEach((o) => o.classList.remove("is-open")); // exclusivity
       if (willOpen) d.classList.add("is-open");
       faqs.forEach((o) => { o.open = true; }); // keep content laid out regardless
+      syncAria();
     });
   });
 }

--- a/site/main.js
+++ b/site/main.js
@@ -29,24 +29,23 @@ async function wireDownloads() {
     }
   }
   const { version, items } = orderDownloads(release, detectPlatform(navigator.userAgent));
-  // Map by platform NAME, not items order: orderDownloads reverses items for Windows
-  // visitors, but every button's icon + label is platform-fixed in the HTML (order
-  // [mac, win] in both the hero and the final CTA). Indexing by items would swap
-  // the href under the wrong icon on Windows.
+  // Map by platform NAME via each button's explicit data-dl-platform, not by DOM
+  // order: orderDownloads reverses items for Windows visitors, and every button's
+  // icon/label is platform-fixed in the HTML. Reading the platform off the element
+  // keeps the href under the right icon even if buttons are reordered/added.
   const byPlatform = Object.fromEntries(items.map((it) => [it.platform, it]));
-  const fixedOrder = ["mac", "win"];
 
-  // Hero buttons (macOS shows the version).
-  document.querySelectorAll("[data-dl]").forEach((a, i) => {
-    const it = byPlatform[fixedOrder[i]]; if (!it) return;
+  // Hero buttons (the macOS one also shows the version).
+  document.querySelectorAll("[data-dl]").forEach((a) => {
+    const it = byPlatform[a.dataset.dlPlatform]; if (!it) return;
     a.href = it.url;
     const label = a.querySelector("[data-dl-label]"); if (label) label.textContent = it.label;
-    const ver = a.querySelector("[data-dl-ver]"); if (ver && i === 0) ver.textContent = version;
+    const ver = a.querySelector("[data-dl-ver]"); if (ver && a.dataset.dlPlatform === "mac") ver.textContent = version;
   });
 
-  // Final-CTA buttons (static labels, same fixed [mac, win] order).
-  document.querySelectorAll("[data-dl-cta]").forEach((btn, i) => {
-    const it = byPlatform[fixedOrder[i]];
+  // Final-CTA buttons (static labels).
+  document.querySelectorAll("[data-dl-cta]").forEach((btn) => {
+    const it = byPlatform[btn.dataset.dlPlatform];
     if (it) btn.href = it.url;
   });
 }

--- a/site/main.js
+++ b/site/main.js
@@ -188,50 +188,8 @@ function initHowScrolly() {
   setScene(0);
 }
 
-function initFAQ() {
-  const faqs = [...document.querySelectorAll("details.faq")];
-  if (faqs.length === 0) return;
-
-  // Progressive enhancement gate: the .js class scopes the collapse CSS (max-height
-  // + visibility). WITHOUT JS, that CSS never applies, so the native <details>
-  // click-toggle reveals answers normally (no-JS fallback, nothing hidden).
-  document.documentElement.classList.add("js");
-
-  // Keep native [open] set permanently so the content is always laid out (native
-  // <details> stops laying out closed content, which would break the max-height
-  // transition). The visible/collapsed state is driven by the .is-open class + a
-  // CSS max-height transition; collapsed bodies are visibility:hidden so screen
-  // readers don't read "closed" answers. preventDefault takes over the native
-  // instant toggle; exclusivity closes the others.
-  faqs.forEach((d) => {
-    const summary = d.querySelector("summary");
-    if (!summary) return; // malformed markup — leave this one to native behavior
-    d.open = true;
-    summary.setAttribute("aria-expanded", "false"); // real state lives here, not [open]
-  });
-
-  // Sync the a11y disclosure state to the .is-open class (not the always-true
-  // [open]) so assistive tech announces the correct expanded/collapsed item.
-  function syncAria() {
-    faqs.forEach((o) => {
-      const s = o.querySelector("summary");
-      if (s) s.setAttribute("aria-expanded", o.classList.contains("is-open") ? "true" : "false");
-    });
-  }
-
-  faqs.forEach((d) => {
-    const summary = d.querySelector("summary");
-    if (!summary) return;
-    summary.addEventListener("click", (e) => {
-      e.preventDefault();
-      const willOpen = !d.classList.contains("is-open");
-      faqs.forEach((o) => o.classList.remove("is-open")); // exclusivity
-      if (willOpen) d.classList.add("is-open");
-      faqs.forEach((o) => { o.open = true; }); // keep content laid out regardless
-      syncAria();
-    });
-  });
-}
+// FAQ needs no JS: native <details name="faq"> gives exclusivity + correct a11y,
+// and the smooth open/close is pure CSS (::details-content + interpolate-size).
 
 function initNavScroll() {
   const nav = document.querySelector("nav");
@@ -261,5 +219,4 @@ wireStars();
 wirePosters();
 initHowScrolly();
 initFeatureReveal();
-initFAQ();
 initNavScroll();

--- a/site/main.js
+++ b/site/main.js
@@ -188,12 +188,17 @@ function initFAQ() {
   const faqs = [...document.querySelectorAll("details.faq")];
   if (faqs.length === 0) return;
 
+  // Progressive enhancement gate: the .js class scopes the collapse CSS (max-height
+  // + visibility). WITHOUT JS, that CSS never applies, so the native <details>
+  // click-toggle reveals answers normally (no-JS fallback, nothing hidden).
+  document.documentElement.classList.add("js");
+
   // Keep native [open] set permanently so the content is always laid out (native
-  // <details> stops laying out closed content, which breaks any height/grid-rows
-  // transition). Visibility is driven by the .is-open class + a CSS grid-rows
-  // transition (0fr↔1fr auto-animates both ways). preventDefault takes over the
-  // native instant toggle; exclusivity closes the others.
-  // No-JS degradation: [open] is never set, so native click-to-toggle still works.
+  // <details> stops laying out closed content, which would break the max-height
+  // transition). The visible/collapsed state is driven by the .is-open class + a
+  // CSS max-height transition; collapsed bodies are visibility:hidden so screen
+  // readers don't read "closed" answers. preventDefault takes over the native
+  // instant toggle; exclusivity closes the others.
   faqs.forEach((d) => { d.open = true; });
 
   faqs.forEach((d) => {
@@ -202,9 +207,7 @@ function initFAQ() {
       const willOpen = !d.classList.contains("is-open");
       faqs.forEach((o) => o.classList.remove("is-open")); // exclusivity
       if (willOpen) d.classList.add("is-open");
-      // Belt-and-suspenders: keep [open] set so content stays laid out even if a
-      // browser let the native toggle through — visibility is the .is-open class's job.
-      faqs.forEach((o) => { o.open = true; });
+      faqs.forEach((o) => { o.open = true; }); // keep content laid out regardless
     });
   });
 }

--- a/site/style.css
+++ b/site/style.css
@@ -971,11 +971,13 @@ section {
 .faq::details-content {
   height: 0;
   overflow: hidden;
+  content-visibility: hidden;
   transition: height .3s ease, content-visibility .3s allow-discrete;
 }
 
 .faq[open]::details-content {
   height: auto;
+  content-visibility: visible;
 }
 
 .faq .faq-body > p {

--- a/site/style.css
+++ b/site/style.css
@@ -955,7 +955,11 @@ section {
   color: var(--text-muted);
 }
 
-.faq.is-open .chev {
+/* JS mode: chevron follows .is-open. No-JS mode: [open] is not forced (initFAQ
+   never ran), so the native toggle's [open] drives it — scoped to html:not(.js)
+   so JS mode (where [open] is permanently true) doesn't rotate every chevron. */
+.faq.is-open .chev,
+html:not(.js) .faq[open] .chev {
   transform: rotate(180deg);
 }
 

--- a/site/style.css
+++ b/site/style.css
@@ -961,12 +961,13 @@ section {
   transform: rotate(180deg);
 }
 
-/* Smooth accordion with zero JS: the ::details-content pseudo animates height 0↔auto
-   (interpolate-size on :root unlocks the keyword), driven purely by native [open] —
-   so exclusivity (name="faq"), a11y (aria-expanded), and the no-JS toggle are all
-   native and correct. Engines without ::details-content / interpolate-size ignore
-   these rules and fall back to the native instant toggle (still functional + a11y-
-   correct). allow-discrete keeps content-visibility from cutting the collapse short. */
+/* Smooth accordion driven purely by native [open]: the ::details-content pseudo
+   animates height 0↔auto (interpolate-size on :root unlocks the keyword). a11y
+   (aria-expanded) and the click toggle are native; exclusivity is native
+   details[name] with a tiny JS toggle-listener fallback (see initFAQ) for older
+   engines. Engines without ::details-content / interpolate-size ignore these rules
+   and fall back to the native instant toggle (still functional + a11y-correct).
+   allow-discrete keeps content-visibility from cutting the collapse short. */
 .faq::details-content {
   height: 0;
   overflow: hidden;

--- a/site/style.css
+++ b/site/style.css
@@ -965,15 +965,22 @@ section {
    the collapse is driven by the .is-open class, not [open]. overflow:hidden clips
    the answer as max-height animates. The open max-height only needs to exceed the
    tallest answer — the ease curve maps to it, and for these short answers reads as
-   a quick, smooth slide. */
-.faq .faq-body {
+   a quick, smooth slide.
+   Scoped under .js so that WITHOUT JavaScript none of this applies and the native
+   <details> click-toggle reveals answers normally. visibility:hidden on a collapsed
+   body keeps "closed" answers out of the accessibility tree (transitioned discretely
+   so it flips to visible on open and back to hidden only after the collapse). */
+.js .faq .faq-body {
   max-height: 0;
   overflow: hidden;
-  transition: max-height .3s ease;
+  visibility: hidden;
+  transition: max-height .3s ease, visibility 0s linear .3s;
 }
 
-.faq.is-open .faq-body {
-  max-height: 320px;
+.js .faq.is-open .faq-body {
+  max-height: 500px;
+  visibility: visible;
+  transition: max-height .3s ease, visibility 0s;
 }
 
 .faq .faq-body > p {

--- a/site/style.css
+++ b/site/style.css
@@ -955,23 +955,30 @@ section {
   color: var(--text-muted);
 }
 
-.faq[open] .chev {
+.faq.is-open .chev {
   transform: rotate(180deg);
 }
 
+/* Smooth accordion via max-height (bulletproof, every browser). initFAQ keeps
+   native [open] set permanently so the content is always laid out (native
+   <details> stops laying out closed content, which would break the transition);
+   the collapse is driven by the .is-open class, not [open]. overflow:hidden clips
+   the answer as max-height animates. The open max-height only needs to exceed the
+   tallest answer — the ease curve maps to it, and for these short answers reads as
+   a quick, smooth slide. */
 .faq .faq-body {
-  display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows .22s ease;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height .3s ease;
 }
 
-.faq[open] .faq-body {
-  grid-template-rows: 1fr;
+.faq.is-open .faq-body {
+  max-height: 320px;
 }
 
 .faq .faq-body > p {
-  overflow: hidden;
-  margin: 0 0 16px;
+  margin: 0;
+  padding: 2px 0 18px;
   color: var(--text-muted);
   font-size: 14px;
   line-height: 1.7;
@@ -1022,16 +1029,19 @@ section {
   border-top: 1px solid var(--border-subtle);
 }
 
+/* Wordmark aspect ratio is ~7.7:1 (viewBox 273.4×35.5). At 60px it rendered ~8px
+   tall and read as illegible garble; 140px → ~18px, a clean, legible TMDB mark. */
 .tmdb-logo {
-  width: 60px;
+  width: 140px;
   height: auto;
   display: block;
-  margin-bottom: 6px;
+  margin-bottom: 10px;
 }
 
 .tmdb-attr p {
   color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1.5;
+  font-size: 12px;
+  line-height: 1.6;
   margin: 0;
+  max-width: 320px;
 }

--- a/site/style.css
+++ b/site/style.css
@@ -8,6 +8,8 @@
   --border-subtle:#242424;
   --dot-red:#f3727f; --dot-orange:#ffa42b;
   --hairline-gradient:linear-gradient(90deg, transparent, #242424 25%, #242424 75%, transparent);
+  /* Unlocks the height:0↔auto animation for the FAQ ::details-content (Chromium 129+). */
+  interpolate-size: allow-keywords;
 }
 * { box-sizing:border-box; } body { margin:0; background:var(--bg-base); color:var(--text); font-family:var(--font); line-height:1.5; }
 .skip-link{position:absolute;top:-40px;left:0;background:var(--accent);color:#000;padding:8px 16px;border-radius:0 0 4px 0;font-weight:700;text-decoration:none;z-index:200}.skip-link:focus{top:0}
@@ -955,36 +957,24 @@ section {
   color: var(--text-muted);
 }
 
-/* JS mode: chevron follows .is-open. No-JS mode: [open] is not forced (initFAQ
-   never ran), so the native toggle's [open] drives it — scoped to html:not(.js)
-   so JS mode (where [open] is permanently true) doesn't rotate every chevron. */
-.faq.is-open .chev,
-html:not(.js) .faq[open] .chev {
+.faq[open] .chev {
   transform: rotate(180deg);
 }
 
-/* Smooth accordion via max-height (bulletproof, every browser). initFAQ keeps
-   native [open] set permanently so the content is always laid out (native
-   <details> stops laying out closed content, which would break the transition);
-   the collapse is driven by the .is-open class, not [open]. overflow:hidden clips
-   the answer as max-height animates. The open max-height only needs to exceed the
-   tallest answer — the ease curve maps to it, and for these short answers reads as
-   a quick, smooth slide.
-   Scoped under .js so that WITHOUT JavaScript none of this applies and the native
-   <details> click-toggle reveals answers normally. visibility:hidden on a collapsed
-   body keeps "closed" answers out of the accessibility tree (transitioned discretely
-   so it flips to visible on open and back to hidden only after the collapse). */
-.js .faq .faq-body {
-  max-height: 0;
+/* Smooth accordion with zero JS: the ::details-content pseudo animates height 0↔auto
+   (interpolate-size on :root unlocks the keyword), driven purely by native [open] —
+   so exclusivity (name="faq"), a11y (aria-expanded), and the no-JS toggle are all
+   native and correct. Engines without ::details-content / interpolate-size ignore
+   these rules and fall back to the native instant toggle (still functional + a11y-
+   correct). allow-discrete keeps content-visibility from cutting the collapse short. */
+.faq::details-content {
+  height: 0;
   overflow: hidden;
-  visibility: hidden;
-  transition: max-height .3s ease, visibility 0s linear .3s;
+  transition: height .3s ease, content-visibility .3s allow-discrete;
 }
 
-.js .faq.is-open .faq-body {
-  max-height: 500px;
-  visibility: visible;
-  transition: max-height .3s ease, visibility 0s;
+.faq[open]::details-content {
+  height: auto;
 }
 
 .faq .faq-body > p {
@@ -996,7 +986,7 @@ html:not(.js) .faq[open] .chev {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .faq .faq-body,
+  .faq::details-content,
   .faq .chev {
     transition: none;
   }


### PR DESCRIPTION
官网打磨四件（用户已批方向 B「系统性技术冷峻」）。

## ① 整站文案改基调（Linear/Zed 范式）
调研依据 [Evil Martians「100 devtool landing pages」](https://evilmartians.com/chronicles/we-studied-100-devtool-landing-pages-here-is-what-actually-works-in-2025)：无营销腔、CTA 具体、断言压过俏皮。保留既定原则（诚实=点一下非一句话、agent 锚点、开源克制）。hero `追剧，只剩点一下` → `自建网盘的媒体获取 agent`；各 section 标题冷却；四功能锚点精简（追更 / 择优检索 / 转存进你的网盘 / 多账户隔离）；ticker/scrollytelling/trust 行转 agent 日志/断言体。head 的 title/description/OG 也同步新定位。

## ② CTA 补 Windows 按钮 + 平台映射修复
`#cta` 补 mac + win 双下载按钮。并修一个既有隐患：orderDownloads 对 Windows 反转 items，原 hero 按 index 填会让 apple 图标配 Windows 链接——hero + CTA 统一改按平台名映射（mac→dmg / win→exe）。

## ③ TMDB 归属修清晰
footer 的 TMDB wordmark（API 条款强制归属）从 60px（约 8px 高、糊成乱码）放大到 140px（约 18px），配 not-endorsed 声明。

## ④ FAQ 顺滑手风琴 —— 纯原生方案
（评审过程中从「max-height + JS [open]-常开」重构为纯原生，见提交历史；因 [open]-常开的 a11y 语义错误。）
- **互斥 + a11y**：native `<details name=\"faq\">`（aria-expanded 自动、no-JS 可用）；`initFAQ` 仅保留一个 toggle 监听做互斥的**渐进增强兜底**（无 details[name] 分组支持的老浏览器）
- **平滑动画**：CSS `::details-content` + `interpolate-size`（:root），height 0↔auto，纯原生 [open] 驱动；`content-visibility` 显式 hidden↔visible（allow-discrete 过渡，折叠态移出无障碍树、且不截断塌缩动画）
- 不支持 ::details-content/interpolate-size 的引擎忽略这些规则、回退原生瞬时 toggle（仍功能 + a11y 正确）
- 零 [open]-hack、零手动 aria juggling

## 验证
- site vitest 19/19；HTML 结构完整（details 5/5、section 8/8）；无过时注释/表述
- 文案：hero 真渲染截图 + grep 全命中、0 旧营销串
- CTA/hero 下载：clean eval 确认按平台映射（mac→dmg / win→exe）
- TMDB：logo 18px
- FAQ：`::details-content` + `interpolate-size` 本浏览器均支持；原生 name 互斥生效（开一个自动关其他）+ toggle 兜底不成环、console 无错；禁 transition 时 ::details-content 正确 0↔auto 塌缩
- ⚠️ **动画曲线未能在本地 preview 视觉确认**：该 preview 浏览器视口高度为 0（vh 全塌、transition 冻结在起始帧，与本 PR 无关的工具环境问题）。已用「禁 transition 时 height 正确解析」坐实 cascade 无误——**请在 Vercel 预览（真浏览器）点一下 FAQ 确认顺滑 + 互斥**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)