### PR TITLE
fix(settings): expose upgrade prompt without clipboard dependency

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3262,6 +3262,23 @@ select.setting-control {
 .update-copy-block {
   min-width: 180px;
 }
+.update-prompt-details {
+  margin-top: 10px;
+  font-size: 12px;
+}
+.update-prompt-details summary {
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.update-prompt-details pre {
+  white-space: pre-wrap;
+  color: var(--text-soft);
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 10px;
+  max-width: 520px;
+}
 
 /* ---------- GitHub nameplate (Settings page bottom — quiet 暗记 + CTA) ---------- */
 .github-nameplate {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3269,6 +3269,10 @@ select.setting-control {
 .update-prompt-details summary {
   color: var(--text-muted);
   cursor: pointer;
+  list-style: none;
+}
+.update-prompt-details summary::-webkit-details-marker {
+  display: none;
 }
 .update-prompt-details pre {
   white-space: pre-wrap;

--- a/apps/web/components/copy-upgrade-prompt-button.tsx
+++ b/apps/web/components/copy-upgrade-prompt-button.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 
-/** One-click copy for the owner-to-agent upgrade instruction. Clipboard API can
- *  be unavailable on non-HTTPS self-host origins; fall back to selection. */
+/** One-click copy for the owner-to-agent upgrade instruction. The full prompt is
+ *  also visible behind <details> so the flow still works when the browser blocks
+ *  Clipboard API (non-HTTPS self-host origins / automation contexts). */
 export function CopyUpgradePromptButton({ prompt }: { prompt: string }) {
   const [copied, setCopied] = useState(false);
   const [manual, setManual] = useState(false);
@@ -53,6 +54,10 @@ export function CopyUpgradePromptButton({ prompt }: { prompt: string }) {
           aria-label="升级指令"
         />
       ) : null}
+      <details className="update-prompt-details">
+        <summary>查看完整升级指令</summary>
+        <pre>{prompt}</pre>
+      </details>
     </div>
   );
 }

--- a/apps/web/components/copy-upgrade-prompt-button.tsx
+++ b/apps/web/components/copy-upgrade-prompt-button.tsx
@@ -53,11 +53,12 @@ export function CopyUpgradePromptButton({ prompt }: { prompt: string }) {
           onFocus={(event) => event.currentTarget.select()}
           aria-label="升级指令"
         />
-      ) : null}
-      <details className="update-prompt-details">
-        <summary>查看完整升级指令</summary>
-        <pre>{prompt}</pre>
-      </details>
+      ) : (
+        <details className="update-prompt-details">
+          <summary>查看完整升级指令</summary>
+          <pre>{prompt}</pre>
+        </details>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Make the self-host update instruction visible behind a native <details> disclosure, so the flow still works when Clipboard API is unavailable or blocked.

## Verification
- [x] deployment update tests: 15 passed
- [x] npm run typecheck
- [x] npx tsc -p apps/web/tsconfig.json --noEmit
- [x] npm run lint
- [x] npm run build:web
- [ ] CI
- [ ] Copilot review
