### PR TITLE
harden DB startup: 永久错 fail-fast + /api/health 探针与 web healthcheck

### DIFF
--- a/apps/web/app/api/health/route.test.ts
+++ b/apps/web/app/api/health/route.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// connection() opts the route out of build-time prerender; stub it (keeping
+// NextResponse real) so the handler runs outside a Next request scope in tests.
+vi.mock("next/server", async () => {
+  const actual = await vi.importActual<typeof import("next/server")>("next/server");
+  return { ...actual, connection: vi.fn().mockResolvedValue(undefined) };
+});
+
+// The health probe must go through the repository's real read path so it reflects
+// whether the app can actually USE the database. Mock the repo getter so we can
+// drive the reachable / unreachable cases without a live postgres.
+vi.mock("../../../lib/workflow-runtime", () => ({
+  getWorkflowRepository: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getWorkflowRepository } from "../../../lib/workflow-runtime";
+
+const mockRepo = (getSetting: () => Promise<unknown>) =>
+  (getWorkflowRepository as ReturnType<typeof vi.fn>).mockReturnValue({ getSetting });
+
+describe("GET /api/health", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 200 ok when the database read path works", async () => {
+    mockRepo(vi.fn().mockResolvedValue(null));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("ok");
+  });
+
+  it("returns 503 degraded when the database read path throws", async () => {
+    mockRepo(vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:5432")));
+    const res = await GET();
+    expect(res.status).toBe(503);
+    expect((await res.json()).status).toBe("degraded");
+  });
+
+  it("does not leak the raw error into the response body", async () => {
+    mockRepo(vi.fn().mockRejectedValue(new Error('password authentication failed for user "mediatrack"')));
+    const res = await GET();
+    const body = await res.json();
+    expect(JSON.stringify(body)).not.toMatch(/password|mediatrack|ECONNREFUSED/);
+  });
+});

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,28 @@
+import { connection, NextResponse } from "next/server";
+import { getWorkflowRepository } from "../../../lib/workflow-runtime";
+
+/**
+ * Liveness + readiness probe for the docker healthcheck and external uptime
+ * monitors. It goes through the repository's REAL read path (getSetting →
+ * ensureSchema), so it reports whether the app can actually USE the database, not
+ * merely whether a TCP socket opens. During the 2026-07-21 wedge (schema-init
+ * latched while postgres was reachable) a raw `SELECT 1` would have reported
+ * healthy; this returns 503 instead, which is what makes it useful for catching
+ * that class of failure. The raw error is logged server-side (docker logs) but
+ * kept out of the response body so the endpoint is safe to expose.
+ */
+export async function GET() {
+  // Request-time only: this reads the DB, so keep it out of build-time prerender.
+  // `export const dynamic` is disallowed under nextConfig.cacheComponents — use
+  // connection() (same pattern as /api/activity).
+  await connection();
+  try {
+    await getWorkflowRepository().getSetting("__healthcheck__");
+    return NextResponse.json({ status: "ok" });
+  } catch (error) {
+    // Log the Error object (not String(error)) so the stack survives in docker
+    // logs; the response body stays generic so nothing sensitive is exposed.
+    console.error("[health] database probe failed:", error);
+    return NextResponse.json({ status: "degraded" }, { status: 503 });
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,19 @@ services:
     # Host port configurable (WEB_PORT) in case 3000 is taken on the host.
     ports:
       - "${WEB_PORT:-3000}:3000"
+    # Probes /api/health, which reads the DB through the app's real query path —
+    # so `docker ps` shows "unhealthy" if the app can't reach postgres (e.g. the
+    # 2026-07-21 wedge), not just when the process dies. Runs inside the container
+    # against localhost (bypasses any Cloudflare Access). node:22-slim has global
+    # fetch and no curl/wget, so probe with node. r.ok is true only for 2xx.
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - node -e "fetch('http://127.0.0.1:3000/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
     restart: unless-stopped
 
   # Optional public HTTPS via Cloudflare Tunnel (no public IP, no open ports).

--- a/packages/workflow/src/postgres-ensure-schema-retry.test.ts
+++ b/packages/workflow/src/postgres-ensure-schema-retry.test.ts
@@ -47,4 +47,54 @@ describe("PostgresWorkflowRepository schema-init self-healing", () => {
     await expect(repository.getSetting("boot")).resolves.toBeNull();
     expect(connectAttempts).toBe(2);
   });
+
+  it("caches the rejection for an unambiguously-permanent error (bad password) instead of hammering", async () => {
+    let connectAttempts = 0;
+    const pool = {
+      connect: async () => {
+        connectAttempts += 1;
+        // Wrong credentials in MEDIA_TRACK_POSTGRES_URL — retrying will never
+        // succeed, so we must NOT re-attempt on every poll. Fail fast.
+        const err = new Error('password authentication failed for user "mediatrack"');
+        (err as NodeJS.ErrnoException).code = "28P01";
+        throw err;
+      },
+      query: async () => ({ rows: [] }),
+    } as unknown as Pool;
+
+    const repository = new PostgresWorkflowRepository(pool);
+
+    await expect(repository.getSetting("boot")).rejects.toThrow(/password/);
+    // A permanent config error must stay cached — the second call must NOT open
+    // another connection (no forever-hammering the DB with a doomed auth).
+    await expect(repository.getSetting("boot")).rejects.toThrow(/password/);
+    expect(connectAttempts).toBe(1);
+  });
+
+  it("retries on an unrecognized error code (default self-heal — never latch on unknown)", async () => {
+    let connectAttempts = 0;
+    const fakeClient = {
+      query: async () => ({ rows: [] }),
+      release: () => {},
+    } as unknown as PoolClient;
+    const pool = {
+      connect: async () => {
+        connectAttempts += 1;
+        if (connectAttempts === 1) {
+          const err = new Error("some unrecognized transient blip");
+          (err as NodeJS.ErrnoException).code = "99999"; // not a known-permanent code
+          throw err;
+        }
+        return fakeClient;
+      },
+      query: async () => ({ rows: [] }),
+    } as unknown as Pool;
+
+    const repository = new PostgresWorkflowRepository(pool);
+
+    await expect(repository.getSetting("boot")).rejects.toThrow(/unrecognized/);
+    // Unknown → treated as transient → retried, so it self-heals on the next call.
+    await expect(repository.getSetting("boot")).resolves.toBeNull();
+    expect(connectAttempts).toBe(2);
+  });
 });

