### PR TITLE
feat(tmdb-proxy): 默认代理换 custom domain,根治 workers.dev 被墙 (#83)

### DIFF
--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -839,8 +839,11 @@ export async function getAssrtToken(
 }
 
 /** Author-deployed CF Worker that proxies TMDB with the author's key (KV-cached).
- *  env TMDB_PROXY_BASE_URL overrides it (e.g. a user who self-hosts the worker). */
-export const DEFAULT_TMDB_PROXY_BASE_URL = "https://media-track-tmdb-proxy.fancydirty.workers.dev";
+ *  env TMDB_PROXY_BASE_URL overrides it (e.g. a user who self-hosts the worker).
+ *  Custom domain, NOT the *.workers.dev alias — several mainland ISPs block the
+ *  whole workers.dev zone (#83), and this default is the ONLY metadata channel
+ *  for a tokenless user. The workers.dev URL still serves older releases. */
+export const DEFAULT_TMDB_PROXY_BASE_URL = "https://tmdb-proxy.mediaryscout.app";
 
 /** Ordered TMDB access channels: user's own key (direct) → env token (direct) →
  *  the proxy Worker (always last, no token — the Worker injects the author's).

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -117,7 +117,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 
 - **自己的 TMDB key**(设置 → TMDB 元数据):直连你自己的额度,调不通自动回退作者代理。
 - **出站代理**(`.env` 设 `HTTP_PROXY` / `HTTPS_PROXY`):墙内想用**自己的 TMDB token / 额度**时用得到。TMDB 的 API 主机(`api.themoviedb.org`)在国内常被单独墙(官网能开 ≠ API 能通),直连不到你的 token 就用不上。给容器配一个能穿透的代理即可让全部出站请求(TMDB / PanSou / Prowlarr)走它:在仓库根 `.env` 里写 `HTTP_PROXY=http://172.17.0.1:7890` 和 `HTTPS_PROXY=http://172.17.0.1:7890`(`172.17.0.1` 是 Docker 默认网关,指向宿主机;端口换成你宿主上代理软件的实际端口,如 Clash 的 7890),再 `docker compose up -d`。`NO_PROXY` 可排除内网地址。**不设代理时行为不变**——TMDB token 留空走作者内置代理依旧开箱即用,这条只为「墙内 + 想用自己 token」准备。
-  - **内置代理也连不上时同样用此法**(#83 实例):内置 TMDB 代理托管在 Cloudflare Workers,`*.workers.dev` 域名在部分国内网络/运营商下也会被阻断——症状是搜索报 `All N TMDB access(es) failed: TimeoutError`(N 为通道数,未配 token 时为 1)。此时无论是否有自己的 token,都需要按上面配 `HTTP_PROXY` / `HTTPS_PROXY` 让容器出站走代理。
+  - **内置代理也连不上时同样用此法**(#83 实例,现已缓解):内置 TMDB 代理曾托管在 `*.workers.dev` 域名下,该域名在部分国内网络/运营商下会被整域阻断——症状是搜索报 `All N TMDB access(es) failed: TimeoutError`(N 为通道数,未配 token 时为 1)。**现默认代理已换自定义域名 `tmdb-proxy.mediaryscout.app`,绝大多数国内网络可直连**;若你的网络连它也阻断,再按上面配 `HTTP_PROXY` / `HTTPS_PROXY` 让容器出站走代理。
   - **WSL2 部署注意**(#83 踩坑实录):容器内的 `127.0.0.1` 指容器自身,填 Windows 宿主上的代理要用 WSL2 虚拟网卡的宿主 IP;且 Windows 防火墙常拦截来自 WSL2 虚拟网卡的入站连接(即使代理软件开了「允许局域网连接」),需要放行防火墙或在 WSL2 内起一层转发(监听 0.0.0.0 转发到 127.0.0.1:代理端口),容器再指向 WSL2 自身 IP。
 - **Prowlarr**(设置 → 资源提供商):接入索引器聚合,磁力与 PanSou 结果合并,走 115 或光鸭的离线下载落盘(夸克无磁力 API)。
 - **换 PanSou 实例**(设置 → 资源提供商):默认用 compose 自带的;想指向别的实例/公共域名在此手填。

--- a/site/lib.mjs
+++ b/site/lib.mjs
@@ -24,7 +24,9 @@ export function formatStars(n) {
 }
 
 // Single source of truth for the proxy worker host (also imported by main.js).
-export const WORKER_BASE = "https://media-track-tmdb-proxy.fancydirty.workers.dev";
+// Custom domain (NOT *.workers.dev, which several mainland ISPs block — #83):
+// the GFW-side visitor is exactly who the poster proxy exists for.
+export const WORKER_BASE = "https://tmdb-proxy.mediaryscout.app";
 
 // Posters route through the worker's /img proxy: image.tmdb.org is GFW-blocked
 // for ordinary mainland visitors (direct URLs only load behind a proxy).

--- a/site/lib.test.mjs
+++ b/site/lib.test.mjs
@@ -44,8 +44,8 @@ describe("postersFrom", () => {
   it("取 poster_path 非空前 N 个拼 worker 图片代理 w342 URL（image.tmdb.org 被墙），movie/tv 标题都认", () => {
     const data = { results: [{ poster_path: "/a.jpg", title: "甲" }, { poster_path: null }, { poster_path: "/b.jpg", name: "乙" }] };
     expect(postersFrom([data], 2)).toEqual([
-      { url: "https://media-track-tmdb-proxy.fancydirty.workers.dev/img/t/p/w342/a.jpg", title: "甲" },
-      { url: "https://media-track-tmdb-proxy.fancydirty.workers.dev/img/t/p/w342/b.jpg", title: "乙" }]);
+      { url: "https://tmdb-proxy.mediaryscout.app/img/t/p/w342/a.jpg", title: "甲" },
+      { url: "https://tmdb-proxy.mediaryscout.app/img/t/p/w342/b.jpg", title: "乙" }]);
   });
   it("跨 feed 收集且尊重 limit", () => {
     const f1 = { results: [{ poster_path: "/1.jpg", title: "一" }] };

--- a/workers/tmdb-proxy/README.md
+++ b/workers/tmdb-proxy/README.md
@@ -12,11 +12,13 @@ npx wrangler kv namespace create TMDB_CACHE --config workers/tmdb-proxy/wrangler
 grep '^TMDB_READ_TOKEN=' .env | cut -d= -f2- | tr -d '"' \
   | npx wrangler secret put TMDB_READ_TOKEN --config workers/tmdb-proxy/wrangler.jsonc
 
-# 3. 部署,记下输出的 https://<name>.<account>.workers.dev URL
+# 3. 部署。wrangler.jsonc 里声明了 custom domain(tmdb-proxy.mediaryscout.app,
+#    要求该 zone 在同一 Cloudflare 账号),部署时自动建 DNS + 证书;
+#    workers.dev URL 同时保留,旧版本客户端继续可用
 npx wrangler deploy --config workers/tmdb-proxy/wrangler.jsonc
 ```
 
-把部署 URL 填入 `apps/web/lib/workflow-runtime.ts` 的 `DEFAULT_TMDB_PROXY_BASE_URL`。
+把部署 URL 填入 `apps/web/lib/workflow-runtime.ts` 的 `DEFAULT_TMDB_PROXY_BASE_URL`(用 custom domain 而非 `*.workers.dev`——后者在部分国内运营商被整域阻断,见 #83)。
 
 ## 校验
 

--- a/workers/tmdb-proxy/wrangler.jsonc
+++ b/workers/tmdb-proxy/wrangler.jsonc
@@ -2,6 +2,14 @@
   "name": "media-track-tmdb-proxy",
   "main": "src/index.ts",
   "compatibility_date": "2026-06-01",
+  // Custom domain: *.workers.dev is blocked wholesale by several mainland ISPs
+  // (#83) and this proxy is the default (often only) metadata channel. The
+  // workers.dev URL stays enabled so older app releases keep working —
+  // workers_dev MUST stay explicit: declaring routes silently disables the
+  // workers.dev subdomain otherwise (bit us on 2026-07-16: every live instance
+  // still pointing at the old URL went 404 until the redeploy).
+  "workers_dev": true,
+  "routes": [{ "pattern": "tmdb-proxy.mediaryscout.app", "custom_domain": true }],
   "kv_namespaces": [
     { "binding": "TMDB_CACHE", "id": "252a662ac5594eec88b7c4d39fd6a5c5" }
   ],


### PR DESCRIPTION
#134 收尾三部曲之三(#136 app 降级、#137 worker 加固已合)。

## 动机

`*.workers.dev` 在部分国内运营商被整域阻断(#83 有实锤案例,deploy.md 此前只能教用户配 HTTP_PROXY),而默认代理是无 token 用户**唯一**的元数据通道。两个域名 zone 都在同一 Cloudflare 账号,custom domain 零成本根治。

## 改动

- `wrangler.jsonc`:声明 custom domain `tmdb-proxy.mediaryscout.app` + **`workers_dev: true` 显式保留**。⚠️ 踩坑实录:只加 routes 会静默禁用 workers.dev 子域——首次部署后老 URL 全网 404(打断所有现网旧版客户端),补 `workers_dev: true` 重部署才恢复。注释已把这个坑钉在配置旁边。
- `workflow-runtime.ts` `DEFAULT_TMDB_PROXY_BASE_URL` + `site/lib.mjs` 官网海报墙 `WORKER_BASE` → custom domain(TDD:site 测试先红后绿)。
- 文档:deploy.md #83 段落(默认已缓解、HTTP_PROXY 降为兜底)、worker README 部署说明。

## 已验证(worker 侧已部署,域名已 live)

- `tmdb-proxy.mediaryscout.app`:trending 200 HIT / search 200 / img 200(从国内网络实测)
- `media-track-tmdb-proxy.fancydirty.workers.dev` 老 URL:恢复 200,旧版客户端不受影响
- site 16/16、全量 vitest 1461 绿、apps/web tsc + root typecheck 绿
- 合并后 Vercel 自动重部署官网,海报墙即切新域名

🤖 Generated with [Claude Code](https://claude.com/claude-code)