### PR TITLE
fix(search): 元数据全通道不可达时搜索页降级,不再整页崩 (#134)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -37,6 +37,22 @@
       "port": 3002
     },
     {
+      "name": "web-gfw-sim",
+      "runtimeExecutable": "env",
+      "runtimeArgs": [
+        "MEDIA_TRACK_POSTGRES_URL=postgresql://mediatrack:mediatrack@localhost:5432/media_track",
+        "MEDIA_TRACK_DEMO_SEED=0",
+        "MEDIA_TRACK_SEARCH_PROVIDER=tmdb",
+        "TMDB_READ_TOKEN=",
+        "TMDB_PROXY_BASE_URL=https://192.0.2.1",
+        "npm",
+        "run",
+        "dev:web"
+      ],
+      "autoPort": true,
+      "port": 3003
+    },
+    {
       "name": "web-multiuser",
       "runtimeExecutable": "env",
       "runtimeArgs": [

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { TriangleAlert } from "lucide-react";
+
+/** Root error boundary. Before this existed, any server-render crash (e.g. every
+ *  TMDB access unreachable on a GFW-blocked deployment, issue #134) fell through
+ *  to Next's bare "This page couldn't load" screen with nothing actionable on it.
+ *  Production redacts server error messages, so the digest is the only safe
+ *  detail to surface — it lets a reporter quote something concrete in an issue. */
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="quiet-state" role="alert">
+      <TriangleAlert size={28} aria-hidden />
+      <strong>页面渲染失败</strong>
+      <span>
+        多半是部署环境连不上某个上游服务（TMDB／资源搜索）——国内网络未配置代理时常见。
+        检查部署主机（或容器）的网络后重试。
+      </span>
+      <button className="primary-button" type="button" onClick={reset}>
+        重试
+      </button>
+      {error.digest ? <span className="panel-note">digest: {error.digest}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -175,6 +175,26 @@ async function SearchResults({
       {inProgress.length > 0 ? <AcquiringPoller /> : null}
       {searchView.state === "empty" ? (
         <TrendingRow activeKind={activeTrending} basePath={basePath} />
+      ) : searchView.state === "provider_error" ? (
+        // Every TMDB access (direct + proxy) is unreachable from this deployment —
+        // a GFW-blocked network without a proxy (issue #134). Degrade with
+        // actionable guidance instead of letting the server component 500.
+        <section className="search-results" aria-label="搜索结果">
+          <div className="quiet-state compact" role="alert">
+            <TriangleAlert size={22} aria-hidden />
+            <strong>搜索暂时不可用：连不上元数据服务（TMDB）</strong>
+            <span>
+              当前部署环境连不上 TMDB，内置代理也不通。国内网络未配置代理时常见——
+              给部署主机（或容器）配置可访问外网的代理后重试。
+            </span>
+            <a className="primary-button" href={`${basePath}?q=${encodeURIComponent(searchView.query)}`}>
+              重试
+            </a>
+            {searchView.providerError ? (
+              <span className="panel-note">{searchView.providerError}</span>
+            ) : null}
+          </div>
+        </section>
       ) : (
         <section className="search-results" aria-label="搜索结果">
           <div className="section-heading">

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -187,6 +187,9 @@ async function SearchResults({
               当前部署环境连不上 TMDB，内置代理也不通。国内网络未配置代理时常见——
               给部署主机（或容器）配置可访问外网的代理后重试。
             </span>
+            {/* Deliberately a full-reload <a>, not <Link>: retry must re-run the
+                server render (re-probe TMDB). A client-side navigation to the
+                SAME URL can be served from the router cache as a no-op. */}
             <a className="primary-button" href={`${basePath}?q=${encodeURIComponent(searchView.query)}`}>
               重试
             </a>

--- a/packages/workflow/src/search-view.ts
+++ b/packages/workflow/src/search-view.ts
@@ -129,7 +129,7 @@ export async function getSearchPageView(input: {
         state: "provider_error",
         cacheStatus: "miss",
         candidates: [],
-        providerError: String(error),
+        providerError: describeError(error),
       };
     }
     await input.cache.set(query, candidates);
@@ -147,6 +147,22 @@ export async function getSearchPageView(input: {
 
 function normalizeSearchQuery(query: string): string {
   return query.trim().replace(/\s+/g, " ");
+}
+
+/** The diagnostic line must stay readable for ANY throw shape: bare String()
+ *  renders non-Error objects as "[object Object]". */
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  if (typeof error === "object" && error !== null) {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
 }
 
 async function toCandidateCard(

--- a/packages/workflow/src/search-view.ts
+++ b/packages/workflow/src/search-view.ts
@@ -3,7 +3,7 @@ import type { EpisodeState, MediaType, TrackedSeason, WorkflowKind } from "./dom
 import type { WorkflowRepository } from "./repository.js";
 import { normalizeScope, type ScopeArg } from "./workflow-scope.js";
 
-export type SearchPageState = "empty" | "ready";
+export type SearchPageState = "empty" | "ready" | "provider_error";
 export type SearchCacheStatus = "none" | "hit" | "miss";
 export type SearchActionState =
   | "can_request"
@@ -73,6 +73,9 @@ export interface SearchPageView {
   state: SearchPageState;
   cacheStatus: SearchCacheStatus;
   candidates: SearchCandidateCard[];
+  /** Only when state === "provider_error": the underlying provider failure, for
+   *  a diagnostic line in the UI and the reporter's issue. */
+  providerError?: string;
 }
 
 export class InMemoryMediaSearchCache implements MediaSearchCache {
@@ -112,8 +115,23 @@ export async function getSearchPageView(input: {
   }
 
   const cached = await input.cache.get(query);
-  const candidates = cached ?? (await input.provider.searchMedia({ query }));
-  if (!cached) {
+  let candidates = cached;
+  if (!candidates) {
+    // A deployment that cannot reach ANY TMDB access (GFW-blocked network: direct
+    // API and the workers.dev proxy both dead — issue #134) makes the provider
+    // throw. Degrade to a dedicated view state instead of crashing the page, and
+    // do NOT cache the failure so the next search retries.
+    try {
+      candidates = await input.provider.searchMedia({ query });
+    } catch (error) {
+      return {
+        query,
+        state: "provider_error",
+        cacheStatus: "miss",
+        candidates: [],
+        providerError: String(error),
+      };
+    }
     await input.cache.set(query, candidates);
   }
 

--- a/packages/workflow/tests/search-view.test.ts
+++ b/packages/workflow/tests/search-view.test.ts
@@ -73,6 +73,24 @@ describe("getSearchPageView", () => {
     expect(view.providerError).toContain("TMDB access(es) failed");
   });
 
+  it("formats a non-Error provider throw into a readable diagnostic (not [object Object])", async () => {
+    const provider: MediaSearchProvider = {
+      async searchMedia() {
+        throw { code: "ECONNRESET" };
+      },
+    };
+
+    const view = await getSearchPageView({
+      query: "翘楚",
+      provider,
+      cache: new InMemoryMediaSearchCache(),
+      repository: new InMemoryWorkflowRepository(),
+    });
+
+    expect(view.state).toBe("provider_error");
+    expect(view.providerError).toBe('{"code":"ECONNRESET"}');
+  });
+
   it("does NOT cache a provider failure — the next search retries the provider", async () => {
     const cache = new InMemoryMediaSearchCache();
     const repository = new InMemoryWorkflowRepository();

--- a/packages/workflow/tests/search-view.test.ts
+++ b/packages/workflow/tests/search-view.test.ts
@@ -48,6 +48,74 @@ describe("getSearchPageView", () => {
     });
   });
 
+  it("degrades to provider_error instead of crashing when every TMDB access is unreachable (issue #134)", async () => {
+    // A GFW-blocked deployment (direct TMDB AND the workers.dev proxy both
+    // unreachable) makes the provider throw — the page must degrade, not 500.
+    const provider: MediaSearchProvider = {
+      async searchMedia() {
+        throw new Error("All 1 TMDB access(es) failed: TypeError: fetch failed");
+      },
+    };
+
+    const view = await getSearchPageView({
+      query: "星际牛仔",
+      provider,
+      cache: new InMemoryMediaSearchCache(),
+      repository: new InMemoryWorkflowRepository(),
+    });
+
+    expect(view).toMatchObject({
+      query: "星际牛仔",
+      state: "provider_error",
+      cacheStatus: "miss",
+      candidates: [],
+    });
+    expect(view.providerError).toContain("TMDB access(es) failed");
+  });
+
+  it("does NOT cache a provider failure — the next search retries the provider", async () => {
+    const cache = new InMemoryMediaSearchCache();
+    const repository = new InMemoryWorkflowRepository();
+    let fail = true;
+    const provider: MediaSearchProvider = {
+      async searchMedia() {
+        if (fail) throw new Error("fetch failed");
+        return [qiaochuCandidate()];
+      },
+    };
+
+    const failed = await getSearchPageView({ query: "翘楚", provider, cache, repository });
+    expect(failed.state).toBe("provider_error");
+
+    fail = false;
+    const recovered = await getSearchPageView({ query: "翘楚", provider, cache, repository });
+    expect(recovered.state).toBe("ready");
+    // cacheStatus "miss" proves the earlier failure was not cached as a result.
+    expect(recovered.cacheStatus).toBe("miss");
+    expect(recovered.candidates).toHaveLength(1);
+  });
+
+  it("still serves a warm cache when the provider is down", async () => {
+    const cache = new InMemoryMediaSearchCache();
+    await cache.set("翘楚", [qiaochuCandidate()]);
+    const provider: MediaSearchProvider = {
+      async searchMedia() {
+        throw new Error("fetch failed");
+      },
+    };
+
+    const view = await getSearchPageView({
+      query: "翘楚",
+      provider,
+      cache,
+      repository: new InMemoryWorkflowRepository(),
+    });
+
+    expect(view.state).toBe("ready");
+    expect(view.cacheStatus).toBe("hit");
+    expect(view.candidates).toHaveLength(1);
+  });
+
   it("maps provider candidates into UI cards with requestable action state", async () => {
     const provider = countingSearchProvider([qiaochuCandidate()]);
 


### PR DESCRIPTION
关联 #134。

## 症状

用户「开始搜索就会有这个问题」:搜索页整页变成 Next.js 默认错误页 `This page couldn't load / A server error occurred`(截图带 ERROR digest)。首页不崩,一搜就崩。

## 根因(两层)

**应用层(本 PR 修的)**:`getSearchPageView` 对 `provider.searchMedia` 没有任何 catch(`packages/workflow/src/search-view.ts`)。当部署环境**所有 TMDB 通道都不可达**时(无 token 用户只有一条通道=作者 workers.dev 代理),`fetchViaAccessChain` 按设计抛 `All N TMDB access(es) failed` → 穿透 `SearchResults` server component → `apps/web` 又没有任何 `error.tsx` → Next 默认整页裸崩。#69 的优雅降级只覆盖「部分通道死」——降级目标是下一条通道;全死时无处可降,照旧硬崩。

**基建层(本 PR 不修,需另行处理)**:取证发现 2026-07-16 当下,`api.themoviedb.org` 从多个 vantage(国内直连、非 GFW 的 VPS 出口、Cloudflare Worker 回源)都超时挂起;workers.dev 代理上凡是 KV 命中/404 的路径秒回、凡是需要现场回源 TMDB 的路径(`search/multi`、`/img/...`)全部挂起 → **作者代理 worker 的上游 fetch 正在挂**,并非只有「没翻墙的用户」受影响——所有默认配置用户的搜索都在崩,#134 大概率只是第一个来报的。

## 复现方法(伪 GFW 环境,已入 launch.json)

`web-gfw-sim` 配置:`TMDB_PROXY_BASE_URL=https://192.0.2.1`(TEST-NET 黑洞 IP,SYN 丢包挂起,忠实模拟 GFW/上游挂起)+ `TMDB_READ_TOKEN=`(屏蔽 .env)→ 全通道死。修复前:搜索 ~4.5s 后整页崩(与 issue 截图逐像素一致);修复后:降级卡。

## 改动

- `search-view.ts`:cache miss 且 provider 抛错 → 返回 `state: "provider_error"` 视图(带 `providerError` 诊断);**失败不写缓存**(下次搜索重试);**暖缓存命中不受影响**(缓存先行,provider 根本不被调)
- `page.tsx`:`provider_error` 渲染降级卡(成因指引 + 重试链接 + 诊断行),复用 `quiet-state`/`primary-button` 既有样式
- `app/error.tsx`(新增):根级错误边界,任何残余 server 渲染崩溃兜底,生产只暴露 digest
- `launch.json`:`web-gfw-sim` 复现配置

## 验证

- TDD:先写失败测试(2 个新测试在旧代码上按预期抛错挂掉)→ 实现 → 14/14 绿
- 全量 vitest 1452 绿;三处 tsc(build:workflow / apps/web / root)全绿
- e2e:伪 GFW dev server 修复前后截图对比(裸崩页 → 降级卡);重试按钮真点(重新探测,仍死则回同卡);服务端日志不再出现 ⨯ 崩溃
- 意外的真实环境验证:公司网络下 Node 进程实际也到不了 TMDB(浏览器翻墙≠进程翻墙),正常 dev 配置(双通道)同样走到降级卡,`All 2 TMDB access(es) failed`

## 后续(不在本 PR)

1. **worker 上游挂起是现行生产事故**:建议给 worker 的回源 fetch 加超时 + 失败时回落 stale KV;并排查 TMDB 侧对 Cloudflare 回源/数据中心 IP 的封锁或故障
2. workers.dev 域名本身被 GFW 整域封锁——考虑给 worker 绑 custom domain(如 tmdb-proxy.mediaryscout.app),让国内不翻墙用户的默认元数据通道真正可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)