### PR TITLE
release: v1.3.0——五盘里程碑

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@media-track/desktop",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "commonjs",
   "main": "dist/main.js",
   "scripts": {

--- a/site/data/release-fallback.json
+++ b/site/data/release-fallback.json
@@ -1,13 +1,13 @@
 {
-  "tag_name": "v1.2.0",
+  "tag_name": "v1.3.0",
   "assets": [
     {
-      "name": "Mediary.Scout-1.2.0-arm64.dmg",
-      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.2.0/Mediary.Scout-1.2.0-arm64.dmg"
+      "name": "Mediary.Scout-1.3.0-arm64.dmg",
+      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.0/Mediary.Scout-1.3.0-arm64.dmg"
     },
     {
-      "name": "Mediary.Scout.Setup.1.2.0.exe",
-      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.2.0/Mediary.Scout.Setup.1.2.0.exe"
+      "name": "Mediary.Scout.Setup.1.3.0.exe",
+      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.0/Mediary.Scout.Setup.1.3.0.exe"
     }
   ]
 }


### PR DESCRIPTION
## Summary
v1.3.0 发版准备:桌面版本号 1.2.0 → 1.3.0,官网下载兜底 JSON 同步。合并后打 `v1.3.0` tag 触发 `release-desktop.yml` 构建 macOS + Windows 并原子发布。

**本版里程碑(v1.2.0 以来)**:
- 第四块盘 **天翼云盘**(#139)+ 第五块盘 **123网盘**(#141)——转存分享品牌;至此支持五盘(夸克/115/光鸭/123/天翼)
- `transferUntilLanded` 放开为全部转存分享品牌(#142)+ 天翼死分享误判/finish 停循环三修
- **网盘 tab 重设计**(#143):盘位卡片网格 + 品牌图库添加流
- 文档/官网五盘化(#144/#145)

## Test Plan
- [x] 兜底 JSON 合法 + 资产名与 electron-builder 输出对齐(`Mediary.Scout-1.3.0-arm64.dmg` / `Mediary.Scout.Setup.1.3.0.exe`)
- [x] site vitest 19/19
- [ ] 合并 → tag v1.3.0 → workflow 双平台构建 + ABI 冒烟 + 原子发布(任一平台挂则不动 Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)