--- a/packages/workflow/src/postgres.ts
+++ b/packages/workflow/src/postgres.ts
@@ -245,6 +245,25 @@ export const WORKFLOW_SCHEMA_ADVISORY_LOCK_KEY = 4_011_989_141;
  * now-existing schema (cheap no-ops). The lock is transaction-scoped, so it is
  * always released — even if the DDL throws and we roll back.
  */
+/**
+ * SQLSTATEs that mean "the connection string / database is misconfigured" —
+ * retrying can never fix these, so a schema-init failure carrying one is cached
+ * (fail fast) rather than re-attempted on every poll. Everything else (connection
+ * refused, timeouts, unknown codes, admin-shutdown during a restart) is treated
+ * as transient and retried — the safe default, because misclassifying a transient
+ * error as permanent is exactly what wedges the process for hours.
+ */
+const PERMANENT_SCHEMA_INIT_SQLSTATES = new Set<string>([
+  "28P01", // invalid_password
+  "28000", // invalid_authorization_specification
+  "3D000", // invalid_catalog_name (database does not exist)
+]);
+
+function isPermanentSchemaInitError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" && PERMANENT_SCHEMA_INIT_SQLSTATES.has(code);
+}
+
 export async function initializeWorkflowPostgresSchema(pool: Pool): Promise<void> {
   const client = await pool.connect();
   try {
@@ -300,17 +319,25 @@ export class PostgresWorkflowRepository implements WorkflowRepository {
   /** Create the schema once, memoized — lets the repo be constructed without
    *  awaiting yet still self-initialize on first query.
    *
-   *  Only a SUCCESSFUL init is memoized. If init rejects (e.g. postgres isn't
-   *  accepting connections yet because the web container won the restart race on
-   *  a host reboot — 2026-07-21 incident), the memo is cleared so the next call
-   *  re-attempts instead of replaying the cached rejection forever. That
-   *  self-heals the whole repo once the database becomes reachable — the worker's
-   *  next poll drains the queue instead of the process staying wedged until a
-   *  manual restart. */
+   *  Only a SUCCESSFUL init is memoized. If init rejects with a TRANSIENT error
+   *  (e.g. postgres isn't accepting connections yet because the web container won
+   *  the restart race on a host reboot — 2026-07-21 incident), the memo is cleared
+   *  so the next call re-attempts instead of replaying the cached rejection
+   *  forever. That self-heals the whole repo once the database becomes reachable —
+   *  the worker's next poll drains the queue instead of the process staying wedged
+   *  until a manual restart.
+   *
+   *  An UNAMBIGUOUSLY-PERMANENT error (bad password, missing database) keeps its
+   *  rejection cached so we fail fast instead of hammering the DB with a doomed
+   *  connection on every poll. Unknown/unclassified errors default to retry — the
+   *  safe direction, since misclassifying a transient error as permanent is what
+   *  reintroduces the multi-hour hang this guards against. */
   private ensureSchema(): Promise<void> {
     if (this.schemaReady === undefined) {
       this.schemaReady = initializeWorkflowPostgresSchema(this.pool).catch((error) => {
-        this.schemaReady = undefined;
+        if (!isPermanentSchemaInitError(error)) {
+          this.schemaReady = undefined;
+        }
         throw error;
       });
     }


### PR DESCRIPTION
延续 #148(schema-init 自愈)的两项硬化,兑现 #148 里 Copilot 评审的合理内核 + 让本类事故秒级可见。

## 1. 永久错 fail-fast(`ensureSchema`)

#148 修复后,init 失败**无差别重试**。对真·永久配置错(密码错、库不存在),这会每次轮询白连一次 DB。本 PR 让 `ensureSchema` 只对**明确永久**的 SQLSTATE 保留缓存(fail-fast),其余仍重试:

- 永久(缓存,fail-fast):`28P01` invalid_password、`28000` invalid_authorization_specification、`3D000` invalid_catalog_name
- 其余(清 memo,重试自愈):连接拒绝 / 超时 / **未知码** / 重启期 admin-shutdown …

**默认重试是安全方向**——把瞬时错判成永久才会重现 #148 那种数小时挂死,所以未知码一律归重试。方向与「缓存非瞬时错」相反(见 #148 讨论)。

TDD:永久错(28P01)第二次调用不再开连接(`connectAttempts=1`);未知码仍重试自愈(`connectAttempts=2`);原瞬时错重试用例保持绿。

## 2. `/api/health` 探针 + web 容器 healthcheck

新增 `GET /api/health`:走 repo 真实读路径(`getSetting`→`ensureSchema`),DB 可用→200 `{status:"ok"}`,不可用→503 `{status:"degraded"}`。

**关键设计**:走 `ensureSchema` 而非裸 `SELECT 1`。2026-07-21 挂死时 postgres 是活的、坏的是 schema-init 闩锁——裸 `select 1` 会**假报健康**;走真实读路径才会正确报 503。原始错误只进服务端日志,不进响应体(可安全暴露)。

compose 给 web 加 `healthcheck`(容器内 `node fetch` 探 `127.0.0.1:3000/api/health`,绕过 CF Access;`node:22-slim` 有全局 fetch 无 curl)。这样 `docker ps` 在「app 连不上 DB」时显示 **unhealthy**,而非只在进程死时——本次事故本可秒级可见。⚠️ 注:Docker 不会因 unhealthy 自动重启,故这是**可观测性 + 探针**,配合 #148 的 app 自愈(自愈才是恢复手段)。

TDD:`route.test.ts` 覆盖 200/503/**不泄露错误详情**。

## 验证

- 新增 6 个单测全绿;`repository-contract-postgres` 契约 **47 项全过**(ensureSchema 改动无回归)
- `npm run typecheck` ✓、`apps/web tsc -p` ✓(新 route)、`build:workflow` ✓、`docker compose config` ✓
- 真机 e2e(`docker ps` 显示 web healthy + 容器内 curl `/api/health` 返回 ok)将在合并部署后于实例验证