### PR TITLE
feat(settings): self-host update hint with agent deploy prompt

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3208,6 +3208,61 @@ select.setting-control {
   justify-content: flex-end;
 }
 
+/* ---------- deployment update hint (self-host compose, Settings top) ---------- */
+.update-card {
+  max-width: 720px;
+  margin-bottom: 24px;
+  background: rgba(30, 215, 96, 0.08);
+  border: 1px solid rgba(30, 215, 96, 0.25);
+  border-radius: var(--radius-card);
+  padding: 16px;
+}
+.update-card-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.update-card p {
+  color: var(--text-soft);
+}
+.update-card code {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.update-card-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+.update-card .ghost-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.update-link {
+  text-decoration: none;
+}
+.update-copy-textarea {
+  width: 100%;
+  margin-top: 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.25);
+  color: var(--text-soft);
+  padding: 10px;
+  font: inherit;
+  resize: vertical;
+}
+.update-copy-block {
+  min-width: 180px;
+}
+
 /* ---------- GitHub nameplate (Settings page bottom — quiet 暗记 + CTA) ---------- */
 .github-nameplate {
   margin-top: 32px;

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -21,6 +21,8 @@ import { SettingsTabs } from "../../components/settings-tabs";
 import { PasswordChangeForm } from "../../components/password-change-form";
 import { AccountAdminPanel } from "../../components/account-admin-panel";
 import { GitHubNameplate } from "../../components/github-nameplate";
+import { DeploymentUpdateCard } from "../../components/deployment-update-card";
+import { loadDeploymentUpdateState } from "../../lib/deployment-update-server";
 import {
   getAccountConnectedStorages,
   getAccountScopedSettings,
@@ -82,7 +84,11 @@ export default function SettingsPage({
             </p>
           </div>
         ) : (
-          <Suspense fallback={<div className="skeleton skeleton-heading" />}>
+          <>
+            <Suspense fallback={null}>
+              <DeploymentUpdateSection />
+            </Suspense>
+            <Suspense fallback={<div className="skeleton skeleton-heading" />}>
             <SettingsTabs
               drives={
                 <Suspense fallback={<div className="skeleton skeleton-heading" />}>
@@ -136,7 +142,8 @@ export default function SettingsPage({
                 </>
               }
             />
-          </Suspense>
+            </Suspense>
+          </>
         )}
         <GitHubNameplate />
       </main>
@@ -148,6 +155,14 @@ async function SettingsSidebar({ searchParams }: { searchParams: Promise<{ w?: s
   const { w } = await searchParams;
   const workspace = await resolveGlobalWorkspace(w);
   return <AppSidebar active="settings" basePath={workspace.basePath} activeStorageId={workspace.activeStorageId} />;
+}
+
+async function DeploymentUpdateSection() {
+  // Request-time only: reads BUILD_COMMIT and probes upstream main. Probe failure
+  // renders null inside the card — an offline instance never gets a false alarm.
+  await connection();
+  const state = await loadDeploymentUpdateState();
+  return <DeploymentUpdateCard state={state} />;
 }
 
 async function PasswordChangeSection() {

--- a/apps/web/components/copy-upgrade-prompt-button.tsx
+++ b/apps/web/components/copy-upgrade-prompt-button.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+/** One-click copy for the owner-to-agent upgrade instruction. Clipboard API can
+ *  be unavailable on non-HTTPS self-host origins; fall back to selection. */
+export function CopyUpgradePromptButton({ prompt }: { prompt: string }) {
+  const [copied, setCopied] = useState(false);
+  const [manual, setManual] = useState(false);
+
+  async function copyPrompt() {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setManual(true);
+    }
+  }
+
+  return (
+    <div className="update-copy-block">
+      <button type="button" className="ghost-button" onClick={copyPrompt}>
+        {copied ? <Check size={14} aria-hidden /> : <Copy size={14} aria-hidden />}
+        {copied ? "已复制" : "复制给本地 Agent"}
+      </button>
+      {manual ? (
+        <textarea
+          className="update-copy-textarea"
+          value={prompt}
+          readOnly
+          rows={6}
+          onFocus={(event) => event.currentTarget.select()}
+          aria-label="升级指令"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/copy-upgrade-prompt-button.tsx
+++ b/apps/web/components/copy-upgrade-prompt-button.tsx
@@ -12,6 +12,7 @@ export function CopyUpgradePromptButton({ prompt }: { prompt: string }) {
   async function copyPrompt() {
     try {
       await navigator.clipboard.writeText(prompt);
+      setManual(false);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1800);
     } catch {

--- a/apps/web/components/copy-upgrade-prompt-button.tsx
+++ b/apps/web/components/copy-upgrade-prompt-button.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 
 /** One-click copy for the owner-to-agent upgrade instruction. Clipboard API can
@@ -8,14 +8,31 @@ import { Check, Copy } from "lucide-react";
 export function CopyUpgradePromptButton({ prompt }: { prompt: string }) {
   const [copied, setCopied] = useState(false);
   const [manual, setManual] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   async function copyPrompt() {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
     try {
       await navigator.clipboard.writeText(prompt);
       setManual(false);
       setCopied(true);
-      window.setTimeout(() => setCopied(false), 1800);
+      timeoutRef.current = window.setTimeout(() => {
+        setCopied(false);
+        timeoutRef.current = null;
+      }, 1800);
     } catch {
+      setCopied(false);
       setManual(true);
     }
   }

--- a/apps/web/components/deployment-update-card.tsx
+++ b/apps/web/components/deployment-update-card.tsx
@@ -1,0 +1,52 @@
+import { ArrowUpCircle, ExternalLink } from "lucide-react";
+import {
+  buildContainerUpgradePrompt,
+  GITHUB_MAIN_COMPARE_URL,
+  type DeploymentUpdateState,
+} from "../lib/deployment-update";
+import { CopyUpgradePromptButton } from "./copy-upgrade-prompt-button";
+
+/** Quiet self-host update hint. Only a confirmed-behind compose container gets
+ *  the copyable agent instruction; probe failure renders nothing (false alarms
+ *  are worse than no reminder). Desktop releases use the download route instead. */
+export function DeploymentUpdateCard({ state }: { state: DeploymentUpdateState }) {
+  if (state.kind === "desktop") {
+    return (
+      <div className="settings-card update-card" role="status">
+        <p>
+          桌面版检查更新请看{" "}
+          <a href="https://github.com/fancydirty/mediary-scout/releases/latest" target="_blank" rel="noreferrer">
+            Releases
+          </a>
+          ；新版本可直接覆盖安装，不需要先卸载。
+        </p>
+      </div>
+    );
+  }
+  if (state.kind !== "container" || state.behind !== true || !state.currentShort || !state.latestShort) {
+    return null;
+  }
+  const prompt = buildContainerUpgradePrompt({
+    currentShort: state.currentShort,
+    latestShort: state.latestShort,
+  });
+  return (
+    <div className="settings-card update-card" role="status">
+      <div className="update-card-heading">
+        <ArrowUpCircle size={18} aria-hidden />
+        <strong>远端 main 有新版本</strong>
+      </div>
+      <p>
+        当前构建 <code>{state.currentShort}</code>，远端 <code>{state.latestShort}</code>。
+        不需要卸载容器；把下面指令发给你部署机上的 Agent，它会按项目自检流程升级。
+      </p>
+      <div className="update-card-actions">
+        <CopyUpgradePromptButton prompt={prompt} />
+        <a className="ghost-button update-link" href={GITHUB_MAIN_COMPARE_URL} target="_blank" rel="noreferrer">
+          <ExternalLink size={14} aria-hidden />
+          查看 main 变更
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/deployment-update-card.tsx
+++ b/apps/web/components/deployment-update-card.tsx
@@ -1,7 +1,7 @@
 import { ArrowUpCircle, ExternalLink } from "lucide-react";
 import {
   buildContainerUpgradePrompt,
-  GITHUB_MAIN_COMPARE_URL,
+  GITHUB_MAIN_COMMITS_URL,
   type DeploymentUpdateState,
 } from "../lib/deployment-update";
 import { CopyUpgradePromptButton } from "./copy-upgrade-prompt-button";
@@ -43,7 +43,7 @@ export function DeploymentUpdateCard({ state }: { state: DeploymentUpdateState }
       </p>
       <div className="update-card-actions">
         <CopyUpgradePromptButton prompt={prompt} />
-        <a className="ghost-button update-link" href={GITHUB_MAIN_COMPARE_URL} target="_blank" rel="noreferrer">
+        <a className="ghost-button update-link" href={GITHUB_MAIN_COMMITS_URL} target="_blank" rel="noreferrer">
           <ExternalLink size={14} aria-hidden />
           查看 main 变更
         </a>

--- a/apps/web/components/deployment-update-card.tsx
+++ b/apps/web/components/deployment-update-card.tsx
@@ -12,15 +12,15 @@ import { CopyUpgradePromptButton } from "./copy-upgrade-prompt-button";
 export function DeploymentUpdateCard({ state }: { state: DeploymentUpdateState }) {
   if (state.kind === "desktop") {
     return (
-      <div className="settings-card update-card" role="status">
-        <p>
+      <section className="settings-card update-card" aria-labelledby="deployment-update-title-desktop">
+        <p id="deployment-update-title-desktop">
           桌面版检查更新请看{" "}
           <a href="https://github.com/fancydirty/mediary-scout/releases/latest" target="_blank" rel="noreferrer">
             Releases
           </a>
           ；新版本可直接覆盖安装，不需要先卸载。
         </p>
-      </div>
+      </section>
     );
   }
   if (state.kind !== "container" || state.behind !== true || !state.currentShort || !state.latestShort) {
@@ -31,13 +31,14 @@ export function DeploymentUpdateCard({ state }: { state: DeploymentUpdateState }
     latestShort: state.latestShort,
   });
   return (
-    <div className="settings-card update-card" role="status">
-      <div className="update-card-heading">
+    <section className="settings-card update-card" aria-labelledby="deployment-update-title">
+      <div className="update-card-heading" id="deployment-update-title">
         <ArrowUpCircle size={18} aria-hidden />
-        <strong>远端 main 有新版本</strong>
+        <strong>当前版本与远端 main 不同</strong>
       </div>
       <p>
         当前构建 <code>{state.currentShort}</code>，远端 <code>{state.latestShort}</code>。
+        如果你按本项目 main 自部署，通常可安全升级；自定义分支/固定版本请先核对变更。
         不需要卸载容器；把下面指令发给你部署机上的 Agent，它会按项目自检流程升级。
       </p>
       <div className="update-card-actions">
@@ -47,6 +48,6 @@ export function DeploymentUpdateCard({ state }: { state: DeploymentUpdateState }
           查看 main 变更
         </a>
       </div>
-    </div>
+    </section>
   );
 }

--- a/apps/web/lib/deployment-update-server.test.ts
+++ b/apps/web/lib/deployment-update-server.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLatestMainCommit } from "./deployment-update-server";
+
+const SHA = "3333333333333333333333333333333333333333";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchLatestMainCommit", () => {
+  it("returns the normalized sha from GitHub", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ sha: SHA.toUpperCase() }), { status: 200 }));
+    await expect(fetchLatestMainCommit(fetchImpl as typeof fetch)).resolves.toBe(SHA);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.github.com/repos/fancydirty/mediary-scout/commits/main",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("returns null on non-2xx", async () => {
+    const fetchImpl = vi.fn(async () => new Response("rate limited", { status: 403 }));
+    await expect(fetchLatestMainCommit(fetchImpl as typeof fetch)).resolves.toBeNull();
+  });
+
+  it("returns null on malformed payload", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ sha: "not-a-sha" }), { status: 200 }));
+    await expect(fetchLatestMainCommit(fetchImpl as typeof fetch)).resolves.toBeNull();
+  });
+});

--- a/apps/web/lib/deployment-update-server.test.ts
+++ b/apps/web/lib/deployment-update-server.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchLatestMainCommit } from "./deployment-update-server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchLatestMainCommit, resetDeploymentUpdateProbeCacheForTests } from "./deployment-update-server";
 
 const SHA = "3333333333333333333333333333333333333333";
 
+beforeEach(() => {
+  resetDeploymentUpdateProbeCacheForTests();
+});
+
 afterEach(() => {
+  resetDeploymentUpdateProbeCacheForTests();
   vi.restoreAllMocks();
 });
 
@@ -25,5 +30,21 @@ describe("fetchLatestMainCommit", () => {
   it("returns null on malformed payload", async () => {
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ sha: "not-a-sha" }), { status: 200 }));
     await expect(fetchLatestMainCommit(fetchImpl as typeof fetch)).resolves.toBeNull();
+  });
+
+  it("caches the last probe briefly so Settings renders do not re-hit GitHub", async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({ sha: SHA }), { status: 200 }));
+    await expect(fetchLatestMainCommit(fetchImpl as typeof fetch)).resolves.toBe(SHA);
+    await expect(fetchLatestMainCommit(fetchImpl as typeof fetch)).resolves.toBe(SHA);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches thrown network failures as a quiet negative result", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    await expect(fetchLatestMainCommit(fetchImpl as typeof fetch)).resolves.toBeNull();
+    await expect(fetchLatestMainCommit(fetchImpl as typeof fetch)).resolves.toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/lib/deployment-update-server.ts
+++ b/apps/web/lib/deployment-update-server.ts
@@ -1,0 +1,51 @@
+import { readFile } from "node:fs/promises";
+import {
+  getDeploymentUpdateState,
+  normalizeCommit,
+  type RemoteCommitFetcher,
+} from "./deployment-update";
+import { resolveIsDesktop } from "./workflow-runtime";
+import { isDemoMode } from "./demo-mode";
+
+const DEFAULT_MAIN_COMMITS_URL =
+  "https://api.github.com/repos/fancydirty/mediary-scout/commits/main";
+
+async function readBuildCommit(): Promise<string | null> {
+  try {
+    return normalizeCommit(await readFile("/app/BUILD_COMMIT", "utf8"));
+  } catch {
+    // Docker runner keeps the stamp at /app/BUILD_COMMIT; dev / desktop may not.
+    try {
+      return normalizeCommit(await readFile("BUILD_COMMIT", "utf8"));
+    } catch {
+      return null;
+    }
+  }
+}
+
+/** Probe upstream main once per render with a short deadline. Failure is
+ *  intentionally non-fatal — an offline instance must still open Settings. */
+export async function fetchLatestMainCommit(
+  fetchImpl: typeof fetch = fetch,
+  url = DEFAULT_MAIN_COMMITS_URL,
+): Promise<string | null> {
+  const response = await fetchImpl(url, {
+    headers: { accept: "application/vnd.github+json", "user-agent": "mediary-scout-update-check" },
+    signal: AbortSignal.timeout(5000),
+    cache: "no-store",
+  });
+  if (!response.ok) return null;
+  const body = (await response.json()) as { sha?: unknown };
+  return typeof body.sha === "string" ? normalizeCommit(body.sha) : null;
+}
+
+export async function loadDeploymentUpdateState(
+  fetchLatest: RemoteCommitFetcher = () => fetchLatestMainCommit(),
+) {
+  return getDeploymentUpdateState({
+    demo: isDemoMode(),
+    desktop: resolveIsDesktop(),
+    currentCommit: await readBuildCommit(),
+    fetchLatest,
+  });
+}

