### PR TITLE
feat(tmdb-proxy): 回源超时 + stale KV 兜底,吸收 TMDB 上游抽风

### DIFF
--- a/workers/tmdb-proxy/src/handler.test.ts
+++ b/workers/tmdb-proxy/src/handler.test.ts
@@ -108,8 +108,9 @@ describe("handleTmdbProxy — KV cache", () => {
       token: "k",
       originFetch: async () => new Response("{}", { status: 200 }),
     });
-    expect(movieKv.puts[0]?.ttl).toBe(7 * 24 * 60 * 60);
-    expect(tvKv.puts[0]?.ttl).toBe(60 * 60);
+    // Physical TTL = freshness window + the 14d stale tail kept for outage fallback.
+    expect(movieKv.puts[0]?.ttl).toBe(7 * 24 * 60 * 60 + 14 * 24 * 60 * 60);
+    expect(tvKv.puts[0]?.ttl).toBe(60 * 60 + 14 * 24 * 60 * 60);
   });
 
   it("normalizes query order so the cache key is stable", async () => {
@@ -122,6 +123,162 @@ describe("handleTmdbProxy — KV cache", () => {
     await handleTmdbProxy({ request: new Request("https://w.example/movie/1?a=1&b=2"), kv, token: "k", originFetch: fetchOnce });
     await handleTmdbProxy({ request: new Request("https://w.example/movie/1?b=2&a=1"), kv, token: "k", originFetch: fetchOnce });
     expect(originCalls).toBe(1);
+  });
+});
+
+describe("handleTmdbProxy — upstream flap absorption (timeout + stale fallback)", () => {
+  // 2026-07-16 incident: TMDB's origin flapped for 1h+ — the worker's origin
+  // fetch hung with NO timeout, every live-fetch path stalled until the client
+  // gave up, and (search having no stale to fall back on) every default-config
+  // instance's search crashed. These tests pin the absorption contract.
+
+  /** An origin that never answers but honors AbortSignal — proves the handler
+   *  actually wires a timeout signal into originFetch. */
+  const hangingFetch: typeof fetch = (_url, init) =>
+    new Promise((_resolve, reject) => {
+      const signal = (init as RequestInit | undefined)?.signal;
+      if (!signal) {
+        reject(new Error("handler passed no AbortSignal to originFetch"));
+        return;
+      }
+      signal.addEventListener("abort", () => reject(signal.reason));
+    });
+
+  function envelope(body: string, freshUntil: number): string {
+    return JSON.stringify({ v: 1, freshUntil, body });
+  }
+
+  it("cold MISS + hanging origin → fast 504 JSON error, bounded by the injected timeout", async () => {
+    const started = Date.now();
+    const res = await handleTmdbProxy({
+      request: new Request("https://w.example/search/multi?query=bebop", {
+        headers: { Origin: "https://mediaryscout.app" },
+      }),
+      kv: fakeKv(),
+      token: "k",
+      originFetch: hangingFetch,
+      upstreamTimeoutMs: 20,
+    });
+    expect(res.status).toBe(504);
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(await res.json()).toMatchObject({ error: "tmdb_upstream_unreachable" });
+    // The failure must stay debuggable from the landing site (CORS on error branch).
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://mediaryscout.app");
+  });
+
+  it("stale envelope + failing origin → serves the stale body with X-Cache: STALE", async () => {
+    const kv = fakeKv({ "movie/278": envelope('{"id":278}', 1_000) });
+    const res = await handleTmdbProxy({
+      request: new Request("https://w.example/movie/278"),
+      kv,
+      token: "k",
+      originFetch: hangingFetch,
+      upstreamTimeoutMs: 20,
+      now: () => 2_000,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("STALE");
+    expect(await res.json()).toEqual({ id: 278 });
+  });
+
+  it("stale envelope + origin 5xx/429 → STALE; semantic 404 passes through instead", async () => {
+    for (const status of [500, 503, 429]) {
+      const kv = fakeKv({ "movie/278": envelope('{"id":278}', 1_000) });
+      const res = await handleTmdbProxy({
+        request: new Request("https://w.example/movie/278"),
+        kv,
+        token: "k",
+        originFetch: async () => new Response("upstream sad", { status }),
+        now: () => 2_000,
+      });
+      expect(res.headers.get("X-Cache")).toBe("STALE");
+      expect(await res.json()).toEqual({ id: 278 });
+    }
+    // A real TMDB 404 is an answer, not an outage — never masked by stale data.
+    const kv = fakeKv({ "movie/278": envelope('{"id":278}', 1_000) });
+    const notFound = await handleTmdbProxy({
+      request: new Request("https://w.example/movie/278"),
+      kv,
+      token: "k",
+      originFetch: async () => new Response('{"status_message":"gone"}', { status: 404 }),
+      now: () => 2_000,
+    });
+    expect(notFound.status).toBe(404);
+  });
+
+  it("stale envelope + healthy origin → refreshes: MISS response and a rewritten envelope", async () => {
+    const kv = fakeKv({ "movie/278": envelope('{"id":1}', 1_000) });
+    const res = await handleTmdbProxy({
+      request: new Request("https://w.example/movie/278"),
+      kv,
+      token: "k",
+      originFetch: async () => new Response('{"id":2}', { status: 200 }),
+      now: () => 2_000,
+    });
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+    expect(await res.json()).toEqual({ id: 2 });
+    const stored = JSON.parse((await kv.get("movie/278"))!);
+    expect(stored).toMatchObject({ v: 1, body: '{"id":2}' });
+    expect(stored.freshUntil).toBe(2_000 + 7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("fresh envelope → HIT without touching origin", async () => {
+    const kv = fakeKv({ "movie/278": envelope('{"id":278}', 10_000) });
+    let originCalls = 0;
+    const res = await handleTmdbProxy({
+      request: new Request("https://w.example/movie/278"),
+      kv,
+      token: "k",
+      originFetch: async () => {
+        originCalls += 1;
+        return new Response("{}", { status: 200 });
+      },
+      now: () => 2_000,
+    });
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(await res.json()).toEqual({ id: 278 });
+    expect(originCalls).toBe(0);
+  });
+
+  it("legacy raw KV value (pre-envelope) still serves as HIT", async () => {
+    const kv = fakeKv({ "movie/278": '{"id":278}' });
+    const res = await handleTmdbProxy({
+      request: new Request("https://w.example/movie/278"),
+      kv,
+      token: "k",
+      originFetch: async () => new Response("SHOULD_NOT_FETCH", { status: 500 }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(await res.json()).toEqual({ id: 278 });
+  });
+
+  it("a successful MISS writes an envelope whose physical TTL = fresh TTL + 14d stale tail", async () => {
+    const kv = fakeKv();
+    await handleTmdbProxy({
+      request: new Request("https://w.example/movie/278"),
+      kv,
+      token: "k",
+      originFetch: async () => new Response('{"id":278}', { status: 200 }),
+      now: () => 2_000,
+    });
+    expect(kv.puts[0]?.ttl).toBe(7 * 24 * 60 * 60 + 14 * 24 * 60 * 60);
+    const stored = JSON.parse((await kv.get("movie/278"))!);
+    expect(stored).toMatchObject({ v: 1, body: '{"id":278}' });
+  });
+
+  it("/img with a hanging origin → fast 502, no-store", async () => {
+    const started = Date.now();
+    const res = await handleTmdbProxy({
+      request: new Request("https://w.example/img/t/p/w342/abc.jpg"),
+      kv: fakeKv(),
+      token: "k",
+      originFetch: hangingFetch,
+      upstreamTimeoutMs: 20,
+    });
+    expect(res.status).toBe(502);
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
   });
 });
 
@@ -159,7 +316,7 @@ describe("trending discovery", () => {
     });
     expect(kv.puts).toHaveLength(getTrendingFeeds().length);
     for (const put of kv.puts) {
-      expect(put.ttl).toBe(25 * 60 * 60);
+      expect(put.ttl).toBe(25 * 60 * 60 + 14 * 24 * 60 * 60);
     }
     expect(kv.puts[0]!.key.startsWith("trending/movie/week")).toBe(true);
 
@@ -185,7 +342,7 @@ describe("trending discovery", () => {
       token: "k",
       originFetch: async () => new Response(JSON.stringify({ results: [] }), { status: 200 }),
     });
-    expect(kv.puts[0]?.ttl).toBe(25 * 60 * 60);
+    expect(kv.puts[0]?.ttl).toBe(25 * 60 * 60 + 14 * 24 * 60 * 60);
 
     // The DYNAMIC anime feed (first_air_date.gte rolls yearly) must get the same
     // daily TTL on a reactive MISS — isTrendingFeedRequest recomputes the feeds,
@@ -197,7 +354,7 @@ describe("trending discovery", () => {
       token: "k",
       originFetch: async () => new Response(JSON.stringify({ results: [] }), { status: 200 }),
     });
-    expect(animeKv.puts[0]?.ttl).toBe(25 * 60 * 60);
+    expect(animeKv.puts[0]?.ttl).toBe(25 * 60 * 60 + 14 * 24 * 60 * 60);
 
     // A non-feed discover/tv call keeps its ordinary short TTL (feed-specific, not
     // a blanket discover override).
@@ -208,7 +365,7 @@ describe("trending discovery", () => {
       token: "k",
       originFetch: async () => new Response("{}", { status: 200 }),
     });
-    expect(other.puts[0]?.ttl).toBe(60 * 60);
+    expect(other.puts[0]?.ttl).toBe(60 * 60 + 14 * 24 * 60 * 60);
   });
 
   it("runScheduledRefresh skips a feed whose origin fetch fails (never aborts the rest)", async () => {

--- a/workers/tmdb-proxy/src/handler.test.ts
+++ b/workers/tmdb-proxy/src/handler.test.ts
@@ -161,7 +161,9 @@ describe("handleTmdbProxy — upstream flap absorption (timeout + stale fallback
     });
     expect(res.status).toBe(504);
     expect(Date.now() - started).toBeLessThan(2000);
-    expect(await res.json()).toMatchObject({ error: "tmdb_upstream_unreachable" });
+    // Exact body: a stable public contract — an enum reason, and NO raw error
+    // detail (a public endpoint must not leak internal runtime strings).
+    expect(await res.json()).toEqual({ error: "tmdb_upstream_unreachable", reason: "timeout" });
     // The failure must stay debuggable from the landing site (CORS on error branch).
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://mediaryscout.app");
   });

--- a/workers/tmdb-proxy/src/handler.test.ts
+++ b/workers/tmdb-proxy/src/handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { getTrendingFeeds, handleTmdbProxy, runScheduledRefresh, type KvLike } from "./handler";
 
 function fakeKv(initial: Record<string, string> = {}): KvLike & { puts: Array<{ key: string; ttl: number | undefined }> } {
@@ -149,6 +149,7 @@ describe("handleTmdbProxy — upstream flap absorption (timeout + stale fallback
   }
 
   it("cold MISS + hanging origin → fast 504 JSON error, bounded by the injected timeout", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const started = Date.now();
     const res = await handleTmdbProxy({
       request: new Request("https://w.example/search/multi?query=bebop", {
@@ -166,6 +167,12 @@ describe("handleTmdbProxy — upstream flap absorption (timeout + stale fallback
     expect(await res.json()).toEqual({ error: "tmdb_upstream_unreachable", reason: "timeout" });
     // The failure must stay debuggable from the landing site (CORS on error branch).
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://mediaryscout.app");
+    // Server-side log keeps the failing endpoint but NEVER the query values —
+    // user search terms must not land in the worker log on every upstream flap.
+    const logged = errSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+    expect(logged).toContain("search/multi");
+    expect(logged).not.toContain("bebop");
+    errSpy.mockRestore();
   });
 
   it("stale envelope + failing origin → serves the stale body with X-Cache: STALE", async () => {

--- a/workers/tmdb-proxy/src/handler.test.ts
+++ b/workers/tmdb-proxy/src/handler.test.ts
@@ -167,11 +167,14 @@ describe("handleTmdbProxy — upstream flap absorption (timeout + stale fallback
     expect(await res.json()).toEqual({ error: "tmdb_upstream_unreachable", reason: "timeout" });
     // The failure must stay debuggable from the landing site (CORS on error branch).
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://mediaryscout.app");
-    // Server-side log keeps the failing endpoint but NEVER the query values —
-    // user search terms must not land in the worker log on every upstream flap.
+    // Server-side log keeps the failing endpoint + a coarse error kind, and
+    // NEVER query values or the raw error string (some runtimes embed the full
+    // request URL — and thus user search terms — in error messages).
     const logged = errSpy.mock.calls.map((args) => args.join(" ")).join("\n");
     expect(logged).toContain("search/multi");
+    expect(logged).toContain("TimeoutError");
     expect(logged).not.toContain("bebop");
+    expect(logged).not.toContain("aborted"); // fragment of the raw message
     errSpy.mockRestore();
   });
 

--- a/workers/tmdb-proxy/src/handler.ts
+++ b/workers/tmdb-proxy/src/handler.ts
@@ -64,8 +64,10 @@ function parseEnvelope(raw: string): CacheEnvelope | null {
       return parsed as unknown as CacheEnvelope;
     }
   } catch {
-    // legacy non-JSON value
+    // Not JSON at all — fall through.
   }
+  // Reaching here usually means a LEGACY value: a raw TMDB body, which is valid
+  // JSON but fails the envelope shape check above (no v/freshUntil/body).
   return null;
 }
 
@@ -240,7 +242,8 @@ export async function handleTmdbProxy(deps: HandleTmdbProxyDeps): Promise<Respon
     }
     // Public endpoint: keep the error contract to a stable enum — raw error
     // strings stay in the worker log (wrangler tail), never in the response.
-    console.error(`tmdb origin fetch failed for ${key}: ${String(error)}`);
+    // Log only the path: the querystring carries user search terms.
+    console.error(`tmdb origin fetch failed for ${key.split("?")[0]}: ${String(error)}`);
     const reason = error instanceof Error && error.name === "TimeoutError" ? "timeout" : "network";
     return new Response(JSON.stringify({ error: "tmdb_upstream_unreachable", reason }), {
       status: 504,

--- a/workers/tmdb-proxy/src/handler.ts
+++ b/workers/tmdb-proxy/src/handler.ts
@@ -238,7 +238,11 @@ export async function handleTmdbProxy(deps: HandleTmdbProxyDeps): Promise<Respon
     if (staleBody !== null) {
       return new Response(staleBody, { status: 200, headers: jsonHeaders("STALE", request) });
     }
-    return new Response(JSON.stringify({ error: "tmdb_upstream_unreachable", detail: String(error) }), {
+    // Public endpoint: keep the error contract to a stable enum — raw error
+    // strings stay in the worker log (wrangler tail), never in the response.
+    console.error(`tmdb origin fetch failed for ${key}: ${String(error)}`);
+    const reason = error instanceof Error && error.name === "TimeoutError" ? "timeout" : "network";
+    return new Response(JSON.stringify({ error: "tmdb_upstream_unreachable", reason }), {
       status: 504,
       headers: jsonHeaders("MISS", request),
     });

--- a/workers/tmdb-proxy/src/handler.ts
+++ b/workers/tmdb-proxy/src/handler.ts
@@ -33,6 +33,47 @@ function corsHeadersFor(request: Request): Record<string, string> {
 const MOVIE_TTL_SECONDS = 7 * 24 * 60 * 60; // movie metadata is effectively static
 const SHORT_TTL_SECONDS = 60 * 60;          // tv/season/search: 追更 needs hourly freshness
 
+/** 2026-07-16 incident: TMDB's origin flapped (hangs + instant 504s) for 1h+ and
+ *  the worker — whose origin fetch had NO timeout — stalled every live path with
+ *  it. Absorption contract: bound the origin fetch, and keep every cached body
+ *  around past its freshness window so an outage degrades to stale data instead
+ *  of an error. Stale is only served when origin is outage-shaped (network
+ *  failure/timeout/5xx/429) — semantic answers like 404 pass through. */
+const STALE_TAIL_SECONDS = 14 * 24 * 60 * 60;
+const DEFAULT_UPSTREAM_TIMEOUT_MS = 3500; // below the app client's 4.5s budget
+
+/** KV value envelope. Legacy entries are the raw TMDB body (a JSON object with
+ *  none of these fields) — parseEnvelope returns null for them and they serve
+ *  as fresh until their own physical TTL cycles them out. */
+interface CacheEnvelope {
+  v: 1;
+  freshUntil: number; // epoch ms
+  body: string;
+}
+
+function parseEnvelope(raw: string): CacheEnvelope | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      (parsed as { v?: unknown }).v === 1 &&
+      typeof (parsed as { freshUntil?: unknown }).freshUntil === "number" &&
+      typeof (parsed as { body?: unknown }).body === "string"
+    ) {
+      return parsed as unknown as CacheEnvelope;
+    }
+  } catch {
+    // legacy non-JSON value
+  }
+  return null;
+}
+
+function envelopeFor(body: string, freshTtlSeconds: number, nowMs: number): string {
+  const envelope: CacheEnvelope = { v: 1, freshUntil: nowMs + freshTtlSeconds * 1000, body };
+  return JSON.stringify(envelope);
+}
+
 function ttlForPath(path: string): number {
   return path.startsWith("movie/") ? MOVIE_TTL_SECONDS : SHORT_TTL_SECONDS;
 }
@@ -92,6 +133,10 @@ export interface HandleTmdbProxyDeps {
   kv: KvLike;
   token: string;
   originFetch?: typeof fetch;
+  /** Bound on the origin fetch (default 3.5s — below the app client's 4.5s). */
+  upstreamTimeoutMs?: number;
+  /** Clock (epoch ms) for envelope freshness; injectable for tests. */
+  now?: () => number;
 }
 
 function pathOf(request: Request): string {
@@ -105,7 +150,11 @@ function isAllowed(path: string): boolean {
 /** Binary passthrough for poster images. No KV (binary content; the immutable
  *  Cache-Control lets the CF edge cache own it) and no CORS (loaded via <img>
  *  tags, which need none). Anything off the strict shape allowlist is 404. */
-async function handleImageProxy(rest: string, originFetch: typeof fetch): Promise<Response> {
+async function handleImageProxy(
+  rest: string,
+  originFetch: typeof fetch,
+  timeoutMs: number,
+): Promise<Response> {
   if (!IMG_PATH_RE.test(rest)) {
     return new Response("Not Found", { status: 404, headers: { "Cache-Control": "no-store" } });
   }
@@ -114,7 +163,17 @@ async function handleImageProxy(rest: string, originFetch: typeof fetch): Promis
   // (cacheTtlByStatus) are Enterprise-only. Default rules cache jpg/png by
   // extension honoring origin headers, with short negative caching — the
   // right behavior here.
-  const originResponse = await originFetch(`${TMDB_IMAGE_ORIGIN}/${rest}`, { method: "GET" });
+  let originResponse: Response;
+  try {
+    originResponse = await originFetch(`${TMDB_IMAGE_ORIGIN}/${rest}`, {
+      method: "GET",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch {
+    // A hung image origin must not hold the request open — the <img> breaks
+    // and the browser retries on the next paint; nothing to serve stale here.
+    return new Response("Bad Gateway", { status: 502, headers: { "Cache-Control": "no-store" } });
+  }
   const headers: Record<string, string> = {
     "Cache-Control": originResponse.ok ? "public, max-age=31536000, immutable" : "no-store",
   };
@@ -125,7 +184,7 @@ async function handleImageProxy(rest: string, originFetch: typeof fetch): Promis
   return new Response(originResponse.body, { status: originResponse.status, headers });
 }
 
-function jsonHeaders(cache: "HIT" | "MISS", request: Request): Record<string, string> {
+function jsonHeaders(cache: "HIT" | "MISS" | "STALE", request: Request): Record<string, string> {
   return { "Content-Type": "application/json;charset=utf-8", "X-Cache": cache, ...corsHeadersFor(request) };
 }
 
@@ -139,32 +198,61 @@ export async function handleTmdbProxy(deps: HandleTmdbProxyDeps): Promise<Respon
     return new Response("Method Not Allowed", { status: 405, headers: { ...corsHeadersFor(request), Allow: "GET" } });
   }
 
+  const timeoutMs = deps.upstreamTimeoutMs ?? DEFAULT_UPSTREAM_TIMEOUT_MS;
+  const now = deps.now ?? Date.now;
+
   const path = pathOf(request);
   if (path.startsWith("img/")) {
-    return handleImageProxy(path.slice("img/".length), originFetch);
+    return handleImageProxy(path.slice("img/".length), originFetch, timeoutMs);
   }
   if (!isAllowed(path)) {
     return new Response("Not Found", { status: 404, headers: corsHeadersFor(request) });
   }
 
   const key = cacheKeyFor(request);
-  const cached = await deps.kv.get(key);
-  if (cached !== null) {
-    return new Response(cached, { status: 200, headers: jsonHeaders("HIT", request) });
+  const cachedRaw = await deps.kv.get(key);
+  let staleBody: string | null = null;
+  if (cachedRaw !== null) {
+    const cached = parseEnvelope(cachedRaw);
+    if (cached === null || now() < cached.freshUntil) {
+      // Legacy raw value (fresh until its own physical TTL) or a fresh envelope.
+      return new Response(cached === null ? cachedRaw : cached.body, {
+        status: 200,
+        headers: jsonHeaders("HIT", request),
+      });
+    }
+    staleBody = cached.body;
   }
 
   const originUrl = `${TMDB_ORIGIN}/${key}`;
-  const originResponse = await originFetch(originUrl, {
-    method: "GET",
-    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json;charset=utf-8" },
-  });
+  let originResponse: Response;
+  let body: string;
+  try {
+    originResponse = await originFetch(originUrl, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json;charset=utf-8" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    body = await originResponse.text();
+  } catch (error) {
+    if (staleBody !== null) {
+      return new Response(staleBody, { status: 200, headers: jsonHeaders("STALE", request) });
+    }
+    return new Response(JSON.stringify({ error: "tmdb_upstream_unreachable", detail: String(error) }), {
+      status: 504,
+      headers: jsonHeaders("MISS", request),
+    });
+  }
 
-  const body = await originResponse.text();
   if (!originResponse.ok) {
+    // Outage-shaped statuses degrade to stale; semantic answers (404 …) pass through.
+    if (staleBody !== null && (originResponse.status >= 500 || originResponse.status === 429)) {
+      return new Response(staleBody, { status: 200, headers: jsonHeaders("STALE", request) });
+    }
     return new Response(body, { status: originResponse.status, headers: jsonHeaders("MISS", request) });
   }
   const ttl = isTrendingFeedRequest(key) ? TRENDING_TTL_SECONDS : ttlForPath(path);
-  await deps.kv.put(key, body, { expirationTtl: ttl });
+  await deps.kv.put(key, envelopeFor(body, ttl, now()), { expirationTtl: ttl + STALE_TAIL_SECONDS });
   return new Response(body, { status: 200, headers: jsonHeaders("MISS", request) });
 }
 
@@ -172,6 +260,9 @@ export interface RunScheduledRefreshDeps {
   kv: KvLike;
   token: string;
   originFetch?: typeof fetch;
+  /** Bound per feed fetch — one hung feed must not eat the cron invocation. */
+  upstreamTimeoutMs?: number;
+  now?: () => number;
 }
 
 /** Daily Cron: pre-warm each feed's KV entry so NO user open triggers a TMDB
@@ -181,18 +272,23 @@ export interface RunScheduledRefreshDeps {
  *  (if any) lives on under its TTL, and one bad feed never aborts the others. */
 export async function runScheduledRefresh(deps: RunScheduledRefreshDeps): Promise<void> {
   const originFetch = deps.originFetch ?? fetch;
+  const timeoutMs = deps.upstreamTimeoutMs ?? DEFAULT_UPSTREAM_TIMEOUT_MS;
+  const now = deps.now ?? Date.now;
   for (const feed of getTrendingFeeds()) {
     const key = cacheKeyFor(new Request(`https://proxy/${feed}`));
     try {
       const originResponse = await originFetch(`${TMDB_ORIGIN}/${key}`, {
         method: "GET",
         headers: { Authorization: `Bearer ${deps.token}`, "Content-Type": "application/json;charset=utf-8" },
+        signal: AbortSignal.timeout(timeoutMs),
       });
       if (!originResponse.ok) {
         continue;
       }
       const body = await originResponse.text();
-      await deps.kv.put(key, body, { expirationTtl: TRENDING_TTL_SECONDS });
+      await deps.kv.put(key, envelopeFor(body, TRENDING_TTL_SECONDS, now()), {
+        expirationTtl: TRENDING_TTL_SECONDS + STALE_TAIL_SECONDS,
+      });
     } catch {
       // network hiccup on one feed must not abort the rest
     }

--- a/workers/tmdb-proxy/src/handler.ts
+++ b/workers/tmdb-proxy/src/handler.ts
@@ -240,11 +240,13 @@ export async function handleTmdbProxy(deps: HandleTmdbProxyDeps): Promise<Respon
     if (staleBody !== null) {
       return new Response(staleBody, { status: 200, headers: jsonHeaders("STALE", request) });
     }
-    // Public endpoint: keep the error contract to a stable enum — raw error
-    // strings stay in the worker log (wrangler tail), never in the response.
-    // Log only the path: the querystring carries user search terms.
-    console.error(`tmdb origin fetch failed for ${key.split("?")[0]}: ${String(error)}`);
-    const reason = error instanceof Error && error.name === "TimeoutError" ? "timeout" : "network";
+    // Public endpoint: keep the error contract to a stable enum. The log gets
+    // only the path (the querystring carries user search terms) and the error
+    // NAME — never the raw message, which some runtimes stuff the full request
+    // URL into.
+    const kind = error instanceof Error ? error.name : "unknown";
+    console.error(`tmdb origin fetch failed for ${key.split("?")[0]}: ${kind}`);
+    const reason = kind === "TimeoutError" ? "timeout" : "network";
     return new Response(JSON.stringify({ error: "tmdb_upstream_unreachable", reason }), {
       status: 504,
       headers: jsonHeaders("MISS", request),


### PR DESCRIPTION
#134 的基建层修复(app 层降级见 #136,两者独立可分别合)。

## 背景:2026-07-16 事故取证

TMDB 源站(自己也在 Cloudflare 后面)flap 了 1 小时+:同一时段内 CF edge 到 TMDB 源站有时 200、有时 9ms 内部 504、有时挂死(无凭证对照组同样如此,与 key 无关,多 vantage 交叉验证)。worker 的回源 fetch **没有任何超时**,于是:凡 KV 命中/404 的路径秒回,凡需现场回源的路径(search/multi、/img)全部随上游挂死 → 所有默认配置实例(无自带 TMDB token,唯一通道=本代理)的搜索整页崩。

## 吸收契约(全部测试钉死)

- **回源超时**:AbortSignal.timeout 默认 3.5s(低于 app 客户端 4.5s 预算,留 stale 读取余量);可注入(测试用 20ms 真验超时接线,断言 wall-clock 有界)
- **stale 兜底**:KV 值升级为 envelope `{v:1, freshUntil, body}`,物理 TTL = 新鲜窗口 + **14 天 stale 尾巴**。新鲜期内 HIT 行为不变;过期后回源刷新,若回源**网络失败/超时/5xx/429** → 回落 stale(`X-Cache: STALE`);**语义性 4xx(404 等)照旧透传**,绝不用 stale 掩盖真实答案
- **冷 MISS 且回源失败**:快速 504 JSON(`{"error":"tmdb_upstream_unreachable"}`,带 CORS)——客户端立即失败进入 access chain 降级,而不是白等到超时
- **/img 回源加超时**:失败 502 no-store(海报断图可重试,不再挂住请求)
- **legacy 兼容**:旧的裸 body KV 值视为 fresh 照常服务,随自身 TTL 自然轮换成 envelope,无需清 KV
- **cron 预热**:每个 feed 独立超时(一个挂死不吃掉整个 cron),写 envelope

## 验证

- TDD:8 个新测试先在旧实现上失败(含真实超时接线验证),后实现转绿;3 处 TTL 契约断言同步更新
- workers 测试 34/34 绿;全量 vitest 1457 绿;worker tsc + root typecheck 绿
- 合并后将 wrangler deploy 并 live 验证(X-Cache: MISS/HIT/STALE 路径)

🤖 Generated with [Claude Code](https://claude.com/claude-code)