### PR TITLE
chore: ignore local AGENTS.md instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ coverage/
 .media-track-credentials-backup.json
 
 # personal dev tooling (keep launch.json as contributor example)
+AGENTS.md
 .claude/settings.json
 .claude/using-superpowers-*
 


### PR DESCRIPTION
Ignore maintainer-local AGENTS.md so it does not remain as an untracked worktree file.