### PR TITLE
fix(quark): live-check cookie before bind (C10)

### DIFF
--- a/apps/web/lib/quark-connect.test.ts
+++ b/apps/web/lib/quark-connect.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Bind-level tests for 夸克 cookie paste (C10). Real connectQuarkCookie against
+ * in-memory SQLite; only QuarkCookieClient is stubbed (no network). Proves the
+ * live probe runs BEFORE bind so a dead cookie never lands in connected_storages.
+ */
+
+let quarkClientConstructions = 0;
+
+class FakeQuarkCookieClient {
+  private readonly cookie: string;
+  constructor(opts: { cookie: string }) {
+    quarkClientConstructions++;
+    this.cookie = opts.cookie;
+  }
+  async listItems(_input: { directoryId: string }) {
+    if (this.cookie.includes("DEAD")) {
+      throw new Error("QUARK_AUTH_FAILED: cookie dead");
+    }
+    return [];
+  }
+}
+
+const prevPg = process.env.MEDIA_TRACK_POSTGRES_URL;
+const prevMultiUser = process.env.MEDIA_TRACK_MULTI_USER;
+
+const LIVE_COOKIE = "__uid=quark_uid_live; __kps=abc";
+const DEAD_COOKIE = "__uid=quark_uid_dead; __kps=DEAD";
+
+const boot = async (opts: { failProvision?: boolean } = {}) => {
+  process.env.MEDIA_TRACK_SQLITE_PATH = ":memory:";
+  delete process.env.MEDIA_TRACK_POSTGRES_URL;
+  delete process.env.MEDIA_TRACK_MULTI_USER;
+  quarkClientConstructions = 0;
+  vi.resetModules();
+  vi.doMock("@media-track/workflow", async () => {
+    const actual = await vi.importActual<typeof import("@media-track/workflow")>("@media-track/workflow");
+    return {
+      ...actual,
+      QuarkCookieClient: FakeQuarkCookieClient,
+      ...(opts.failProvision
+        ? {
+            createExecutorForBrand: () => {
+              throw new Error("PROVISION_BOOM: no network in test");
+            },
+          }
+        : {}),
+    };
+  });
+  return import("./workflow-runtime");
+};
+
+afterEach(() => {
+  vi.doUnmock("@media-track/workflow");
+  delete process.env.MEDIA_TRACK_SQLITE_PATH;
+  if (prevPg !== undefined) process.env.MEDIA_TRACK_POSTGRES_URL = prevPg;
+  if (prevMultiUser !== undefined) process.env.MEDIA_TRACK_MULTI_USER = prevMultiUser;
+  vi.resetModules();
+});
+
+describe("connectQuarkCookie (C10 live-check before bind)", () => {
+  it("dead cookie → friendly error, nothing stored", async () => {
+    const rt = await boot();
+    await expect(rt.connectQuarkCookie(DEAD_COOKIE)).rejects.toThrow(/无法用该 cookie 连接夸克/);
+    expect(await rt.getWorkflowRepository().listConnectedStorages("acct_default")).toEqual([]);
+    expect(quarkClientConstructions).toBeGreaterThan(0);
+  });
+
+  it("live cookie → binds with providerUid from __uid", async () => {
+    const rt = await boot({ failProvision: true });
+    const { providerUid } = await rt.connectQuarkCookie(`  ${LIVE_COOKIE}  `);
+    expect(providerUid).toBe("quark_uid_live");
+    const drives = await rt.getWorkflowRepository().listConnectedStorages("acct_default");
+    expect(drives).toHaveLength(1);
+    expect(drives[0]?.provider).toBe("quark");
+    expect(drives[0]?.providerUid).toBe("quark_uid_live");
+    expect((drives[0]?.payload as { cookie?: string }).cookie).toContain("__uid=quark_uid_live");
+  });
+
+  it("unparseable cookie → error without network probe", async () => {
+    const rt = await boot();
+    await expect(rt.connectQuarkCookie("not-a-cookie")).rejects.toThrow(/无法从该 cookie 解析/);
+    expect(quarkClientConstructions).toBe(0);
+  });
+
+  it("cross-account bind rejected", async () => {
+    const rt = await boot();
+    const repo = rt.getWorkflowRepository();
+    await repo.createAccount({
+      id: "acct_other",
+      username: "other",
+      passwordHash: "x",
+      groupId: null,
+      isOwner: false,
+      createdAt: "2026-07-01T00:00:00.000Z",
+    });
+    await repo.upsertConnectedStorage({
+      id: "cs_quark_taken",
+      accountId: "acct_other",
+      provider: "quark",
+      providerUid: "quark_uid_live",
+      label: null,
+      payload: { cookie: LIVE_COOKIE },
+      rootCid: "0",
+      moviesCid: null,
+      tvCid: null,
+      animeCid: null,
+      createdAt: "2026-07-01T00:00:00.000Z",
+    });
+    await expect(rt.connectQuarkCookie(LIVE_COOKIE)).rejects.toBeInstanceOf(rt.StorageOwnedByOtherAccountError);
+  });
+});

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -2601,10 +2601,11 @@ export async function connectQuarkCookie(rawCookie: string): Promise<{ providerU
     throw new StorageOwnedByOtherAccountError();
   }
   // Live-check BEFORE bind (parity with 123/天翼/光鸭): dead/revoked cookie must
