### PR TITLE
fix(notifications): 例行巡检无事发生折叠降噪（already_current 接线）

### DIFF
--- a/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
@@ -279,7 +279,13 @@ function buildNotification(input: {
             ? "no_coverage"
             : report.status === "complete"
               ? "tracking_completed"
-              : "episodes_restored",
+              : // 例行巡检查过、追更中且本季无新增 = 无事发生：already_current 让
+                // 通知页折叠成一张例行巡检卡、digest 归入「其余已是最新」，不再每日
+                // 刷屏。airing 构造上保证 realMissing 为空（notification-report.ts
+                // buildSeasonReport），有新增的 airing 必须保持 episodes_restored。
+                report.status === "airing" && newlyObtained.length === 0
+                ? "already_current"
+                : "episodes_restored",
       title: `${report.titleName} ${report.seasonLabel}`,
       body: formatReportPushText(report),
       createdAt: input.now(),

--- a/packages/workflow/tests/type3-worker.test.ts
+++ b/packages/workflow/tests/type3-worker.test.ts
@@ -235,6 +235,34 @@ describe("runScheduledType3Monitoring (V2 engine)", () => {
     ]);
   });
 
+  it("no-op patrol of a still-airing season persists an already_current notification (routine, folds in UI)", async () => {
+    const repository = new InMemoryWorkflowRepository();
+    const { title, season } = trackedFixture();
+    // Still airing: 2 of 3 episodes aired, both already obtained — nothing to do.
+    season.totalEpisodes = 3;
+    season.latestAiredEpisode = 2;
+    await seedTrackedSeason({ repository, title, season, obtainedCodes: ["S01E01", "S01E02"] });
+    const storage = new FakeStorageExecutor();
+    await seedV2Season(storage, title, season, ["S01E01", "S01E02"]);
+
+    await runScheduledType3Monitoring({
+      repository,
+      resourceProvider: emptyProvider(),
+      storage,
+      model: throwingModel(), // no gap → the agent must never be invoked
+      storageParentDirectoryId: "library_root",
+      now: fixedNow,
+      createWorkflowRunId: () => "run_airing_noop",
+    });
+
+    const notifications = await repository.listNotifications();
+    const patrol = notifications.filter((notification) => notification.workflowRunId === "run_airing_noop");
+    expect(patrol).toHaveLength(1);
+    expect(patrol[0]!.kind).toBe("already_current");
+    expect(patrol[0]!.trigger).toBe("scheduled");
+    expect(patrol[0]!.report?.status).toBe("airing");
+  });
+
   it("skips a season that already has an active workflow run", async () => {
     const repository = new InMemoryWorkflowRepository();
     const { title, season } = trackedFixture();

--- a/packages/workflow/tests/v2-bridge.test.ts
+++ b/packages/workflow/tests/v2-bridge.test.ts
@@ -126,6 +126,63 @@ describe("bridgeV2WorkflowToResult — V2 facts → per-season WorkflowResult sh
     expect(result.notification.trigger).toBe("scheduled");
   });
 
+  it("type3 patrol no-op: airing 且本次无新增 → kind already_current（例行巡检折叠降噪）", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type3",
+      // 追更中：已播 4/12，S01E01-E04 全在库，无缺无新增（金特务场景）
+      seasons: [{ seasonNumber: 1, totalEpisodes: 12, latestAiredEpisode: 4, qualityPreference: "4K", status: "active" }],
+      v2: v2Result({
+        missingBefore: [],
+        obtained: ["S01E01", "S01E02", "S01E03", "S01E04"],
+        stillMissing: [],
+      }),
+      workflowRunId: "run-noop",
+      now: () => "2026-07-09T00:00:00.000Z",
+    });
+
+    expect(result.notification.kind).toBe("already_current");
+    expect(result.notification.trigger).toBe("scheduled");
+    expect(result.notification.report?.status).toBe("airing");
+    expect(result.notification.report?.newlyObtained).toEqual([]);
+  });
+
+  it("type3 patrol: airing 但本次真收到新集 → 仍是 episodes_restored（不许把有效更新降噪掉）", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type3",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 12, latestAiredEpisode: 5, qualityPreference: "4K", status: "active" }],
+      v2: v2Result({
+        missingBefore: ["S01E05"],
+        obtained: ["S01E01", "S01E02", "S01E03", "S01E04", "S01E05"],
+        stillMissing: [],
+      }),
+      workflowRunId: "run-gain",
+      now: () => "2026-07-09T00:00:00.000Z",
+    });
+
+    expect(result.notification.kind).toBe("episodes_restored");
+    expect(result.notification.report?.newlyObtained).toEqual(["E05"]);
+  });
+
+  it("type3 patrol: 有已播缺集（partial）→ 仍是 episodes_restored（真缺集不降噪）", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type3",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 12, latestAiredEpisode: 6, qualityPreference: "4K", status: "active" }],
+      v2: v2Result({
+        missingBefore: ["S01E05", "S01E06"],
+        obtained: ["S01E01", "S01E02", "S01E03", "S01E04", "S01E05"],
+        stillMissing: ["S01E06"],
+      }),
+      workflowRunId: "run-partial",
+      now: () => "2026-07-09T00:00:00.000Z",
+    });
+
+    expect(result.notification.report?.status).toBe("partial");
+    expect(result.notification.kind).toBe("episodes_restored");
+  });
+
   // The finale graduation promised by season-sync.ts ("only the finale — all
   // obtained — graduates it to completed"). Callers pass the persisted status
   // through, so without graduating HERE an active season stays active forever:


### PR DESCRIPTION
## 问题
每日巡检对「追更中且已获取至最新」的剧（无缺集、无新增、无事发生）每天发一条 episodes_restored 通知（「已获取至最新第 N 集 · 后续更新自动追踪」），同一部剧连日刷屏（通知页 今天/昨天/前天 三条一模一样的卡）。

## 根因
`already_current`（例行巡检、无事发生）这个 kind 的**读侧全部就位**——通知页折叠成一张例行巡检卡（notifications/page.tsx:382,407-409）、推送 digest 归入「其余已是最新」（notification-report.ts:353-361）、活动页排除（activity-view.ts:138）——但全仓没有任何生产者发出它。巡检桥接层把 type3 的 airing 一律映射成 episodes_restored（workflow-v2-bridge.ts）。

## 修复
workflow-v2-bridge.ts type3 kind 映射加一个分支：`report.status === "airing"` 且本季 `newlyObtained` 为空 → `already_current`。airing 在构造上保证 realMissing 为空（notification-report.ts buildSeasonReport）；真收到新集 / 真缺集(partial) / 无资源 / 转存失败的通知行为全部不变，护栏用例锁死。

## 测试
- v2-bridge 单测 ×3：no-op airing → already_current；airing+新增 → episodes_restored；partial → episodes_restored。
- type3-worker 全链 e2e：追更中 no-op 巡检（agent 不被唤起）→ 持久化通知 kind=already_current、trigger=scheduled。
- 全量 vitest 绿 + 三处 tsc + apps/web tsc + build:workflow。

🤖 Generated with [Claude Code](https://claude.com/claude-code)