### PR TITLE
feat(show): movie detail A1 + folder {tmdb-id}

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2427,6 +2427,12 @@ select.setting-control {
   color: var(--text-soft);
   font-weight: 600;
 }
+.hub-missing-note {
+  margin: 8px 0 0;
+  font-size: 12.5px;
+  color: var(--text-muted);
+  max-width: 36ch;
+}
 
 /* Season picker dropdown on search cards */
 .season-menu {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2355,11 +2355,77 @@ select.setting-control {
 
 .back-link {
   display: inline-flex;
+  align-items: center;
+  gap: 6px;
   margin-bottom: 16px;
-  background: none;
-  border: none;
+  padding: 6px 12px;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--text-soft);
   cursor: pointer;
   font: inherit;
+  font-size: 13px;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+.back-link:hover {
+  background: rgba(0, 0, 0, 0.5);
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.movie-synopsis {
+  position: relative;
+  max-width: 720px;
+  margin: 4px 0 0;
+}
+.movie-synopsis-label {
+  margin: 0 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.movie-synopsis-body {
+  margin: 0;
+  font-size: 14.5px;
+  line-height: 1.75;
+  color: var(--text-soft);
+  white-space: pre-wrap;
+}
+.movie-synopsis-toggle {
+  margin-top: 8px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--accent);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.movie-meta-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-width: 720px;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.movie-meta-chip {
+  font-size: 12px;
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 9999px;
+  padding: 5px 10px;
+}
+.movie-meta-chip strong {
+  color: var(--text-soft);
+  font-weight: 600;
 }
 
 /* Season picker dropdown on search cards */

--- a/apps/web/app/show/[tmdbId]/page.tsx
+++ b/apps/web/app/show/[tmdbId]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { connection } from "next/server";
 import { Suspense, type ReactNode } from "react";
 import { TriangleAlert } from "lucide-react";
+import { isMovieUnreleased } from "@media-track/workflow";
 import { AcquiringPoller } from "../../../components/acquiring-poller";
 import { AcquisitionLockProvider } from "../../../components/acquisition-lock";
 import { AppSidebar } from "../../../components/app-sidebar";
@@ -277,9 +278,10 @@ function MovieHub({
 }) {
   const meta = movieStateMeta[view.state];
   const activityHref = storageId ? `/activity?w=${encodeURIComponent(storageId)}` : "/activity";
-  const unreleased = Boolean(view.releaseDate && view.state === "untracked");
-  // RequestTrackButton: unreleased untracked → 预定; missing → 重新获取; else 获取.
-  const requestLabel = view.state === "missing" ? "重新获取" : unreleased ? "预定" : "获取";
+  const nowIso = new Date().toISOString();
+  const unreleased =
+    view.state === "untracked" && isMovieUnreleased(view.releaseDate, nowIso);
+  const movieCandidateId = `tmdb_movie_${view.tmdbId}`;
   const chips: Array<{ label: string; value: string }> = [];
   if (view.releaseDate) chips.push({ label: "上映", value: formatMovieDate(view.releaseDate) });
   if (view.originalTitle && view.originalTitle !== view.title) {
@@ -312,16 +314,14 @@ function MovieHub({
             <h1>
               {view.title} <span className="hub-year">({view.year})</span>
             </h1>
-            <p className="hub-attributes">
-              电影
-              {view.originalTitle && view.originalTitle !== view.title ? ` · ${view.originalTitle}` : ""}
-            </p>
+            <p className="hub-attributes">电影</p>
             <div className="hub-actions">
-              {view.state === "untracked" || view.state === "missing" ? (
+              {view.state === "untracked" ? (
                 <RequestTrackButton
+                  candidateId={movieCandidateId}
                   tmdbId={view.tmdbId}
-                  actionState="can_request"
-                  label={requestLabel}
+                  actionState={unreleased ? "can_reserve" : "can_request"}
+                  label={unreleased ? "预定" : "获取"}
                   storageId={storageId}
                 />
               ) : null}
@@ -334,6 +334,9 @@ function MovieHub({
                 <UntrackButton tmdbId={view.tmdbId} storageId={storageId} mediaKind="movie" basePath={basePath} />
               ) : null}
             </div>
+            {view.state === "missing" ? (
+              <p className="hub-missing-note">已上映但仍缺资源，日常巡检会继续尝试。</p>
+            ) : null}
           </div>
         </header>
         {view.overview ? <MovieSynopsis overview={view.overview} /> : null}
@@ -356,11 +359,8 @@ function formatMovieDate(releaseDate: string): string {
   return match ? `${match[1]}年${Number(match[2])}月${Number(match[3])}日` : releaseDate;
 }
 
-/** Contextual placeholder while the hub's first render streams in. Mirrors the
- *  real hub SHAPE (poster + title block header, then the season list) so the
- *  swap to real content doesn't reflow — reuses the same layout containers. A
- *  movie resolves with no seasons, but the header (the dominant region) matches
- *  both, and the season rows cover the common TV case. */
+/** Shared placeholder while the hub streams. Header-only — no fake TV season
+ *  rows (movies have none; TV content replaces this quickly). */
 function HubSkeleton() {
   return (
     <section className="title-hub">
@@ -374,14 +374,12 @@ function HubSkeleton() {
           <div className="skeleton skeleton-hub-line short" />
         </div>
       </header>
-      <section className="hub-seasons" aria-hidden>
+      <div className="movie-synopsis" aria-hidden>
         <div className="skeleton skeleton-hub-section" />
-        <ul className="hub-season-list">
-          <li className="skeleton skeleton-hub-row" />
-          <li className="skeleton skeleton-hub-row" />
-          <li className="skeleton skeleton-hub-row" />
-        </ul>
-      </section>
+        <div className="skeleton skeleton-hub-line" />
+        <div className="skeleton skeleton-hub-line" />
+        <div className="skeleton skeleton-hub-line short" />
+      </div>
     </section>
   );
 }

--- a/apps/web/app/show/[tmdbId]/page.tsx
+++ b/apps/web/app/show/[tmdbId]/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { connection } from "next/server";
 import { Suspense, type ReactNode } from "react";
 import { TriangleAlert } from "lucide-react";
@@ -5,6 +6,8 @@ import { AcquiringPoller } from "../../../components/acquiring-poller";
 import { AcquisitionLockProvider } from "../../../components/acquisition-lock";
 import { AppSidebar } from "../../../components/app-sidebar";
 import { BackLink } from "../../../components/back-link";
+import { MovieSynopsis } from "../../../components/movie-synopsis";
+import { RequestTrackButton } from "../../../components/request-track-button";
 import {
   RequestRemainingButton,
   RequestSeasonButton,
@@ -17,8 +20,8 @@ import {
   type TitleHubSeason,
   type TitleHubView,
 } from "../../../lib/title-hub";
-import { resolveGlobalWorkspace } from "../../../lib/workflow-runtime";
 import { seasonBadgeState } from "../../../lib/title-aggregate";
+import { resolveGlobalWorkspace } from "../../../lib/workflow-runtime";
 
 const aggregateBadge = {
   untracked: null,
@@ -114,7 +117,7 @@ async function ShowContent({
   return (
     <ShowShell
       active={from ?? "none"}
-      backLabel={from === "search" ? "返回搜索" : from === "library" ? "返回媒体库" : "返回"}
+      backLabel={from === "search" ? "搜索" : from === "library" ? "媒体库" : "返回"}
       backHref={
         from === "library" ? `${workspace.basePath}?tab=library` : `${workspace.basePath}?tab=search`
       }
@@ -262,7 +265,7 @@ const movieStateMeta = {
   untracked: { label: "未追踪", tone: "muted" },
 } as const;
 
-/** A movie's detail page: a single status, no season grid. */
+/** A movie's detail page: hero + full synopsis body (no season grid). */
 function MovieHub({
   view,
   storageId,
@@ -273,8 +276,17 @@ function MovieHub({
   basePath: string;
 }) {
   const meta = movieStateMeta[view.state];
-  const releaseLine =
-    view.state === "reserved" && view.releaseDate ? `${formatMovieDate(view.releaseDate)} 上映` : null;
+  const activityHref = storageId ? `/activity?w=${encodeURIComponent(storageId)}` : "/activity";
+  const unreleased = Boolean(view.releaseDate && view.state === "untracked");
+  // RequestTrackButton: unreleased untracked → 预定; missing → 重新获取; else 获取.
+  const requestLabel = view.state === "missing" ? "重新获取" : unreleased ? "预定" : "获取";
+  const chips: Array<{ label: string; value: string }> = [];
+  if (view.releaseDate) chips.push({ label: "上映", value: formatMovieDate(view.releaseDate) });
+  if (view.originalTitle && view.originalTitle !== view.title) {
+    chips.push({ label: "原名", value: view.originalTitle });
+  }
+  chips.push({ label: "类型", value: "电影" });
+
   return (
     <AcquisitionLockProvider>
       {view.acquiring ? <AcquiringPoller /> : null}
@@ -303,16 +315,37 @@ function MovieHub({
             <p className="hub-attributes">
               电影
               {view.originalTitle && view.originalTitle !== view.title ? ` · ${view.originalTitle}` : ""}
-              {releaseLine ? ` · ${releaseLine}` : ""}
             </p>
-            {view.overview ? <p className="hub-overview">{view.overview}</p> : null}
-            {view.state !== "untracked" ? (
-              <div className="hub-actions">
+            <div className="hub-actions">
+              {view.state === "untracked" || view.state === "missing" ? (
+                <RequestTrackButton
+                  tmdbId={view.tmdbId}
+                  actionState="can_request"
+                  label={requestLabel}
+                  storageId={storageId}
+                />
+              ) : null}
+              {view.state === "acquiring" ? (
+                <Link className="primary-button" href={activityHref}>
+                  查看活动
+                </Link>
+              ) : null}
+              {view.state !== "untracked" ? (
                 <UntrackButton tmdbId={view.tmdbId} storageId={storageId} mediaKind="movie" basePath={basePath} />
-              </div>
-            ) : null}
+              ) : null}
+            </div>
           </div>
         </header>
+        {view.overview ? <MovieSynopsis overview={view.overview} /> : null}
+        {chips.length > 0 ? (
+          <div className="movie-meta-chips">
+            {chips.map((chip) => (
+              <span key={`${chip.label}-${chip.value}`} className="movie-meta-chip">
+                {chip.label} <strong>{chip.value}</strong>
+              </span>
+            ))}
+          </div>
+        ) : null}
       </section>
     </AcquisitionLockProvider>
   );

--- a/apps/web/components/movie-synopsis.tsx
+++ b/apps/web/components/movie-synopsis.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import {
+  collapseMovieSynopsis,
+  shouldCollapseMovieSynopsis,
+} from "../lib/movie-synopsis";
+
+/** Full overview body for movie detail. Long copy collapses behind 展开/收起. */
+export function MovieSynopsis({ overview }: { overview: string }) {
+  const text = overview.trim();
+  const collapsible = shouldCollapseMovieSynopsis(text);
+  const [expanded, setExpanded] = useState(!collapsible);
+  if (!text) return null;
+
+  const body = expanded || !collapsible ? text : collapseMovieSynopsis(text);
+
+  return (
+    <section className="movie-synopsis" aria-labelledby="movie-synopsis-title">
+      <h2 className="movie-synopsis-label" id="movie-synopsis-title">
+        简介
+      </h2>
+      <p className="movie-synopsis-body">{body}</p>
+      {collapsible ? (
+        <button
+          type="button"
+          className="movie-synopsis-toggle"
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? "收起" : "展开"}
+        </button>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/lib/movie-synopsis.test.ts
+++ b/apps/web/lib/movie-synopsis.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  MOVIE_SYNOPSIS_COLLAPSE_AT,
+  collapseMovieSynopsis,
+  shouldCollapseMovieSynopsis,
+} from "./movie-synopsis";
+
+describe("movie synopsis collapse", () => {
+  it("keeps short text fully expanded", () => {
+    expect(shouldCollapseMovieSynopsis("短简介")).toBe(false);
+    expect(collapseMovieSynopsis("短简介")).toBe("短简介");
+  });
+
+  it("collapses long text at the threshold", () => {
+    const long = "字".repeat(MOVIE_SYNOPSIS_COLLAPSE_AT + 20);
+    expect(shouldCollapseMovieSynopsis(long)).toBe(true);
+    const collapsed = collapseMovieSynopsis(long);
+    expect(collapsed.endsWith("…")).toBe(true);
+    expect(collapsed.length).toBe(MOVIE_SYNOPSIS_COLLAPSE_AT + 1);
+  });
+});

--- a/apps/web/lib/movie-synopsis.ts
+++ b/apps/web/lib/movie-synopsis.ts
@@ -1,0 +1,12 @@
+/** Overview longer than this (CJK-friendly char count) gets a collapse control. */
+export const MOVIE_SYNOPSIS_COLLAPSE_AT = 280;
+
+export function shouldCollapseMovieSynopsis(overview: string): boolean {
+  return overview.trim().length > MOVIE_SYNOPSIS_COLLAPSE_AT;
+}
+
+export function collapseMovieSynopsis(overview: string): string {
+  const text = overview.trim();
+  if (text.length <= MOVIE_SYNOPSIS_COLLAPSE_AT) return text;
+  return `${text.slice(0, MOVIE_SYNOPSIS_COLLAPSE_AT).trimEnd()}…`;
+}

--- a/apps/web/lib/title-hub.ts
+++ b/apps/web/lib/title-hub.ts
@@ -294,8 +294,8 @@ export async function getDetailView(
     if (!movieTarget) {
       return null;
     }
-    const reserved = isMovieUnreleased(movieTarget.title.releaseDate, now);
-    return movieHubViewFromTitle(movieTarget.title, reserved ? "reserved" : "untracked", false);
+    // Untracked stays untracked even if unreleased — `reserved` means tracked + waiting.
+    return movieHubViewFromTitle(movieTarget.title, "untracked", false);
   };
 
   if (typeHint === "movie") {

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -2198,6 +2198,9 @@ export async function importForeignWorkFiles(input: {
   movieTitle: string;
   year: number;
 }): Promise<{ movieDirectoryId: string; movedFileIds: string[] }> {
+  // Foreign-work UI is free-text title/year only (no TMDB id). Folder stays the
+  // legacy `Title (Year)` form on purpose — `importForeignWorkAsMovie` supports
+  // `{tmdb-N}` only when a caller passes tmdbId.
   const accountId = await getCurrentAccountId();
   const parents = await getWorkerStorageParents(accountId);
   return importForeignWorkAsMovie({

--- a/packages/workflow/src/acquisition-v2/directory-lifecycle.ts
+++ b/packages/workflow/src/acquisition-v2/directory-lifecycle.ts
@@ -1,3 +1,4 @@
+import { ensureMediaLibraryDirectory } from "../media-library-folder.js";
 import type { StorageExecutor } from "../ports.js";
 
 /**
@@ -19,11 +20,13 @@ export interface AcquisitionDirectories {
 }
 
 export interface EnsureSeasonDirectoriesRequest {
-  executor: Pick<StorageExecutor, "createDirectory">;
+  executor: Pick<StorageExecutor, "createDirectory" | "listChildDirectories">;
   /** Library category parent (Movies/TV/Anime), chosen by title.type upstream. */
   categoryParentId: string;
   showName: string;
   year: number;
+  /** TMDB id — encoded into the show folder name as `{tmdb-N}`. */
+  tmdbId: number;
   /** The season number(s) this task covers (one, several, or all). */
   seasons: number[];
   /** Run-scoped suffix so each run gets its own staging dir under the show dir. */
@@ -33,11 +36,14 @@ export interface EnsureSeasonDirectoriesRequest {
 export async function ensureSeasonAcquisitionDirectories(
   request: EnsureSeasonDirectoriesRequest,
 ): Promise<AcquisitionDirectories> {
-  // Show dir under the category. find-or-create = verify-or-create: reused if it
-  // exists, recreated if the user deleted it.
-  const showDirectoryId = await request.executor.createDirectory({
-    name: `${request.showName} (${request.year})`,
+  // Show dir under the category. Prefer `Title (Year) {tmdb-N}`; reuse legacy
+  // `Title (Year)` when present so we never fork a second library folder.
+  const showDirectoryId = await ensureMediaLibraryDirectory({
+    executor: request.executor,
     parentId: request.categoryParentId,
+    title: request.showName,
+    year: request.year,
+    tmdbId: request.tmdbId,
   });
   // Each requested season's Season NN directory under the show dir.
   const seasonDirectoryIds: Record<number, string> = {};

--- a/packages/workflow/src/acquisition-v2/run-tv-v2.ts
+++ b/packages/workflow/src/acquisition-v2/run-tv-v2.ts
@@ -70,6 +70,7 @@ export async function runTvAcquisitionV2(request: RunTvAcquisitionV2Request): Pr
       name: request.title.title,
       year: request.title.year ?? 0,
       aliases: request.title.aliases ?? [],
+      tmdbId: request.title.tmdbId,
     },
     categoryParentId: request.categoryParentId,
     seasons: request.seasons.map((season) => ({

--- a/packages/workflow/src/acquisition-v2/workflow-v2.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2.ts
@@ -32,7 +32,7 @@ export interface RunAcquisitionV2WorkflowRequest {
   executor: StorageExecutor;
   model: LanguageModel;
   workflowRunId: string;
-  title: { name: string; year: number; aliases: string[] };
+  title: { name: string; year: number; aliases: string[]; tmdbId: number };
   /** Library category parent (Movies/TV/Anime), chosen by title.type upstream. */
   categoryParentId: string;
   seasons: V2WorkflowSeason[];
@@ -88,6 +88,7 @@ export async function runAcquisitionV2Workflow(
     categoryParentId: request.categoryParentId,
     showName: request.title.name,
     year: request.title.year,
+    tmdbId: request.title.tmdbId,
     seasons: request.seasons.map((season) => season.seasonNumber),
     workflowRunId: request.workflowRunId,
   });

--- a/packages/workflow/src/commands.ts
+++ b/packages/workflow/src/commands.ts
@@ -8,6 +8,10 @@ import {
   type TrackedSeason,
   type WorkflowStatus,
 } from "./domain.js";
+import {
+  ensureMediaLibraryDirectory,
+  legacyMediaLibraryFolderName,
+} from "./media-library-folder.js";
 import type { StorageExecutor } from "./ports.js";
 import type { WorkflowRepository } from "./repository.js";
 
@@ -418,15 +422,25 @@ export async function importForeignWorkAsMovie(input: {
   movieTitle: string;
   year: number;
   moviesParentDirectoryId: string;
+  /** When known, folder becomes `Title (Year) {tmdb-N}`; otherwise legacy name. */
+  tmdbId?: number;
 }): Promise<ForeignWorkImportResult> {
   if (input.providerFileIds.length === 0) {
     throw new Error("FOREIGN_WORK_IMPORT_EMPTY: no files to import");
   }
-  const movieName = `${input.movieTitle} (${input.year})`;
-  const movieDirectoryId = await input.storage.createDirectory({
-    name: movieName,
-    parentId: input.moviesParentDirectoryId,
-  });
+  const movieDirectoryId =
+    input.tmdbId != null
+      ? await ensureMediaLibraryDirectory({
+          executor: input.storage,
+          parentId: input.moviesParentDirectoryId,
+          title: input.movieTitle,
+          year: input.year,
+          tmdbId: input.tmdbId,
+        })
+      : await input.storage.createDirectory({
+          name: legacyMediaLibraryFolderName({ title: input.movieTitle, year: input.year }),
+          parentId: input.moviesParentDirectoryId,
+        });
   const { moved } = await input.storage.moveFiles({
     fileIds: input.providerFileIds,
     targetDirectoryId: movieDirectoryId,

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -2,6 +2,7 @@ export * from "./domain.js";
 export * from "./agent-model.js";
 export * from "./agent-error.js";
 export * from "./media-classification.js";
+export * from "./media-library-folder.js";
 export * from "./movie-workflow-v2.js";
 export * from "./notification-report.js";
 export * from "./season-sync.js";

--- a/packages/workflow/src/media-library-folder.ts
+++ b/packages/workflow/src/media-library-folder.ts
@@ -1,0 +1,54 @@
+import type { StorageExecutor } from "./ports.js";
+
+/** Canonical cloud folder name for a title root under Movies/TV/Anime. */
+export function mediaLibraryFolderName(input: {
+  title: string;
+  year: number | string | null | undefined;
+  tmdbId: number;
+}): string {
+  const year =
+    input.year === null || input.year === undefined || input.year === ""
+      ? "—"
+      : String(input.year);
+  return `${input.title} (${year}) {tmdb-${input.tmdbId}}`;
+}
+
+/** Pre-tmdb-suffix name. Kept so existing pan folders are reused, not duplicated. */
+export function legacyMediaLibraryFolderName(input: {
+  title: string;
+  year: number | string | null | undefined;
+}): string {
+  const year =
+    input.year === null || input.year === undefined || input.year === ""
+      ? "—"
+      : String(input.year);
+  return `${input.title} (${year})`;
+}
+
+/**
+ * Find-or-create the title root under a category parent.
+ * Prefer the new `{tmdb-N}` name; if only the legacy `Title (Year)` exists, reuse it
+ * (do not auto-rename this round).
+ */
+export async function ensureMediaLibraryDirectory(input: {
+  executor: Pick<StorageExecutor, "createDirectory" | "listChildDirectories">;
+  parentId: string;
+  title: string;
+  year: number | string | null | undefined;
+  tmdbId: number;
+}): Promise<string> {
+  const preferred = mediaLibraryFolderName({
+    title: input.title,
+    year: input.year,
+    tmdbId: input.tmdbId,
+  });
+  const legacy = legacyMediaLibraryFolderName({ title: input.title, year: input.year });
+
+  const children = await input.executor.listChildDirectories(input.parentId);
+  const hitPreferred = children.find((child) => child.name === preferred);
+  if (hitPreferred) return hitPreferred.id;
+  const hitLegacy = children.find((child) => child.name === legacy);
+  if (hitLegacy) return hitLegacy.id;
+
+  return input.executor.createDirectory({ name: preferred, parentId: input.parentId });
+}

--- a/packages/workflow/src/media-library-folder.ts
+++ b/packages/workflow/src/media-library-folder.ts
@@ -1,16 +1,19 @@
 import type { StorageExecutor } from "./ports.js";
 
+function folderYear(year: number | string | null | undefined): string {
+  if (year === null || year === undefined || year === "" || year === 0 || year === "0") {
+    return "—";
+  }
+  return String(year);
+}
+
 /** Canonical cloud folder name for a title root under Movies/TV/Anime. */
 export function mediaLibraryFolderName(input: {
   title: string;
   year: number | string | null | undefined;
   tmdbId: number;
 }): string {
-  const year =
-    input.year === null || input.year === undefined || input.year === ""
-      ? "—"
-      : String(input.year);
-  return `${input.title} (${year}) {tmdb-${input.tmdbId}}`;
+  return `${input.title} (${folderYear(input.year)}) {tmdb-${input.tmdbId}}`;
 }
 
 /** Pre-tmdb-suffix name. Kept so existing pan folders are reused, not duplicated. */
@@ -18,11 +21,7 @@ export function legacyMediaLibraryFolderName(input: {
   title: string;
   year: number | string | null | undefined;
 }): string {
-  const year =
-    input.year === null || input.year === undefined || input.year === ""
-      ? "—"
-      : String(input.year);
-  return `${input.title} (${year})`;
+  return `${input.title} (${folderYear(input.year)})`;
 }
 
 /**

--- a/packages/workflow/src/movie-workflow-v2.ts
+++ b/packages/workflow/src/movie-workflow-v2.ts
@@ -21,6 +21,7 @@ import { readLandedSize, type LandedSize } from "./acquisition-v2/landed-size.js
 import type { AgentToolEvent } from "./acquisition-v2/activity.js";
 import { runAcquisitionV2 } from "./acquisition-v2/orchestrator.js";
 import { getQualityGuidance, getSearchRecipe } from "./acquisition-v2/search-profile.js";
+import { ensureMediaLibraryDirectory } from "./media-library-folder.js";
 
 function defaultNowIso(): string {
   return new Date().toISOString();
@@ -59,13 +60,17 @@ export async function runMovieAcquisitionV2(
 ): Promise<MovieWorkflowResult> {
   const now = request.now ?? defaultNowIso;
 
-  // verify-or-create Movies/Title (Year). For a movie this dir IS the staging,
-  // the flatten target, and the final location — there is NO separate staging
-  // (§5): transfer lands here, the wrapper is flattened in place, mark. So
-  // stagingDirectoryId === targetMovieDirectoryId === the movie dir.
-  const movieDirectoryId = await request.storage.createDirectory({
-    name: `${request.title.title} (${request.title.year ?? "—"})`,
+  // verify-or-create Movies/Title (Year) {tmdb-N} (legacy Title (Year) reused).
+  // For a movie this dir IS the staging, the flatten target, and the final
+  // location — there is NO separate staging (§5): transfer lands here, the
+  // wrapper is flattened in place, mark. So stagingDirectoryId ===
+  // targetMovieDirectoryId === the movie dir.
+  const movieDirectoryId = await ensureMediaLibraryDirectory({
+    executor: request.storage,
     parentId: request.moviesParentDirectoryId,
+    title: request.title.title,
+    year: request.title.year ?? "—",
+    tmdbId: request.title.tmdbId,
   });
 
   const v2 = await runAcquisitionV2({

--- a/packages/workflow/tests/media-library-folder.test.ts
+++ b/packages/workflow/tests/media-library-folder.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  ensureMediaLibraryDirectory,
+  legacyMediaLibraryFolderName,
+  mediaLibraryFolderName,
+} from "../src/media-library-folder.js";
+import { FakeStorageExecutor } from "../src/fakes.js";
+
+describe("mediaLibraryFolderName", () => {
+  it("formats Title (Year) {tmdb-id}", () => {
+    expect(mediaLibraryFolderName({ title: "2001太空漫游", year: 1968, tmdbId: 62 })).toBe(
+      "2001太空漫游 (1968) {tmdb-62}",
+    );
+  });
+
+  it("falls back year to em-dash when missing", () => {
+    expect(mediaLibraryFolderName({ title: "X", year: null, tmdbId: 1 })).toBe("X (—) {tmdb-1}");
+    expect(legacyMediaLibraryFolderName({ title: "X", year: undefined })).toBe("X (—)");
+  });
+});
+
+describe("ensureMediaLibraryDirectory", () => {
+  it("creates the new-format name when parent is empty", async () => {
+    const executor = new FakeStorageExecutor();
+    const id = await ensureMediaLibraryDirectory({
+      executor,
+      parentId: "movies_root",
+      title: "盗梦空间",
+      year: 2010,
+      tmdbId: 27205,
+    });
+    const kids = await executor.listChildDirectories("movies_root");
+    expect(kids).toEqual([{ id, name: "盗梦空间 (2010) {tmdb-27205}" }]);
+  });
+
+  it("reuses legacy Title (Year) without creating a duplicate", async () => {
+    const executor = new FakeStorageExecutor();
+    const legacyId = await executor.createDirectory({
+      name: "盗梦空间 (2010)",
+      parentId: "movies_root",
+    });
+    const id = await ensureMediaLibraryDirectory({
+      executor,
+      parentId: "movies_root",
+      title: "盗梦空间",
+      year: 2010,
+      tmdbId: 27205,
+    });
+    expect(id).toBe(legacyId);
+    const kids = await executor.listChildDirectories("movies_root");
+    expect(kids).toHaveLength(1);
+    expect(kids[0]!.name).toBe("盗梦空间 (2010)");
+  });
+
+  it("prefers the new-format name when both could exist", async () => {
+    const executor = new FakeStorageExecutor();
+    await executor.createDirectory({ name: "Show (2024)", parentId: "tv_root" });
+    const preferredId = await executor.createDirectory({
+      name: "Show (2024) {tmdb-99}",
+      parentId: "tv_root",
+    });
+    const id = await ensureMediaLibraryDirectory({
+      executor,
+      parentId: "tv_root",
+      title: "Show",
+      year: 2024,
+      tmdbId: 99,
+    });
+    expect(id).toBe(preferredId);
+  });
+});

--- a/packages/workflow/tests/media-library-folder.test.ts
+++ b/packages/workflow/tests/media-library-folder.test.ts
@@ -13,8 +13,9 @@ describe("mediaLibraryFolderName", () => {
     );
   });
 
-  it("falls back year to em-dash when missing", () => {
+  it("falls back year to em-dash when missing or zero", () => {
     expect(mediaLibraryFolderName({ title: "X", year: null, tmdbId: 1 })).toBe("X (—) {tmdb-1}");
+    expect(mediaLibraryFolderName({ title: "X", year: 0, tmdbId: 1 })).toBe("X (—) {tmdb-1}");
     expect(legacyMediaLibraryFolderName({ title: "X", year: undefined })).toBe("X (—)");
   });
 });

--- a/packages/workflow/tests/v2-directory-lifecycle.test.ts
+++ b/packages/workflow/tests/v2-directory-lifecycle.test.ts
@@ -10,6 +10,7 @@ describe("ensureSeasonAcquisitionDirectories — verify-or-create the 115 direct
       categoryParentId: "tv_root",
       showName: "绝命毒师",
       year: 2008,
+      tmdbId: 1396,
       seasons: [1, 2, 3],
       workflowRunId: "run-1",
     });
@@ -29,10 +30,10 @@ describe("ensureSeasonAcquisitionDirectories — verify-or-create the 115 direct
   it("is idempotent: re-running reuses the SAME show/season dirs (find-or-create, never duplicates)", async () => {
     const executor = new FakeStorageExecutor();
     const a = await ensureSeasonAcquisitionDirectories({
-      executor, categoryParentId: "tv_root", showName: "Show", year: 2024, seasons: [1], workflowRunId: "run-1",
+      executor, categoryParentId: "tv_root", showName: "Show", year: 2024, tmdbId: 1, seasons: [1], workflowRunId: "run-1",
     });
     const b = await ensureSeasonAcquisitionDirectories({
-      executor, categoryParentId: "tv_root", showName: "Show", year: 2024, seasons: [1], workflowRunId: "run-1",
+      executor, categoryParentId: "tv_root", showName: "Show", year: 2024, tmdbId: 1, seasons: [1], workflowRunId: "run-1",
     });
     expect(b.showDirectoryId).toBe(a.showDirectoryId);
     expect(b.seasonDirectoryIds[1]).toBe(a.seasonDirectoryIds[1]);
@@ -41,12 +42,29 @@ describe("ensureSeasonAcquisitionDirectories — verify-or-create the 115 direct
   it("adds a new season dir under the SAME show dir when later acquiring another season", async () => {
     const executor = new FakeStorageExecutor();
     const first = await ensureSeasonAcquisitionDirectories({
-      executor, categoryParentId: "tv_root", showName: "Show", year: 2024, seasons: [1], workflowRunId: "r1",
+      executor, categoryParentId: "tv_root", showName: "Show", year: 2024, tmdbId: 1, seasons: [1], workflowRunId: "r1",
     });
     const second = await ensureSeasonAcquisitionDirectories({
-      executor, categoryParentId: "tv_root", showName: "Show", year: 2024, seasons: [2], workflowRunId: "r2",
+      executor, categoryParentId: "tv_root", showName: "Show", year: 2024, tmdbId: 1, seasons: [2], workflowRunId: "r2",
     });
     expect(second.showDirectoryId).toBe(first.showDirectoryId); // same show dir reused
     expect(second.seasonDirectoryIds[2]).toContain(first.showDirectoryId); // new season under it
+  });
+
+  it("reuses a legacy Title (Year) show folder instead of forking a tmdb-suffixed twin", async () => {
+    const executor = new FakeStorageExecutor();
+    const legacyId = await executor.createDirectory({ name: "Show (2024)", parentId: "tv_root" });
+    const dirs = await ensureSeasonAcquisitionDirectories({
+      executor,
+      categoryParentId: "tv_root",
+      showName: "Show",
+      year: 2024,
+      tmdbId: 99,
+      seasons: [1],
+      workflowRunId: "run-legacy",
+    });
+    expect(dirs.showDirectoryId).toBe(legacyId);
+    const kids = await executor.listChildDirectories("tv_root");
+    expect(kids.map((k) => k.name)).toEqual(["Show (2024)"]);
   });
 });

--- a/packages/workflow/tests/v2-movie-workflow.test.ts
+++ b/packages/workflow/tests/v2-movie-workflow.test.ts
@@ -53,6 +53,7 @@ class RecordingExecutor extends FakeStorageExecutor {
 
 const title = {
   id: "tmdb_movie_27205",
+  tmdbId: 27205,
   title: "盗梦空间",
   year: 2010,
   aliases: ["Inception"],
@@ -224,6 +225,8 @@ describe("runMovieAcquisitionV2 — obtained comes from the AGENT'S coverage, ne
     });
 
     // Exactly one directory is created — the movie dir. No `staging-*` sibling.
-    expect(executor.createdDirs).toEqual([{ name: "盗梦空间 (2010)", parentId: "movies_root" }]);
+    expect(executor.createdDirs).toEqual([
+      { name: "盗梦空间 (2010) {tmdb-27205}", parentId: "movies_root" },
+    ]);
   });
 });

--- a/packages/workflow/tests/v2-workflow.test.ts
+++ b/packages/workflow/tests/v2-workflow.test.ts
@@ -49,7 +49,7 @@ describe("runAcquisitionV2Workflow — outer orchestration (dirs → sync → ag
       executor,
       model: searchThenReportModel(),
       workflowRunId: "run-1",
-      title: { name: "Show", year: 2024, aliases: [] },
+      title: { name: "Show", year: 2024, aliases: [], tmdbId: 42 },
       categoryParentId: "tv_root",
       seasons: [{ seasonNumber: 1, latestAiredEpisode: 3 }],
       qualityPreference: "1080p",
@@ -79,7 +79,7 @@ describe("runAcquisitionV2Workflow — outer orchestration (dirs → sync → ag
       executor,
       model,
       workflowRunId: "run-2",
-      title: { name: "Show", year: 2024, aliases: [] },
+      title: { name: "Show", year: 2024, aliases: [], tmdbId: 42 },
       categoryParentId: "tv_root",
       seasons: [{ seasonNumber: 1, latestAiredEpisode: 0 }], // nothing aired → nothing missing
       qualityPreference: "1080p",
@@ -97,7 +97,7 @@ describe("runAcquisitionV2Workflow — outer orchestration (dirs → sync → ag
       executor,
       model: searchThenReportModel(), // finds no new coverage this run
       workflowRunId: "run-3",
-      title: { name: "Show", year: 2024, aliases: [] },
+      title: { name: "Show", year: 2024, aliases: [], tmdbId: 42 },
       categoryParentId: "tv_root",
       seasons: [{ seasonNumber: 1, latestAiredEpisode: 3 }],
       qualityPreference: "1080p",


### PR DESCRIPTION
## Summary
- Movie detail A1: pill back (媒体库/搜索), full synopsis body + expand/collapse, soft chips, state CTAs — no pan-open / breadcrumbs / fake metrics
- Library folder names: `Title (Year) {tmdb-N}` for new movie/show roots; legacy `Title (Year)` reused (no twin folders)
- Shared `mediaLibraryFolderName` / `ensureMediaLibraryDirectory` helper

## Test plan
- [x] `npx vitest run` (1792 passed)
- [x] typecheck + web tsc + lint + `build:web`
- [ ] CI green
- [ ] Deploy: open a movie detail (acquired/missing), check synopsis + back pill
- [ ] New acquisition creates `{tmdb-N}` folder; existing legacy folders still resolve