### PR TITLE
revert: undo accidental direct main update-prompt push

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3262,23 +3262,6 @@ select.setting-control {
 .update-copy-block {
   min-width: 180px;
 }
-.update-prompt-details {
-  margin-top: 10px;
-  font-size: 12px;
-}
-.update-prompt-details summary {
-  color: var(--text-muted);
-  cursor: pointer;
-}
-.update-prompt-details pre {
-  white-space: pre-wrap;
-  color: var(--text-soft);
-  background: rgba(0, 0, 0, 0.25);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 8px;
-  padding: 10px;
-  max-width: 520px;
-}
 
 /* ---------- GitHub nameplate (Settings page bottom — quiet 暗记 + CTA) ---------- */
 .github-nameplate {

--- a/apps/web/components/copy-upgrade-prompt-button.tsx
+++ b/apps/web/components/copy-upgrade-prompt-button.tsx
@@ -3,9 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 
-/** One-click copy for the owner-to-agent upgrade instruction. The full prompt is
- *  also visible behind <details> so the flow still works when the browser blocks
- *  Clipboard API (non-HTTPS self-host origins / automation contexts). */
+/** One-click copy for the owner-to-agent upgrade instruction. Clipboard API can
+ *  be unavailable on non-HTTPS self-host origins; fall back to selection. */
 export function CopyUpgradePromptButton({ prompt }: { prompt: string }) {
   const [copied, setCopied] = useState(false);
   const [manual, setManual] = useState(false);
@@ -54,10 +53,6 @@ export function CopyUpgradePromptButton({ prompt }: { prompt: string }) {
           aria-label="升级指令"
         />
       ) : null}
-      <details className="update-prompt-details">
-        <summary>查看完整升级指令</summary>
-        <pre>{prompt}</pre>
-      </details>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Revert the follow-up that was accidentally pushed directly to main outside the required PR flow.

## Verification
- [ ] CI
- [ ] Copilot review