--- a/apps/web/lib/deployment-update-server.ts
+++ b/apps/web/lib/deployment-update-server.ts
@@ -9,6 +9,11 @@ import { isDemoMode } from "./demo-mode";
 
 const DEFAULT_MAIN_COMMITS_URL =
   "https://api.github.com/repos/fancydirty/mediary-scout/commits/main";
+const REMOTE_PROBE_TTL_MS = 10 * 60 * 1000;
+
+let remoteProbeCache:
+  | { checkedAt: number; commit: string | null }
+  | null = null;
 
 async function readBuildCommit(): Promise<string | null> {
   try {
@@ -23,20 +28,37 @@ async function readBuildCommit(): Promise<string | null> {
   }
 }
 
-/** Probe upstream main once per render with a short deadline. Failure is
- *  intentionally non-fatal — an offline instance must still open Settings. */
+/** Probe upstream main with a short in-process TTL. Failure is intentionally
+ *  non-fatal — an offline instance must still open Settings — but frequent page
+ *  renders must not burn GitHub's anonymous rate limit. */
 export async function fetchLatestMainCommit(
   fetchImpl: typeof fetch = fetch,
   url = DEFAULT_MAIN_COMMITS_URL,
 ): Promise<string | null> {
-  const response = await fetchImpl(url, {
-    headers: { accept: "application/vnd.github+json", "user-agent": "mediary-scout-update-check" },
-    signal: AbortSignal.timeout(5000),
-    cache: "no-store",
-  });
-  if (!response.ok) return null;
-  const body = (await response.json()) as { sha?: unknown };
-  return typeof body.sha === "string" ? normalizeCommit(body.sha) : null;
+  if (remoteProbeCache && Date.now() - remoteProbeCache.checkedAt < REMOTE_PROBE_TTL_MS) {
+    return remoteProbeCache.commit;
+  }
+  let commit: string | null = null;
+  try {
+    const response = await fetchImpl(url, {
+      headers: { accept: "application/vnd.github+json", "user-agent": "mediary-scout-update-check" },
+      signal: AbortSignal.timeout(5000),
+      cache: "no-store",
+    });
+    if (response.ok) {
+      const body = (await response.json()) as { sha?: unknown };
+      commit = typeof body.sha === "string" ? normalizeCommit(body.sha) : null;
+    }
+  } catch {
+    // Offline/rate-limited instance: keep Settings usable and cache the failure
+    // briefly so every refresh doesn't wait out another 5s timeout.
+  }
+  remoteProbeCache = { checkedAt: Date.now(), commit };
+  return commit;
+}
+
+export function resetDeploymentUpdateProbeCacheForTests() {
+  remoteProbeCache = null;
 }
 
 export async function loadDeploymentUpdateState(

--- a/apps/web/lib/deployment-update.test.ts
+++ b/apps/web/lib/deployment-update.test.ts
@@ -18,6 +18,11 @@ describe("normalizeCommit", () => {
     expect(normalizeCommit("1111111")).toBeNull();
     expect(normalizeCommit(`${CURRENT}junk`)).toBeNull();
   });
+
+  it("rejects 39-char prefix and non-hex content", () => {
+    expect(normalizeCommit(CURRENT.slice(0, 39))).toBeNull();
+    expect(normalizeCommit("g".repeat(40))).toBeNull();
+  });
 });
 
 describe("getDeploymentUpdateState", () => {

--- a/apps/web/lib/deployment-update.test.ts
+++ b/apps/web/lib/deployment-update.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildContainerUpgradePrompt,
+  getDeploymentUpdateState,
+  normalizeCommit,
+} from "./deployment-update";
+
+const CURRENT = "1111111111111111111111111111111111111111";
+const LATEST = "2222222222222222222222222222222222222222";
+
+describe("normalizeCommit", () => {
+  it("accepts exactly 40 lowercase/uppercase hex chars", () => {
+    expect(normalizeCommit(CURRENT.toUpperCase())).toBe(CURRENT);
+  });
+
+  it("rejects unknown and short build stamps", () => {
+    expect(normalizeCommit("unknown")).toBeNull();
+    expect(normalizeCommit("1111111")).toBeNull();
+    expect(normalizeCommit(`${CURRENT}junk`)).toBeNull();
+  });
+});
+
+describe("getDeploymentUpdateState", () => {
+  it("marks containers behind when main commit differs", async () => {
+    const state = await getDeploymentUpdateState({
+      demo: false,
+      desktop: false,
+      currentCommit: CURRENT,
+      fetchLatest: async () => LATEST,
+    });
+    expect(state).toMatchObject({
+      kind: "container",
+      behind: true,
+      reason: "ok",
+      currentShort: "1111111",
+      latestShort: "2222222",
+    });
+  });
+
+  it("is up to date when commits match", async () => {
+    const state = await getDeploymentUpdateState({
+      demo: false,
+      desktop: false,
+      currentCommit: CURRENT,
+      fetchLatest: async () => CURRENT,
+    });
+    expect(state.behind).toBe(false);
+  });
+
+  it("never asks the demo web deploy to update", async () => {
+    const state = await getDeploymentUpdateState({
+      demo: true,
+      desktop: false,
+      currentCommit: CURRENT,
+      fetchLatest: async () => LATEST,
+    });
+    expect(state.kind).toBe("web");
+    expect(state.reason).toBe("demo");
+    expect(state.behind).toBeNull();
+  });
+
+  it("keeps desktop out of the container-upgrade path", async () => {
+    const state = await getDeploymentUpdateState({
+      demo: false,
+      desktop: true,
+      currentCommit: CURRENT,
+      fetchLatest: async () => LATEST,
+    });
+    expect(state.kind).toBe("desktop");
+    expect(state.reason).toBe("desktop");
+  });
+
+  it("fails quiet when the remote probe throws or returns garbage", async () => {
+    for (const fetchLatest of [async () => { throw new Error("offline"); }, async () => "junk"]) {
+      const state = await getDeploymentUpdateState({
+        demo: false,
+        desktop: false,
+        currentCommit: CURRENT,
+        fetchLatest,
+      });
+      expect(state.behind).toBeNull();
+      expect(state.reason).toBe("probe_failed");
+    }
+  });
+
+  it("fails quiet when BUILD_COMMIT was not stamped", async () => {
+    const state = await getDeploymentUpdateState({
+      demo: false,
+      desktop: false,
+      currentCommit: "unknown",
+      fetchLatest: async () => LATEST,
+    });
+    expect(state.reason).toBe("missing_current");
+  });
+});
+
+describe("buildContainerUpgradePrompt", () => {
+  it("contains both commits and requires the self-verifying deploy gate", () => {
+    const prompt = buildContainerUpgradePrompt({ currentShort: "1111111", latestShort: "2222222" });
+    expect(prompt).toContain("1111111");
+    expect(prompt).toContain("2222222");
+    expect(prompt).toContain("git pull --ff-only");
+    expect(prompt).toContain("./scripts/deploy.sh");
+    expect(prompt).toContain("/api/health");
+    expect(prompt).toContain("不要绕过校验");
+  });
+});

--- a/apps/web/lib/deployment-update.ts
+++ b/apps/web/lib/deployment-update.ts
@@ -1,0 +1,92 @@
+export type DeploymentKind = "container" | "desktop" | "web" | "unknown";
+
+export interface DeploymentUpdateState {
+  kind: DeploymentKind;
+  currentCommit: string | null;
+  latestCommit: string | null;
+  currentShort: string | null;
+  latestShort: string | null;
+  behind: boolean | null;
+  reason: "demo" | "desktop" | "missing_current" | "probe_failed" | "ok";
+}
+
+export interface RemoteCommitFetcher {
+  (): Promise<string | null>;
+}
+
+const COMMIT_RE = /^[0-9a-f]{7,40}$/i;
+
+export function normalizeCommit(value: string | null | undefined): string | null {
+  const commit = value?.trim().toLowerCase() ?? "";
+  if (!COMMIT_RE.test(commit)) return null;
+  return commit.length === 40 ? commit : null;
+}
+
+export function shortCommit(commit: string | null): string | null {
+  return commit ? commit.slice(0, 7) : null;
+}
+
+/**
+ * Self-host containers can tell the user when main has moved beyond the image's
+ * BUILD_COMMIT. The UI never asks the web container to self-upgrade (no Docker
+ * socket); it gives the owner an auditable instruction for their local agent.
+ */
+export async function getDeploymentUpdateState(input: {
+  demo: boolean;
+  desktop: boolean;
+  currentCommit: string | null | undefined;
+  fetchLatest: RemoteCommitFetcher;
+}): Promise<DeploymentUpdateState> {
+  const currentCommit = normalizeCommit(input.currentCommit);
+  const base = {
+    currentCommit,
+    currentShort: shortCommit(currentCommit),
+    latestCommit: null,
+    latestShort: null,
+  };
+  if (input.demo) {
+    return { ...base, kind: "web", behind: null, reason: "demo" };
+  }
+  if (input.desktop) {
+    return { ...base, kind: "desktop", behind: null, reason: "desktop" };
+  }
+  if (!currentCommit) {
+    return { ...base, kind: "container", behind: null, reason: "missing_current" };
+  }
+  let latestCommit: string | null;
+  try {
+    latestCommit = normalizeCommit(await input.fetchLatest());
+  } catch {
+    latestCommit = null;
+  }
+  if (!latestCommit) {
+    return { ...base, kind: "container", behind: null, reason: "probe_failed" };
+  }
+  return {
+    ...base,
+    latestCommit,
+    latestShort: shortCommit(latestCommit),
+    kind: "container",
+    behind: latestCommit !== currentCommit,
+    reason: "ok",
+  };
+}
+
+/** Instruction copied to the owner's local coding/deploy agent. Deliberately
+ *  asks for the repo's own self-verifying deploy script and health proof instead
+ *  of a blind `docker compose up` — this is the safe "almost in-place update". */
+export function buildContainerUpgradePrompt(input: {
+  currentShort: string;
+  latestShort: string;
+}): string {
+  return [
+    "请在这台部署机的 Mediary Scout 仓库目录执行一次安全升级：",
+    `1. 确认当前服务 commit 是 ${input.currentShort}，远端 main 目标是 ${input.latestShort}。`,
+    "2. 运行 `git pull --ff-only`，然后执行 `./scripts/deploy.sh`。",
+    "3. deploy.sh 必须证明运行容器 BUILD_COMMIT 等于新 HEAD，并通过 DB-backed /api/health；如果失败，停止并报告日志，不要绕过校验。",
+    "4. 完成后检查 `docker compose ps` 与 `/api/health`，告诉我升级结果。",
+  ].join("\n");
+}
+
+export const GITHUB_MAIN_COMPARE_URL =
+  "https://github.com/fancydirty/mediary-scout/commits/main";

--- a/apps/web/lib/deployment-update.ts
+++ b/apps/web/lib/deployment-update.ts
@@ -89,5 +89,5 @@ export function buildContainerUpgradePrompt(input: {
   ].join("\n");
 }
 
-export const GITHUB_MAIN_COMPARE_URL =
+export const GITHUB_MAIN_COMMITS_URL =
   "https://github.com/fancydirty/mediary-scout/commits/main";

--- a/apps/web/lib/deployment-update.ts
+++ b/apps/web/lib/deployment-update.ts
@@ -14,12 +14,11 @@ export interface RemoteCommitFetcher {
   (): Promise<string | null>;
 }
 
-const COMMIT_RE = /^[0-9a-f]{7,40}$/i;
+const COMMIT_RE = /^[0-9a-f]{40}$/i;
 
 export function normalizeCommit(value: string | null | undefined): string | null {
   const commit = value?.trim().toLowerCase() ?? "";
-  if (!COMMIT_RE.test(commit)) return null;
-  return commit.length === 40 ? commit : null;
+  return COMMIT_RE.test(commit) ? commit : null;
 }
 
 export function shortCommit(commit: string | null): string | null {
@@ -67,6 +66,8 @@ export async function getDeploymentUpdateState(input: {
     latestCommit,
     latestShort: shortCommit(latestCommit),
     kind: "container",
+    // "not latest main", not necessarily strictly behind: a custom/fork build can
+    // differ without main being ahead. The UI copy stays conservative.
     behind: latestCommit !== currentCommit,
     reason: "ok",
   };


### PR DESCRIPTION
## Summary
Add a safe, in-place-like update flow for self-hosted containers.

- Settings reads the image BUILD_COMMIT and probes upstream main with a short deadline.
- A confirmed-behind compose install shows current/latest SHAs, a main link, and a one-click copyable instruction for the owner's local deploy agent.
- The instruction requires `git pull --ff-only` plus `./scripts/deploy.sh`, including BUILD_COMMIT and DB-backed /api/health proof.
- Probe failures render nothing, so offline instances never get false alarms.
- Desktop uses the existing Releases/download path rather than pretending web code can update Electron.

## Security boundary
No Docker socket or host mutation is added to the web container; upgrade execution remains on the owner's machine/agent.

## Verification
- [x] deployment update tests: 12 passed
- [x] npm run typecheck
- [x] npx tsc -p apps/web/tsconfig.json --noEmit
- [x] npm run lint
- [x] npm run build:web
- [ ] CI
- [ ] Copilot review
