### PR TITLE
docs: 五盘时代——README/deploy/site 品牌全量更新 + PanSou 分享量实测排序

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,18 +90,30 @@ Multiple drives appear as a workspace switcher with per-brand icons:
 
 Most "media automation" either searches well but doesn't know what you're actually missing, or moves files but never verifies what landed. Mediary Scout treats acquisition as a **state problem**, driven by an agent that acts from evidence, not vibes:
 
-- **Multi-drive, brand-extensible** — 115, Quark, and 光鸭 (GuangYaPan) today, each a first-class workspace (a tree model: one account, many drives). Adding a new drive brand is a contained plugin.
+- **Multi-drive, brand-extensible** — five drives today (Quark, 115, 光鸭 GuangYaPan, 123, 天翼 Tianyi), each a first-class workspace (a tree model: one account, many drives). Adding a new drive brand is a contained plugin.
 - **Agent-driven selection** — the agent reads real search results and picks by quality preference, **Chinese-subtitle** needs, and de-duplication, then verifies the transfer after it happens.
 - **Tracking & scheduled gap-fill** — season-level state machine; a scheduled sweep comes back only for shows that still have missing episodes.
 - **Cloud-native** — it **transfers** shares/magnets straight into your drive (秒传 / save), it does not download to a local disk.
 
 ## Supported drives
 
-Three Chinese cloud drives, each a first-class workspace:
+Five Chinese cloud drives, each a first-class workspace — ordered by how many PanSou resources each can consume:
 
