### PR TITLE
fix(postgres): schema-init 失败不再闩死连接池,启动竞态可自愈

### DIFF
--- a/packages/workflow/src/postgres-ensure-schema-retry.test.ts
+++ b/packages/workflow/src/postgres-ensure-schema-retry.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { Pool, PoolClient } from "pg";
+import { PostgresWorkflowRepository } from "./postgres.js";
+
+/**
+ * Regression for the 2026-07-21 incident: on a host reboot the web container
+ * won the restart race against a still-recovering postgres, so the very first
+ * schema-init at startup rejected with ECONNREFUSED. `ensureSchema` memoized
+ * that rejected promise (`this.schemaReady ??= init(...)`) and every subsequent
+ * repository call replayed the cached rejection forever — the process never
+ * retried even after postgres came up seconds later, so the queue sat stuck for
+ * 47 hours until a manual restart.
+ *
+ * The repository must SELF-HEAL: a failed schema init must not latch. The next
+ * call has to re-attempt initialization so the app recovers on its own once the
+ * database is reachable.
+ */
+describe("PostgresWorkflowRepository schema-init self-healing", () => {
+  it("re-attempts schema init after a failed one instead of latching the rejection", async () => {
+    let connectAttempts = 0;
+    const fakeClient = {
+      query: async () => ({ rows: [] }),
+      release: () => {},
+    } as unknown as PoolClient;
+
+    const pool = {
+      connect: async () => {
+        connectAttempts += 1;
+        if (connectAttempts === 1) {
+          // Postgres still coming up — refuse the first connection.
+          const err = new Error("connect ECONNREFUSED 127.0.0.1:5432");
+          (err as NodeJS.ErrnoException).code = "ECONNREFUSED";
+          throw err;
+        }
+        return fakeClient;
+      },
+      query: async () => ({ rows: [] }),
+    } as unknown as Pool;
+
+    const repository = new PostgresWorkflowRepository(pool);
+
+    // First query: schema init fails because postgres is not ready yet.
+    await expect(repository.getSetting("boot")).rejects.toThrow(/ECONNREFUSED/);
+
+    // Postgres is up now. The next query MUST re-run schema init and succeed,
+    // not replay the cached rejection.
+    await expect(repository.getSetting("boot")).resolves.toBeNull();
+    expect(connectAttempts).toBe(2);
+  });
+});

--- a/packages/workflow/src/postgres.ts
+++ b/packages/workflow/src/postgres.ts
@@ -298,9 +298,23 @@ export class PostgresWorkflowRepository implements WorkflowRepository {
   }
 
   /** Create the schema once, memoized — lets the repo be constructed without
-   *  awaiting yet still self-initialize on first query. */
+   *  awaiting yet still self-initialize on first query.
+   *
+   *  Only a SUCCESSFUL init is memoized. If init rejects (e.g. postgres isn't
+   *  accepting connections yet because the web container won the restart race on
+   *  a host reboot — 2026-07-21 incident), the memo is cleared so the next call
+   *  re-attempts instead of replaying the cached rejection forever. That
+   *  self-heals the whole repo once the database becomes reachable — the worker's
+   *  next poll drains the queue instead of the process staying wedged until a
+   *  manual restart. */
   private ensureSchema(): Promise<void> {
-    return (this.schemaReady ??= initializeWorkflowPostgresSchema(this.pool));
+    if (this.schemaReady === undefined) {
+      this.schemaReady = initializeWorkflowPostgresSchema(this.pool).catch((error) => {
+        this.schemaReady = undefined;
+        throw error;
+      });
+    }
+    return this.schemaReady;
   }
 
   async saveWorkflowRunSnapshot(input: PersistWorkflowRunSnapshotInput): Promise<void> {


### PR DESCRIPTION
## 背景:实例卡「排队」47 小时

2026-07-21 排查:软路由上的实例卡死在排队。web 容器每 3s 刷屏
`[media-track] failed to load storage credentials … connect ECONNREFUSED 172.31.0.4:5432`,累计 **5.6 万条**,持续 47 小时;队列里 1 个 run 卡 `queued` 一直没被认领。

取证定性(经 CF tunnel 连容器):
- postgres 健康、监听 `0.0.0.0:5432`、`pg_isready` 通过;web/postgres 同网络,DNS 解析正确。
- **从同一个 web 容器新起进程、用 app 一模一样的连接串 → `PG OK`**;裸 TCP 也通。→ 不是基础设施,是 app 进程自身坏态。
- 时间线:07-19 04:05 宿主重启,web 与 postgres 同时起,postgres 那次经历「非正常关机→崩溃自动恢复」,到 04:05:55 才 ready;web 早约 8–12s,首错正是 `startup migration failed`。

## 根因

`PostgresWorkflowRepository.ensureSchema`:

```ts
return (this.schemaReady ??= initializeWorkflowPostgresSchema(this.pool));
```

首次 init 因 postgres 没起来而 **reject**,`??=` 把这个**已 reject 的 promise 永久缓存**(rejected promise 非 nullish,再不重算)。之后每次 repo 调用都返回同一个坏 promise → **永不重试**,重放的还是首次那条旧 `ECONNREFUSED`(IP 都是 04:05:47 抓的),所以新进程能连、它却自己好不了。`runStartupMigrations` 是 best-effort 全 catch,worker 照常启动,于是每 3s 重放缓存 reject。

⚠️ compose 里其实**有** `depends_on: postgres: condition: service_healthy`,但它**只在 `docker compose up` 生效**;宿主重启走 Docker `restart: unless-stopped` 并行独立拉起、无视 depends_on。所以健康门挡不住这个竞态,必须在 app 层自愈。

## 修复

只 memoize **成功**的 init;失败则清空 memo,下次调用重新初始化。一旦 DB 可达,worker 下一次轮询即自动排空队列,无需人工重启。改动集中在 `ensureSchema` 一处(repo 是进程级单例,修一处即全链路自愈)。

## 验证

- **TDD**:新增 `postgres-ensure-schema-retry.test.ts`——fake pool 首次 `connect()` 抛 ECONNREFUSED、二次成功。修前 **RED**(二次重放旧 reject、`connectAttempts=1`),修后 **GREEN**(二次重连成功、`connectAttempts=2`)。
- `repository-contract-postgres` 契约测试 **47 项全过**(所有 repo 方法走新 ensureSchema,无回归)。
- `npm run typecheck` ✓、`build:workflow` ✓。
- 本次事故的即时处置已在实例做 `docker restart web` 解除;本 PR 是持久修复,合并后实例 `git pull` + 重新构建即可根治。
- 说明:完整「宿主重启竞态自愈」的真机 e2e 需要在实例上重放重启,单测已忠实复现该机制(memoized rejection 闩锁)并证明消除。

## 可选后续硬化(未纳入本 PR)

给 web 服务加 `healthcheck`,让编排在进程 wedged 时也能兜底重启。app 层自愈已使其非必需,故本 PR 保持聚焦。