### PR TITLE
release: v1.3.1 robustness hardening desktop update

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@media-track/desktop",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "commonjs",
   "main": "dist/main.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
     },
     "apps/desktop": {
       "name": "@media-track/desktop",
-      "version": "1.2.0",
+      "version": "1.3.1",
       "dependencies": {
         "better-sqlite3": "^12.11.1"
       },

--- a/site/data/release-fallback.json
+++ b/site/data/release-fallback.json
@@ -1,13 +1,13 @@
 {
-  "tag_name": "v1.3.0",
+  "tag_name": "v1.3.1",
   "assets": [
     {
-      "name": "Mediary.Scout-1.3.0-arm64.dmg",
-      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.0/Mediary.Scout-1.3.0-arm64.dmg"
+      "name": "Mediary.Scout-1.3.1-arm64.dmg",
+      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.1/Mediary.Scout-1.3.1-arm64.dmg"
     },
     {
-      "name": "Mediary.Scout.Setup.1.3.0.exe",
-      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.0/Mediary.Scout.Setup.1.3.0.exe"
+      "name": "Mediary.Scout.Setup.1.3.1.exe",
+      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.1/Mediary.Scout.Setup.1.3.1.exe"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Prepare the v1.3.1 desktop release after robustness hardening PRs #150-#152.

- Desktop app version: 1.3.0 -> 1.3.1
- Repair stale desktop workspace version in package-lock.json: 1.2.0 -> 1.3.1
- Align the offline website fallback with the forthcoming macOS arm64 DMG and Windows x64 installer

## Release scope
- Worker/API auth and demo gates, race-safe queue claiming, stale-run liveness, network deadlines
- Five-drive queue/unbind/auth hardening and Quark pasted-cookie live check

## Verification
- [x] Version and fallback asset names validated
- [x] npx vitest run site - 19 passed
- [x] npm run build --workspace @media-track/desktop
- [x] npm run build:web
- [ ] CI
- [ ] Copilot review
- [ ] Merge, tag v1.3.1, atomic macOS + Windows release workflow
