### PR TITLE
feat(settings): 网盘 tab 重设计——盘位卡片网格 + 集成图库式添加流

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -17,6 +17,7 @@
   --info: #539df5;
   --border: #4d4d4d;
   --border-soft: #7c7c7c;
+  --text-faint: #8f8f8f;
   --radius-pill: 9999px;
   --radius-card: 8px;
   --shadow-heavy: rgba(0, 0, 0, 0.5) 0px 8px 24px;
@@ -3484,7 +3485,7 @@ select.setting-control {
 }
 
 .drive-card-meta {
-  color: #6f6f6f;
+  color: var(--text-faint);
   font-size: 11px;
   margin-top: 2px;
 }
@@ -3520,7 +3521,7 @@ select.setting-control {
 }
 
 .drive-add-hint {
-  color: #6f6f6f;
+  color: var(--text-faint);
   font-size: 11px;
   margin-left: 8px;
 }
@@ -3528,7 +3529,7 @@ select.setting-control {
 .drive-risk-note {
   margin-top: 12px;
   font-size: 11px;
-  color: #8f8f8f;
+  color: var(--text-faint);
 }
 
 /* 品牌图库瓦片(集成图库范式:图标 + 名称 + 认证方式) */

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3448,6 +3448,16 @@ select.setting-control {
   flex: none;
 }
 
+/* 未注册品牌的图标占位:方形,绝不与状态圆点撞形 */
+.drive-card-icon-fallback {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.08);
+  flex: none;
+  display: inline-block;
+}
+
 .drive-card-name {
   font-weight: 600;
   font-size: 13px;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3414,3 +3414,177 @@ select.setting-control {
   cursor: pointer;
   padding: 0;
 }
+
+/* ── 设置页·网盘 tab 重设计(盘位卡片网格 + 品牌图库添加流)──────────────── */
+
+.drive-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 8px;
+  margin: 14px 0 18px;
+}
+
+.drive-card {
+  background: var(--bg-surface);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-card);
+  padding: 10px 12px;
+  min-width: 0;
+}
+
+.drive-card.is-frozen {
+  border-color: rgba(255, 164, 43, 0.35);
+}
+
+.drive-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.drive-card-icon {
+  border-radius: 6px;
+  flex: none;
+}
+
+.drive-card-name {
+  font-weight: 600;
+  font-size: 13px;
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.drive-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+  display: inline-block;
+}
+
+.drive-dot.green {
+  background: var(--accent);
+}
+
+.drive-dot.amber {
+  background: var(--warning);
+}
+
+.drive-card-uid {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 7px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.drive-card-meta {
+  color: #6f6f6f;
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+.tone-amber-text {
+  color: var(--warning);
+}
+
+/* 动作降权:默认弱化,悬停/键盘聚焦时提到全亮(opacity 不挡触控,手机可直接点) */
+.drive-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 9px;
+  opacity: 0.55;
+  transition: opacity 0.15s;
+}
+
+.drive-card:hover .drive-card-actions,
+.drive-card:focus-within .drive-card-actions {
+  opacity: 1;
+}
+
+.drive-card-actions .ghost-button,
+.drive-card-actions .secondary-button {
+  font-size: 12px;
+  padding: 3px 10px;
+}
+
+.drive-add-heading {
+  margin-bottom: 8px;
+}
+
+.drive-add-hint {
+  color: #6f6f6f;
+  font-size: 11px;
+  margin-left: 8px;
+}
+
+.drive-risk-note {
+  margin-top: 12px;
+  font-size: 11px;
+  color: #8f8f8f;
+}
+
+/* 品牌图库瓦片(集成图库范式:图标 + 名称 + 认证方式) */
+.brand-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
+  gap: 8px;
+}
+
+.brand-tile {
+  background: var(--bg-surface);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-card);
+  padding: 12px 8px 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  cursor: pointer;
+  color: var(--text);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.brand-tile:hover {
+  border-color: rgba(255, 255, 255, 0.22);
+  background: var(--bg-raised);
+}
+
+.brand-tile.is-selected {
+  border-color: var(--accent);
+  background: var(--bg-raised);
+}
+
+.brand-tile-icon {
+  border-radius: 7px;
+  margin-bottom: 5px;
+}
+
+.brand-tile-label {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.brand-tile-note {
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+.brand-tile.is-selected .brand-tile-note {
+  color: var(--accent);
+}
+
+.brand-connect-area {
+  margin-top: 10px;
+  background: var(--bg-surface);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-card);
+  padding: 14px;
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,4 +1,5 @@
 import { driveConnectionBadge } from "../../lib/settings-badge";
+import { maskProviderUid } from "../../lib/mask-provider-uid";
 import { connection } from "next/server";
 import { Suspense } from "react";
 import { Bell, Bot, Cable, CalendarClock, Clapperboard, Gauge, KeyRound, Languages, Radio, ShieldCheck, Subtitles, TriangleAlert, Users } from "lucide-react";
@@ -343,6 +344,19 @@ async function SubtitleSourceSection() {
   );
 }
 
+/** 品牌显示名(与注册表 label 一致);盘卡与解绑确认共用。 */
+const PROVIDER_LABELS: Record<string, string> = {
+  pan115: "115网盘",
+  quark: "夸克网盘",
+  guangya: "光鸭云盘",
+  tianyi: "天翼云盘",
+  pan123: "123网盘",
+};
+
+function providerLabel(provider: string): string {
+  return PROVIDER_LABELS[provider] ?? provider;
+}
+
 async function Pan115Section() {
   await connection();
   const status = await getPan115ConnectionStatus();
@@ -356,7 +370,7 @@ async function Pan115Section() {
             <Cable size={16} aria-hidden style={{ verticalAlign: "-2px", marginRight: 8 }} />
             网盘连接
           </h2>
-          <p className="panel-note">连接 115（扫码）、夸克（粘贴 cookie）、光鸭（粘贴 token）、天翼（扫码）或 123网盘（扫码／粘 token）；凭证持久化到数据库，自动用于后续转存。每块盘是独立工作区</p>
+          <p className="panel-note">每块盘是独立工作区，左上角可切换；凭证入库后自动用于转存</p>
         </div>
         {(() => {
           // #93: derive the header badge from ALL drives — 115-only status made
@@ -376,56 +390,66 @@ async function Pan115Section() {
       </div>
 
       {drives.length === 0 ? (
-        <p className="qr-hint">还没有连接任何网盘，扫码 115 或粘贴夸克 cookie 后即可开始获取资源。</p>
+        <p className="qr-hint">还没有连接任何网盘，选择下方品牌完成连接后即可开始获取资源。</p>
       ) : null}
 
       {drives.length > 0 ? (
-        <div style={{ margin: "14px 0" }}>
-          <p className="panel-note" style={{ marginBottom: 8 }}>
-            本账号已连接的网盘{drives.length >= 2 ? "（左上角可切换工作区，每块盘各自独立）" : ""}
-          </p>
-          <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 8 }}>
-            {drives.map((drive) => (
-              <li key={drive.id} className="setting-row" style={{ justifyContent: "space-between" }}>
-                <span>
-                  {drive.provider === "pan115" ? "115网盘" : drive.provider === "quark" ? "夸克网盘" : drive.provider === "guangya" ? "光鸭云盘" : drive.provider === "tianyi" ? "天翼云盘" : drive.provider === "pan123" ? "123网盘" : drive.provider}
-                  <span className="push-help"> · 账号 {drive.providerUid}</span>
-                  {drive.connectedAt ? (
-                    <span className="push-help"> · 连接于 {drive.connectedAt.slice(0, 16).replace("T", " ")}</span>
-                  ) : null}
-                </span>
-                <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-                  {drive.status === "frozen" ? (
-                    <span className="hub-badge tone-amber" title="cookie 已失效，重新扫码绑定同一个 115 即可恢复">
-                      <TriangleAlert size={12} aria-hidden />
-                      掉线
-                    </span>
+        <div className="drive-grid">
+          {drives.map((drive) => {
+            const frozen = drive.status === "frozen";
+            const ready = !frozen && drive.provisioned;
+            return (
+              <div key={drive.id} className={`drive-card${frozen ? " is-frozen" : ""}`}>
+                <div className="drive-card-head">
+                  {PROVIDER_LABELS[drive.provider] ? (
+                    // 已注册品牌必有 svg(workspace-switcher 同款资产)
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img className="drive-card-icon" src={`/brands/${drive.provider}.svg`} alt="" width={26} height={26} />
                   ) : (
-                    <span className={`hub-badge ${drive.provisioned ? "tone-green" : "tone-amber"}`}>
-                      {drive.provisioned ? "目录已就绪" : "目录待建"}
-                    </span>
+                    <span className="drive-dot amber" aria-hidden />
                   )}
-                  <TestConnectionButton storageId={drive.id} />
-                  <UnbindStorageButton
-                    storageId={drive.id}
-                    label={drive.provider === "pan115" ? "115网盘" : drive.provider === "quark" ? "夸克网盘" : drive.provider === "guangya" ? "光鸭云盘" : drive.provider === "tianyi" ? "天翼云盘" : drive.provider === "pan123" ? "123网盘" : drive.provider}
+                  <span className="drive-card-name">{providerLabel(drive.provider)}</span>
+                  <span
+                    className={`drive-dot ${ready ? "green" : "amber"}`}
+                    title={frozen ? "凭证已失效，重新绑定同一账号即可恢复" : ready ? "目录已就绪" : "目录待建"}
+                    aria-label={frozen ? "掉线" : ready ? "就绪" : "目录待建"}
                   />
-                </span>
-              </li>
-            ))}
-          </ul>
+                </div>
+                <div className="drive-card-uid" title={drive.providerUid}>
+                  {maskProviderUid(drive.providerUid)}
+                </div>
+                <div className="drive-card-meta">
+                  {frozen ? (
+                    <span className="tone-amber-text">掉线 · 重新绑定即恢复</span>
+                  ) : !drive.provisioned ? (
+                    <span className="tone-amber-text">目录待建</span>
+                  ) : drive.connectedAt ? (
+                    <span>{drive.connectedAt.slice(0, 10)} 连接</span>
+                  ) : (
+                    <span>就绪</span>
+                  )}
+                </div>
+                <div className="drive-card-actions">
+                  <TestConnectionButton storageId={drive.id} />
+                  <UnbindStorageButton storageId={drive.id} label={providerLabel(drive.provider)} />
+                </div>
+              </div>
+            );
+          })}
         </div>
       ) : null}
 
-      <p className="panel-note" style={{ marginBottom: 8 }}>
-        {drives.length > 0
-          ? "添加另一块网盘（115／夸克／光鸭／天翼／123）——不同账号即新增一块独立工作区；绑到已连的同一账号会自动刷新登录"
-          : "添加你的第一块网盘"}
+      <p className="panel-note drive-add-heading">
+        {drives.length > 0 ? "添加网盘 · 选择品牌开始连接" : "添加你的第一块网盘"}
+        {drives.length > 0 ? (
+          <span className="drive-add-hint">不同账号即新增一块独立工作区；绑已连的同一账号会自动刷新登录</span>
+        ) : null}
       </p>
-      <AddDriveBrandTabs />
+      <AddDriveBrandTabs defaultBrand={drives.length > 0 ? null : "pan115"} />
 
-      <p className="panel-note" style={{ marginTop: 12 }}>
-        ⚠️ 请勿在多个账号或多个实例上绑定同一个网盘账号，易触发风控。每个网盘账号在本实例内只能归属一个用户。
+      <p className="panel-note drive-risk-note">
+        <TriangleAlert size={12} aria-hidden style={{ verticalAlign: "-2px", marginRight: 4 }} />
+        同一网盘账号勿在多个账号或多个实例绑定，易触发风控；每个网盘账号在本实例内只能归属一个用户。
       </p>
     </section>
   );

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -47,7 +47,7 @@ import {
   resolveGlobalWorkspace,
   resolveIsDesktop,
 } from "../../lib/workflow-runtime";
-import { brandSupportsProwlarr } from "@media-track/workflow";
+import { brandSupportsProwlarr, getStorageBrand, isRegisteredStorageProvider } from "@media-track/workflow";
 import { isDemoMode } from "../../lib/demo-mode";
 
 export default function SettingsPage({
@@ -344,17 +344,10 @@ async function SubtitleSourceSection() {
   );
 }
 
-/** 品牌显示名(与注册表 label 一致);盘卡与解绑确认共用。 */
-const PROVIDER_LABELS: Record<string, string | undefined> = {
-  pan115: "115网盘",
-  quark: "夸克网盘",
-  guangya: "光鸭云盘",
-  tianyi: "天翼云盘",
-  pan123: "123网盘",
-};
-
+/** 品牌显示名直读 workflow 注册表(单一事实源,与 workspace-switcher 一致),
+ *  未注册品牌兜底显示原始 provider 串。盘卡与解绑确认共用。 */
 function providerLabel(provider: string): string {
-  return PROVIDER_LABELS[provider] ?? provider;
+  return isRegisteredStorageProvider(provider) ? getStorageBrand(provider).label : provider;
 }
 
 async function Pan115Section() {
@@ -401,7 +394,7 @@ async function Pan115Section() {
             return (
               <div key={drive.id} className={`drive-card${frozen ? " is-frozen" : ""}`}>
                 <div className="drive-card-head">
-                  {PROVIDER_LABELS[drive.provider] ? (
+                  {isRegisteredStorageProvider(drive.provider) ? (
                     // 已注册品牌必有 svg(workspace-switcher 同款资产)
                     // eslint-disable-next-line @next/next/no-img-element
                     <img className="drive-card-icon" src={`/brands/${drive.provider}.svg`} alt="" width={26} height={26} />

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -345,7 +345,7 @@ async function SubtitleSourceSection() {
 }
 
 /** 品牌显示名(与注册表 label 一致);盘卡与解绑确认共用。 */
-const PROVIDER_LABELS: Record<string, string> = {
+const PROVIDER_LABELS: Record<string, string | undefined> = {
   pan115: "115网盘",
   quark: "夸克网盘",
   guangya: "光鸭云盘",
@@ -411,6 +411,7 @@ async function Pan115Section() {
                   <span className="drive-card-name">{providerLabel(drive.provider)}</span>
                   <span
                     className={`drive-dot ${ready ? "green" : "amber"}`}
+                    role="img"
                     title={frozen ? "凭证已失效，重新绑定同一账号即可恢复" : ready ? "目录已就绪" : "目录待建"}
                     aria-label={frozen ? "掉线" : ready ? "就绪" : "目录待建"}
                   />

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -399,7 +399,8 @@ async function Pan115Section() {
                     // eslint-disable-next-line @next/next/no-img-element
                     <img className="drive-card-icon" src={`/brands/${drive.provider}.svg`} alt="" width={26} height={26} />
                   ) : (
-                    <span className="drive-dot amber" aria-hidden />
+                    // 未注册品牌:中性方形占位(与右侧状态圆点区分形状,避免双点误读)
+                    <span className="drive-card-icon-fallback" aria-hidden />
                   )}
                   <span className="drive-card-name">{providerLabel(drive.provider)}</span>
                   <span

--- a/apps/web/components/add-drive-brand-tabs.tsx
+++ b/apps/web/components/add-drive-brand-tabs.tsx
@@ -13,7 +13,7 @@ import { Pan123TokenConnect } from "./pan123-token-connect";
 type Brand = "pan115" | "quark" | "guangya" | "tianyi" | "pan123";
 
 /** 品牌图库瓦片的静态元数据:图标走 /brands/<key>.svg(workspace-switcher 同款资产),
- *  authNote 把认证方式前置到选择时刻(选之前就知道要扫码还是粘贴)。加新品牌 = 加一行。 */
+ *  authNote 把认证方式前置到选择时刻(选之前就知道要扫码还是粘贴)。加新品牌:此表加一行 + Brand 联合 + 下方连接区分支 + /brands svg(完整触点见加品牌清单)。 */
 const BRAND_TILES: Array<{ key: Brand; label: string; authNote: string }> = [
   { key: "pan115", label: "115网盘", authNote: "扫码登录" },
   { key: "quark", label: "夸克网盘", authNote: "扫码 / 粘 cookie" },

--- a/apps/web/components/add-drive-brand-tabs.tsx
+++ b/apps/web/components/add-drive-brand-tabs.tsx
@@ -12,63 +12,55 @@ import { Pan123TokenConnect } from "./pan123-token-connect";
 
 type Brand = "pan115" | "quark" | "guangya" | "tianyi" | "pan123";
 
-/** Settings "添加网盘": pick a brand, then connect it. 115/夸克/天翼/123 scan a QR
- *  (夸克折叠 cookie 粘贴回退、天翼折叠 SSON 粘贴回退、123 折叠粘 token 回退——QR 的
- *  凭证兑换是易碎跳),光鸭粘 token。Each bound drive becomes its own isolated
- *  workspace (tree model). */
-export function AddDriveBrandTabs() {
-  const [brand, setBrand] = useState<Brand>("pan115");
+/** 品牌图库瓦片的静态元数据:图标走 /brands/<key>.svg(workspace-switcher 同款资产),
+ *  authNote 把认证方式前置到选择时刻(选之前就知道要扫码还是粘贴)。加新品牌 = 加一行。 */
+const BRAND_TILES: Array<{ key: Brand; label: string; authNote: string }> = [
+  { key: "pan115", label: "115网盘", authNote: "扫码登录" },
+  { key: "quark", label: "夸克网盘", authNote: "扫码 / 粘 cookie" },
+  { key: "guangya", label: "光鸭云盘", authNote: "粘贴 token" },
+  { key: "tianyi", label: "天翼云盘", authNote: "扫码 / SSON" },
+  { key: "pan123", label: "123网盘", authNote: "扫码 / 粘 token" },
+];
+
+/** Settings「添加网盘」:集成图库式品牌选择(图标 + 名称 + 认证方式瓦片),选中后
+ *  瓦片下方展开该品牌的连接区。115/夸克/天翼/123 scan a QR(夸克折叠 cookie 粘贴
+ *  回退、天翼折叠 SSON 回退、123 折叠粘 token 回退——QR 的凭证兑换是易碎跳),光鸭
+ *  粘 token。Each bound drive becomes its own isolated workspace (tree model).
+ *  defaultBrand:首盘用户传 "pan115" 直接引导扫码;已有盘时传 null,连接区收起,
+ *  点瓦片才展开(添加是低频动作,别让 115 连接区常驻占位)。再点选中瓦片可收起。 */
+export function AddDriveBrandTabs({ defaultBrand = "pan115" }: { defaultBrand?: Brand | null }) {
+  const [brand, setBrand] = useState<Brand | null>(defaultBrand);
 
   return (
     <div>
-      <div className="tab-row" style={{ display: "flex", gap: 8, marginBottom: 12 }}>
-        <button
-          type="button"
-          className={brand === "pan115" ? "primary-button" : "secondary-button"}
-          onClick={() => setBrand("pan115")}
-          aria-pressed={brand === "pan115"}
-        >
-          115 网盘
-        </button>
-        <button
-          type="button"
-          className={brand === "quark" ? "primary-button" : "secondary-button"}
-          onClick={() => setBrand("quark")}
-          aria-pressed={brand === "quark"}
-        >
-          夸克网盘
-        </button>
-        <button
-          type="button"
-          className={brand === "guangya" ? "primary-button" : "secondary-button"}
-          onClick={() => setBrand("guangya")}
-          aria-pressed={brand === "guangya"}
-        >
-          光鸭云盘
-        </button>
-        <button
-          type="button"
-          className={brand === "tianyi" ? "primary-button" : "secondary-button"}
-          onClick={() => setBrand("tianyi")}
-          aria-pressed={brand === "tianyi"}
-        >
-          天翼云盘
-        </button>
-        <button
-          type="button"
-          className={brand === "pan123" ? "primary-button" : "secondary-button"}
-          onClick={() => setBrand("pan123")}
-          aria-pressed={brand === "pan123"}
-        >
-          123网盘
-        </button>
+      <div className="brand-gallery" role="group" aria-label="选择网盘品牌">
+        {BRAND_TILES.map((tile) => (
+          <button
+            key={tile.key}
+            type="button"
+            className={`brand-tile${brand === tile.key ? " is-selected" : ""}`}
+            onClick={() => setBrand(brand === tile.key ? null : tile.key)}
+            aria-pressed={brand === tile.key}
+          >
+            {/* 已注册品牌必有 svg(加品牌 touch-point 清单项);alt 空,名称由下方文字承担。
+                本地小 svg 无需 next/image 优化(workspace-switcher 同款惯例)。 */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img className="brand-tile-icon" src={`/brands/${tile.key}.svg`} alt="" width={32} height={32} />
+            <span className="brand-tile-label">{tile.label}</span>
+            <span className="brand-tile-note">{tile.authNote}</span>
+          </button>
+        ))}
       </div>
       {brand === "pan115" ? (
-        <Pan115QrConnect />
+        <div className="brand-connect-area">
+          <Pan115QrConnect />
+        </div>
       ) : brand === "guangya" ? (
-        <GuangYaTokenConnect />
+        <div className="brand-connect-area">
+          <GuangYaTokenConnect />
+        </div>
       ) : brand === "tianyi" ? (
-        <div>
+        <div className="brand-connect-area">
           <TianyiQrConnect />
           <details style={{ marginTop: 12 }}>
             <summary className="panel-note" style={{ cursor: "pointer" }}>
@@ -80,7 +72,7 @@ export function AddDriveBrandTabs() {
           </details>
         </div>
       ) : brand === "pan123" ? (
-        <div>
+        <div className="brand-connect-area">
           <Pan123QrConnect />
           <details style={{ marginTop: 12 }}>
             <summary className="panel-note" style={{ cursor: "pointer" }}>
@@ -91,8 +83,8 @@ export function AddDriveBrandTabs() {
             </div>
           </details>
         </div>
-      ) : (
-        <div>
+      ) : brand === "quark" ? (
+        <div className="brand-connect-area">
           <QuarkQrConnect />
           <details style={{ marginTop: 12 }}>
             <summary className="panel-note" style={{ cursor: "pointer" }}>
@@ -103,7 +95,7 @@ export function AddDriveBrandTabs() {
             </div>
           </details>
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/apps/web/lib/mask-provider-uid.test.ts
+++ b/apps/web/lib/mask-provider-uid.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { maskProviderUid } from "./mask-provider-uid";
+
+describe("maskProviderUid(设置页盘卡的 uid 展示)", () => {
+  it("手机号形 uid 打码中段(天翼 loginName 带 @189.cn 后缀也认,展示去后缀)", () => {
+    expect(maskProviderUid("17358529532")).toBe("173****9532");
+    expect(maskProviderUid("17358529532@189.cn")).toBe("173****9532");
+  });
+
+  it("长 uid 中段截断(夸克/光鸭式随机串)", () => {
+    expect(maskProviderUid("AARtNzjHERIBIZ2mQ8SE5Kr2")).toBe("AARt…5Kr2");
+    expect(maskProviderUid("aj6Qo5l86EF4O2AM")).toBe("aj6Q…O2AM");
+  });
+
+  it("短 uid 原样(115/123 的数字 id)", () => {
+    expect(maskProviderUid("103164004")).toBe("103164004");
+    expect(maskProviderUid("1843112717")).toBe("1843112717");
+  });
+
+  it("空值兜底为空串", () => {
+    expect(maskProviderUid("")).toBe("");
+  });
+});

--- a/apps/web/lib/mask-provider-uid.ts
+++ b/apps/web/lib/mask-provider-uid.ts
@@ -1,0 +1,16 @@
+/** 设置页盘卡的 uid 展示归一:手机号形打码中段(天翼 loginName 去 @ 后缀)、
+ *  长随机串中段截断、短数字 id 原样。完整值放 title 悬停可见,展示层不泄手机号。 */
+export function maskProviderUid(uid: string): string {
+  const v = (uid ?? "").trim();
+  if (!v) {
+    return "";
+  }
+  const phone = /^(1\d{2})\d{4}(\d{4})(?:@.*)?$/.exec(v);
+  if (phone) {
+    return `${phone[1]}****${phone[2]}`;
+  }
+  if (v.length > 14) {
+    return `${v.slice(0, 4)}…${v.slice(-4)}`;
+  }
+  return v;
+}


### PR DESCRIPTION
## Summary
随品牌增至 5 个,设置页网盘 tab 的文本行列表 + 胶囊排已不优雅。经 visual companion 三方案比稿,用户选定方案 C:

- **已连盘 → 盘位卡片网格**:品牌 svg 图标(workspace-switcher 同款资产)+ 名称 + 状态点(就绪绿/掉线·待建琥珀,title 带完整提示)、mono uid(手机号形打码 `173****9532`、长随机串中段截断 `AARt…5Kr2`,完整值 title 悬停)、连接日期;「测试连接/取消绑定」降权(默认 55% 透明度,悬停/聚焦提亮,不挡触控)。`auto-fill minmax(280px)` 网格,10+ 盘不乱,手机 1 列。
- **添加流 → 品牌图库瓦片**:胶囊排 → 图标 + 名称 + 认证方式前置的瓦片(Notion 接集成范式);有盘时连接区默认收起、点瓦片展开(再点收起),首盘用户仍预选 115 直接引导扫码。各品牌连接组件零改动复用。
- **文案收敛**:头部品牌枚举散文 → 一句;五枚重复绿胶囊 → 头部汇总徽章 + 每盘状态点;风控提示一行(图标替 emoji)。
- `maskProviderUid` 纯函数 TDD(4 用例);加新品牌 = BRAND_TILES 加一行。

## Test Plan
- [x] vitest apps/web 295+4 全绿;`tsc -p apps/web` / `npm run build:web` / `eslint --max-warnings 0` 全 EXIT 0
- [x] dev 真机验证(真 DB 4 块盘):卡网格渲染、瓦片图标 `naturalWidth>0` 像素断言、123 瓦片点选展开/选中态、a11y(aria-pressed + 按钮可访问名)
- [x] 手机 375px 真值:无横滚(scrollWidth 375=375)、盘卡 1 列、瓦片 2 列

🤖 Generated with [Claude Code](https://claude.com/claude-code)