### PR TITLE
[codex] Fix pan123 WRITE_SCOPE_VIOLATION on reused show folders

### DIFF
--- a/packages/workflow/src/pan123-storage-executor.test.ts
+++ b/packages/workflow/src/pan123-storage-executor.test.ts
@@ -527,6 +527,38 @@ describe("Pan123StorageExecutor write-scope guard (derived scope)", () => {
     expect(trash).toHaveBeenCalledWith([{ id: wrapperId, isFolder: true }]);
   });
 
+  it("authorizes createDirectory under a show folder REUSED via listChildDirectories (production 莉可丽丝 bug)", async () => {
+    // Real production failure 2026-07-23: a legacy show folder (`莉可丽丝 (2022)`)
+    // already existed on the 123 drive from an earlier run. ensureMediaLibraryDirectory
+    // found it via listChildDirectories(anime_cid) and returned its id — but
+    // listChildDirectories never registered it in derived scope, so the follow-up
+    // createDirectory(Season 01, parentId=showId) died with WRITE_SCOPE_VIOLATION.
+    const fs = new Map<string, Pan123Item[]>();
+    fs.set(SCOPE, [folder("existing-show", "莉可丽丝 (2022)")]);
+    fs.set("existing-show", []);
+    const listFiles = vi.fn<Pan123Client["listFiles"]>(async (dirId) => fs.get(dirId ?? "") ?? []);
+    const executor = makeExecutor(fakeClient({ listFiles }));
+
+    const children = await executor.listChildDirectories(SCOPE);
+    expect(children).toEqual([{ id: "existing-show", name: "莉可丽丝 (2022)" }]);
+
+    await expect(
+      executor.createDirectory({ name: "Season 01", parentId: "existing-show" }),
+    ).resolves.toBe("newdir123");
+  });
+
+  it("does NOT widen scope via listChildDirectories on an OUT-of-scope dir (read ≠ write)", async () => {
+    const fs = new Map<string, Pan123Item[]>();
+    fs.set("elsewhere", [folder("stranger", "x")]);
+    const listFiles = vi.fn<Pan123Client["listFiles"]>(async (dirId) => fs.get(dirId ?? "") ?? []);
+    const executor = makeExecutor(fakeClient({ listFiles }));
+
+    await executor.listChildDirectories("elsewhere");
+    await expect(
+      executor.createDirectory({ name: "Season 01", parentId: "stranger" }),
+    ).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
+  });
+
   it("does NOT widen scope by listing an OUT-of-scope dir (read ≠ write)", async () => {
     const fs = new Map<string, Pan123Item[]>();
     fs.set("elsewhere", [folder("stranger", "x")]);

--- a/packages/workflow/src/pan123-storage-executor.ts
+++ b/packages/workflow/src/pan123-storage-executor.ts
@@ -432,6 +432,14 @@ export class Pan123StorageExecutor implements StorageExecutor {
   }
 
   async listChildDirectories(directoryId: string): Promise<Array<{ id: string; name: string }>> {
+    // Derived-scope registration (same rule as the recursive lister above):
+    // a subdir DISCOVERED under an in-scope parent is itself in scope. Without
+    // this, ensureMediaLibraryDirectory reusing an EXISTING show folder returns
+    // an unregistered id and the follow-up createDirectory(Season NN) dies with
+    // WRITE_SCOPE_VIOLATION (production 莉可丽丝 2026-07-23). Listing an
+    // OUT-of-scope dir must NOT widen scope (read ≠ write) — gate on the
+    // parent, computed BEFORE listing.
+    const parentInScope = this.isWithinWriteScope(directoryId);
     const items = await this.client.listFiles(directoryId);
     const dirs: Array<{ id: string; name: string }> = [];
     for (const item of items) {
@@ -440,6 +448,9 @@ export class Pan123StorageExecutor implements StorageExecutor {
       }
       const id = idOf(item);
       if (id) {
+        if (parentInScope) {
+          this.derivedScopeIds.add(normalizeId(id));
+        }
         dirs.push({ id, name: nameOf(item) });
       }
     }


### PR DESCRIPTION
## Root cause
Found by real e2e on production (first pan123 acquisition of 莉可丽丝 after #166): `ensureMediaLibraryDirectory` reuses an existing show folder discovered via `listChildDirectories` under an in-scope category dir — but pan123's `listChildDirectories` never registered discoveries in `derivedScopeIds` (only the recursive lister and `createDirectory` did). The follow-up `createDirectory(Season NN, parentId=showId)` then died with `WRITE_SCOPE_VIOLATION`, failing every repeat/continue acquisition on pan123.

## Fix
Register discovered subdirs in `listChildDirectories`, gated on the listed parent being in scope (same `parentInScope` rule as the recursive lister; out-of-scope listing still does not widen scope).

## Tests
- New regression: reused show folder via listChildDirectories authorizes createDirectory under it (RED before fix, reproducing the exact production error).
- New negative: listChildDirectories on an out-of-scope dir does NOT widen scope.
- Full suite: 1814 passed / 13 skipped; typecheck, lint, build:web pass.