### PR TITLE
fix(show): back pill no longer stacks on mobile

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -2471,7 +2471,10 @@ select.setting-control {
 }
 
 .back-link {
+  /* Must NOT use .nav-item — mobile .nav-item is column (tab bar), which
+     stacks the arrow above the label and "squishes" 媒体库 into two lines. */
   display: inline-flex;
+  flex-direction: row;
   align-items: center;
   gap: 6px;
   margin-bottom: 16px;
@@ -2483,6 +2486,10 @@ select.setting-control {
   cursor: pointer;
   font: inherit;
   font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  flex-shrink: 0;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
 }

--- a/apps/web/components/back-link.tsx
+++ b/apps/web/components/back-link.tsx
@@ -18,7 +18,7 @@ export function BackLink({
   const router = useRouter();
   return (
     <button
-      className="nav-item back-link"
+      className="back-link"
       type="button"
       onClick={() => {
         if (window.history.length > 1) {


### PR DESCRIPTION
## Summary
Root cause: `BackLink` used `nav-item`, and mobile CSS sets `.nav-item { flex-direction: column }` for the bottom tab bar — so the arrow sat above 媒体库.

- Drop `nav-item` from BackLink
- Explicit `flex-direction: row` + `white-space: nowrap` on `.back-link`

## Test plan
- [x] tsc + lint
- [ ] Mobile detail: 媒体库 back pill is one horizontal line