### PR TITLE
feat(settings): 设置页五 tab 重构（下划线样式，?tab= 深链）

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3333,3 +3333,42 @@ select.setting-control {
 .trending-card:hover .trending-poster {
   border-color: var(--border-strong, #3a3a40);
 }
+
+/* Settings tabs — Spotify 艺人页式下划线 tab（spec §2，用户拍板 B 方案） */
+.settings-tabs {
+  display: flex;
+  gap: 22px;
+  margin-top: 18px;
+  border-bottom: 1px solid #2a2a2a;
+}
+
+.settings-tab {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0 0 9px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  white-space: nowrap;
+}
+
+.settings-tab:hover {
+  color: var(--text);
+}
+
+.settings-tab.is-active {
+  color: var(--text);
+  font-weight: 600;
+  border-bottom-color: var(--accent);
+}
+
+@media (max-width: 860px) {
+  .settings-tabs {
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -15,6 +15,7 @@ import { AssrtTokenForm } from "../../components/assrt-token-form";
 import { ProwlarrConfigForm } from "../../components/prowlarr-config-form";
 import { PanSouConfigForm } from "../../components/pansou-config-form";
 import { DailySweepForm } from "../../components/daily-sweep-form";
+import { SettingsTabs } from "../../components/settings-tabs";
 import { PasswordChangeForm } from "../../components/password-change-form";
 import { AccountAdminPanel } from "../../components/account-admin-panel";
 import { GitHubNameplate } from "../../components/github-nameplate";
@@ -76,41 +77,61 @@ export default function SettingsPage({
             </p>
           </div>
         ) : (
-          <>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <Pan115Section />
-            </Suspense>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <PreferredLanguageSection />
-            </Suspense>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <QualityPreferenceSection />
-            </Suspense>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <LlmConfigSection />
-            </Suspense>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <TmdbApiKeySection />
-            </Suspense>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <ResourceProviderSection />
-            </Suspense>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <SubtitleSourceSection />
-            </Suspense>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <DailySweepSection />
-            </Suspense>
-            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
-              <PushNotificationSection />
-            </Suspense>
-            <Suspense fallback={null}>
-              <PasswordChangeSection />
-            </Suspense>
-            <Suspense fallback={null}>
-              <AccountManagementSection />
-            </Suspense>
-          </>
+          <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+            <SettingsTabs
+              drives={
+                <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                  <Pan115Section />
+                </Suspense>
+              }
+              services={
+                <>
+                  <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                    <LlmConfigSection />
+                  </Suspense>
+                  <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                    <TmdbApiKeySection />
+                  </Suspense>
+                  <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                    <ResourceProviderSection />
+                  </Suspense>
+                  <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                    <SubtitleSourceSection />
+                  </Suspense>
+                </>
+              }
+              preferences={
+                <>
+                  <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                    <PreferredLanguageSection />
+                  </Suspense>
+                  <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                    <QualityPreferenceSection />
+                  </Suspense>
+                </>
+              }
+              patrol={
+                <>
+                  <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                    <DailySweepSection />
+                  </Suspense>
+                  <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+                    <PushNotificationSection />
+                  </Suspense>
+                </>
+              }
+              account={
+                <>
+                  <Suspense fallback={null}>
+                    <PasswordChangeSection />
+                  </Suspense>
+                  <Suspense fallback={null}>
+                    <AccountManagementSection />
+                  </Suspense>
+                </>
+              }
+            />
+          </Suspense>
         )}
         <GitHubNameplate />
       </main>

--- a/apps/web/components/account-identity.tsx
+++ b/apps/web/components/account-identity.tsx
@@ -30,12 +30,12 @@ export function AccountIdentity({ username, isOwner }: { username: string; isOwn
         {isOwner ? <span className="account-identity-owner">站主</span> : null}
       </summary>
       <div className="account-identity-menu">
-        <Link className="account-identity-item" href="/settings#password">
+        <Link className="account-identity-item" href="/settings?tab=account#password">
           <KeyRound size={14} aria-hidden />
           修改密码
         </Link>
         {isOwner ? (
-          <Link className="account-identity-item" href="/settings#accounts">
+          <Link className="account-identity-item" href="/settings?tab=account#accounts">
             <Users size={14} aria-hidden />
             账号管理
           </Link>

--- a/apps/web/components/account-identity.tsx
+++ b/apps/web/components/account-identity.tsx
@@ -2,6 +2,7 @@
 
 import { useTransition } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { LogOut, KeyRound, Users, LoaderCircle } from "lucide-react";
 
 /**
@@ -12,6 +13,11 @@ import { LogOut, KeyRound, Users, LoaderCircle } from "lucide-react";
 export function AccountIdentity({ username, isOwner }: { username: string; isOwner: boolean }) {
   const [isPending, startTransition] = useTransition();
   const initial = username.trim().charAt(0).toUpperCase() || "?";
+  // Preserve the active workspace (?w) like the sidebar's globalNavHref does —
+  // otherwise opening 账号 settings from a non-primary drive resets the context.
+  const w = useSearchParams().get("w");
+  const accountHref = (hash: string) =>
+    `/settings?tab=account${w ? `&w=${encodeURIComponent(w)}` : ""}${hash}`;
 
   const logout = () => {
     startTransition(async () => {
@@ -30,12 +36,12 @@ export function AccountIdentity({ username, isOwner }: { username: string; isOwn
         {isOwner ? <span className="account-identity-owner">站主</span> : null}
       </summary>
       <div className="account-identity-menu">
-        <Link className="account-identity-item" href="/settings?tab=account#password">
+        <Link className="account-identity-item" href={accountHref("#password")}>
           <KeyRound size={14} aria-hidden />
           修改密码
         </Link>
         {isOwner ? (
-          <Link className="account-identity-item" href="/settings?tab=account#accounts">
+          <Link className="account-identity-item" href={accountHref("#accounts")}>
             <Users size={14} aria-hidden />
             账号管理
           </Link>

--- a/apps/web/components/settings-tabs.tsx
+++ b/apps/web/components/settings-tabs.tsx
@@ -77,7 +77,11 @@ export function SettingsTabs(props: {
   const onTablistKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
     event.preventDefault();
-    const index = visibleTabs.findIndex((tab) => tab.id === active);
+    // Roving tabindex：方向键以「焦点所在 tab」为基准，不是 active——back/forward
+    // 或账号 tab 迟到显现时两者会分离，按 active 起跳会从错误位置移动。
+    const focusedId = (event.target as HTMLElement).id?.replace("settings-tab-", "");
+    const focusedIndex = visibleTabs.findIndex((tab) => tab.id === focusedId);
+    const index = focusedIndex >= 0 ? focusedIndex : visibleTabs.findIndex((tab) => tab.id === active);
     const step = event.key === "ArrowRight" ? 1 : -1;
     const next = visibleTabs[(index + step + visibleTabs.length) % visibleTabs.length]!;
     select(next.id);

--- a/apps/web/components/settings-tabs.tsx
+++ b/apps/web/components/settings-tabs.tsx
@@ -31,14 +31,24 @@ export function SettingsTabs(props: {
   const [hash, setHash] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    setHash(window.location.hash || undefined);
+    // Hash 只能挂载后读 + 订阅变化：SSR 渲染不知道 hash，若用 lazy initializer
+    // 从 window.location.hash 初始化会造成 hydration mismatch——一帧回落是
+    // hydration-safe 的代价。
+    const readHash = () => setHash(window.location.hash || undefined);
+    readHash();
+    window.addEventListener("hashchange", readHash);
     const node = accountRef.current;
-    if (!node) return;
-    const check = () => setAccountVisible(node.childElementCount > 0);
-    check();
-    const observer = new MutationObserver(check);
-    observer.observe(node, { childList: true, subtree: true });
-    return () => observer.disconnect();
+    let observer: MutationObserver | undefined;
+    if (node) {
+      const check = () => setAccountVisible(node.childElementCount > 0);
+      check();
+      observer = new MutationObserver(check);
+      observer.observe(node, { childList: true, subtree: true });
+    }
+    return () => {
+      window.removeEventListener("hashchange", readHash);
+      observer?.disconnect();
+    };
   }, []);
 
   const active = resolveSettingsTab(searchParams.get("tab"), accountVisible, hash);

--- a/apps/web/components/settings-tabs.tsx
+++ b/apps/web/components/settings-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   SETTINGS_TABS,
@@ -56,26 +56,44 @@ export function SettingsTabs(props: {
     { id: "account", content: props.account },
   ];
 
+  // WAI-ARIA tabs pattern: same-page state, not page navigation — so
+  // tablist/tab/tabpanel + aria-selected (not aria-current), arrows move tabs.
+  const visibleTabs = SETTINGS_TABS.filter((tab) => tab.id !== "account" || accountVisible);
+  const onTablistKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
+    event.preventDefault();
+    const index = visibleTabs.findIndex((tab) => tab.id === active);
+    const step = event.key === "ArrowRight" ? 1 : -1;
+    const next = visibleTabs[(index + step + visibleTabs.length) % visibleTabs.length]!;
+    select(next.id);
+    document.getElementById(`settings-tab-${next.id}`)?.focus();
+  };
+
   return (
     <>
-      <nav className="settings-tabs" aria-label="设置分区">
-        {SETTINGS_TABS.map((tab) =>
-          tab.id === "account" && !accountVisible ? null : (
-            <button
-              key={tab.id}
-              type="button"
-              className={`settings-tab${active === tab.id ? " is-active" : ""}`}
-              aria-current={active === tab.id ? "page" : undefined}
-              onClick={() => select(tab.id)}
-            >
-              {tab.label}
-            </button>
-          ),
-        )}
-      </nav>
+      <div className="settings-tabs" role="tablist" aria-label="设置分区" onKeyDown={onTablistKeyDown}>
+        {visibleTabs.map((tab) => (
+          <button
+            key={tab.id}
+            id={`settings-tab-${tab.id}`}
+            type="button"
+            role="tab"
+            className={`settings-tab${active === tab.id ? " is-active" : ""}`}
+            aria-selected={active === tab.id}
+            aria-controls={`settings-panel-${tab.id}`}
+            tabIndex={active === tab.id ? 0 : -1}
+            onClick={() => select(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
       {panels.map((panel) => (
         <div
           key={panel.id}
+          id={`settings-panel-${panel.id}`}
+          role="tabpanel"
+          aria-labelledby={`settings-tab-${panel.id}`}
           ref={panel.id === "account" ? accountRef : undefined}
           hidden={active !== panel.id}
         >

--- a/apps/web/components/settings-tabs.tsx
+++ b/apps/web/components/settings-tabs.tsx
@@ -43,7 +43,9 @@ export function SettingsTabs(props: {
       const check = () => setAccountVisible(node.childElementCount > 0);
       check();
       observer = new MutationObserver(check);
-      observer.observe(node, { childList: true, subtree: true });
+      // 只看直接子元素：account 两个 section 流出即成为 slot 的直接 child，
+      // subtree 只会放大无关触发。
+      observer.observe(node, { childList: true });
     }
     return () => {
       window.removeEventListener("hashchange", readHash);
@@ -54,6 +56,9 @@ export function SettingsTabs(props: {
   const active = resolveSettingsTab(searchParams.get("tab"), accountVisible, hash);
 
   const select = (tab: SettingsTabId) => {
+    // 显式选 tab 即废弃 legacy hash 提示：router.replace(replaceState) 清 URL
+    // 片段但不触发 hashchange，不清状态的话旧 #password 会把默认 tab 拽回 account。
+    setHash(undefined);
     const query = settingsTabQuery(new URLSearchParams(searchParams), tab);
     router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
   };

--- a/apps/web/components/settings-tabs.tsx
+++ b/apps/web/components/settings-tabs.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import {
+  SETTINGS_TABS,
+  resolveSettingsTab,
+  settingsTabQuery,
+  type SettingsTabId,
+} from "../lib/settings-tabs-model";
+
+/**
+ * 设置页 tab 壳：五个 slot 常挂载（Suspense 流式照旧），按当前 tab 显隐。
+ * - tab 状态 = ?tab=（router.replace 软导航，保留 ?w）。
+ * - 「账号」tab 可见性不读服务端 flag（cacheComponents 会把 build 时的 env 值
+ *   烤进静态壳，docker 镜像 build/run 环境不同——PasswordChangeSection 同款教训）：
+ *   观察 account slot 是否真的流出了内容（多用户关时两个 section 都渲染 null）。
+ */
+export function SettingsTabs(props: {
+  drives: ReactNode;
+  services: ReactNode;
+  preferences: ReactNode;
+  patrol: ReactNode;
+  account: ReactNode;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const accountRef = useRef<HTMLDivElement | null>(null);
+  const [accountVisible, setAccountVisible] = useState(false);
+  const [hash, setHash] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    setHash(window.location.hash || undefined);
+    const node = accountRef.current;
+    if (!node) return;
+    const check = () => setAccountVisible(node.childElementCount > 0);
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(node, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, []);
+
+  const active = resolveSettingsTab(searchParams.get("tab"), accountVisible, hash);
+
+  const select = (tab: SettingsTabId) => {
+    const query = settingsTabQuery(new URLSearchParams(searchParams), tab);
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  };
+
+  const panels: Array<{ id: SettingsTabId; content: ReactNode }> = [
+    { id: "drives", content: props.drives },
+    { id: "services", content: props.services },
+    { id: "preferences", content: props.preferences },
+    { id: "patrol", content: props.patrol },
+    { id: "account", content: props.account },
+  ];
+
+  return (
+    <>
+      <nav className="settings-tabs" aria-label="设置分区">
+        {SETTINGS_TABS.map((tab) =>
+          tab.id === "account" && !accountVisible ? null : (
+            <button
+              key={tab.id}
+              type="button"
+              className={`settings-tab${active === tab.id ? " is-active" : ""}`}
+              aria-current={active === tab.id ? "page" : undefined}
+              onClick={() => select(tab.id)}
+            >
+              {tab.label}
+            </button>
+          ),
+        )}
+      </nav>
+      {panels.map((panel) => (
+        <div
+          key={panel.id}
+          ref={panel.id === "account" ? accountRef : undefined}
+          hidden={active !== panel.id}
+        >
+          {panel.content}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/apps/web/lib/settings-tabs-model.test.ts
+++ b/apps/web/lib/settings-tabs-model.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SETTINGS_TAB,
+  SETTINGS_TABS,
+  resolveSettingsTab,
+  settingsTabQuery,
+} from "./settings-tabs-model";
+
+describe("resolveSettingsTab", () => {
+  it("已知 tab 原样返回", () => {
+    expect(resolveSettingsTab("patrol", false)).toBe("patrol");
+    expect(resolveSettingsTab("services", false)).toBe("services");
+  });
+
+  it("未知/缺失 → 默认 drives", () => {
+    expect(resolveSettingsTab(null, false)).toBe(DEFAULT_SETTINGS_TAB);
+    expect(resolveSettingsTab(undefined, false)).toBe("drives");
+    expect(resolveSettingsTab("nonsense", false)).toBe("drives");
+  });
+
+  it("account 仅在账号 tab 可见时可达，否则回落默认", () => {
+    expect(resolveSettingsTab("account", true)).toBe("account");
+    expect(resolveSettingsTab("account", false)).toBe("drives");
+  });
+
+  it("legacy 锚点 hash 映射到 account（tab 参数缺失时）", () => {
+    expect(resolveSettingsTab(null, true, "#password")).toBe("account");
+    expect(resolveSettingsTab(null, true, "#accounts")).toBe("account");
+    expect(resolveSettingsTab(null, false, "#password")).toBe("drives");
+    // 显式 tab 参数优先于 hash
+    expect(resolveSettingsTab("patrol", true, "#password")).toBe("patrol");
+  });
+});
+
+describe("settingsTabQuery", () => {
+  it("写 tab 且保留既有参数（w 工作区）", () => {
+    expect(settingsTabQuery(new URLSearchParams("w=abc"), "patrol")).toBe("tab=patrol&w=abc");
+  });
+  it("默认 tab 时删掉 tab 参数保持 URL 干净", () => {
+    expect(settingsTabQuery(new URLSearchParams("tab=patrol&w=abc"), "drives")).toBe("w=abc");
+  });
+});
+
+describe("SETTINGS_TABS", () => {
+  it("五个 tab、顺序与标签固定", () => {
+    expect(SETTINGS_TABS.map((tab) => tab.id)).toEqual(["drives", "services", "preferences", "patrol", "account"]);
+    expect(SETTINGS_TABS.map((tab) => tab.label)).toEqual(["网盘", "资源与服务", "获取偏好", "巡检与通知", "账号"]);
+  });
+});

--- a/apps/web/lib/settings-tabs-model.ts
+++ b/apps/web/lib/settings-tabs-model.ts
@@ -1,0 +1,42 @@
+/** 设置页 tab 的纯模型：id/标签/解析/URL 写回。UI 无关，node 环境可测。 */
+
+export const SETTINGS_TABS = [
+  { id: "drives", label: "网盘" },
+  { id: "services", label: "资源与服务" },
+  { id: "preferences", label: "获取偏好" },
+  { id: "patrol", label: "巡检与通知" },
+  { id: "account", label: "账号" },
+] as const;
+
+export type SettingsTabId = (typeof SETTINGS_TABS)[number]["id"];
+
+export const DEFAULT_SETTINGS_TAB: SettingsTabId = "drives";
+
+const TAB_IDS = new Set<string>(SETTINGS_TABS.map((tab) => tab.id));
+
+/** legacy 深链锚点（account-identity 菜单）→ 账号 tab。 */
+const ACCOUNT_HASHES = new Set(["#password", "#accounts"]);
+
+export function resolveSettingsTab(
+  param: string | null | undefined,
+  accountTabVisible: boolean,
+  hash?: string,
+): SettingsTabId {
+  const candidate =
+    param && TAB_IDS.has(param)
+      ? (param as SettingsTabId)
+      : !param && hash && ACCOUNT_HASHES.has(hash)
+        ? "account"
+        : DEFAULT_SETTINGS_TAB;
+  if (candidate === "account" && !accountTabVisible) return DEFAULT_SETTINGS_TAB;
+  return candidate;
+}
+
+/** 写回 URL query：保留其他参数（?w 工作区）；默认 tab 不留 tab 参数。 */
+export function settingsTabQuery(current: URLSearchParams, tab: SettingsTabId): string {
+  const next = new URLSearchParams(current);
+  if (tab === DEFAULT_SETTINGS_TAB) next.delete("tab");
+  else next.set("tab", tab);
+  next.sort();
+  return next.toString();
+}


### PR DESCRIPTION
## 动机
设置页 11 个 section（~15 个表单）一条长滚动，配置密度高到 overwhelming（千 star 后新用户第一屏劝退点）。

## 分组（5 tabs，按域）
| tab | 内容 |
|---|---|
| 网盘 | 115/夸克/光鸭 连接、测试、解绑 |
| 资源与服务 | AI 模型 · TMDB · PanSou/Prowlarr · 字幕来源 |
| 获取偏好 | 偏好语言 · 偏好画质 |
| 巡检与通知 | 每日定时巡检 · 推送通知 |
| 账号 | 修改密码 · 账号管理（仅多用户模式出现） |

## 实现要点
- 页面保持 sync server component + 每 section 独立 Suspense 流式；新客户端壳 SettingsTabs 位于静态壳内（自带 Suspense 边界满足 useSearchParams 预渲染规则），5 个 slot 常挂载按 tab 显隐——不改任何 section 的数据获取。
- tab 状态 `?tab=` + router.replace 软导航，保留 `?w` 工作区参数；默认 tab 不留参数。
- 「账号」tab 可见性用 MutationObserver 探测 slot 是否流出真实内容——不读服务端 env flag，避免 cacheComponents 把 build 时的 MULTI_USER 值烤死进静态壳（PasswordChangeSection 同款教训）。
- legacy 深链 /settings#password、#accounts（account-identity 菜单）改 ?tab=account#…，SettingsTabs 对裸 hash 也做回退映射。
- 下划线 tab 样式（--accent 绿），≤860px 横向滚动；demo 模式仍是整页只读卡无 tabs。

## 验证
settings-tabs-model 单测（解析/回落/hash 映射/URL 写回保留 ?w）+ 全量 vitest + 三处 tsc + apps/web tsc + `npm run build:web`（prod prerender 排雷全绿）+ preview 截图逐 tab 真验：默认网盘 tab、四 tab 切换与 ?tab= 软导航、单用户账号 tab 隐藏、?tab=account 深链回落、375px tab 栏横滚（overflow-x:auto 实测）、demo 实例仍整页只读卡无 tabs。

🤖 Generated with [Claude Code](https://claude.com/claude-code)