### PR TITLE
chore(release): prepare v1.3.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@media-track/desktop",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "commonjs",
   "main": "dist/main.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
     },
     "apps/desktop": {
       "name": "@media-track/desktop",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "better-sqlite3": "^12.11.1"
       },

--- a/site/data/release-fallback.json
+++ b/site/data/release-fallback.json
@@ -1,13 +1,13 @@
 {
-  "tag_name": "v1.3.1",
+  "tag_name": "v1.3.2",
   "assets": [
     {
-      "name": "Mediary.Scout-1.3.1-arm64.dmg",
-      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.1/Mediary.Scout-1.3.1-arm64.dmg"
+      "name": "Mediary.Scout-1.3.2-arm64.dmg",
+      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.2/Mediary.Scout-1.3.2-arm64.dmg"
     },
     {
-      "name": "Mediary.Scout.Setup.1.3.1.exe",
-      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.1/Mediary.Scout.Setup.1.3.1.exe"
+      "name": "Mediary.Scout.Setup.1.3.2.exe",
+      "browser_download_url": "https://github.com/fancydirty/mediary-scout/releases/download/v1.3.2/Mediary.Scout.Setup.1.3.2.exe"
     }
   ]
 }


### PR DESCRIPTION
## Release\n- bump the desktop application to 1.3.2\n- point the site download fallback at v1.3.2 assets\n\n## Included since v1.3.1\n- native 123 cloud-drive offline downloads for magnet and ed2k resources\n- bigint-safe 123 resource and task IDs\n- robust offline task cleanup, transfer polling, and derived write-scope handling\n\n## Verification\n- npx vitest run (1814 passed, 13 skipped)\n- npm run typecheck\n- npm run lint\n- npm run build:web