### PR TITLE
feat(settings): Action Inbox + nav badge

### DIFF
--- a/apps/web/app/api/settings/attention/route.test.ts
+++ b/apps/web/app/api/settings/attention/route.test.ts
@@ -18,23 +18,43 @@ import { GET } from "./route";
 import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
 import { resolveGlobalWorkspace } from "../../../../lib/workflow-runtime";
 
-describe("GET /api/settings/attention", () => {
-  beforeEach(() => vi.clearAllMocks());
+const fullItem = {
+  id: "update_available",
+  kind: "update_available",
+  href: "/settings?w=cs_other",
+  prompt: "long prompt",
+};
 
-  it("returns summary json and forwards workspace", async () => {
+describe("GET /api/settings/attention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     (resolveGlobalWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue({
       activeStorageId: "cs_other",
     });
     (loadSettingsAttentionSummary as ReturnType<typeof vi.fn>).mockResolvedValue({
       count: 1,
       severity: "warning",
-      items: [{ id: "update_available", kind: "update_available", href: "/settings?w=cs_other" }],
+      items: [fullItem],
     });
+  });
+
+  it("returns count/severity and omits items by default (badge poll)", async () => {
     const res = await GET(new NextRequest("http://localhost/api/settings/attention?w=cs_other"));
     expect(resolveGlobalWorkspace).toHaveBeenCalledWith("cs_other");
     expect(loadSettingsAttentionSummary).toHaveBeenCalledWith({ activeStorageId: "cs_other" });
     expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toMatchObject({ count: 1, severity: "warning" });
+    await expect(res.json()).resolves.toEqual({ count: 1, severity: "warning", items: [] });
+  });
+
+  it("includes full items when items=1", async () => {
+    const res = await GET(
+      new NextRequest("http://localhost/api/settings/attention?w=cs_other&items=1"),
+    );
+    await expect(res.json()).resolves.toEqual({
+      count: 1,
+      severity: "warning",
+      items: [fullItem],
+    });
   });
 
   it("fails quiet to empty summary", async () => {

--- a/apps/web/app/api/settings/attention/route.test.ts
+++ b/apps/web/app/api/settings/attention/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
 
 vi.mock("next/server", async () => {
   const actual = await vi.importActual<typeof import("next/server")>("next/server");
@@ -9,26 +10,39 @@ vi.mock("../../../../lib/settings-attention-server", () => ({
   loadSettingsAttentionSummary: vi.fn(),
 }));
 
+vi.mock("../../../../lib/workflow-runtime", () => ({
+  resolveGlobalWorkspace: vi.fn(),
+}));
+
 import { GET } from "./route";
 import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
+import { resolveGlobalWorkspace } from "../../../../lib/workflow-runtime";
 
 describe("GET /api/settings/attention", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("returns summary json", async () => {
+  it("returns summary json and forwards workspace", async () => {
+    (resolveGlobalWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue({
+      activeStorageId: "cs_other",
+    });
     (loadSettingsAttentionSummary as ReturnType<typeof vi.fn>).mockResolvedValue({
       count: 1,
       severity: "warning",
-      items: [{ id: "update_available", kind: "update_available" }],
+      items: [{ id: "update_available", kind: "update_available", href: "/settings?w=cs_other" }],
     });
-    const res = await GET();
+    const res = await GET(new NextRequest("http://localhost/api/settings/attention?w=cs_other"));
+    expect(resolveGlobalWorkspace).toHaveBeenCalledWith("cs_other");
+    expect(loadSettingsAttentionSummary).toHaveBeenCalledWith({ activeStorageId: "cs_other" });
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toMatchObject({ count: 1, severity: "warning" });
   });
 
   it("fails quiet to empty summary", async () => {
+    (resolveGlobalWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue({
+      activeStorageId: undefined,
+    });
     (loadSettingsAttentionSummary as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("db down"));
-    const res = await GET();
+    const res = await GET(new NextRequest("http://localhost/api/settings/attention"));
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ count: 0, severity: null, items: [] });
   });

--- a/apps/web/app/api/settings/attention/route.test.ts
+++ b/apps/web/app/api/settings/attention/route.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/server", async () => {
+  const actual = await vi.importActual<typeof import("next/server")>("next/server");
+  return { ...actual, connection: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock("../../../../lib/settings-attention-server", () => ({
+  loadSettingsAttentionSummary: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
+
+describe("GET /api/settings/attention", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns summary json", async () => {
+    (loadSettingsAttentionSummary as ReturnType<typeof vi.fn>).mockResolvedValue({
+      count: 1,
+      severity: "warning",
+      items: [{ id: "update_available", kind: "update_available" }],
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ count: 1, severity: "warning" });
+  });
+
+  it("fails quiet to empty summary", async () => {
+    (loadSettingsAttentionSummary as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("db down"));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ count: 0, severity: null, items: [] });
+  });
+});

--- a/apps/web/app/api/settings/attention/route.test.ts
+++ b/apps/web/app/api/settings/attention/route.test.ts
@@ -10,13 +10,8 @@ vi.mock("../../../../lib/settings-attention-server", () => ({
   loadSettingsAttentionSummary: vi.fn(),
 }));
 
-vi.mock("../../../../lib/workflow-runtime", () => ({
-  resolveGlobalWorkspace: vi.fn(),
-}));
-
 import { GET } from "./route";
 import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
-import { resolveGlobalWorkspace } from "../../../../lib/workflow-runtime";
 
 const fullItem = {
   id: "update_available",
@@ -28,9 +23,6 @@ const fullItem = {
 describe("GET /api/settings/attention", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (resolveGlobalWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue({
-      activeStorageId: "cs_other",
-    });
     (loadSettingsAttentionSummary as ReturnType<typeof vi.fn>).mockResolvedValue({
       count: 1,
       severity: "warning",
@@ -40,8 +32,7 @@ describe("GET /api/settings/attention", () => {
 
   it("returns count/severity and omits items by default (badge poll)", async () => {
     const res = await GET(new NextRequest("http://localhost/api/settings/attention?w=cs_other"));
-    expect(resolveGlobalWorkspace).toHaveBeenCalledWith("cs_other");
-    expect(loadSettingsAttentionSummary).toHaveBeenCalledWith({ activeStorageId: "cs_other" });
+    expect(loadSettingsAttentionSummary).toHaveBeenCalledWith({ w: "cs_other" });
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({ count: 1, severity: "warning", items: [] });
   });
@@ -58,9 +49,6 @@ describe("GET /api/settings/attention", () => {
   });
 
   it("fails quiet to empty summary", async () => {
-    (resolveGlobalWorkspace as ReturnType<typeof vi.fn>).mockResolvedValue({
-      activeStorageId: undefined,
-    });
     (loadSettingsAttentionSummary as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("db down"));
     const res = await GET(new NextRequest("http://localhost/api/settings/attention"));
     expect(res.status).toBe(200);

--- a/apps/web/app/api/settings/attention/route.ts
+++ b/apps/web/app/api/settings/attention/route.ts
@@ -2,6 +2,8 @@ import { connection, NextResponse, type NextRequest } from "next/server";
 import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
 import { resolveGlobalWorkspace } from "../../../../lib/workflow-runtime";
 
+const NO_STORE = { "Cache-Control": "no-store" } as const;
+
 /** Lightweight badge/inbox payload. Poll-friendly; never throws to the client.
  *  Badge polls only need count/severity — pass `items=1` for full inbox items. */
 export async function GET(request: NextRequest) {
@@ -14,13 +16,16 @@ export async function GET(request: NextRequest) {
       workspace.activeStorageId ? { activeStorageId: workspace.activeStorageId } : undefined,
     );
     const includeItems = request.nextUrl.searchParams.get("items") === "1";
-    return NextResponse.json({
-      count: summary.count,
-      severity: summary.severity,
-      items: includeItems ? summary.items : [],
-    });
+    return NextResponse.json(
+      {
+        count: summary.count,
+        severity: summary.severity,
+        items: includeItems ? summary.items : [],
+      },
+      { headers: NO_STORE },
+    );
   } catch {
     // Fail quiet — badge polls every few seconds; never spam logs or break nav.
-    return NextResponse.json({ count: 0, severity: null, items: [] });
+    return NextResponse.json({ count: 0, severity: null, items: [] }, { headers: NO_STORE });
   }
 }

--- a/apps/web/app/api/settings/attention/route.ts
+++ b/apps/web/app/api/settings/attention/route.ts
@@ -2,7 +2,8 @@ import { connection, NextResponse, type NextRequest } from "next/server";
 import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
 import { resolveGlobalWorkspace } from "../../../../lib/workflow-runtime";
 
-/** Lightweight badge/inbox payload. Poll-friendly; never throws to the client. */
+/** Lightweight badge/inbox payload. Poll-friendly; never throws to the client.
+ *  Badge polls only need count/severity — pass `items=1` for full inbox items. */
 export async function GET(request: NextRequest) {
   await connection();
   try {
@@ -12,10 +13,11 @@ export async function GET(request: NextRequest) {
     const summary = await loadSettingsAttentionSummary(
       workspace.activeStorageId ? { activeStorageId: workspace.activeStorageId } : undefined,
     );
+    const includeItems = request.nextUrl.searchParams.get("items") === "1";
     return NextResponse.json({
       count: summary.count,
       severity: summary.severity,
-      items: summary.items,
+      items: includeItems ? summary.items : [],
     });
   } catch {
     // Fail quiet — badge polls every few seconds; never spam logs or break nav.

--- a/apps/web/app/api/settings/attention/route.ts
+++ b/apps/web/app/api/settings/attention/route.ts
@@ -5,8 +5,8 @@ import { resolveGlobalWorkspace } from "../../../../lib/workflow-runtime";
 /** Lightweight badge/inbox payload. Poll-friendly; never throws to the client.
  *  Badge polls only need count/severity — pass `items=1` for full inbox items. */
 export async function GET(request: NextRequest) {
-  await connection();
   try {
+    await connection();
     const workspace = await resolveGlobalWorkspace(
       request.nextUrl.searchParams.get("w") ?? undefined,
     );

--- a/apps/web/app/api/settings/attention/route.ts
+++ b/apps/web/app/api/settings/attention/route.ts
@@ -1,18 +1,24 @@
-import { connection, NextResponse } from "next/server";
+import { connection, NextResponse, type NextRequest } from "next/server";
 import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
+import { resolveGlobalWorkspace } from "../../../../lib/workflow-runtime";
 
 /** Lightweight badge/inbox payload. Poll-friendly; never throws to the client. */
-export async function GET() {
+export async function GET(request: NextRequest) {
   await connection();
   try {
-    const summary = await loadSettingsAttentionSummary();
+    const workspace = await resolveGlobalWorkspace(
+      request.nextUrl.searchParams.get("w") ?? undefined,
+    );
+    const summary = await loadSettingsAttentionSummary(
+      workspace.activeStorageId ? { activeStorageId: workspace.activeStorageId } : undefined,
+    );
     return NextResponse.json({
       count: summary.count,
       severity: summary.severity,
       items: summary.items,
     });
-  } catch (error) {
-    console.error("[settings/attention] failed:", error);
+  } catch {
+    // Fail quiet — badge polls every few seconds; never spam logs or break nav.
     return NextResponse.json({ count: 0, severity: null, items: [] });
   }
 }

--- a/apps/web/app/api/settings/attention/route.ts
+++ b/apps/web/app/api/settings/attention/route.ts
@@ -1,0 +1,18 @@
+import { connection, NextResponse } from "next/server";
+import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
+
+/** Lightweight badge/inbox payload. Poll-friendly; never throws to the client. */
+export async function GET() {
+  await connection();
+  try {
+    const summary = await loadSettingsAttentionSummary();
+    return NextResponse.json({
+      count: summary.count,
+      severity: summary.severity,
+      items: summary.items,
+    });
+  } catch (error) {
+    console.error("[settings/attention] failed:", error);
+    return NextResponse.json({ count: 0, severity: null, items: [] });
+  }
+}

--- a/apps/web/app/api/settings/attention/route.ts
+++ b/apps/web/app/api/settings/attention/route.ts
@@ -1,6 +1,5 @@
 import { connection, NextResponse, type NextRequest } from "next/server";
 import { loadSettingsAttentionSummary } from "../../../../lib/settings-attention-server";
-import { resolveGlobalWorkspace } from "../../../../lib/workflow-runtime";
 
 const NO_STORE = { "Cache-Control": "no-store" } as const;
 
@@ -9,12 +8,9 @@ const NO_STORE = { "Cache-Control": "no-store" } as const;
 export async function GET(request: NextRequest) {
   try {
     await connection();
-    const workspace = await resolveGlobalWorkspace(
-      request.nextUrl.searchParams.get("w") ?? undefined,
-    );
-    const summary = await loadSettingsAttentionSummary(
-      workspace.activeStorageId ? { activeStorageId: workspace.activeStorageId } : undefined,
-    );
+    const summary = await loadSettingsAttentionSummary({
+      w: request.nextUrl.searchParams.get("w"),
+    });
     const includeItems = request.nextUrl.searchParams.get("items") === "1";
     return NextResponse.json(
       {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3208,6 +3208,66 @@ select.setting-control {
   justify-content: flex-end;
 }
 
+/* Settings footer/desktop card can host the attention badge on the right. */
+.health-card {
+  position: relative;
+}
+.health-card .nav-badge {
+  margin-left: auto;
+}
+
+/* ---------- settings attention inbox ---------- */
+.attention-inbox {
+  max-width: 720px;
+  margin-bottom: 24px;
+  background: rgba(255, 164, 43, 0.08);
+  border: 1px solid rgba(255, 164, 43, 0.35);
+  border-radius: var(--radius-card);
+  padding: 16px;
+}
+.attention-inbox-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--warning);
+  margin-bottom: 12px;
+}
+.attention-inbox-list {
+  display: grid;
+  gap: 8px;
+}
+.attention-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 10px;
+  padding: 12px;
+}
+.attention-item-title {
+  font-weight: 700;
+  color: var(--text);
+}
+.attention-item-body {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+.attention-item-action {
+  flex: 0 0 auto;
+  text-decoration: none;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+.attention-item-prompt {
+  margin-top: 8px;
+}
+.nav-badge-warning {
+  background: var(--warning);
+  color: #121212;
+}
+
 /* ---------- deployment update hint (self-host compose, Settings top) ---------- */
 .update-card {
   max-width: 720px;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3238,8 +3238,15 @@ select.setting-control {
   gap: 12px;
   align-items: center;
   background: rgba(0, 0, 0, 0.25);
+  border: 1px solid transparent;
   border-radius: 10px;
   padding: 12px;
+}
+.attention-item.severity-blocker {
+  border-color: rgba(229, 72, 77, 0.45);
+}
+.attention-item.severity-warning {
+  border-color: rgba(255, 164, 43, 0.45);
 }
 .attention-item-title {
   font-weight: 700;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -183,6 +183,10 @@ p {
   padding: 12px;
 }
 
+.health-card .nav-badge {
+  margin-left: auto;
+}
+
 .health-card strong {
   display: block;
   font-size: 13px;
@@ -3206,14 +3210,6 @@ select.setting-control {
   margin-top: 12px;
   display: flex;
   justify-content: flex-end;
-}
-
-/* Settings footer/desktop card can host the attention badge on the right. */
-.health-card {
-  position: relative;
-}
-.health-card .nav-badge {
-  margin-left: auto;
 }
 
 /* ---------- settings attention inbox ---------- */

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -21,8 +21,8 @@ import { SettingsTabs } from "../../components/settings-tabs";
 import { PasswordChangeForm } from "../../components/password-change-form";
 import { AccountAdminPanel } from "../../components/account-admin-panel";
 import { GitHubNameplate } from "../../components/github-nameplate";
-import { DeploymentUpdateCard } from "../../components/deployment-update-card";
-import { loadDeploymentUpdateState } from "../../lib/deployment-update-server";
+import { SettingsActionInbox } from "../../components/settings-action-inbox";
+import { loadSettingsAttentionSummary } from "../../lib/settings-attention-server";
 import {
   getAccountConnectedStorages,
   getAccountScopedSettings,
@@ -86,7 +86,7 @@ export default function SettingsPage({
         ) : (
           <>
             <Suspense fallback={null}>
-              <DeploymentUpdateSection />
+              <SettingsAttentionSection />
             </Suspense>
             <Suspense fallback={<div className="skeleton skeleton-heading" />}>
             <SettingsTabs
@@ -157,12 +157,11 @@ async function SettingsSidebar({ searchParams }: { searchParams: Promise<{ w?: s
   return <AppSidebar active="settings" basePath={workspace.basePath} activeStorageId={workspace.activeStorageId} />;
 }
 
-async function DeploymentUpdateSection() {
-  // Request-time only: reads BUILD_COMMIT and probes upstream main. Probe failure
-  // renders null inside the card — an offline instance never gets a false alarm.
+async function SettingsAttentionSection() {
+  // Request-time only: account drives + LLM config + optional update probe.
   await connection();
-  const state = await loadDeploymentUpdateState();
-  return <DeploymentUpdateCard state={state} />;
+  const summary = await loadSettingsAttentionSummary();
+  return <SettingsActionInbox items={summary.items} />;
 }
 
 async function PasswordChangeSection() {

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -86,7 +86,7 @@ export default function SettingsPage({
         ) : (
           <>
             <Suspense fallback={null}>
-              <SettingsAttentionSection />
+              <SettingsAttentionSection searchParams={searchParams} />
             </Suspense>
             <Suspense fallback={<div className="skeleton skeleton-heading" />}>
             <SettingsTabs
@@ -157,10 +157,18 @@ async function SettingsSidebar({ searchParams }: { searchParams: Promise<{ w?: s
   return <AppSidebar active="settings" basePath={workspace.basePath} activeStorageId={workspace.activeStorageId} />;
 }
 
-async function SettingsAttentionSection() {
+async function SettingsAttentionSection({
+  searchParams,
+}: {
+  searchParams: Promise<{ w?: string }>;
+}) {
   // Request-time only: account drives + LLM config + optional update probe.
   await connection();
-  const summary = await loadSettingsAttentionSummary();
+  const { w } = await searchParams;
+  const workspace = await resolveGlobalWorkspace(w);
+  const summary = await loadSettingsAttentionSummary(
+    workspace.activeStorageId ? { activeStorageId: workspace.activeStorageId } : undefined,
+  );
   return <SettingsActionInbox items={summary.items} />;
 }
 

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -163,12 +163,10 @@ async function SettingsAttentionSection({
   searchParams: Promise<{ w?: string }>;
 }) {
   // Request-time only: account drives + LLM config + optional update probe.
+  // Loader resolves account/drives once (including optional ?w deep-link context).
   await connection();
   const { w } = await searchParams;
-  const workspace = await resolveGlobalWorkspace(w);
-  const summary = await loadSettingsAttentionSummary(
-    workspace.activeStorageId ? { activeStorageId: workspace.activeStorageId } : undefined,
-  );
+  const summary = await loadSettingsAttentionSummary(w ? { w } : undefined);
   return <SettingsActionInbox items={summary.items} />;
 }
 

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -93,7 +93,7 @@ export function AppSidebar({
             >
               <Settings size={16} aria-hidden />
               设置
-              <SettingsAttentionBadge />
+              <SettingsAttentionBadge storageId={activeStorageId} />
             </Link>
           </li>
         </ul>
@@ -121,7 +121,7 @@ export function AppSidebar({
             <strong>设置</strong>
             <span>网盘连接 · 推送 · 偏好</span>
           </span>
-          <SettingsAttentionBadge />
+          <SettingsAttentionBadge storageId={activeStorageId} />
         </Link>
       </div>
     </aside>

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -93,7 +93,7 @@ export function AppSidebar({
             >
               <Settings size={16} aria-hidden />
               设置
-              <SettingsAttentionBadge storageId={activeStorageId} />
+              <SettingsAttentionBadge storageId={activeStorageId} visibleWhen="mobile" />
             </Link>
           </li>
         </ul>
@@ -121,7 +121,7 @@ export function AppSidebar({
             <strong>设置</strong>
             <span>网盘连接 · 推送 · 偏好</span>
           </span>
-          <SettingsAttentionBadge storageId={activeStorageId} />
+          <SettingsAttentionBadge storageId={activeStorageId} visibleWhen="desktop" />
         </Link>
       </div>
     </aside>

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -5,6 +5,7 @@ import { globalNavHref } from "@media-track/workflow";
 import { SearchNavLink } from "./search-memory";
 import { ActivityNavBadge } from "./activity-nav-badge";
 import { NotificationsNavBadge } from "./notifications-nav-badge";
+import { SettingsAttentionBadge } from "./settings-attention-badge";
 import { WorkspaceSwitcherLoader } from "./workspace-switcher-loader";
 import { AccountIdentityLoader } from "./account-identity-loader";
 
@@ -92,6 +93,7 @@ export function AppSidebar({
             >
               <Settings size={16} aria-hidden />
               设置
+              <SettingsAttentionBadge />
             </Link>
           </li>
         </ul>
@@ -119,6 +121,7 @@ export function AppSidebar({
             <strong>设置</strong>
             <span>网盘连接 · 推送 · 偏好</span>
           </span>
+          <SettingsAttentionBadge />
         </Link>
       </div>
     </aside>

--- a/apps/web/components/settings-action-inbox.tsx
+++ b/apps/web/components/settings-action-inbox.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { AlertTriangle } from "lucide-react";
+import type { SettingsAttentionItem } from "../lib/settings-attention";
+import { CopyUpgradePromptButton } from "./copy-upgrade-prompt-button";
+
+/** Settings-page Action Inbox. Empty => render nothing (quiet is a feature). */
+export function SettingsActionInbox({ items }: { items: SettingsAttentionItem[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <section className="settings-card attention-inbox" aria-labelledby="settings-attention-title">
+      <div className="attention-inbox-heading" id="settings-attention-title">
+        <AlertTriangle size={16} aria-hidden />
+        <strong>需要处理（{items.length}）</strong>
+      </div>
+      <div className="attention-inbox-list">
+        {items.map((item) => (
+          <div key={item.id} className={`attention-item severity-${item.severity}`}>
+            <div className="attention-item-copy">
+              <div className="attention-item-title">{item.title}</div>
+              <div className="attention-item-body">{item.body}</div>
+              {item.kind === "update_available" && item.prompt ? (
+                <div className="attention-item-prompt">
+                  <CopyUpgradePromptButton prompt={item.prompt} />
+                </div>
+              ) : null}
+            </div>
+            {item.kind === "update_available" ? null : (
+              <Link className="primary-button attention-item-action" href={item.href}>
+                {item.actionLabel}
+              </Link>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/settings-attention-badge.tsx
+++ b/apps/web/components/settings-attention-badge.tsx
@@ -46,11 +46,13 @@ export function SettingsAttentionBadge({
     let timer: ReturnType<typeof setTimeout> | undefined;
     const epochAtStart = epochRef.current;
     const poll = async () => {
+      const controller = new AbortController();
+      const abortTimer = setTimeout(() => controller.abort(), 10000);
       try {
         const url = storageId
           ? `/api/settings/attention?w=${encodeURIComponent(storageId)}`
           : "/api/settings/attention";
-        const res = await fetch(url, { cache: "no-store" });
+        const res = await fetch(url, { cache: "no-store", signal: controller.signal });
         if (!res.ok) return;
         const data = (await res.json()) as {
           count?: number;
@@ -60,9 +62,10 @@ export function SettingsAttentionBadge({
         setCount(typeof data.count === "number" ? data.count : 0);
         setSeverity(data.severity === "blocker" || data.severity === "warning" ? data.severity : null);
       } catch {
-        // keep last
+        // keep last (including abort/timeout)
       } finally {
-        // Self-schedule so slow requests never overlap.
+        clearTimeout(abortTimer);
+        // Self-schedule so slow/hung requests never stall the loop forever.
         if (alive && epochRef.current === epochAtStart) {
           timer = setTimeout(() => void poll(), 8000);
         }

--- a/apps/web/components/settings-attention-badge.tsx
+++ b/apps/web/components/settings-attention-badge.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 
 /** Live count of Settings attention items. Hidden at zero. Desktop footer + mobile
  *  tab both mount this; CSS decides placement (inline vs icon overlay). */
-export function SettingsAttentionBadge() {
+export function SettingsAttentionBadge({ storageId }: { storageId?: string | undefined }) {
   const [count, setCount] = useState(0);
   const [severity, setSeverity] = useState<"warning" | "blocker" | null>(null);
 
@@ -12,7 +12,10 @@ export function SettingsAttentionBadge() {
     let alive = true;
     const poll = async () => {
       try {
-        const res = await fetch("/api/settings/attention", { cache: "no-store" });
+        const url = storageId
+          ? `/api/settings/attention?w=${encodeURIComponent(storageId)}`
+          : "/api/settings/attention";
+        const res = await fetch(url, { cache: "no-store" });
         if (!res.ok) return;
         const data = (await res.json()) as {
           count?: number;
@@ -31,7 +34,7 @@ export function SettingsAttentionBadge() {
       alive = false;
       clearInterval(id);
     };
-  }, []);
+  }, [storageId]);
 
   if (count <= 0) return null;
   const tone = severity === "blocker" ? "nav-badge-alert" : "nav-badge-warning";

--- a/apps/web/components/settings-attention-badge.tsx
+++ b/apps/web/components/settings-attention-badge.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 /** Live count of Settings attention items. Hidden at zero.
  *  Mobile nav + desktop footer each mount one instance; only the instance
@@ -15,6 +15,8 @@ export function SettingsAttentionBadge({
   const [visible, setVisible] = useState(false);
   const [count, setCount] = useState(0);
   const [severity, setSeverity] = useState<"warning" | "blocker" | null>(null);
+  // Bumped when hidden so late poll responses from a previous visible window are ignored.
+  const epochRef = useRef(0);
 
   useEffect(() => {
     const mq = window.matchMedia("(max-width: 860px)");
@@ -22,6 +24,7 @@ export function SettingsAttentionBadge({
       const next = visibleWhen === "mobile" ? mq.matches : !mq.matches;
       setVisible(next);
       if (!next) {
+        epochRef.current += 1;
         // Drop stale count so a later resize doesn't flash an old badge.
         setCount(0);
         setSeverity(null);
@@ -41,6 +44,7 @@ export function SettingsAttentionBadge({
     if (!visible) return;
     let alive = true;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    const epochAtStart = epochRef.current;
     const poll = async () => {
       try {
         const url = storageId
@@ -52,14 +56,16 @@ export function SettingsAttentionBadge({
           count?: number;
           severity?: "warning" | "blocker" | null;
         };
-        if (!alive) return;
+        if (!alive || epochRef.current !== epochAtStart) return;
         setCount(typeof data.count === "number" ? data.count : 0);
         setSeverity(data.severity === "blocker" || data.severity === "warning" ? data.severity : null);
       } catch {
         // keep last
       } finally {
         // Self-schedule so slow requests never overlap.
-        if (alive) timer = setTimeout(() => void poll(), 8000);
+        if (alive && epochRef.current === epochAtStart) {
+          timer = setTimeout(() => void poll(), 8000);
+        }
       }
     };
     void poll();

--- a/apps/web/components/settings-attention-badge.tsx
+++ b/apps/web/components/settings-attention-badge.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** Live count of Settings attention items. Hidden at zero. Desktop footer + mobile
+ *  tab both mount this; CSS decides placement (inline vs icon overlay). */
+export function SettingsAttentionBadge() {
+  const [count, setCount] = useState(0);
+  const [severity, setSeverity] = useState<"warning" | "blocker" | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const poll = async () => {
+      try {
+        const res = await fetch("/api/settings/attention", { cache: "no-store" });
+        if (!res.ok) return;
+        const data = (await res.json()) as {
+          count?: number;
+          severity?: "warning" | "blocker" | null;
+        };
+        if (!alive) return;
+        setCount(typeof data.count === "number" ? data.count : 0);
+        setSeverity(data.severity === "blocker" || data.severity === "warning" ? data.severity : null);
+      } catch {
+        // keep last
+      }
+    };
+    void poll();
+    const id = setInterval(() => void poll(), 8000);
+    return () => {
+      alive = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (count <= 0) return null;
+  const tone = severity === "blocker" ? "nav-badge-alert" : "nav-badge-warning";
+  return <span className={`nav-badge ${tone}`}>{count}</span>;
+}

--- a/apps/web/components/settings-attention-badge.tsx
+++ b/apps/web/components/settings-attention-badge.tsx
@@ -28,8 +28,13 @@ export function SettingsAttentionBadge({
       }
     };
     sync();
-    mq.addEventListener("change", sync);
-    return () => mq.removeEventListener("change", sync);
+    // Older Safari only has addListener/removeListener on MediaQueryList.
+    if (typeof mq.addEventListener === "function") {
+      mq.addEventListener("change", sync);
+      return () => mq.removeEventListener("change", sync);
+    }
+    mq.addListener(sync);
+    return () => mq.removeListener(sync);
   }, [visibleWhen]);
 
   useEffect(() => {

--- a/apps/web/components/settings-attention-badge.tsx
+++ b/apps/web/components/settings-attention-badge.tsx
@@ -40,6 +40,7 @@ export function SettingsAttentionBadge({
   useEffect(() => {
     if (!visible) return;
     let alive = true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const poll = async () => {
       try {
         const url = storageId
@@ -56,13 +57,15 @@ export function SettingsAttentionBadge({
         setSeverity(data.severity === "blocker" || data.severity === "warning" ? data.severity : null);
       } catch {
         // keep last
+      } finally {
+        // Self-schedule so slow requests never overlap.
+        if (alive) timer = setTimeout(() => void poll(), 8000);
       }
     };
     void poll();
-    const id = setInterval(() => void poll(), 8000);
     return () => {
       alive = false;
-      clearInterval(id);
+      if (timer) clearTimeout(timer);
     };
   }, [storageId, visible]);
 

--- a/apps/web/components/settings-attention-badge.tsx
+++ b/apps/web/components/settings-attention-badge.tsx
@@ -2,13 +2,32 @@
 
 import { useEffect, useState } from "react";
 
-/** Live count of Settings attention items. Hidden at zero. Desktop footer + mobile
- *  tab both mount this; CSS decides placement (inline vs icon overlay). */
-export function SettingsAttentionBadge({ storageId }: { storageId?: string | undefined }) {
+/** Live count of Settings attention items. Hidden at zero.
+ *  Mobile nav + desktop footer each mount one instance; only the instance
+ *  matching the current breakpoint polls (same 860px switch as the sidebar). */
+export function SettingsAttentionBadge({
+  storageId,
+  visibleWhen,
+}: {
+  storageId?: string | undefined;
+  visibleWhen: "mobile" | "desktop";
+}) {
+  const [visible, setVisible] = useState(false);
   const [count, setCount] = useState(0);
   const [severity, setSeverity] = useState<"warning" | "blocker" | null>(null);
 
   useEffect(() => {
+    const mq = window.matchMedia("(max-width: 860px)");
+    const sync = () => {
+      setVisible(visibleWhen === "mobile" ? mq.matches : !mq.matches);
+    };
+    sync();
+    mq.addEventListener("change", sync);
+    return () => mq.removeEventListener("change", sync);
+  }, [visibleWhen]);
+
+  useEffect(() => {
+    if (!visible) return;
     let alive = true;
     const poll = async () => {
       try {
@@ -34,9 +53,9 @@ export function SettingsAttentionBadge({ storageId }: { storageId?: string | und
       alive = false;
       clearInterval(id);
     };
-  }, [storageId]);
+  }, [storageId, visible]);
 
-  if (count <= 0) return null;
+  if (!visible || count <= 0) return null;
   const tone = severity === "blocker" ? "nav-badge-alert" : "nav-badge-warning";
   return <span className={`nav-badge ${tone}`}>{count}</span>;
 }

--- a/apps/web/components/settings-attention-badge.tsx
+++ b/apps/web/components/settings-attention-badge.tsx
@@ -19,7 +19,13 @@ export function SettingsAttentionBadge({
   useEffect(() => {
     const mq = window.matchMedia("(max-width: 860px)");
     const sync = () => {
-      setVisible(visibleWhen === "mobile" ? mq.matches : !mq.matches);
+      const next = visibleWhen === "mobile" ? mq.matches : !mq.matches;
+      setVisible(next);
+      if (!next) {
+        // Drop stale count so a later resize doesn't flash an old badge.
+        setCount(0);
+        setSeverity(null);
+      }
     };
     sync();
     mq.addEventListener("change", sync);

--- a/apps/web/lib/settings-attention-server.ts
+++ b/apps/web/lib/settings-attention-server.ts
@@ -1,4 +1,8 @@
-import { getStorageBrand } from "@media-track/workflow";
+import {
+  getStorageBrand,
+  isRegisteredStorageProvider,
+  resolveWorkspaceFromParam,
+} from "@media-track/workflow";
 import { isDemoMode } from "./demo-mode";
 import { loadDeploymentUpdateState } from "./deployment-update-server";
 import {
@@ -21,20 +25,24 @@ function brandLabel(provider: string): string {
   }
 }
 
-/** Account-scoped attention items for Settings badge + Action Inbox. */
+/** Account-scoped attention items for Settings badge + Action Inbox.
+ *  Resolves account + drives once; optional `w` preserves workspace on deep-links. */
 export async function loadSettingsAttentionSummary(options?: {
-  activeStorageId?: string;
+  w?: string | null;
 }): Promise<SettingsAttentionSummary> {
   if (isDemoMode()) {
     return { count: 0, severity: null, items: [] };
   }
 
-  // Resolve account once — listConnectedStorages(accountId) avoids a second
-  // getCurrentAccountId()/session verify on the poll path.
   const accountId = await getCurrentAccountId();
   const repository = getWorkflowRepository();
-  const [drives, llm, update] = await Promise.all([
-    repository.listConnectedStorages(accountId),
+  const drives = await repository.listConnectedStorages(accountId);
+  const workspace = resolveWorkspaceFromParam(
+    drives.filter((drive) => isRegisteredStorageProvider(drive.provider)),
+    options?.w ?? undefined,
+  );
+
+  const [llm, update] = await Promise.all([
     getLlmConfig(getAccountScopedSettings(accountId)),
     loadDeploymentUpdateState(),
   ]);
@@ -50,7 +58,7 @@ export async function loadSettingsAttentionSummary(options?: {
     brandLabel,
     llmConfigured: Boolean(llm.baseURL && llm.modelId),
     update,
-    ...(options?.activeStorageId ? { activeStorageId: options.activeStorageId } : {}),
+    ...(workspace.activeStorageId ? { activeStorageId: workspace.activeStorageId } : {}),
   });
   return summarizeSettingsAttention(items);
 }

--- a/apps/web/lib/settings-attention-server.ts
+++ b/apps/web/lib/settings-attention-server.ts
@@ -7,10 +7,10 @@ import {
   type SettingsAttentionSummary,
 } from "./settings-attention";
 import {
-  getAccountConnectedStorages,
   getAccountScopedSettings,
   getCurrentAccountId,
   getLlmConfig,
+  getWorkflowRepository,
 } from "./workflow-runtime";
 
 function brandLabel(provider: string): string {
@@ -22,14 +22,19 @@ function brandLabel(provider: string): string {
 }
 
 /** Account-scoped attention items for Settings badge + Action Inbox. */
-export async function loadSettingsAttentionSummary(): Promise<SettingsAttentionSummary> {
+export async function loadSettingsAttentionSummary(options?: {
+  activeStorageId?: string;
+}): Promise<SettingsAttentionSummary> {
   if (isDemoMode()) {
     return { count: 0, severity: null, items: [] };
   }
 
+  // Resolve account once — listConnectedStorages(accountId) avoids a second
+  // getCurrentAccountId()/session verify on the poll path.
   const accountId = await getCurrentAccountId();
+  const repository = getWorkflowRepository();
   const [drives, llm, update] = await Promise.all([
-    getAccountConnectedStorages(),
+    repository.listConnectedStorages(accountId),
     getLlmConfig(getAccountScopedSettings(accountId)),
     loadDeploymentUpdateState(),
   ]);
@@ -45,6 +50,7 @@ export async function loadSettingsAttentionSummary(): Promise<SettingsAttentionS
     brandLabel,
     llmConfigured: Boolean(llm.baseURL && llm.modelId),
     update,
+    ...(options?.activeStorageId ? { activeStorageId: options.activeStorageId } : {}),
   });
   return summarizeSettingsAttention(items);
 }

--- a/apps/web/lib/settings-attention-server.ts
+++ b/apps/web/lib/settings-attention-server.ts
@@ -1,0 +1,50 @@
+import { getStorageBrand } from "@media-track/workflow";
+import { isDemoMode } from "./demo-mode";
+import { loadDeploymentUpdateState } from "./deployment-update-server";
+import {
+  buildSettingsAttentionItems,
+  summarizeSettingsAttention,
+  type SettingsAttentionSummary,
+} from "./settings-attention";
+import {
+  getAccountConnectedStorages,
+  getAccountScopedSettings,
+  getCurrentAccountId,
+  getLlmConfig,
+} from "./workflow-runtime";
+
+function brandLabel(provider: string): string {
+  try {
+    return getStorageBrand(provider).label;
+  } catch {
+    return provider;
+  }
+}
+
+/** Account-scoped attention items for Settings badge + Action Inbox. */
+export async function loadSettingsAttentionSummary(): Promise<SettingsAttentionSummary> {
+  if (isDemoMode()) {
+    return { count: 0, severity: null, items: [] };
+  }
+
+  const accountId = await getCurrentAccountId();
+  const [drives, llm, update] = await Promise.all([
+    getAccountConnectedStorages(),
+    getLlmConfig(getAccountScopedSettings(accountId)),
+    loadDeploymentUpdateState(),
+  ]);
+
+  const items = buildSettingsAttentionItems({
+    demo: false,
+    drives: drives.map((drive) => ({
+      id: drive.id,
+      provider: drive.provider,
+      label: drive.label,
+      status: drive.status,
+    })),
+    brandLabel,
+    llmConfigured: Boolean(llm.baseURL && llm.modelId),
+    update,
+  });
+  return summarizeSettingsAttention(items);
+}

--- a/apps/web/lib/settings-attention.test.ts
+++ b/apps/web/lib/settings-attention.test.ts
@@ -122,4 +122,19 @@ describe("buildSettingsAttentionItems", () => {
     );
     expect(summary).toMatchObject({ count: 1, severity: "warning" });
   });
+
+  it("preserves non-primary workspace on deep-links", () => {
+    const items = buildSettingsAttentionItems({
+      demo: false,
+      drives: [{ id: "cs_q", provider: "quark", label: null, status: "frozen" }],
+      brandLabel,
+      llmConfigured: false,
+      update: null,
+      activeStorageId: "cs_other",
+    });
+    expect(items.map((i) => i.href)).toEqual([
+      "/settings?w=cs_other",
+      "/settings?tab=services&w=cs_other",
+    ]);
+  });
 });

--- a/apps/web/lib/settings-attention.test.ts
+++ b/apps/web/lib/settings-attention.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { buildSettingsAttentionItems, summarizeSettingsAttention } from "./settings-attention";
+
+const brandLabel = (provider: string) =>
+  ({ pan115: "115网盘", quark: "夸克网盘", guangya: "光鸭云盘" }[provider] ?? provider);
+
+describe("buildSettingsAttentionItems", () => {
+  it("returns empty in demo mode even with problems", () => {
+    const items = buildSettingsAttentionItems({
+      demo: true,
+      drives: [{ id: "cs1", provider: "quark", label: null, status: "frozen" }],
+      brandLabel,
+      llmConfigured: false,
+      update: {
+        kind: "container",
+        behind: true,
+        currentShort: "1111111",
+        latestShort: "2222222",
+      },
+    });
+    expect(items).toEqual([]);
+  });
+
+  it("lists frozen drives as blockers with plain labels", () => {
+    const items = buildSettingsAttentionItems({
+      demo: false,
+      drives: [
+        { id: "cs_q", provider: "quark", label: null, status: "frozen" },
+        { id: "cs_a", provider: "pan115", label: "家里115", status: "active" },
+      ],
+      brandLabel,
+      llmConfigured: true,
+      update: null,
+    });
+    expect(items).toEqual([
+      expect.objectContaining({
+        id: "frozen:cs_q",
+        kind: "frozen_drive",
+        severity: "blocker",
+        title: "夸克网盘 已失效",
+        actionLabel: "去处理",
+        href: "/settings",
+      }),
+    ]);
+  });
+
+  it("flags missing LLM config", () => {
+    const items = buildSettingsAttentionItems({
+      demo: false,
+      drives: [],
+      brandLabel,
+      llmConfigured: false,
+      update: null,
+    });
+    expect(items.map((i) => i.kind)).toEqual(["missing_llm"]);
+    expect(items[0]?.href).toBe("/settings?tab=services");
+  });
+
+  it("adds container update with agent prompt, skips desktop/web", () => {
+    const container = buildSettingsAttentionItems({
+      demo: false,
+      drives: [],
+      brandLabel,
+      llmConfigured: true,
+      update: {
+        kind: "container",
+        behind: true,
+        currentShort: "aaaaaaa",
+        latestShort: "bbbbbbb",
+      },
+    });
+    expect(container).toHaveLength(1);
+    expect(container[0]?.kind).toBe("update_available");
+    expect(container[0]?.severity).toBe("warning");
+    expect(container[0]?.prompt).toContain("./scripts/deploy.sh");
+    expect(container[0]?.prompt).toContain("aaaaaaa");
+
+    for (const kind of ["desktop", "web"] as const) {
+      const items = buildSettingsAttentionItems({
+        demo: false,
+        drives: [],
+        brandLabel,
+        llmConfigured: true,
+        update: { kind, behind: true, currentShort: "a", latestShort: "b" },
+      });
+      expect(items).toEqual([]);
+    }
+  });
+
+  it("aggregates severity: any blocker wins", () => {
+    const items = buildSettingsAttentionItems({
+      demo: false,
+      drives: [{ id: "cs1", provider: "quark", label: null, status: "frozen" }],
+      brandLabel,
+      llmConfigured: true,
+      update: {
+        kind: "container",
+        behind: true,
+        currentShort: "1111111",
+        latestShort: "2222222",
+      },
+    });
+    const summary = summarizeSettingsAttention(items);
+    expect(summary.count).toBe(2);
+    expect(summary.severity).toBe("blocker");
+  });
+
+  it("warning-only when only update is open", () => {
+    const summary = summarizeSettingsAttention(
+      buildSettingsAttentionItems({
+        demo: false,
+        drives: [],
+        brandLabel,
+        llmConfigured: true,
+        update: {
+          kind: "container",
+          behind: true,
+          currentShort: "1111111",
+          latestShort: "2222222",
+        },
+      }),
+    );
+    expect(summary).toMatchObject({ count: 1, severity: "warning" });
+  });
+});

--- a/apps/web/lib/settings-attention.ts
+++ b/apps/web/lib/settings-attention.ts
@@ -1,0 +1,107 @@
+import type { DeploymentUpdateState } from "./deployment-update";
+import { buildContainerUpgradePrompt } from "./deployment-update";
+
+export type AttentionSeverity = "warning" | "blocker";
+export type AttentionKind = "frozen_drive" | "update_available" | "missing_llm";
+
+export interface SettingsAttentionItem {
+  id: string;
+  kind: AttentionKind;
+  severity: AttentionSeverity;
+  title: string;
+  body: string;
+  actionLabel: string;
+  /** Settings deep-link path+query (no origin), e.g. `/settings?tab=services`. */
+  href: string;
+  /** Present only for update_available — full agent deploy prompt. */
+  prompt?: string;
+}
+
+export interface SettingsAttentionSummary {
+  count: number;
+  severity: AttentionSeverity | null;
+  items: SettingsAttentionItem[];
+}
+
+export function buildSettingsAttentionItems(input: {
+  demo: boolean;
+  drives: Array<{
+    id: string;
+    provider: string;
+    label: string | null;
+    status: "active" | "frozen";
+  }>;
+  brandLabel: (provider: string) => string;
+  llmConfigured: boolean;
+  update: Pick<DeploymentUpdateState, "kind" | "behind" | "currentShort" | "latestShort"> | null;
+  settingsHref?: (tab?: "drives" | "services" | "preferences" | "patrol" | "account") => string;
+}): SettingsAttentionItem[] {
+  if (input.demo) return [];
+
+  const href = input.settingsHref ?? defaultSettingsHref;
+  const items: SettingsAttentionItem[] = [];
+
+  for (const drive of input.drives) {
+    if (drive.status !== "frozen") continue;
+    const name = (drive.label?.trim() || input.brandLabel(drive.provider) || "网盘").trim();
+    items.push({
+      id: `frozen:${drive.id}`,
+      kind: "frozen_drive",
+      severity: "blocker",
+      title: `${name} 已失效`,
+      body: "重新扫码或重新绑定即可恢复，不影响已有媒体库。",
+      actionLabel: "去处理",
+      href: href("drives"),
+    });
+  }
+
+  if (!input.llmConfigured) {
+    items.push({
+      id: "missing_llm",
+      kind: "missing_llm",
+      severity: "blocker",
+      title: "还没配置 AI 模型",
+      body: "填写 Base URL 和模型名后才能自动搜索与获取。",
+      actionLabel: "去填写",
+      href: href("services"),
+    });
+  }
+
+  if (
+    input.update &&
+    input.update.kind === "container" &&
+    input.update.behind === true &&
+    input.update.currentShort &&
+    input.update.latestShort
+  ) {
+    items.push({
+      id: "update_available",
+      kind: "update_available",
+      severity: "warning",
+      title: "有新版本可用",
+      body: `当前 ${input.update.currentShort} · 远端 ${input.update.latestShort}。复制指令给本地 Agent 按自检流程升级。`,
+      actionLabel: "复制指令",
+      href: href(),
+      prompt: buildContainerUpgradePrompt({
+        currentShort: input.update.currentShort,
+        latestShort: input.update.latestShort,
+      }),
+    });
+  }
+
+  return items;
+}
+
+export function summarizeSettingsAttention(items: SettingsAttentionItem[]): SettingsAttentionSummary {
+  const severity = items.some((item) => item.severity === "blocker")
+    ? "blocker"
+    : items.length > 0
+      ? "warning"
+      : null;
+  return { count: items.length, severity, items };
+}
+
+function defaultSettingsHref(tab?: "drives" | "services" | "preferences" | "patrol" | "account"): string {
+  if (!tab || tab === "drives") return "/settings";
+  return `/settings?tab=${tab}`;
+}

--- a/apps/web/lib/settings-attention.ts
+++ b/apps/web/lib/settings-attention.ts
@@ -1,9 +1,10 @@
 import type { DeploymentUpdateState } from "./deployment-update";
 import { buildContainerUpgradePrompt } from "./deployment-update";
+import type { SettingsTabId } from "./settings-tabs-model";
 
 export type AttentionSeverity = "warning" | "blocker";
 export type AttentionKind = "frozen_drive" | "update_available" | "missing_llm";
-export type SettingsAttentionTab = "drives" | "services" | "preferences" | "patrol" | "account";
+export type SettingsAttentionTab = SettingsTabId;
 
 export interface SettingsAttentionItem {
   id: string;

--- a/apps/web/lib/settings-attention.ts
+++ b/apps/web/lib/settings-attention.ts
@@ -3,6 +3,7 @@ import { buildContainerUpgradePrompt } from "./deployment-update";
 
 export type AttentionSeverity = "warning" | "blocker";
 export type AttentionKind = "frozen_drive" | "update_available" | "missing_llm";
+export type SettingsAttentionTab = "drives" | "services" | "preferences" | "patrol" | "account";
 
 export interface SettingsAttentionItem {
   id: string;
@@ -23,6 +24,18 @@ export interface SettingsAttentionSummary {
   items: SettingsAttentionItem[];
 }
 
+/** Settings deep-link that keeps non-primary workspace (`?w`) like sidebar links. */
+export function settingsAttentionHref(
+  tab?: SettingsAttentionTab,
+  activeStorageId?: string,
+): string {
+  const params = new URLSearchParams();
+  if (tab && tab !== "drives") params.set("tab", tab);
+  if (activeStorageId) params.set("w", activeStorageId);
+  const query = params.toString();
+  return query ? `/settings?${query}` : "/settings";
+}
+
 export function buildSettingsAttentionItems(input: {
   demo: boolean;
   drives: Array<{
@@ -34,11 +47,15 @@ export function buildSettingsAttentionItems(input: {
   brandLabel: (provider: string) => string;
   llmConfigured: boolean;
   update: Pick<DeploymentUpdateState, "kind" | "behind" | "currentShort" | "latestShort"> | null;
-  settingsHref?: (tab?: "drives" | "services" | "preferences" | "patrol" | "account") => string;
+  /** Non-primary workspace id — preserved on deep-links so inbox actions don't reset context. */
+  activeStorageId?: string;
+  settingsHref?: (tab?: SettingsAttentionTab) => string;
 }): SettingsAttentionItem[] {
   if (input.demo) return [];
 
-  const href = input.settingsHref ?? defaultSettingsHref;
+  const href =
+    input.settingsHref ??
+    ((tab?: SettingsAttentionTab) => settingsAttentionHref(tab, input.activeStorageId));
   const items: SettingsAttentionItem[] = [];
 
   for (const drive of input.drives) {
@@ -99,9 +116,4 @@ export function summarizeSettingsAttention(items: SettingsAttentionItem[]): Sett
       ? "warning"
       : null;
   return { count: items.length, severity, items };
-}
-
-function defaultSettingsHref(tab?: "drives" | "services" | "preferences" | "patrol" | "account"): string {
-  if (!tab || tab === "drives") return "/settings";
-  return `/settings?tab=${tab}`;
 }

--- a/apps/web/lib/settings-attention.ts
+++ b/apps/web/lib/settings-attention.ts
@@ -1,6 +1,6 @@
 import type { DeploymentUpdateState } from "./deployment-update";
 import { buildContainerUpgradePrompt } from "./deployment-update";
-import type { SettingsTabId } from "./settings-tabs-model";
+import { DEFAULT_SETTINGS_TAB, type SettingsTabId } from "./settings-tabs-model";
 
 export type AttentionSeverity = "warning" | "blocker";
 export type AttentionKind = "frozen_drive" | "update_available" | "missing_llm";
@@ -31,8 +31,9 @@ export function settingsAttentionHref(
   activeStorageId?: string,
 ): string {
   const params = new URLSearchParams();
-  if (tab && tab !== "drives") params.set("tab", tab);
+  if (tab && tab !== DEFAULT_SETTINGS_TAB) params.set("tab", tab);
   if (activeStorageId) params.set("w", activeStorageId);
+  params.sort();
   const query = params.toString();
   return query ? `/settings?${query}` : "/settings";
 }


### PR DESCRIPTION
## Summary
- Settings Action Inbox for frozen drives, missing LLM, and container update available
- Shared live badge on desktop footer settings card + mobile bottom-tab Settings
- Pure attention model + `/api/settings/attention` (fails quiet); demo mode shows nothing
- Reuses existing upgrade-prompt copy button; deep-links to drives/services tabs

## Test plan
- [x] `npx vitest run` (1782 passed)
- [x] `npm run typecheck` + web tsc + `npm run lint`
- [x] `npm run build:web`
- [ ] CI green + Copilot review
- [ ] Deploy instance; verify badge count, inbox actions, demo quiet