-- **115** (`pan115`) — full support, including magnet via Prowlarr.
-- **Quark** (`quark`) — share-link transfer (no magnet web API).
-- **GuangYaPan / 光鸭云盘** (`guangya`) — Xunlei-family drive; **magnet / offline-download first** (transfers magnet/ed2k/BT via its offline-task API, like 115's offline path — it does **not** transfer 115/Quark/光鸭 share-links in v1). Token auth (`access_token` + `refresh_token`). Pairs well with Prowlarr. **[Setup guide](docs/deploy.md#光鸭云盘guangyapan连接)**
+- **Quark / 夸克** (`quark`) — share-link transfer (no magnet web API). The largest share pool on PanSou by far.
+- **115** (`pan115`) — full support: 115 share links **and** magnets (built-in offline path, plus Prowlarr).
+- **GuangYaPan / 光鸭云盘** (`guangya`) — Xunlei-family drive; **magnet / offline-download only** (transfers magnet/ed2k/BT via its offline-task API — it does **not** transfer share links in v1). Token auth. Pairs well with Prowlarr. **[Setup guide](docs/deploy.md#光鸭云盘guangyapan连接)**
+- **123网盘** (`pan123`) — share-link transfer (`123pan.com/s/…`); QR login (~90-day token) or paste a token. Free accounts can transfer (server-side copy costs no download quota). **[Setup guide](docs/deploy.md#123网盘连接)**
+- **Tianyi / 天翼云盘** (`tianyi`) — share-link transfer (`cloud.189.cn/t/…`); QR login or paste an SSON cookie. Smallest share pool on PanSou today (weak for movies, workable for shows/anime). **[Setup guide](docs/deploy.md#天翼云盘连接)**
+
+Measured share volume per drive (2026-07 point-in-time sample: six popular titles across movie / drama / anime, one PanSou instance with curated channels — your channels will vary):
+
+| Drive | Own share links | Magnets it can also eat | Usable pool |
+| --- | ---: | ---: | ---: |
+| Quark | 523 | — | **523** |
+| 115 | 100 | 361 | **461** |
+| 光鸭 | — | 361 | **361** |
+| 123 | 120 | — | **120** |
+| 天翼 | 63 | — | **63** |
 
 New brands plug into a storage-brand registry; the bulk of adding one is a drive client + a storage executor for that drive's transfer API.
 
@@ -140,7 +152,7 @@ flowchart LR
     Q --> W["In-process worker"]
     W --> AG["V2 sandbox agent"]
     AG -->|search| SRC["PanSou / Prowlarr"]
-    AG -->|transfer| DR["115 / Quark / 光鸭 drive"]
+    AG -->|transfer| DR["Quark / 115 / 光鸭 / 123 / 天翼 drive"]
     AG -->|read back| DR
     AG -->|verify + mark| Q
     Q -->|realtime| UI
@@ -176,7 +188,7 @@ You are deploying Mediary Scout, a self-hosted media-acquisition agent. Follow t
    - Local network only (default — open `http://<host>:3000` from devices on the same LAN)
    - Tailscale (private mesh — recommended for home; no public IP, auto-encrypted)
    - Cloudflare Tunnel (public HTTPS like `https://media.yourdomain.com` — needs a domain on Cloudflare + Access in front)
-4. **Configure real acquisition now, or just get it running first?** Real acquisition needs a 115/Quark/光鸭 drive + an LLM endpoint (OpenAI-compatible) + (if using 115) 115 directory CIDs. Skipping means it boots and you can look around, configure later in Settings.
+4. **Configure real acquisition now, or just get it running first?** Real acquisition needs a supported drive (Quark/115/光鸭/123/天翼) + an LLM endpoint (OpenAI-compatible) + (if using 115) 115 directory CIDs. Skipping means it boots and you can look around, configure later in Settings.
 
 ## OPTIONAL — one question, skip all if the user doesn't care
 5. Any of these you want to set up now? Reply "none" to skip and use defaults:
@@ -199,7 +211,7 @@ You are deploying Mediary Scout, a self-hosted media-acquisition agent. Follow t
 
 ## Status & limitations
 
-- Self-hosted, for advanced users; you need usable 115/Quark/光鸭 access (a membership is most practical).
+- Self-hosted, for advanced users; you need usable access to a supported drive (Quark/115/光鸭/123/天翼 — a membership is most practical on 115/夸克; 123/天翼 work on free accounts).
 - Scheduled monitoring is most valuable on an always-on host (Docker path).
 - This is not a hosted product and ships no hosted backend.
 
@@ -211,9 +223,11 @@ Built on top of, and grateful to:
 - [Prowlarr](https://github.com/Prowlarr/Prowlarr) — indexer manager (optional)
 - [p115client](https://github.com/ChenyangGao/p115client) — 115 API reference
 - [AList](https://github.com/AlistGo/alist) — GuangYaPan (光鸭云盘) API integration reference (the `drivers/guangyapan` driver)
+- [p123client](https://github.com/ChenyangGao/p123client) — 123网盘 API reference
+- [cloud189-auto-save](https://github.com/1307super/cloud189-auto-save) / [cloudpan189-api](https://github.com/tickstep/cloudpan189-api) — 天翼云盘 API references
 - [TMDB](https://www.themoviedb.org/) — metadata (this product is not endorsed or certified by TMDB)
 
-Not affiliated with 115, Quark, 光鸭云盘 (GuangYaPan), TMDB, or any indexer. Mediary Scout is an independent, disciplined workflow built around these pieces.
+Not affiliated with 115, Quark, 光鸭云盘 (GuangYaPan), 123网盘, 天翼云盘, TMDB, or any indexer. Mediary Scout is an independent, disciplined workflow built around these pieces.
 
 ## Star History
 ![Star History Chart](https://api.star-history.com/svg?repos=fancydirty/mediary-scout)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -15,7 +15,7 @@ Mediary Scout 有两种部署方式:
 
 ---
 
-> **English summary.** Self-host with one command — `docker compose up -d` brings up web (Next.js + in-process worker) + Postgres + a bundled PanSou. Open `http://<host>:3000`, go to Settings, scan-login your 115 / Quark drive (or paste a 光鸭 / GuangYaPan `access_token` + `refresh_token`), add an OpenAI-compatible LLM endpoint, and you're running. To reach it from your phone / TV / on the go, use **Tailscale** (private mesh — safest) or a **Cloudflare Tunnel** (public HTTPS, no public IP). **Never expose `:3000` raw to the internet.** Full walkthrough below (Chinese).
+> **English summary.** Self-host with one command — `docker compose up -d` brings up web (Next.js + in-process worker) + Postgres + a bundled PanSou. Open `http://<host>:3000`, go to Settings, scan-login your drive (115 / Quark / 123 / Tianyi by QR; GuangYaPan by pasted token), add an OpenAI-compatible LLM endpoint, and you're running. To reach it from your phone / TV / on the go, use **Tailscale** (private mesh — safest) or a **Cloudflare Tunnel** (public HTTPS, no public IP). **Never expose `:3000` raw to the internet.** Full walkthrough below (Chinese).
 
 一行命令起整套:**web(Next + 进程内 worker)+ Postgres + 自带 PanSou**。本指南覆盖:选宿主 → compose 起服务 → 从自己的设备访问 → 安全/升级。
 
@@ -23,6 +23,8 @@ Mediary Scout 有两种部署方式:
 - [选择你的宿主](#选择你的宿主)
 - [Compose 快速开始](#compose-快速开始)
 - [光鸭云盘(GuangYaPan)连接](#光鸭云盘guangyapan连接)
+- [天翼云盘连接](#天翼云盘连接)
+- [123网盘连接](#123网盘连接)
 - [想跑真实获取还需要](#想跑真实获取还需要)
 - [可选增强](#可选增强)
 - [从你的设备访问](#从你的设备访问)
@@ -49,7 +51,7 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 ```
 
 打开 `http://<你的主机>:3000`:
-1. **设置 → 网盘**:115 扫码登录(cookie 持久化到数据库,后续自动转存);夸克在设置选夸克品牌粘贴 cookie;光鸭云盘在设置选光鸭品牌粘贴 `access_token` + `refresh_token` 两个值(见 [光鸭云盘连接](#光鸭云盘guangyapan连接))。
+1. **设置 → 网盘**:在品牌瓦片里选一个开始连接——115 / 夸克 / 天翼 / 123 扫码登录,光鸭粘贴 token(见各品牌连接小节);凭证入库后自动用于转存。五个品牌可各绑一块盘,互为独立工作区。
 2. 就这样。**TMDB 元数据经作者 CF Worker 开箱即用**(想用自己额度可在设置填 TMDB key);**PanSou 网盘搜索源已自带**。
 
 ### 组成 / 端口
@@ -107,6 +109,22 @@ docker compose up -d        # 首次会构建 web 镜像,几分钟
 ### 3. 来源致谢(API 逆向)
 
 光鸭云盘的网盘 API 集成,基于开源项目 **[AList](https://github.com/AlistGo/alist)** 的 `guangyapan` driver(目录 [`drivers/guangyapan`](https://github.com/AlistGo/alist/tree/main/drivers/guangyapan))。该 driver 是本项目逆向光鸭 API 的来源,在此致谢。
+
+## 天翼云盘连接
+
+天翼云盘(中国电信)是第四个支持的品牌,走**转存分享**路径(`cloud.189.cn/t/…` 分享链,与夸克同模型;无磁力/离线 API,Prowlarr 不适用)。
+
+- **连接**:设置 → 网盘 → 选「天翼云盘」→ 用天翼云盘 App 扫码。扫码不便时点开「手动粘 SSON cookie」:浏览器登录 [cloud.189.cn](https://cloud.189.cn) 后,从开发者工具 → Application → Cookies 里复制 `SSON` 的值粘入。
+- 会话由系统自动续期;显示「掉线」时重新扫码绑定同一账号即可恢复,追踪数据不丢。
+- 资源量提示:PanSou 上天翼分享目前偏少(电影尤其弱,剧/动漫可用),见 README 的分享量对比表。
+
+## 123网盘连接
+
+123网盘是第五个支持的品牌,走**转存分享**路径(`123pan.com/s/…` 分享链;免费账号即可转存——转存是服务端秒传复制,不消耗提取流量)。
+
+- **连接**:设置 → 网盘 → 选「123网盘」→ 用 123网盘 App 扫码(登录约 **90 天**有效)。扫码不便时点开「手动粘 token」:浏览器登录 [123pan.com](https://www.123pan.com) 网页版后,开发者工具 → Application → Local Storage 里找 `eyJ…` 开头的登录 token 整段粘入。
+- token 到期后显示「掉线」,重新扫码即恢复。
+- v1 未启用 123 的磁力离线接口(免费配额极少);候选全部来自 PanSou 的 123 分享。
 
 ## 想跑真实获取还需要
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mediary Scout — 自建网盘的媒体获取 agent</title>
-  <meta name="description" content="指定一部影视，agent 跨源检索、择优转存进你自己的 115/夸克/光鸭网盘、回读核对，并持续追踪缺集。macOS / Windows 桌面版，AGPL 开源、自部署。">
+  <meta name="description" content="指定一部影视，agent 跨源检索、择优转存进你自己的 夸克/115/光鸭/123/天翼 网盘、回读核对，并持续追踪缺集。macOS / Windows 桌面版，AGPL 开源、自部署。">
 
   <!-- Open Graph -->
   <meta property="og:title" content="Mediary Scout — 自建网盘的媒体获取 agent">
-  <meta property="og:description" content="指定一部影视，agent 跨源检索、择优转存进你自己的 115/夸克/光鸭网盘、回读核对，并持续追踪缺集。macOS / Windows 桌面版，AGPL 开源、自部署。">
+  <meta property="og:description" content="指定一部影视，agent 跨源检索、择优转存进你自己的 夸克/115/光鸭/123/天翼 网盘、回读核对，并持续追踪缺集。macOS / Windows 桌面版，AGPL 开源、自部署。">
   <meta property="og:image" content="https://mediaryscout.app/assets/og.png">
   <meta property="og:url" content="https://mediaryscout.app/">
   <meta property="og:type" content="website">
@@ -201,7 +201,7 @@
           <div class="feat-item">
             <div class="feat-num">03</div>
             <b>转存进你的网盘</b>
-            <span>115 / 夸克 / 光鸭，秒传 / 离线转存，不占本地磁盘；缺字幕自动补配。</span>
+            <span>夸克 / 115 / 光鸭 / 123 / 天翼，秒传 / 离线转存，不占本地磁盘；缺字幕自动补配。</span>
           </div>
           <div class="feat-item">
             <div class="feat-num">04</div>
@@ -313,7 +313,7 @@
           </svg>
         </summary>
         <div class="faq-body">
-          <p>115、夸克、光鸭；网盘层是插件化接口，欢迎 PR 加新品牌。</p>
+          <p>夸克、115、光鸭、123、天翼；网盘层是插件化接口，欢迎 PR 加新品牌。</p>
         </div>
       </details>
       <details name="faq" class="faq">


### PR DESCRIPTION
## Summary
- 新增天翼(#139)与 123(#141)后,README/deploy.md/site 仍写三盘;本 PR 全量更新为五品牌。
- **排序有数据背书**:对实例内置 PanSou 实测 6 个跨品类标题(电影/剧/国漫/日漫,零结果复测)的各类型分享量,README 附表:夸克 523 > 115 461(100 分享+361 磁力)> 光鸭 361(磁力)> 123 120 > 天翼 63,注明为单实例时点样本。
- deploy.md 新增「天翼云盘连接」(扫码/SSON cookie)与「123网盘连接」(扫码约 90 天/粘 localStorage token,免费号可转存不吃提取流量)两节;快速上手改为品牌瓦片图库流程。
- Credits 补 p123client 与 cloud189-auto-save/cloudpan189-api 参考实现署名;affiliation 声明补 123网盘/天翼云盘。
- 仓库简介已由 `gh repo edit` 同步:`(Quark 夸克 / 115 / 光鸭 GuangYa / 123网盘 / 天翼 Tianyi)`。

## Test Plan
- [x] 纯文档/静态站变更,无代码路径;PanSou 数据为真机实测(命令与原始数据见会话记录)
- [x] anchor 链接(#天翼云盘连接/#123网盘连接)与 TOC 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)