### PR TITLE
docs(demo): 只读演示站横幅品牌枚举补齐五盘

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -74,7 +74,7 @@ export default function SettingsPage({
           <div className="settings-card">
             <p>
               🔭 这是只读演示站,不提供网盘连接、登录与任何写入设置。
-              想真正使用(连 115/夸克、配 LLM key、自定义画质/通知)请{" "}
+              想真正使用(连 夸克/115/光鸭/123/天翼、配 LLM key、自定义画质/通知)请{" "}
               <a href="https://github.com/fancydirty/mediary-scout" target="_blank" rel="noreferrer">
                 自部署
               </a>


### PR DESCRIPTION
## Summary
两个宣传站中,mediaryscout.app(site/)已在 #144 更新;**demo.mediaryscout.app**(mediary-scout Vercel 项目,从 repo 根构建 apps/web)的只读演示横幅仍写两盘时代「想真正使用(连 115/夸克…)」。补齐为「夸克/115/光鸭/123/天翼」,与官网/README/仓库简介一致。

用户可见文案里唯一的两盘残留(其余 `115/夸克` 命中全是代码注释,不渲染)。

## Test Plan
- [x] tsc / vitest 295 / lint / build:web 全绿
- [x] grep 复核:apps/web 用户可见文案再无盘数量/枚举的旧串
- [ ] 合并后 Vercel 自动部署 demo.mediaryscout.app,横幅显示五品牌(demo-mode 仅演示站开启)

🤖 Generated with [Claude Code](https://claude.com/claude-code)