### PR TITLE
fix(settings): tab 切换浅路由化——消除每次点击的 RSC 往返（CF Tunnel 卡顿根治）

### DIFF
--- a/apps/web/components/settings-tabs.tsx
+++ b/apps/web/components/settings-tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import {
   SETTINGS_TABS,
   resolveSettingsTab,
@@ -23,7 +23,6 @@ export function SettingsTabs(props: {
   patrol: ReactNode;
   account: ReactNode;
 }) {
-  const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const accountRef = useRef<HTMLDivElement | null>(null);
@@ -56,11 +55,15 @@ export function SettingsTabs(props: {
   const active = resolveSettingsTab(searchParams.get("tab"), accountVisible, hash);
 
   const select = (tab: SettingsTabId) => {
-    // 显式选 tab 即废弃 legacy hash 提示：router.replace(replaceState) 清 URL
-    // 片段但不触发 hashchange，不清状态的话旧 #password 会把默认 tab 拽回 account。
+    // 显式选 tab 即废弃 legacy hash 提示：replaceState 清 URL 片段但不触发
+    // hashchange，不清状态的话旧 #password 会把默认 tab 拽回 account。
     setHash(undefined);
     const query = settingsTabQuery(new URLSearchParams(searchParams), tab);
-    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    // 浅路由（官方 Native History API 姿势）：tab 状态只有客户端消费、面板全部
+    // 常挂载，用 router.replace 会走一次 RSC 服务器往返且高亮要等提交——高延迟
+    // 链路（CF Tunnel）下每次点击都卡。原生 replaceState 与 useSearchParams
+    // 保持同步，零网络、即时切换。
+    window.history.replaceState(null, "", query ? `${pathname}?${query}` : pathname);
   };
 
   const panels: Array<{ id: SettingsTabId; content: ReactNode }> = [


### PR DESCRIPTION
## 问题
设置页 tab 切换在高延迟链路（CF Tunnel 访问 media.dirtyfancy.sbs）上明显卡顿。

## 根因（取证）
`router.replace` 是真导航：点击 tab 抓包实测每次发出 `GET /settings?tab=…&_rsc=…`，且 `useSearchParams` 新值要等导航提交——高亮与面板切换全程等这次服务器往返。本地几十 ms 无感，隧道数百 ms 即卡。而五个面板本就全部常挂载、`?tab=` 只有客户端消费，这趟 RSC 纯属白跑。

## 修复
按 Next 官方 Native History API 姿势（"Use useSearchParams when search parameters are used only on the client"）把 `select()` 换成 `window.history.replaceState`——与 `useSearchParams` 同步、零网络。删除不再使用的 `useRouter`。

## 验证
- 修前：点击 tab → `?tab=services&_rsc=…` 请求 1 次
- 修后：`rscFetches: []`，点击到渲染 **2.3ms**，URL 更新/高亮/深链/回默认 tab 清参数/`?w` 保留全部复测通过
- 全量 vitest + 三处 tsc 绿；settings-tabs-model 单测不变（URL 构造逻辑未动）

🤖 Generated with [Claude Code](https://claude.com/claude-code)