-  // not land in connected_storages. Best-effort provision below is separate —
-  // auth failures here abort the whole connect.
+  // not land in connected_storages. Always probe the account root ("0"), not
+  // existing.rootCid (that is the mediary category tree — user may have deleted
+  // it; a missing layout dir must not block cookie refresh).
   try {
-    await probeStorageConnection("quark", cookie, existing?.rootCid ?? "0", null);
+    await probeStorageConnection("quark", cookie, "0", null);
   } catch (error) {
     throw new Error(
       `无法用该 cookie 连接夸克：${error instanceof Error ? error.message : String(error)}`,

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -2600,6 +2600,16 @@ export async function connectQuarkCookie(rawCookie: string): Promise<{ providerU
   if (decision.action === "reject") {
     throw new StorageOwnedByOtherAccountError();
   }
+  // Live-check BEFORE bind (parity with 123/天翼/光鸭): dead/revoked cookie must
+  // not land in connected_storages. Best-effort provision below is separate —
+  // auth failures here abort the whole connect.
+  try {
+    await probeStorageConnection("quark", cookie, existing?.rootCid ?? "0", null);
+  } catch (error) {
+    throw new Error(
+      `无法用该 cookie 连接夸克：${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   const payload = { cookie, meta: { connectedAt: new Date().toISOString() } };
   if (decision.action === "refresh" && existing) {
     // Same account re-bind → refresh the cookie, keep the resolved CIDs.
@@ -2620,6 +2630,7 @@ export async function connectQuarkCookie(rawCookie: string): Promise<{ providerU
   }
   // insert: provision the category tree under the 夸克 root ("0"). Best-effort —
   // a failure still stores the connection (worker falls back to env CIDs / none).
+  // Auth already proved live above; provision errors are non-fatal layout issues.
   let cids: { rootCid: string | null; moviesCid: string | null; tvCid: string | null; animeCid: string | null } = {
     rootCid: null,
     moviesCid: null,

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -2609,6 +2609,7 @@ export async function connectQuarkCookie(rawCookie: string): Promise<{ providerU
   } catch (error) {
     throw new Error(
       `无法用该 cookie 连接夸克：${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
   const payload = { cookie, meta: { connectedAt: new Date().toISOString() } };

--- a/docs/HANDOFF-robustness-audit-2026-07-21.md
+++ b/docs/HANDOFF-robustness-audit-2026-07-21.md
@@ -11,7 +11,11 @@ media-track(产品名 Mediary Scout):媒体资源自动获取/追踪产品。Nex
 **刚合并发版(勿重复处理)**:
 - **PR #148**(`af32fa4`):postgres schema-init 失败不再闩死连接池,启动竞态自愈。
 - **PR #149**(`560bfea`):ensureSchema 永久错(28P01/28000/3D000)fail-fast、其余重试;新增 `/api/health`(走真实 DB 读路径)+ web 容器 healthcheck。
-- 两者已合并进 main、已部署到实例(软路由 `media-router-tunnel`,运行 `560bfea`)、真机 e2e 通过(`/api/health`→200、容器 healthy、ECONNREFUSED=0)。
+- **PR #150**(`89c7bc6`):Wave1 — A1–A6 + B3 + proxy/C8 + C3/C7。
+- **PR #151**(`798a465`):Wave2 — B1/B2/B4 + C1/C2/C4–C6。
+- 全部已合并 main；实例 `media-router-tunnel` 已 `deploy.sh` 到 `798a465`，真机 e2e 通过（health 200、页面 200、日志轮转、backup 脚本在位）。
+
+**审计剩余（低优先，勿当紧急）**: C9 热路径全表读老化；C10 夸克粘贴验活 / 孤儿 run 重试上限 / testPush SSRF（内网有限）。Tier D 仍勿修。
 
 ## 1. 审计方法(可信度依据)
 


### PR DESCRIPTION
## Summary
- **C10** — `connectQuarkCookie` now `probeStorageConnection` before bind (parity with 123/天翼/光鸭); dead cookie → friendly error, nothing stored.
- Docs: Wave1 (#150) + Wave2 (#151) merged @ `798a465`, instance e2e recorded; remaining hang = C9 / orphan retry / testPush SSRF.

## Test plan
- [x] `npx vitest run apps/web/lib/quark-connect.test.ts` (4)
- [ ] CI build-and-test
- [ ] Copilot review