### PR TITLE
feat(connect): Scout Connect invite-only remote access MVP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       - run: npx tsc -p apps/web/tsconfig.json --noEmit
       - run: npx tsc -p apps/desktop/tsconfig.json --noEmit
       - run: npx tsc -p workers/tmdb-proxy/tsconfig.json --noEmit
+      - run: npx tsc -p workers/scout-connect/tsconfig.json --noEmit
       # Production build with NO database — mirrors `docker compose build` (no .env
       # at image-build time). cacheComponents prerenders pages at build; any server
       # component that reads the DB outside a connection()/cookies()/searchParams

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -192,6 +192,18 @@ Mediary Scout 默认单用户、无登录,公网入口必须靠 Access 这类前
 
 > 想自启:`cloudflared` 容器已 `restart: unless-stopped`,宿主重启会自动拉起;隧道配置在 Cloudflare 侧托管,改公网主机名 / Access 策略都在控制台改,不用动宿主。
 
+### 方式三:Scout Connect（受邀）
+
+若你收到作者的 Scout Connect 邀请链接（`https://mediaryconnect.app/i/...`）:
+
+1. 打开链接，按页显示一次连接信息（含 `TUNNEL_TOKEN`）。
+2. 写入实例 `.env` 的 `TUNNEL_TOKEN=...`（可复制页上的 Agent 提示词交给 coding agent 代配）。
+3. `docker compose --profile tunnel up -d`
+4. 浏览器打开页上的 `https://<slug>.mediaryconnect.app`，完成 Cloudflare Access 邮箱验证。
+
+Public Hostname 与 Access 已由 Connect 控制面配好，服务目标固定为 compose 内 `http://web:3000`。
+网络不稳时可加 `TUNNEL_TRANSPORT_PROTOCOL=http2`。
+
 ## 安全
 
 - 本项目只走**自部署**,作者不托管(见 [distribution-and-legal-positioning.md](distribution-and-legal-positioning.md))。默认单用户、无登录。

--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -1,0 +1,90 @@
+# Scout Connect — remote access control plane
+
+Invite-only remote access for self-hosted Mediary Scout instances. The control
+plane provisions, per invitee, a Cloudflare Tunnel + public hostname
+(`<slug>.mediaryconnect.app`) + Cloudflare Access email-OTP gate, and hands the
+home side a one-time `TUNNEL_TOKEN`. Content and credentials never leave the
+user's own machines — this worker only brokers the tunnel/dns/access setup.
+
+Deployed at `https://mediaryconnect.app` (custom domain).
+
+## Architecture
+
+```
+admin ──► mediaryconnect.app (this worker)
+            ├─ GET  /            intro
+            ├─ GET  /admin       admin page (bearer token in sessionStorage)
+            ├─ POST /api/admin/invites                     create invite
+            ├─ POST /api/admin/invites/:id/provision       tunnel+ingress+access+dns
+            ├─ POST /api/admin/endpoints/:id/revoke        delete all three
+            ├─ GET  /i/:code     invitee page (state machine, never pre-burns)
+            └─ POST /api/i/:code/reveal                    one-time token reveal
+                 │
+                 ▼ Cloudflare API
+            tunnel (scout-<slug>, config_src=cloudflare)
+            ingress → http://web:3000 (fixed) + catch-all 404
+            DNS CNAME <slug> → <tunnel-id>.cfargotunnel.com
+            Access self_hosted app, email allow policy (OTP)
+                 │
+                 ▼ invitee home
+            docker compose --profile tunnel up -d   (TUNNEL_TOKEN in .env)
+```
+
+Token secrecy: the connector token is returned to the caller exactly once (at
+provision to the admin, or at `/api/i/:code/reveal` to the invitee). D1 stores
+AES-GCM ciphertext (`TOKEN_WRAP_KEY`) until the first reveal, then only a
+sha256. After `token_shown_at` is set, the plaintext is unrecoverable.
+
+## Secrets (`wrangler secret put`, never commit)
+
+| Name | What |
+| --- | --- |
+| `ADMIN_TOKEN` | Bearer for all `/api/admin/*` + `/admin` page JS |
+| `CF_API_TOKEN` | Cloudflare API token — Tunnel:Edit, Access Apps & Policies:Edit (account), DNS:Edit (mediaryconnect.app zone only) |
+| `CF_ACCOUNT_ID` | account holding Zero Trust / tunnels |
+| `CF_ZONE_ID` | mediaryconnect.app zone |
+| `TOKEN_WRAP_KEY` | `openssl rand -hex 32` — AES-256-GCM key for token-at-rest |
+
+Vars (wrangler.jsonc, non-secret): `CONNECT_ROOT_DOMAIN=mediaryconnect.app`.
+
+## Deploy
+
+```bash
+cd workers/scout-connect
+# first time only:
+npx wrangler d1 create scout-connect          # put database_id into wrangler.jsonc
+npx wrangler d1 execute scout-connect --remote --file=./schema.sql
+# secrets above, then:
+npx wrangler deploy
+curl https://mediaryconnect.app/healthz       # → ok
+```
+
+⚠️ If you have `CF_API_TOKEN` in your shell env (e.g. for other scripts),
+wrangler picks it up as *its own* auth and fails with account-list errors —
+run deploy/secret commands as `env -u CF_API_TOKEN npx wrangler ...`.
+
+## Operations
+
+**Invite someone** (admin page `https://mediaryconnect.app/admin`):
+1. Paste `ADMIN_TOKEN`, create invite with their email (+ optional slug).
+2. Click 开通 — copy the invite URL (`/i/<code>`) and send it privately.
+   The page also shows the token + agent prompt once (admin backup copy).
+3. Invitee opens the link, clicks 显示连接信息 (shown once), pastes the token
+   into their home `.env` as `TUNNEL_TOKEN=...`, then
+   `docker compose --profile tunnel up -d`. The page offers a
+   「复制给 Agent」 prompt that does this for them.
+4. Their `https://<slug>.mediaryconnect.app` is live behind Access email OTP.
+
+**Revoke**: admin page → 吊销. Deletes Access app + DNS + tunnel (connections
+closed first; CF error 1022 retried automatically). Idempotent.
+
+**Home-side network issues**: if the tunnel won't register or keeps dropping
+on a UDP-restricted network, tell the invitee to add
+`TUNNEL_TRANSPORT_PROTOCOL=http2` to `.env` and restart the tunnel profile.
+
+## Tests
+
+`npx vitest run workers/scout-connect` from the repo root (auto-discovered).
+101 unit tests cover slug/auth, crypto wrap/unwrap, CF API client (incl. token
+non-leakage), D1 SQL shape, provision compensation (CF + D1 failure paths),
+revoke idempotency, one-time reveal state machine, and HTTP routes.

--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -85,6 +85,6 @@ on a UDP-restricted network, tell the invitee to add
 ## Tests
 
 `npx vitest run workers/scout-connect` from the repo root (auto-discovered).
-101 unit tests cover slug/auth, crypto wrap/unwrap, CF API client (incl. token
+104 unit tests cover slug/auth, crypto wrap/unwrap, CF API client (incl. token
 non-leakage), D1 SQL shape, provision compensation (CF + D1 failure paths),
 revoke idempotency, one-time reveal state machine, and HTTP routes.

--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -85,6 +85,6 @@ on a UDP-restricted network, tell the invitee to add
 ## Tests
 
 `npx vitest run workers/scout-connect` from the repo root (auto-discovered).
-104 unit tests cover slug/auth, crypto wrap/unwrap, CF API client (incl. token
+106 unit tests cover slug/auth, crypto wrap/unwrap, CF API client (incl. token
 non-leakage), D1 SQL shape, provision compensation (CF + D1 failure paths),
 revoke idempotency, one-time reveal state machine, and HTTP routes.

--- a/workers/scout-connect/schema.sql
+++ b/workers/scout-connect/schema.sql
@@ -37,5 +37,6 @@ CREATE TABLE audit_events (
   detail_json TEXT
 );
 
-CREATE INDEX idx_invites_code ON invites(code);
+-- code is already covered by the UNIQUE constraint above (SQLite auto-indexes it).
+-- status index supports admin filtering by endpoint state (revoke_failed sweep).
 CREATE INDEX idx_endpoints_status ON endpoints(status);

--- a/workers/scout-connect/schema.sql
+++ b/workers/scout-connect/schema.sql
@@ -1,0 +1,41 @@
+CREATE TABLE invites (
+  id TEXT PRIMARY KEY,
+  code TEXT NOT NULL UNIQUE,
+  invitee_label TEXT,
+  email TEXT NOT NULL,
+  slug TEXT,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  provisioned_at TEXT,
+  revoked_at TEXT
+);
+
+CREATE TABLE endpoints (
+  id TEXT PRIMARY KEY,
+  invite_id TEXT NOT NULL UNIQUE,
+  slug TEXT NOT NULL UNIQUE,
+  hostname TEXT NOT NULL UNIQUE,
+  cf_tunnel_id TEXT NOT NULL,
+  cf_access_app_id TEXT NOT NULL,
+  cf_access_policy_id TEXT,
+  cf_dns_record_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  token_sha256 TEXT NOT NULL,
+  token_ciphertext TEXT,
+  token_shown_at TEXT,
+  created_at TEXT NOT NULL,
+  revoked_at TEXT
+);
+
+CREATE TABLE audit_events (
+  id TEXT PRIMARY KEY,
+  at TEXT NOT NULL,
+  actor TEXT NOT NULL,
+  action TEXT NOT NULL,
+  invite_id TEXT,
+  endpoint_id TEXT,
+  detail_json TEXT
+);
+
+CREATE INDEX idx_invites_code ON invites(code);
+CREATE INDEX idx_endpoints_status ON endpoints(status);

--- a/workers/scout-connect/src/agent-prompt.test.ts
+++ b/workers/scout-connect/src/agent-prompt.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { buildAgentPrompt } from "./agent-prompt.js";
+
+const INPUT = {
+  hostname: "kiki-connect.example.com",
+  tunnelToken: "eyJsecret-tunnel-token-value",
+};
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("buildAgentPrompt", () => {
+  it("contains the hostname exactly twice", () => {
+    const out = buildAgentPrompt(INPUT);
+    expect(countOccurrences(out, INPUT.hostname)).toBe(2);
+  });
+
+  it("contains the tunnel token exactly once", () => {
+    const out = buildAgentPrompt(INPUT);
+    expect(countOccurrences(out, INPUT.tunnelToken)).toBe(1);
+  });
+
+  it("contains key fixed phrases", () => {
+    const out = buildAgentPrompt(INPUT);
+    expect(out).toContain("Scout Connect");
+    expect(out).toContain("docker compose --profile tunnel up -d");
+    expect(out).toContain("TUNNEL_TRANSPORT_PROTOCOL=http2");
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(buildAgentPrompt(INPUT)).toBe(buildAgentPrompt(INPUT));
+  });
+});

--- a/workers/scout-connect/src/agent-prompt.ts
+++ b/workers/scout-connect/src/agent-prompt.ts
@@ -1,0 +1,35 @@
+export function buildAgentPrompt(input: {
+  hostname: string;
+  tunnelToken: string;
+}): string {
+  return `你是在帮用户配置 Mediary Scout 的「Scout Connect」远程访问。
+
+目标:让用户的自托管实例经 Cloudflare Tunnel 发布到:
+  https://${input.hostname}
+门禁是 Cloudflare Access 邮箱 OTP(用户浏览器打开时会要求邮箱验证码)。
+不要修改获取/网盘/LLM 业务逻辑。
+
+安全:
+- TUNNEL_TOKEN 是机密,不要提交到 git,不要写进 README,不要出现在截图 issue 里。
+- 只写入实例目录的 .env(该文件应已被 gitignore)。
+
+步骤:
+1. 进入用户的 mediary-scout 部署目录(常见 docker compose 项目根)。
+2. 确保 .env 中有且仅有一行有效:
+     TUNNEL_TOKEN=${input.tunnelToken}
+   若已有旧 TUNNEL_TOKEN,先备份再替换。
+3. 可选:若用户网络不稳定/UDP 受限,追加:
+     TUNNEL_TRANSPORT_PROTOCOL=http2
+4. 执行:
+     docker compose --profile tunnel up -d
+5. 查看日志直到出现 Registered tunnel connection 一类成功字样:
+     docker compose logs -f cloudflared
+6. 让用户在浏览器打开 https://${input.hostname}
+   - 应先看到 Cloudflare Access 邮箱验证
+   - 通过后进入 Mediary Scout UI
+7. 若失败:检查 compose 服务名是否仍为 web、cloudflared 是否与 web 同网络、
+   token 是否完整一行、防火墙是否拦截出站。
+
+完成后用简短中文汇报:是否 up、Access 是否出现、打开面板是否成功。
+`;
+}

--- a/workers/scout-connect/src/auth.test.ts
+++ b/workers/scout-connect/src/auth.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { requireAdmin } from "./auth.js";
+import { HttpError } from "./http.js";
+
+const TOKEN = "test-admin-token-fixture";
+
+function req(authorization?: string): Request {
+  const headers = new Headers();
+  if (authorization !== undefined) {
+    headers.set("authorization", authorization);
+  }
+  return new Request("https://mediaryconnect.app/api/admin/invites", { headers });
+}
+
+function expect401(fn: () => void): void {
+  try {
+    fn();
+    expect.unreachable("expected HttpError(401)");
+  } catch (e) {
+    expect(e).toBeInstanceOf(HttpError);
+    expect((e as HttpError).status).toBe(401);
+    expect((e as HttpError).message).toBe("unauthorized");
+  }
+}
+
+describe("requireAdmin", () => {
+  it("accepts the exact Bearer token", () => {
+    expect(() => requireAdmin(req(`Bearer ${TOKEN}`), TOKEN)).not.toThrow();
+  });
+
+  it("missing Authorization header → 401", () => {
+    expect401(() => requireAdmin(req(), TOKEN));
+  });
+
+  it("wrong token (same length, exercises the full compare loop) → 401", () => {
+    const wrong = `${TOKEN.slice(0, -1)}X`;
+    expect401(() => requireAdmin(req(`Bearer ${wrong}`), TOKEN));
+  });
+
+  it("Basic scheme → 401", () => {
+    expect401(() => requireAdmin(req(`Basic ${btoa("user:pass")}`), TOKEN));
+  });
+
+  it("different length → 401", () => {
+    expect401(() => requireAdmin(req("Bearer short"), TOKEN));
+  });
+});

--- a/workers/scout-connect/src/auth.ts
+++ b/workers/scout-connect/src/auth.ts
@@ -1,0 +1,20 @@
+import { HttpError } from "./http.js";
+
+// The Authorization header must exactly equal `Bearer ${adminToken}`.
+export function requireAdmin(request: Request, adminToken: string): void {
+  const header = request.headers.get("authorization");
+  const expected = `Bearer ${adminToken}`;
+  if (header === null || header.length !== expected.length) {
+    throw new HttpError(401, "unauthorized");
+  }
+  // Best-effort constant-time compare: no early exit on the first mismatching
+  // byte. True constant-time is impossible to guarantee in JS (the JIT may
+  // optimize the loop), hence best-effort.
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= header.charCodeAt(i) ^ expected.charCodeAt(i);
+  }
+  if (diff !== 0) {
+    throw new HttpError(401, "unauthorized");
+  }
+}

--- a/workers/scout-connect/src/cf-api.test.ts
+++ b/workers/scout-connect/src/cf-api.test.ts
@@ -197,23 +197,54 @@ describe("cf-api", () => {
     expect(err.message).not.toContain("response-token-secret");
   });
 
-  it("deleteTunnel resolves on HTTP 404 (idempotent)", async () => {
+  it("deleteTunnel closes connections first, then deletes the tunnel", async () => {
     const { api, calls } = makeApi([
+      { json: { success: true, errors: [], result: null } }, // connections
+      { json: { success: true, errors: [], result: null } }, // tunnel
+    ]);
+    await expect(api.deleteTunnel("tid")).resolves.toBeUndefined();
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.method).toBe("DELETE");
+    expect(calls[0]!.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/cfd_tunnel/tid/connections`);
+    expect(calls[1]!.method).toBe("DELETE");
+    expect(calls[1]!.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/cfd_tunnel/tid`);
+    expect(calls[1]!.headers.Authorization).toBe(`Bearer ${API_TOKEN}`);
+  });
+
+  it("deleteTunnel resolves on HTTP 404 for either call (idempotent)", async () => {
+    const { api } = makeApi([
+      {
+        status: 404,
+        json: { success: false, errors: [{ message: "tunnel not found" }], result: null },
+      },
       {
         status: 404,
         json: { success: false, errors: [{ message: "tunnel not found" }], result: null },
       },
     ]);
     await expect(api.deleteTunnel("tid")).resolves.toBeUndefined();
-    const call = calls[0]!;
-    expect(call.method).toBe("DELETE");
-    expect(call.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/cfd_tunnel/tid`);
-    expect(call.headers.Authorization).toBe(`Bearer ${API_TOKEN}`);
-    expect(call.body).toBeUndefined();
+  });
+
+  it("deleteTunnel retries on active-connections (1022) then succeeds", async () => {
+    const { api, calls } = makeApi([
+      { json: { success: true, errors: [], result: null } }, // connections closed
+      {
+        json: {
+          success: false,
+          errors: [{ code: 1022, message: "This tunnel has active connections." }],
+          result: null,
+        },
+      },
+      { json: { success: true, errors: [], result: null } }, // retry succeeds
+    ]);
+    await expect(api.deleteTunnel("tid")).resolves.toBeUndefined();
+    expect(calls).toHaveLength(3);
+    expect(calls[2]!.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/cfd_tunnel/tid`);
   });
 
   it("deleteTunnel resolves on a success:false not-found envelope", async () => {
     const { api } = makeApi([
+      { json: { success: true, errors: [], result: null } },
       {
         json: { success: false, errors: [{ code: 11000, message: "Tunnel not found" }], result: null },
       },
@@ -223,6 +254,7 @@ describe("cf-api", () => {
 
   it("deleteTunnel still throws on other errors", async () => {
     const { api } = makeApi([
+      { json: { success: true, errors: [], result: null } },
       { status: 500, json: { success: false, errors: [{ message: "internal" }], result: null } },
     ]);
     const err = await catchError(api.deleteTunnel("tid"));

--- a/workers/scout-connect/src/cf-api.test.ts
+++ b/workers/scout-connect/src/cf-api.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import { createCfApi } from "./cf-api.js";
+
+const ACCOUNT_ID = "acc-1";
+const ZONE_ID = "zone-1";
+const API_TOKEN = "secret-token-fixture"; // fixture only — must never leak into errors
+const BASE = "https://api.cloudflare.com/client/v4";
+
+interface QueuedResponse {
+  status?: number;
+  json?: unknown;
+}
+
+interface RecordedCall {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function mockFetch(queue: QueuedResponse[]): {
+  fetchImpl: typeof fetch;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const fetchImpl = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const method = init?.method ?? "GET";
+    const headers = { ...((init?.headers ?? {}) as Record<string, string>) };
+    const body = typeof init?.body === "string" ? (JSON.parse(init.body) as unknown) : undefined;
+    calls.push({ method, url, headers, body });
+    const next = queue.shift();
+    if (next === undefined) {
+      throw new Error(`mockFetch: unexpected ${method} ${url}`);
+    }
+    return new Response(
+      JSON.stringify(next.json ?? { success: true, errors: [], result: {} }),
+      { status: next.status ?? 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+function makeApi(queue: QueuedResponse[]) {
+  const mock = mockFetch(queue);
+  const api = createCfApi({
+    accountId: ACCOUNT_ID,
+    zoneId: ZONE_ID,
+    apiToken: API_TOKEN,
+    fetchImpl: mock.fetchImpl,
+  });
+  return { api, calls: mock.calls };
+}
+
+async function catchError(p: Promise<unknown>): Promise<Error> {
+  try {
+    await p;
+  } catch (e) {
+    if (e instanceof Error) return e;
+    throw new Error(`threw non-Error: ${String(e)}`);
+  }
+  throw new Error("expected promise to reject, but it resolved");
+}
+
+describe("cf-api", () => {
+  it("createTunnel POSTs and parses id+token", async () => {
+    const { api, calls } = makeApi([
+      { json: { success: true, errors: [], result: { id: "tid", token: "tok" } } },
+    ]);
+    const out = await api.createTunnel("my-tunnel");
+    expect(out).toEqual({ tunnelId: "tid", token: "tok" });
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.method).toBe("POST");
+    expect(call.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/cfd_tunnel`);
+    expect(call.headers.Authorization).toBe(`Bearer ${API_TOKEN}`);
+    expect(call.headers["content-type"]).toBe("application/json");
+    expect(call.body).toEqual({ name: "my-tunnel", config_src: "cloudflare" });
+  });
+
+  it("putTunnelIngress sends web service + catch-all 404", async () => {
+    const { api, calls } = makeApi([{}]);
+    await api.putTunnelIngress("tid", "slug.example.com");
+    const call = calls[0]!;
+    expect(call.method).toBe("PUT");
+    expect(call.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/cfd_tunnel/tid/configurations`);
+    const body = call.body as { config: { ingress: Array<Record<string, unknown>> } };
+    expect(body.config.ingress).toHaveLength(2);
+    expect(body.config.ingress[0]).toEqual({
+      hostname: "slug.example.com",
+      service: "http://web:3000",
+    });
+    expect(body.config.ingress[1]).toEqual({ service: "http_status:404" });
+  });
+
+  it("createDnsCname POSTs a proxied CNAME at <tunnelId>.cfargotunnel.com", async () => {
+    const { api, calls } = makeApi([
+      { json: { success: true, errors: [], result: { id: "rec-1" } } },
+    ]);
+    const out = await api.createDnsCname("slug", "tid");
+    expect(out).toEqual({ recordId: "rec-1" });
+    const call = calls[0]!;
+    expect(call.method).toBe("POST");
+    expect(call.url).toBe(`${BASE}/zones/${ZONE_ID}/dns_records`);
+    expect(call.body).toEqual({
+      type: "CNAME",
+      name: "slug",
+      content: "tid.cfargotunnel.com",
+      proxied: true,
+      ttl: 1,
+    });
+  });
+
+  it("createAccessApp POSTs a self_hosted app with an inline email allow policy", async () => {
+    const { api, calls } = makeApi([
+      {
+        json: {
+          success: true,
+          errors: [],
+          result: { id: "app-1", policies: [{ id: "pol-1", name: "allow-invitee" }] },
+        },
+      },
+    ]);
+    const out = await api.createAccessApp({
+      name: "Scout Connect slug",
+      domain: "slug.example.com",
+      email: "user@example.com",
+    });
+    expect(out).toEqual({ appId: "app-1", policyId: "pol-1" });
+    const call = calls[0]!;
+    expect(call.method).toBe("POST");
+    expect(call.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/access/apps`);
+    const body = call.body as {
+      name: string;
+      domain: string;
+      type: string;
+      session_duration: string;
+      policies: Array<{
+        decision: string;
+        name: string;
+        precedence: number;
+        include: Array<{ email: { email: string } }>;
+      }>;
+    };
+    expect(body.name).toBe("Scout Connect slug");
+    expect(body.domain).toBe("slug.example.com");
+    expect(body.type).toBe("self_hosted");
+    expect(body.session_duration).toBe("24h");
+    expect(body.policies[0]).toEqual({
+      decision: "allow",
+      name: "allow-invitee",
+      precedence: 1,
+      include: [{ email: { email: "user@example.com" } }],
+    });
+  });
+
+  it("createAccessApp leaves policyId undefined when the response has no policy id", async () => {
+    const { api } = makeApi([
+      { json: { success: true, errors: [], result: { id: "app-2", policies: [] } } },
+    ]);
+    const out = await api.createAccessApp({
+      name: "n",
+      domain: "d.example.com",
+      email: "e@example.com",
+    });
+    expect(out.appId).toBe("app-2");
+    expect(out.policyId).toBeUndefined();
+    expect("policyId" in out).toBe(false);
+  });
+
+  it("success:false throws the api error message without leaking the apiToken", async () => {
+    const { api } = makeApi([
+      { json: { success: false, errors: [{ code: 1001, message: "bad slug" }], result: null } },
+    ]);
+    const err = await catchError(api.createDnsCname("bad-slug", "tid"));
+    expect(err.message).toContain("bad slug");
+    expect(err.message).not.toContain(API_TOKEN);
+  });
+
+  it("HTTP 500 throws without leaking the apiToken or response-body secrets", async () => {
+    const { api } = makeApi([
+      {
+        status: 500,
+        json: {
+          success: false,
+          errors: [],
+          result: { id: "tid", token: "response-token-secret" },
+        },
+      },
+    ]);
+    const err = await catchError(api.createTunnel("x"));
+    expect(err.message).toContain("HTTP 500");
+    expect(err.message).not.toContain(API_TOKEN);
+    expect(err.message).not.toContain("response-token-secret");
+  });
+
+  it("deleteTunnel resolves on HTTP 404 (idempotent)", async () => {
+    const { api, calls } = makeApi([
+      {
+        status: 404,
+        json: { success: false, errors: [{ message: "tunnel not found" }], result: null },
+      },
+    ]);
+    await expect(api.deleteTunnel("tid")).resolves.toBeUndefined();
+    const call = calls[0]!;
+    expect(call.method).toBe("DELETE");
+    expect(call.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/cfd_tunnel/tid`);
+    expect(call.headers.Authorization).toBe(`Bearer ${API_TOKEN}`);
+    expect(call.body).toBeUndefined();
+  });
+
+  it("deleteTunnel resolves on a success:false not-found envelope", async () => {
+    const { api } = makeApi([
+      {
+        json: { success: false, errors: [{ code: 11000, message: "Tunnel not found" }], result: null },
+      },
+    ]);
+    await expect(api.deleteTunnel("tid")).resolves.toBeUndefined();
+  });
+
+  it("deleteTunnel still throws on other errors", async () => {
+    const { api } = makeApi([
+      { status: 500, json: { success: false, errors: [{ message: "internal" }], result: null } },
+    ]);
+    const err = await catchError(api.deleteTunnel("tid"));
+    expect(err.message).toContain("internal");
+  });
+
+  it("deleteDnsRecord and deleteAccessApp resolve on HTTP 404", async () => {
+    const { api, calls } = makeApi([
+      { status: 404, json: { success: false, errors: [{ message: "record not found" }], result: null } },
+      { status: 404, json: { success: false, errors: [{ message: "app not found" }], result: null } },
+    ]);
+    await expect(api.deleteDnsRecord("rec-1")).resolves.toBeUndefined();
+    await expect(api.deleteAccessApp("app-1")).resolves.toBeUndefined();
+    expect(calls[0]!.method).toBe("DELETE");
+    expect(calls[0]!.url).toBe(`${BASE}/zones/${ZONE_ID}/dns_records/rec-1`);
+    expect(calls[1]!.method).toBe("DELETE");
+    expect(calls[1]!.url).toBe(`${BASE}/accounts/${ACCOUNT_ID}/access/apps/app-1`);
+  });
+});

--- a/workers/scout-connect/src/cf-api.ts
+++ b/workers/scout-connect/src/cf-api.ts
@@ -74,6 +74,17 @@ function cfError(envelope: CfEnvelope | null, status: number): Error {
   return new Error(firstErrorMessage(envelope) ?? `HTTP ${status}`);
 }
 
+function isActiveConnectionsError(e: unknown): boolean {
+  return (
+    e instanceof Error &&
+    (e.message.includes("active connections") || e.message.includes("1022"))
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function requireString(value: unknown, field: string): string {
   if (typeof value !== "string" || value === "") {
     throw new Error(`cloudflare response missing ${field}`);
@@ -214,9 +225,28 @@ export function createCfApi(opts: CfApiOptions): CfApi {
     },
 
     async deleteTunnel(tunnelId) {
-      await cfDelete(resolved, `${accountPath}/cfd_tunnel/${encodeURIComponent(tunnelId)}`, {
-        notFoundIsSuccess: true,
-      });
+      // CF rejects tunnel deletion with error 1022 while cloudflared still
+      // holds connections open (e.g. revoke right after a live e2e). Close
+      // them first — DELETE .../connections disconnects all replicas — then
+      // retry the delete a few times while connections drain.
+      await cfDelete(
+        resolved,
+        `${accountPath}/cfd_tunnel/${encodeURIComponent(tunnelId)}/connections`,
+        { notFoundIsSuccess: true },
+      );
+      const deleteUrl = `${accountPath}/cfd_tunnel/${encodeURIComponent(tunnelId)}`;
+      let lastError: unknown;
+      for (let attemptIdx = 0; attemptIdx < 4; attemptIdx++) {
+        try {
+          await cfDelete(resolved, deleteUrl, { notFoundIsSuccess: true });
+          return;
+        } catch (e) {
+          lastError = e;
+          if (!isActiveConnectionsError(e)) throw e;
+          await sleep(1500 * (attemptIdx + 1));
+        }
+      }
+      throw lastError;
     },
 
     async deleteDnsRecord(recordId) {

--- a/workers/scout-connect/src/cf-api.ts
+++ b/workers/scout-connect/src/cf-api.ts
@@ -147,7 +147,9 @@ export function createCfApi(opts: CfApiOptions): CfApi {
     accountId: opts.accountId,
     zoneId: opts.zoneId,
     apiToken: opts.apiToken,
-    fetchImpl: opts.fetchImpl ?? globalThis.fetch,
+    // workerd throws "Illegal invocation" when fetch is called detached from
+    // globalThis — always wrap the default so it's invoked as a plain call.
+    fetchImpl: opts.fetchImpl ?? ((url, init) => globalThis.fetch(url, init)),
   };
   const accountPath = `${API_BASE}/accounts/${encodeURIComponent(resolved.accountId)}`;
   const zonePath = `${API_BASE}/zones/${encodeURIComponent(resolved.zoneId)}`;

--- a/workers/scout-connect/src/cf-api.ts
+++ b/workers/scout-connect/src/cf-api.ts
@@ -1,0 +1,228 @@
+const API_BASE = "https://api.cloudflare.com/client/v4";
+const WEB_SERVICE = "http://web:3000";
+const CATCH_ALL_SERVICE = "http_status:404";
+
+export interface CfApi {
+  createTunnel(name: string): Promise<{ tunnelId: string; token: string }>;
+  /** service fixed http://web:3000 + catch-all 404 */
+  putTunnelIngress(tunnelId: string, hostname: string): Promise<void>;
+  createDnsCname(slug: string, tunnelId: string): Promise<{ recordId: string }>;
+  createAccessApp(input: {
+    name: string;
+    domain: string;
+    email: string;
+  }): Promise<{ appId: string; policyId?: string }>;
+  deleteTunnel(tunnelId: string): Promise<void>;
+  deleteDnsRecord(recordId: string): Promise<void>;
+  deleteAccessApp(appId: string): Promise<void>;
+}
+
+export interface CfApiOptions {
+  accountId: string;
+  zoneId: string;
+  apiToken: string;
+  fetchImpl?: typeof fetch; // injected for tests
+}
+
+interface ResolvedOptions {
+  accountId: string;
+  zoneId: string;
+  apiToken: string;
+  fetchImpl: typeof fetch;
+}
+
+interface CfEnvelope {
+  success: boolean;
+  errors: ReadonlyArray<{ code?: unknown; message?: unknown }> | null;
+  result: unknown;
+}
+
+function toEnvelope(raw: unknown): CfEnvelope | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const obj = raw as Record<string, unknown>;
+  return {
+    success: obj.success === true,
+    errors: Array.isArray(obj.errors)
+      ? (obj.errors as ReadonlyArray<{ code?: unknown; message?: unknown }>)
+      : null,
+    result: obj.result,
+  };
+}
+
+function firstErrorMessage(envelope: CfEnvelope | null): string | undefined {
+  const first = envelope?.errors?.[0];
+  if (first !== undefined && typeof first.message === "string" && first.message !== "") {
+    return first.message;
+  }
+  return undefined;
+}
+
+function isNotFoundEnvelope(envelope: CfEnvelope | null): boolean {
+  return (
+    envelope?.errors?.some((e) => {
+      if (typeof e.message !== "string") return false;
+      const msg = e.message.toLowerCase();
+      return msg.includes("not found") || msg.includes("does not exist");
+    }) ?? false
+  );
+}
+
+// SECURITY: error messages must never carry the apiToken, the Authorization
+// header, or request/response bodies (a tunnel-create response contains the
+// tunnel token). Only the api's own errors[].message or the HTTP status.
+function cfError(envelope: CfEnvelope | null, status: number): Error {
+  return new Error(firstErrorMessage(envelope) ?? `HTTP ${status}`);
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value === "") {
+    throw new Error(`cloudflare response missing ${field}`);
+  }
+  return value;
+}
+
+function requestInit(resolved: ResolvedOptions, method: string, body: unknown): RequestInit {
+  return {
+    method,
+    headers: {
+      Authorization: `Bearer ${resolved.apiToken}`,
+      "content-type": "application/json",
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  };
+}
+
+async function cfJson(
+  resolved: ResolvedOptions,
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<unknown> {
+  const res = await resolved.fetchImpl(url, requestInit(resolved, method, body));
+  let envelope: CfEnvelope | null = null;
+  try {
+    envelope = toEnvelope(await res.json());
+  } catch {
+    envelope = null;
+  }
+  if (!res.ok || envelope === null || !envelope.success) {
+    throw cfError(envelope, res.status);
+  }
+  return envelope.result;
+}
+
+async function cfDelete(
+  resolved: ResolvedOptions,
+  url: string,
+  opts: { notFoundIsSuccess?: boolean } = {},
+): Promise<void> {
+  const res = await resolved.fetchImpl(url, requestInit(resolved, "DELETE", undefined));
+  // 404 → already gone; revoke is idempotent. Checked BEFORE parsing the body.
+  if (res.status === 404) return;
+  let envelope: CfEnvelope | null = null;
+  try {
+    envelope = toEnvelope(await res.json());
+  } catch {
+    envelope = null;
+  }
+  if (!res.ok || (envelope !== null && !envelope.success)) {
+    if (opts.notFoundIsSuccess === true && isNotFoundEnvelope(envelope)) return;
+    throw cfError(envelope, res.status);
+  }
+}
+
+function extractPolicyId(policies: unknown): string | undefined {
+  if (!Array.isArray(policies)) return undefined;
+  for (const policy of policies) {
+    if (typeof policy === "object" && policy !== null) {
+      const id = (policy as Record<string, unknown>).id;
+      if (typeof id === "string" && id !== "") return id;
+    }
+  }
+  return undefined;
+}
+
+export function createCfApi(opts: CfApiOptions): CfApi {
+  const resolved: ResolvedOptions = {
+    accountId: opts.accountId,
+    zoneId: opts.zoneId,
+    apiToken: opts.apiToken,
+    fetchImpl: opts.fetchImpl ?? globalThis.fetch,
+  };
+  const accountPath = `${API_BASE}/accounts/${encodeURIComponent(resolved.accountId)}`;
+  const zonePath = `${API_BASE}/zones/${encodeURIComponent(resolved.zoneId)}`;
+
+  return {
+    async createTunnel(name) {
+      const result = (await cfJson(resolved, "POST", `${accountPath}/cfd_tunnel`, {
+        name,
+        config_src: "cloudflare",
+      })) as { id?: unknown; token?: unknown } | null;
+      return {
+        tunnelId: requireString(result?.id, "tunnel id"),
+        token: requireString(result?.token, "tunnel token"),
+      };
+    },
+
+    async putTunnelIngress(tunnelId, hostname) {
+      await cfJson(
+        resolved,
+        "PUT",
+        `${accountPath}/cfd_tunnel/${encodeURIComponent(tunnelId)}/configurations`,
+        {
+          config: {
+            ingress: [
+              { hostname, service: WEB_SERVICE },
+              { service: CATCH_ALL_SERVICE },
+            ],
+          },
+        },
+      );
+    },
+
+    async createDnsCname(slug, tunnelId) {
+      const result = (await cfJson(resolved, "POST", `${zonePath}/dns_records`, {
+        type: "CNAME",
+        name: slug,
+        content: `${tunnelId}.cfargotunnel.com`,
+        proxied: true,
+        ttl: 1,
+      })) as { id?: unknown } | null;
+      return { recordId: requireString(result?.id, "dns record id") };
+    },
+
+    async createAccessApp(input) {
+      const result = (await cfJson(resolved, "POST", `${accountPath}/access/apps`, {
+        name: input.name,
+        domain: input.domain,
+        type: "self_hosted",
+        session_duration: "24h",
+        policies: [
+          {
+            decision: "allow",
+            name: "allow-invitee",
+            precedence: 1,
+            include: [{ email: { email: input.email } }],
+          },
+        ],
+      })) as { id?: unknown; policies?: unknown } | null;
+      const appId = requireString(result?.id, "access app id");
+      const policyId = extractPolicyId(result?.policies);
+      return { appId, ...(policyId === undefined ? {} : { policyId }) };
+    },
+
+    async deleteTunnel(tunnelId) {
+      await cfDelete(resolved, `${accountPath}/cfd_tunnel/${encodeURIComponent(tunnelId)}`, {
+        notFoundIsSuccess: true,
+      });
+    },
+
+    async deleteDnsRecord(recordId) {
+      await cfDelete(resolved, `${zonePath}/dns_records/${encodeURIComponent(recordId)}`);
+    },
+
+    async deleteAccessApp(appId) {
+      await cfDelete(resolved, `${accountPath}/access/apps/${encodeURIComponent(appId)}`);
+    },
+  };
+}

--- a/workers/scout-connect/src/cf-api.ts
+++ b/workers/scout-connect/src/cf-api.ts
@@ -122,13 +122,14 @@ async function cfJson(
   return envelope.result;
 }
 
-async function cfDelete(
-  resolved: ResolvedOptions,
-  url: string,
-  opts: { notFoundIsSuccess?: boolean } = {},
-): Promise<void> {
+// ALL deletes are idempotent by design (revoke can be retried safely):
+//  - HTTP 404 → already gone, success.
+//  - 2xx with success:false whose errors say "not found"/"does not exist" →
+//    also success (CF products phrase not-found differently per resource).
+// Anything else is a real error.
+async function cfDelete(resolved: ResolvedOptions, url: string): Promise<void> {
   const res = await resolved.fetchImpl(url, requestInit(resolved, "DELETE", undefined));
-  // 404 → already gone; revoke is idempotent. Checked BEFORE parsing the body.
+  // 404 → already gone. Checked BEFORE parsing the body.
   if (res.status === 404) return;
   let envelope: CfEnvelope | null = null;
   try {
@@ -137,7 +138,7 @@ async function cfDelete(
     envelope = null;
   }
   if (!res.ok || (envelope !== null && !envelope.success)) {
-    if (opts.notFoundIsSuccess === true && isNotFoundEnvelope(envelope)) return;
+    if (isNotFoundEnvelope(envelope)) return;
     throw cfError(envelope, res.status);
   }
 }
@@ -232,13 +233,12 @@ export function createCfApi(opts: CfApiOptions): CfApi {
       await cfDelete(
         resolved,
         `${accountPath}/cfd_tunnel/${encodeURIComponent(tunnelId)}/connections`,
-        { notFoundIsSuccess: true },
       );
       const deleteUrl = `${accountPath}/cfd_tunnel/${encodeURIComponent(tunnelId)}`;
       let lastError: unknown;
       for (let attemptIdx = 0; attemptIdx < 4; attemptIdx++) {
         try {
-          await cfDelete(resolved, deleteUrl, { notFoundIsSuccess: true });
+          await cfDelete(resolved, deleteUrl);
           return;
         } catch (e) {
           lastError = e;

--- a/workers/scout-connect/src/cf-api.ts
+++ b/workers/scout-connect/src/cf-api.ts
@@ -243,7 +243,9 @@ export function createCfApi(opts: CfApiOptions): CfApi {
         } catch (e) {
           lastError = e;
           if (!isActiveConnectionsError(e)) throw e;
-          await sleep(1500 * (attemptIdx + 1));
+          if (attemptIdx < 3) {
+            await sleep(1500 * (attemptIdx + 1));
+          }
         }
       }
       throw lastError;

--- a/workers/scout-connect/src/crypto-token.test.ts
+++ b/workers/scout-connect/src/crypto-token.test.ts
@@ -19,7 +19,17 @@ describe("crypto-token", () => {
 
   it("unwrap fails on tamper", async () => {
     const wrapped = await wrapToken("secret", KEY_HEX);
-    await expect(unwrapToken(wrapped.slice(0, -2) + "ff", KEY_HEX)).rejects.toThrow();
+    // Flip a fully-significant middle base64url char deterministically — the
+    // final char carries discarded padding bits, so mutating it can be a no-op.
+    const mid = Math.floor(wrapped.length / 2);
+    const tampered =
+      wrapped.slice(0, mid) + (wrapped[mid] === "A" ? "B" : "A") + wrapped.slice(mid + 1);
+    await expect(unwrapToken(tampered, KEY_HEX)).rejects.toThrow();
+  });
+
+  it("unwrap fails with the wrong key", async () => {
+    const wrapped = await wrapToken("s", KEY_HEX);
+    await expect(unwrapToken(wrapped, "11".repeat(32))).rejects.toThrow();
   });
 
   it("wrapToken rejects non-32-byte keys", async () => {

--- a/workers/scout-connect/src/crypto-token.test.ts
+++ b/workers/scout-connect/src/crypto-token.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { sha256Hex, wrapToken, unwrapToken } from "./crypto-token.js";
+
+const KEY_HEX = "00".repeat(32); // test only
+
+describe("crypto-token", () => {
+  it("sha256Hex is stable", async () => {
+    expect(await sha256Hex("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  it("wrap/unwrap roundtrips", async () => {
+    const plain = "eyJtest-tunnel-token-value";
+    const wrapped = await wrapToken(plain, KEY_HEX);
+    expect(wrapped).not.toContain(plain);
+    expect(await unwrapToken(wrapped, KEY_HEX)).toBe(plain);
+  });
+
+  it("unwrap fails on tamper", async () => {
+    const wrapped = await wrapToken("secret", KEY_HEX);
+    await expect(unwrapToken(wrapped.slice(0, -2) + "ff", KEY_HEX)).rejects.toThrow();
+  });
+
+  it("wrapToken rejects non-32-byte keys", async () => {
+    await expect(wrapToken("x", "00".repeat(16))).rejects.toThrow();
+    await expect(wrapToken("x", "0")).rejects.toThrow(); // odd-length hex
+  });
+});

--- a/workers/scout-connect/src/crypto-token.ts
+++ b/workers/scout-connect/src/crypto-token.ts
@@ -1,0 +1,88 @@
+const IV_BYTES = 12;
+const KEY_BYTES = 32;
+
+function hexToKeyBytes(keyHex: string): Uint8Array {
+  if (keyHex.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(keyHex)) {
+    throw new Error("key must be even-length hex");
+  }
+  const bytes = new Uint8Array(keyHex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(keyHex.slice(i * 2, i * 2 + 2), 16);
+  }
+  if (bytes.length !== KEY_BYTES) {
+    throw new Error(`key must decode to exactly ${KEY_BYTES} bytes, got ${bytes.length}`);
+  }
+  return bytes;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (const byte of bytes) {
+    bin += String.fromCharCode(byte);
+  }
+  return btoa(bin).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+  const b64 = s.replaceAll("-", "+").replaceAll("_", "/");
+  const bin = atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4));
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) {
+    bytes[i] = bin.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export async function sha256Hex(s: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(s),
+  );
+  let hex = "";
+  for (const byte of new Uint8Array(digest)) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+export async function wrapToken(plain: string, keyHex: string): Promise<string> {
+  const keyBytes = hexToKeyBytes(keyHex);
+  const key = await globalThis.crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    "AES-GCM",
+    false,
+    ["encrypt"],
+  );
+  const iv = globalThis.crypto.getRandomValues(new Uint8Array(IV_BYTES));
+  const ciphertext = await globalThis.crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(plain),
+  );
+  const out = new Uint8Array(IV_BYTES + ciphertext.byteLength);
+  out.set(iv, 0);
+  out.set(new Uint8Array(ciphertext), IV_BYTES);
+  return base64UrlEncode(out);
+}
+
+export async function unwrapToken(blob: string, keyHex: string): Promise<string> {
+  const keyBytes = hexToKeyBytes(keyHex);
+  const data = base64UrlDecode(blob);
+  if (data.length <= IV_BYTES) {
+    throw new Error("ciphertext too short");
+  }
+  const key = await globalThis.crypto.subtle.importKey(
+    "raw",
+    keyBytes,
+    "AES-GCM",
+    false,
+    ["decrypt"],
+  );
+  const plain = await globalThis.crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: data.slice(0, IV_BYTES) },
+    key,
+    data.slice(IV_BYTES),
+  );
+  return new TextDecoder().decode(plain);
+}

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   createMemoryConnectDb,
+  createD1ConnectDb,
+  type D1Database,
+  type D1PreparedStatement,
   type InviteRow,
   type EndpointRow,
   type AuditRow,
@@ -174,5 +177,127 @@ describe("memory ConnectDb", () => {
     }
     first.code = "mutated";
     expect((await db.getInviteById("inv_1"))?.code).toBe("code-1");
+  });
+
+  it("mutations on nonexistent ids are silent no-ops (D1 UPDATE parity contract)", async () => {
+    const db = createMemoryConnectDb();
+    await expect(db.markTokenShown("nope", "2026-07-24T04:00:00.000Z")).resolves.toBeUndefined();
+    await expect(db.markEndpointRevoked("nope", "2026-07-24T04:00:00.000Z")).resolves.toBeUndefined();
+    await expect(db.markEndpointRevokeFailed("nope")).resolves.toBeUndefined();
+    await expect(db.updateInviteStatus("nope", { status: "revoked" })).resolves.toBeUndefined();
+    expect(await db.listEndpoints()).toHaveLength(0);
+    expect(await db.listInvites()).toHaveLength(0);
+  });
+
+  it("list ordering ties break deterministically by id DESC", async () => {
+    const db = createMemoryConnectDb();
+    const sameAt = "2026-07-24T00:00:00.000Z";
+    await db.insertInvite(makeInvite({ id: "inv_a", code: "ca", created_at: sameAt }));
+    await db.insertInvite(makeInvite({ id: "inv_b", code: "cb", created_at: sameAt }));
+    await db.insertEndpoint(makeEndpoint({ id: "ep_a", invite_id: "inv_a", slug: "sa", hostname: "sa.x", created_at: sameAt }));
+    await db.insertEndpoint(makeEndpoint({ id: "ep_b", invite_id: "inv_b", slug: "sb", hostname: "sb.x", created_at: sameAt }));
+    expect((await db.listInvites()).map((row) => row.id)).toEqual(["inv_b", "inv_a"]);
+    expect((await db.listEndpoints()).map((row) => row.id)).toEqual(["ep_b", "ep_a"]);
+  });
+
+  it("updateInviteStatus supports the revoke-shaped patch (slug cleared)", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite({ status: "provisioned", slug: "alice", provisioned_at: "2026-07-24T01:00:00.000Z" }));
+    await db.updateInviteStatus("inv_1", {
+      status: "revoked",
+      slug: null,
+      revoked_at: "2026-07-24T05:00:00.000Z",
+    });
+    const row = await db.getInviteById("inv_1");
+    expect(row?.status).toBe("revoked");
+    expect(row?.slug).toBeNull();
+    expect(row?.revoked_at).toBe("2026-07-24T05:00:00.000Z");
+    expect(row?.provisioned_at).toBe("2026-07-24T01:00:00.000Z");
+  });
+});
+
+interface SpyCall {
+  query: string;
+  binds: unknown[];
+  method: "first" | "all" | "run";
+}
+
+function createSpyD1(respond: { first?: unknown; all?: unknown[] } = {}): {
+  d1: D1Database;
+  calls: SpyCall[];
+} {
+  const calls: SpyCall[] = [];
+  const d1: D1Database = {
+    prepare(query: string): D1PreparedStatement {
+      const binds: unknown[] = [];
+      const stmt: D1PreparedStatement = {
+        bind(...values: unknown[]) {
+          binds.push(...values);
+          return stmt;
+        },
+        async first<T>(): Promise<T | null> {
+          calls.push({ query, binds: [...binds], method: "first" });
+          return (respond.first ?? null) as T | null;
+        },
+        async all<T>(): Promise<{ results: T[] }> {
+          calls.push({ query, binds: [...binds], method: "all" });
+          return { results: (respond.all ?? []) as T[] };
+        },
+        async run(): Promise<unknown> {
+          calls.push({ query, binds: [...binds], method: "run" });
+          return {};
+        },
+      };
+      return stmt;
+    },
+  };
+  return { d1, calls };
+}
+
+describe("D1 ConnectDb SQL", () => {
+  it("markTokenShown issues exactly one UPDATE nulling the ciphertext", async () => {
+    const { d1, calls } = createSpyD1();
+    const db = createD1ConnectDb(d1);
+    await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z");
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call?.method).toBe("run");
+    expect(call?.query).toContain("token_shown_at = ?");
+    expect(call?.query).toContain("token_ciphertext = NULL");
+    expect(call?.binds).toEqual(["2026-07-24T02:00:00.000Z", "ep_1"]);
+  });
+
+  it("updateInviteStatus full patch keeps placeholder↔bind alignment", async () => {
+    const { d1, calls } = createSpyD1();
+    const db = createD1ConnectDb(d1);
+    await db.updateInviteStatus("inv_1", {
+      status: "provisioned",
+      slug: "alice",
+      provisioned_at: "2026-07-24T01:00:00.000Z",
+      revoked_at: null,
+    });
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call?.query).toBe(
+      "UPDATE invites SET status = ?, slug = ?, provisioned_at = ?, revoked_at = ? WHERE id = ?",
+    );
+    expect(call?.binds).toEqual(["provisioned", "alice", "2026-07-24T01:00:00.000Z", null, "inv_1"]);
+  });
+
+  it("updateInviteStatus status-only patch emits one placeholder", async () => {
+    const { d1, calls } = createSpyD1();
+    const db = createD1ConnectDb(d1);
+    await db.updateInviteStatus("inv_1", { status: "revoked" });
+    expect(calls[0]?.query).toBe("UPDATE invites SET status = ? WHERE id = ?");
+    expect(calls[0]?.binds).toEqual(["revoked", "inv_1"]);
+  });
+
+  it("insertEndpoint binds token fields without leaking them into SQL text", async () => {
+    const { d1, calls } = createSpyD1();
+    const db = createD1ConnectDb(d1);
+    await db.insertEndpoint(makeEndpoint({ token_ciphertext: "s3cret-ciphertext" }));
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.query).not.toContain("s3cret-ciphertext");
+    expect(calls[0]?.binds).toContain("s3cret-ciphertext");
   });
 });

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  createMemoryConnectDb,
+  type InviteRow,
+  type EndpointRow,
+  type AuditRow,
+} from "./db.js";
+
+function makeInvite(overrides: Partial<InviteRow> = {}): InviteRow {
+  return {
+    id: "inv_1",
+    code: "code-1",
+    invitee_label: null,
+    email: "alice@example.com",
+    slug: null,
+    status: "pending",
+    created_at: "2026-07-24T00:00:00.000Z",
+    provisioned_at: null,
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+function makeEndpoint(overrides: Partial<EndpointRow> = {}): EndpointRow {
+  return {
+    id: "ep_1",
+    invite_id: "inv_1",
+    slug: "alice",
+    hostname: "alice.connect.example.com",
+    cf_tunnel_id: "tun_1",
+    cf_access_app_id: "app_1",
+    cf_access_policy_id: null,
+    cf_dns_record_id: "dns_1",
+    status: "active",
+    token_sha256: "sha256hex",
+    token_ciphertext: "ciphertext",
+    token_shown_at: null,
+    created_at: "2026-07-24T00:00:00.000Z",
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+describe("memory ConnectDb", () => {
+  it("insertInvite roundtrips via getInviteById and getInviteByCode", async () => {
+    const db = createMemoryConnectDb();
+    const invite = makeInvite();
+    const inserted = await db.insertInvite(invite);
+    expect(inserted).toEqual(invite);
+    expect(await db.getInviteById("inv_1")).toEqual(invite);
+    expect(await db.getInviteByCode("code-1")).toEqual(invite);
+    expect(await db.getInviteById("missing")).toBeNull();
+    expect(await db.getInviteByCode("missing")).toBeNull();
+  });
+
+  it("rejects duplicate invite code and id with UNIQUE error", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await expect(db.insertInvite(makeInvite({ id: "inv_2" }))).rejects.toThrow(/UNIQUE/i);
+    await expect(db.insertInvite(makeInvite({ code: "code-2" }))).rejects.toThrow(/UNIQUE/i);
+  });
+
+  it("listInvites returns newest first", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite({ id: "inv_1", code: "c1", created_at: "2026-07-20T00:00:00.000Z" }));
+    await db.insertInvite(makeInvite({ id: "inv_2", code: "c2", created_at: "2026-07-22T00:00:00.000Z" }));
+    await db.insertInvite(makeInvite({ id: "inv_3", code: "c3", created_at: "2026-07-21T00:00:00.000Z" }));
+    const list = await db.listInvites();
+    expect(list.map((row) => row.id)).toEqual(["inv_2", "inv_3", "inv_1"]);
+  });
+
+  it("updateInviteStatus applies status, slug and provisioned_at", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await db.updateInviteStatus("inv_1", {
+      status: "provisioned",
+      slug: "alice",
+      provisioned_at: "2026-07-24T01:00:00.000Z",
+    });
+    const row = await db.getInviteById("inv_1");
+    expect(row?.status).toBe("provisioned");
+    expect(row?.slug).toBe("alice");
+    expect(row?.provisioned_at).toBe("2026-07-24T01:00:00.000Z");
+    expect(row?.revoked_at).toBeNull();
+  });
+
+  it("insertEndpoint roundtrips via getEndpointById and getEndpointByInviteId", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    const endpoint = makeEndpoint();
+    const inserted = await db.insertEndpoint(endpoint);
+    expect(inserted).toEqual(endpoint);
+    expect(await db.getEndpointById("ep_1")).toEqual(endpoint);
+    expect(await db.getEndpointByInviteId("inv_1")).toEqual(endpoint);
+    expect(await db.getEndpointById("missing")).toBeNull();
+    expect(await db.getEndpointByInviteId("missing")).toBeNull();
+  });
+
+  it("rejects duplicate endpoint slug, invite_id and hostname with UNIQUE error", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertEndpoint(makeEndpoint());
+    await expect(
+      db.insertEndpoint(makeEndpoint({ id: "ep_2", invite_id: "inv_2", hostname: "other.connect.example.com" })),
+    ).rejects.toThrow(/UNIQUE/i);
+    await expect(
+      db.insertEndpoint(makeEndpoint({ id: "ep_2", slug: "other", hostname: "other.connect.example.com" })),
+    ).rejects.toThrow(/UNIQUE/i);
+    await expect(
+      db.insertEndpoint(makeEndpoint({ id: "ep_2", invite_id: "inv_2", slug: "other" })),
+    ).rejects.toThrow(/UNIQUE/i);
+  });
+
+  it("markTokenShown sets token_shown_at and nulls token_ciphertext", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertEndpoint(makeEndpoint());
+    await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z");
+    const row = await db.getEndpointById("ep_1");
+    expect(row?.token_shown_at).toBe("2026-07-24T02:00:00.000Z");
+    expect(row?.token_ciphertext).toBeNull();
+  });
+
+  it("markEndpointRevoked sets status revoked and revoked_at", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertEndpoint(makeEndpoint());
+    await db.markEndpointRevoked("ep_1", "2026-07-24T03:00:00.000Z");
+    const row = await db.getEndpointById("ep_1");
+    expect(row?.status).toBe("revoked");
+    expect(row?.revoked_at).toBe("2026-07-24T03:00:00.000Z");
+  });
+
+  it("markEndpointRevokeFailed sets status revoke_failed", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertEndpoint(makeEndpoint());
+    await db.markEndpointRevokeFailed("ep_1");
+    const row = await db.getEndpointById("ep_1");
+    expect(row?.status).toBe("revoke_failed");
+    expect(row?.revoked_at).toBeNull();
+  });
+
+  it("insertAudit roundtrips via listAudits", async () => {
+    const db = createMemoryConnectDb();
+    const audit: AuditRow = {
+      id: "aud_1",
+      at: "2026-07-24T00:00:00.000Z",
+      actor: "admin",
+      action: "invite.create",
+      invite_id: "inv_1",
+      endpoint_id: null,
+      detail_json: null,
+    };
+    await db.insertAudit(audit);
+    const audits = await db.listAudits();
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toEqual(audit);
+  });
+
+  it("returned rows are defensive copies and cannot mutate the store", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    const row = await db.getInviteById("inv_1");
+    if (row === null) {
+      throw new Error("expected invite to exist");
+    }
+    row.email = "hacked@example.com";
+    row.status = "revoked";
+    const again = await db.getInviteById("inv_1");
+    expect(again?.email).toBe("alice@example.com");
+    expect(again?.status).toBe("pending");
+
+    const listed = await db.listInvites();
+    const first = listed[0];
+    if (first === undefined) {
+      throw new Error("expected invite to exist");
+    }
+    first.code = "mutated";
+    expect((await db.getInviteById("inv_1"))?.code).toBe("code-1");
+  });
+});

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -116,10 +116,22 @@ describe("memory ConnectDb", () => {
   it("markTokenShown sets token_shown_at and nulls token_ciphertext", async () => {
     const db = createMemoryConnectDb();
     await db.insertEndpoint(makeEndpoint());
-    await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z");
+    const burned = await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z");
+    expect(burned).toBe(true);
     const row = await db.getEndpointById("ep_1");
     expect(row?.token_shown_at).toBe("2026-07-24T02:00:00.000Z");
     expect(row?.token_ciphertext).toBeNull();
+  });
+
+  it("markTokenShown returns false on the second call (once-only race semantics)", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertEndpoint(makeEndpoint());
+    expect(await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z")).toBe(true);
+    expect(await db.markTokenShown("ep_1", "2026-07-24T03:00:00.000Z")).toBe(false);
+    // first burn wins
+    expect((await db.getEndpointById("ep_1"))?.token_shown_at).toBe("2026-07-24T02:00:00.000Z");
+    // nonexistent id also false
+    expect(await db.markTokenShown("nope", "2026-07-24T03:00:00.000Z")).toBe(false);
   });
 
   it("markEndpointRevoked sets status revoked and revoked_at", async () => {
@@ -181,7 +193,8 @@ describe("memory ConnectDb", () => {
 
   it("mutations on nonexistent ids are silent no-ops (D1 UPDATE parity contract)", async () => {
     const db = createMemoryConnectDb();
-    await expect(db.markTokenShown("nope", "2026-07-24T04:00:00.000Z")).resolves.toBeUndefined();
+    // markTokenShown returns false (no row burned); the others resolve void
+    await expect(db.markTokenShown("nope", "2026-07-24T04:00:00.000Z")).resolves.toBe(false);
     await expect(db.markEndpointRevoked("nope", "2026-07-24T04:00:00.000Z")).resolves.toBeUndefined();
     await expect(db.markEndpointRevokeFailed("nope")).resolves.toBeUndefined();
     await expect(db.updateInviteStatus("nope", { status: "revoked" })).resolves.toBeUndefined();
@@ -255,15 +268,20 @@ function createSpyD1(respond: { first?: unknown; all?: unknown[] } = {}): {
 }
 
 describe("D1 ConnectDb SQL", () => {
-  it("markTokenShown issues exactly one UPDATE nulling the ciphertext", async () => {
-    const { d1, calls } = createSpyD1();
+  it("markTokenShown issues one conditional UPDATE and reports the burn from meta.changes", async () => {
+    const { d1, calls } = createSpyD1({ first: null, all: [] });
+    // spy run() returns {} — meta.changes undefined → false. Patch run to
+    // report one change so we can assert the true path too.
     const db = createD1ConnectDb(d1);
-    await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z");
+    const burned = await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z");
+    expect(burned).toBe(false); // spy run() has no meta.changes
     expect(calls).toHaveLength(1);
     const call = calls[0];
     expect(call?.method).toBe("run");
     expect(call?.query).toContain("token_shown_at = ?");
     expect(call?.query).toContain("token_ciphertext = NULL");
+    expect(call?.query).toContain("token_shown_at IS NULL");
+    expect(call?.query).toContain("token_ciphertext IS NOT NULL");
     expect(call?.binds).toEqual(["2026-07-24T02:00:00.000Z", "ep_1"]);
   });
 

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -53,6 +53,8 @@ export interface ConnectDb {
   insertEndpoint(row: EndpointRow): Promise<EndpointRow>;
   getEndpointById(id: string): Promise<EndpointRow | null>;
   getEndpointByInviteId(inviteId: string): Promise<EndpointRow | null>;
+  /** Targeted existence check for the slug/hostname availability precheck. */
+  findEndpointBySlugOrHostname(slug: string, hostname: string): Promise<Pick<EndpointRow, "slug" | "hostname"> | null>;
   listEndpoints(): Promise<EndpointRow[]>;
   /**
    * Atomic burn: sets shown_at + nulls ciphertext only if not already burned.
@@ -237,6 +239,16 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
       return row === null ? null : mapEndpoint(row);
     },
 
+    async findEndpointBySlugOrHostname(slug, hostname) {
+      const row = await d1
+        .prepare(`SELECT slug, hostname FROM endpoints WHERE slug = ? OR hostname = ? LIMIT 1`)
+        .bind(slug, hostname)
+        .first<RawRow>();
+      return row === null
+        ? null
+        : { slug: row.slug as string, hostname: row.hostname as string };
+    },
+
     async listEndpoints() {
       const { results } = await d1
         .prepare(`SELECT * FROM endpoints ORDER BY created_at DESC, id DESC`)
@@ -384,6 +396,15 @@ export function createMemoryConnectDb(): ConnectDb {
       for (const row of endpoints.values()) {
         if (row.invite_id === inviteId) {
           return { ...row };
+        }
+      }
+      return null;
+    },
+
+    async findEndpointBySlugOrHostname(slug, hostname) {
+      for (const row of endpoints.values()) {
+        if (row.slug === slug || row.hostname === hostname) {
+          return { slug: row.slug, hostname: row.hostname };
         }
       }
       return null;

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -1,0 +1,414 @@
+export interface InviteRow {
+  id: string;
+  code: string;
+  invitee_label: string | null;
+  email: string;
+  slug: string | null;
+  status: "pending" | "provisioned" | "revoked";
+  created_at: string;
+  provisioned_at: string | null;
+  revoked_at: string | null;
+}
+
+export interface EndpointRow {
+  id: string;
+  invite_id: string;
+  slug: string;
+  hostname: string;
+  cf_tunnel_id: string;
+  cf_access_app_id: string;
+  cf_access_policy_id: string | null;
+  cf_dns_record_id: string;
+  status: "active" | "revoked" | "revoke_failed";
+  token_sha256: string;
+  token_ciphertext: string | null;
+  token_shown_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export interface AuditRow {
+  id: string;
+  at: string;
+  actor: string;
+  action: string;
+  invite_id: string | null;
+  endpoint_id: string | null;
+  detail_json: string | null;
+}
+
+export interface InviteStatusPatch {
+  status: InviteRow["status"];
+  slug?: string | null;
+  provisioned_at?: string | null;
+  revoked_at?: string | null;
+}
+
+export interface ConnectDb {
+  insertInvite(row: InviteRow): Promise<InviteRow>;
+  getInviteById(id: string): Promise<InviteRow | null>;
+  getInviteByCode(code: string): Promise<InviteRow | null>;
+  listInvites(): Promise<InviteRow[]>;
+  updateInviteStatus(id: string, patch: InviteStatusPatch): Promise<void>;
+  insertEndpoint(row: EndpointRow): Promise<EndpointRow>;
+  getEndpointById(id: string): Promise<EndpointRow | null>;
+  getEndpointByInviteId(inviteId: string): Promise<EndpointRow | null>;
+  listEndpoints(): Promise<EndpointRow[]>;
+  markTokenShown(endpointId: string, at: string): Promise<void>;
+  markEndpointRevoked(endpointId: string, at: string): Promise<void>;
+  markEndpointRevokeFailed(endpointId: string): Promise<void>;
+  insertAudit(row: AuditRow): Promise<void>;
+  listAudits(): Promise<AuditRow[]>;
+}
+
+// Minimal ambient D1 types (intentionally not @cloudflare/workers-types).
+export interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = unknown>(): Promise<T | null>;
+  all<T = unknown>(): Promise<{ results: T[] }>;
+  run(): Promise<unknown>;
+}
+
+export interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+}
+
+type RawRow = Record<string, unknown>;
+
+function mapInvite(row: RawRow): InviteRow {
+  return {
+    id: row.id as string,
+    code: row.code as string,
+    invitee_label: row.invitee_label as string | null,
+    email: row.email as string,
+    slug: row.slug as string | null,
+    status: row.status as InviteRow["status"],
+    created_at: row.created_at as string,
+    provisioned_at: row.provisioned_at as string | null,
+    revoked_at: row.revoked_at as string | null,
+  };
+}
+
+function mapEndpoint(row: RawRow): EndpointRow {
+  return {
+    id: row.id as string,
+    invite_id: row.invite_id as string,
+    slug: row.slug as string,
+    hostname: row.hostname as string,
+    cf_tunnel_id: row.cf_tunnel_id as string,
+    cf_access_app_id: row.cf_access_app_id as string,
+    cf_access_policy_id: row.cf_access_policy_id as string | null,
+    cf_dns_record_id: row.cf_dns_record_id as string,
+    status: row.status as EndpointRow["status"],
+    token_sha256: row.token_sha256 as string,
+    token_ciphertext: row.token_ciphertext as string | null,
+    token_shown_at: row.token_shown_at as string | null,
+    created_at: row.created_at as string,
+    revoked_at: row.revoked_at as string | null,
+  };
+}
+
+function mapAudit(row: RawRow): AuditRow {
+  return {
+    id: row.id as string,
+    at: row.at as string,
+    actor: row.actor as string,
+    action: row.action as string,
+    invite_id: row.invite_id as string | null,
+    endpoint_id: row.endpoint_id as string | null,
+    detail_json: row.detail_json as string | null,
+  };
+}
+
+export function createD1ConnectDb(d1: D1Database): ConnectDb {
+  return {
+    async insertInvite(row) {
+      await d1
+        .prepare(
+          `INSERT INTO invites (id, code, invitee_label, email, slug, status, created_at, provisioned_at, revoked_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+          row.id,
+          row.code,
+          row.invitee_label,
+          row.email,
+          row.slug,
+          row.status,
+          row.created_at,
+          row.provisioned_at,
+          row.revoked_at,
+        )
+        .run();
+      return row;
+    },
+
+    async getInviteById(id) {
+      const row = await d1
+        .prepare(`SELECT * FROM invites WHERE id = ?`)
+        .bind(id)
+        .first<RawRow>();
+      return row === null ? null : mapInvite(row);
+    },
+
+    async getInviteByCode(code) {
+      const row = await d1
+        .prepare(`SELECT * FROM invites WHERE code = ?`)
+        .bind(code)
+        .first<RawRow>();
+      return row === null ? null : mapInvite(row);
+    },
+
+    async listInvites() {
+      const { results } = await d1
+        .prepare(`SELECT * FROM invites ORDER BY created_at DESC`)
+        .all<RawRow>();
+      return results.map(mapInvite);
+    },
+
+    async updateInviteStatus(id, patch) {
+      const sets: string[] = ["status = ?"];
+      const values: unknown[] = [patch.status];
+      if (patch.slug !== undefined) {
+        sets.push("slug = ?");
+        values.push(patch.slug);
+      }
+      if (patch.provisioned_at !== undefined) {
+        sets.push("provisioned_at = ?");
+        values.push(patch.provisioned_at);
+      }
+      if (patch.revoked_at !== undefined) {
+        sets.push("revoked_at = ?");
+        values.push(patch.revoked_at);
+      }
+      values.push(id);
+      await d1
+        .prepare(`UPDATE invites SET ${sets.join(", ")} WHERE id = ?`)
+        .bind(...values)
+        .run();
+    },
+
+    async insertEndpoint(row) {
+      await d1
+        .prepare(
+          `INSERT INTO endpoints (id, invite_id, slug, hostname, cf_tunnel_id, cf_access_app_id, cf_access_policy_id, cf_dns_record_id, status, token_sha256, token_ciphertext, token_shown_at, created_at, revoked_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+          row.id,
+          row.invite_id,
+          row.slug,
+          row.hostname,
+          row.cf_tunnel_id,
+          row.cf_access_app_id,
+          row.cf_access_policy_id,
+          row.cf_dns_record_id,
+          row.status,
+          row.token_sha256,
+          row.token_ciphertext,
+          row.token_shown_at,
+          row.created_at,
+          row.revoked_at,
+        )
+        .run();
+      return row;
+    },
+
+    async getEndpointById(id) {
+      const row = await d1
+        .prepare(`SELECT * FROM endpoints WHERE id = ?`)
+        .bind(id)
+        .first<RawRow>();
+      return row === null ? null : mapEndpoint(row);
+    },
+
+    async getEndpointByInviteId(inviteId) {
+      const row = await d1
+        .prepare(`SELECT * FROM endpoints WHERE invite_id = ?`)
+        .bind(inviteId)
+        .first<RawRow>();
+      return row === null ? null : mapEndpoint(row);
+    },
+
+    async listEndpoints() {
+      const { results } = await d1
+        .prepare(`SELECT * FROM endpoints ORDER BY created_at DESC`)
+        .all<RawRow>();
+      return results.map(mapEndpoint);
+    },
+
+    async markTokenShown(endpointId, at) {
+      await d1
+        .prepare(`UPDATE endpoints SET token_shown_at = ?, token_ciphertext = NULL WHERE id = ?`)
+        .bind(at, endpointId)
+        .run();
+    },
+
+    async markEndpointRevoked(endpointId, at) {
+      await d1
+        .prepare(`UPDATE endpoints SET status = 'revoked', revoked_at = ? WHERE id = ?`)
+        .bind(at, endpointId)
+        .run();
+    },
+
+    async markEndpointRevokeFailed(endpointId) {
+      await d1
+        .prepare(`UPDATE endpoints SET status = 'revoke_failed' WHERE id = ?`)
+        .bind(endpointId)
+        .run();
+    },
+
+    async insertAudit(row) {
+      await d1
+        .prepare(
+          `INSERT INTO audit_events (id, at, actor, action, invite_id, endpoint_id, detail_json)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(row.id, row.at, row.actor, row.action, row.invite_id, row.endpoint_id, row.detail_json)
+        .run();
+    },
+
+    async listAudits() {
+      const { results } = await d1
+        .prepare(`SELECT * FROM audit_events ORDER BY at DESC`)
+        .all<RawRow>();
+      return results.map(mapAudit);
+    },
+  };
+}
+
+function byCreatedAtDesc(a: { created_at: string }, b: { created_at: string }): number {
+  return b.created_at.localeCompare(a.created_at);
+}
+
+export function createMemoryConnectDb(): ConnectDb {
+  const invites = new Map<string, InviteRow>();
+  const endpoints = new Map<string, EndpointRow>();
+  const audits = new Map<string, AuditRow>();
+
+  return {
+    async insertInvite(row) {
+      if (invites.has(row.id)) {
+        throw new Error(`UNIQUE constraint failed: invites.id (${row.id})`);
+      }
+      for (const existing of invites.values()) {
+        if (existing.code === row.code) {
+          throw new Error(`UNIQUE constraint failed: invites.code (${row.code})`);
+        }
+      }
+      invites.set(row.id, { ...row });
+      return { ...row };
+    },
+
+    async getInviteById(id) {
+      const row = invites.get(id);
+      return row === undefined ? null : { ...row };
+    },
+
+    async getInviteByCode(code) {
+      for (const row of invites.values()) {
+        if (row.code === code) {
+          return { ...row };
+        }
+      }
+      return null;
+    },
+
+    async listInvites() {
+      return [...invites.values()].sort(byCreatedAtDesc).map((row) => ({ ...row }));
+    },
+
+    async updateInviteStatus(id, patch) {
+      const row = invites.get(id);
+      if (row === undefined) {
+        return;
+      }
+      row.status = patch.status;
+      if (patch.slug !== undefined) {
+        row.slug = patch.slug;
+      }
+      if (patch.provisioned_at !== undefined) {
+        row.provisioned_at = patch.provisioned_at;
+      }
+      if (patch.revoked_at !== undefined) {
+        row.revoked_at = patch.revoked_at;
+      }
+    },
+
+    async insertEndpoint(row) {
+      if (endpoints.has(row.id)) {
+        throw new Error(`UNIQUE constraint failed: endpoints.id (${row.id})`);
+      }
+      for (const existing of endpoints.values()) {
+        if (existing.invite_id === row.invite_id) {
+          throw new Error(`UNIQUE constraint failed: endpoints.invite_id (${row.invite_id})`);
+        }
+        if (existing.slug === row.slug) {
+          throw new Error(`UNIQUE constraint failed: endpoints.slug (${row.slug})`);
+        }
+        if (existing.hostname === row.hostname) {
+          throw new Error(`UNIQUE constraint failed: endpoints.hostname (${row.hostname})`);
+        }
+      }
+      endpoints.set(row.id, { ...row });
+      return { ...row };
+    },
+
+    async getEndpointById(id) {
+      const row = endpoints.get(id);
+      return row === undefined ? null : { ...row };
+    },
+
+    async getEndpointByInviteId(inviteId) {
+      for (const row of endpoints.values()) {
+        if (row.invite_id === inviteId) {
+          return { ...row };
+        }
+      }
+      return null;
+    },
+
+    async listEndpoints() {
+      return [...endpoints.values()].sort(byCreatedAtDesc).map((row) => ({ ...row }));
+    },
+
+    async markTokenShown(endpointId, at) {
+      const row = endpoints.get(endpointId);
+      if (row === undefined) {
+        return;
+      }
+      row.token_shown_at = at;
+      row.token_ciphertext = null;
+    },
+
+    async markEndpointRevoked(endpointId, at) {
+      const row = endpoints.get(endpointId);
+      if (row === undefined) {
+        return;
+      }
+      row.status = "revoked";
+      row.revoked_at = at;
+    },
+
+    async markEndpointRevokeFailed(endpointId) {
+      const row = endpoints.get(endpointId);
+      if (row === undefined) {
+        return;
+      }
+      row.status = "revoke_failed";
+    },
+
+    async insertAudit(row) {
+      if (audits.has(row.id)) {
+        throw new Error(`UNIQUE constraint failed: audit_events.id (${row.id})`);
+      }
+      audits.set(row.id, { ...row });
+    },
+
+    async listAudits() {
+      return [...audits.values()]
+        .sort((a, b) => b.at.localeCompare(a.at))
+        .map((row) => ({ ...row }));
+    },
+  };
+}

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -57,6 +57,8 @@ export interface ConnectDb {
   markTokenShown(endpointId: string, at: string): Promise<void>;
   markEndpointRevoked(endpointId: string, at: string): Promise<void>;
   markEndpointRevokeFailed(endpointId: string): Promise<void>;
+  /** Best-effort row removal for orphan compensation (no-op when absent). */
+  deleteEndpoint(endpointId: string): Promise<void>;
   insertAudit(row: AuditRow): Promise<void>;
   listAudits(): Promise<AuditRow[]>;
 }
@@ -258,6 +260,13 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
         .run();
     },
 
+    async deleteEndpoint(endpointId) {
+      await d1
+        .prepare(`DELETE FROM endpoints WHERE id = ?`)
+        .bind(endpointId)
+        .run();
+    },
+
     async insertAudit(row) {
       await d1
         .prepare(
@@ -399,6 +408,10 @@ export function createMemoryConnectDb(): ConnectDb {
         return;
       }
       row.status = "revoke_failed";
+    },
+
+    async deleteEndpoint(endpointId) {
+      endpoints.delete(endpointId);
     },
 
     async insertAudit(row) {

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -140,7 +140,7 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
           row.revoked_at,
         )
         .run();
-      return row;
+      return { ...row };
     },
 
     async getInviteById(id) {
@@ -161,7 +161,7 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
 
     async listInvites() {
       const { results } = await d1
-        .prepare(`SELECT * FROM invites ORDER BY created_at DESC`)
+        .prepare(`SELECT * FROM invites ORDER BY created_at DESC, id DESC`)
         .all<RawRow>();
       return results.map(mapInvite);
     },
@@ -211,7 +211,7 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
           row.revoked_at,
         )
         .run();
-      return row;
+      return { ...row };
     },
 
     async getEndpointById(id) {
@@ -232,7 +232,7 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
 
     async listEndpoints() {
       const { results } = await d1
-        .prepare(`SELECT * FROM endpoints ORDER BY created_at DESC`)
+        .prepare(`SELECT * FROM endpoints ORDER BY created_at DESC, id DESC`)
         .all<RawRow>();
       return results.map(mapEndpoint);
     },
@@ -270,15 +270,18 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
 
     async listAudits() {
       const { results } = await d1
-        .prepare(`SELECT * FROM audit_events ORDER BY at DESC`)
+        .prepare(`SELECT * FROM audit_events ORDER BY at DESC, id DESC`)
         .all<RawRow>();
       return results.map(mapAudit);
     },
   };
 }
 
-function byCreatedAtDesc(a: { created_at: string }, b: { created_at: string }): number {
-  return b.created_at.localeCompare(a.created_at);
+// Deterministic list ordering: timestamp DESC, id DESC as tiebreaker. Mirrors
+// SQL `ORDER BY created_at DESC, id DESC`. localeCompare vs SQLite BINARY
+// collation is equivalent here because callers write fixed-width ISO-8601 UTC.
+function byCreatedAtDesc(a: { created_at: string; id: string }, b: { created_at: string; id: string }): number {
+  return b.created_at.localeCompare(a.created_at) || b.id.localeCompare(a.id);
 }
 
 export function createMemoryConnectDb(): ConnectDb {
@@ -407,7 +410,7 @@ export function createMemoryConnectDb(): ConnectDb {
 
     async listAudits() {
       return [...audits.values()]
-        .sort((a, b) => b.at.localeCompare(a.at))
+        .sort((a, b) => b.at.localeCompare(a.at) || b.id.localeCompare(a.id))
         .map((row) => ({ ...row }));
     },
   };

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -54,7 +54,12 @@ export interface ConnectDb {
   getEndpointById(id: string): Promise<EndpointRow | null>;
   getEndpointByInviteId(inviteId: string): Promise<EndpointRow | null>;
   listEndpoints(): Promise<EndpointRow[]>;
-  markTokenShown(endpointId: string, at: string): Promise<void>;
+  /**
+   * Atomic burn: sets shown_at + nulls ciphertext only if not already burned.
+   * Returns true when THIS call performed the burn (won the race), false when
+   * the token was already shown/burned — callers use this for once-only reveal.
+   */
+  markTokenShown(endpointId: string, at: string): Promise<boolean>;
   markEndpointRevoked(endpointId: string, at: string): Promise<void>;
   markEndpointRevokeFailed(endpointId: string): Promise<void>;
   /** Best-effort row removal for orphan compensation (no-op when absent). */
@@ -240,10 +245,14 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
     },
 
     async markTokenShown(endpointId, at) {
-      await d1
-        .prepare(`UPDATE endpoints SET token_shown_at = ?, token_ciphertext = NULL WHERE id = ?`)
+      const result = (await d1
+        .prepare(
+          `UPDATE endpoints SET token_shown_at = ?, token_ciphertext = NULL
+           WHERE id = ? AND token_shown_at IS NULL AND token_ciphertext IS NOT NULL`,
+        )
         .bind(at, endpointId)
-        .run();
+        .run()) as { meta?: { changes?: number } };
+      return result.meta?.changes === 1;
     },
 
     async markEndpointRevoked(endpointId, at) {
@@ -386,11 +395,14 @@ export function createMemoryConnectDb(): ConnectDb {
 
     async markTokenShown(endpointId, at) {
       const row = endpoints.get(endpointId);
-      if (row === undefined) {
-        return;
+      // Synchronous check-and-set is atomic here — mirrors the D1 conditional
+      // UPDATE's race semantics: only the first caller burns.
+      if (row === undefined || row.token_shown_at !== null || row.token_ciphertext === null) {
+        return false;
       }
       row.token_shown_at = at;
       row.token_ciphertext = null;
+      return true;
     },
 
     async markEndpointRevoked(endpointId, at) {

--- a/workers/scout-connect/src/env.ts
+++ b/workers/scout-connect/src/env.ts
@@ -1,0 +1,11 @@
+import type { D1Database } from "./db.js";
+
+export interface Env {
+  DB: D1Database;
+  ADMIN_TOKEN: string;
+  CF_API_TOKEN: string;
+  CF_ACCOUNT_ID: string;
+  CF_ZONE_ID: string;
+  TOKEN_WRAP_KEY: string;
+  CONNECT_ROOT_DOMAIN: string;
+}

--- a/workers/scout-connect/src/html/admin-page.ts
+++ b/workers/scout-connect/src/html/admin-page.ts
@@ -1,0 +1,140 @@
+// Self-contained admin page: inline module script, no external resources.
+// The admin token lives only in sessionStorage and is sent as a bearer on
+// every /api/admin/* call.
+export function adminPage(): string {
+  return `<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Scout Connect Admin</title>
+<style>
+body{font-family:system-ui,sans-serif;max-width:1000px;margin:2rem auto;padding:0 1rem;color:#222;font-size:14px}
+input,button{font:inherit;padding:.35rem .5rem}
+table{border-collapse:collapse;width:100%;margin-top:.5rem}
+td,th{border:1px solid #ccc;padding:.35rem .5rem;text-align:left;vertical-align:top}
+pre{background:#f4f4f4;padding:.75rem;border-radius:6px;overflow-x:auto;word-break:break-all}
+code{background:#f4f4f4;padding:.1rem .3rem;border-radius:4px}
+.err{color:#b00020}.ok{color:#0a7d2c}
+.warn{border:1px solid #e3b341;background:#fffbe6;padding:.75rem;border-radius:6px;margin-top:1rem}
+h1{font-size:1.3rem}h2{font-size:1.05rem;margin-top:2rem}
+</style>
+</head>
+<body>
+<h1>Scout Connect Admin</h1>
+<p>
+<label>Admin Token <input id="token" type="password" size="42" autocomplete="off"></label>
+<button id="save-token">保存 Token</button>
+<button id="refresh">刷新</button>
+<span id="msg"></span>
+</p>
+
+<h2>创建邀请</h2>
+<form id="create">
+<input name="email" type="text" placeholder="invitee@email.com" required>
+<input name="invitee_label" type="text" placeholder="称呼(可选)">
+<input name="slug" type="text" placeholder="slug(可选,开通时也可填)">
+<button type="submit">创建邀请</button>
+</form>
+<div id="created"></div>
+
+<h2>邀请列表</h2>
+<table>
+<thead><tr><th>email</th><th>称呼</th><th>状态</th><th>slug</th><th>邀请链接</th><th>操作</th></tr></thead>
+<tbody id="invites"></tbody>
+</table>
+<div id="provision-result"></div>
+
+<h2>端点列表</h2>
+<table>
+<thead><tr><th>hostname</th><th>状态</th><th>token 显示时间</th><th>创建时间</th><th>吊销时间</th><th>操作</th></tr></thead>
+<tbody id="endpoints"></tbody>
+</table>
+
+<script type="module">
+const $=(id)=>document.getElementById(id);
+const esc=(s)=>String(s).replace(/[&<>"']/g,(c)=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+const msg=(t,cls)=>{const m=$("msg");m.textContent=t;m.className=cls||"";};
+const tokenEl=$("token");
+tokenEl.value=sessionStorage.getItem("adminToken")||"";
+$("save-token").onclick=()=>{sessionStorage.setItem("adminToken",tokenEl.value);msg("token 已保存","ok");};
+
+async function api(path,opts){
+  const r=await fetch(path,{
+    method:(opts&&opts.method)||"GET",
+    headers:{"authorization":"Bearer "+(sessionStorage.getItem("adminToken")||""),"content-type":"application/json"},
+    body:opts&&opts.body?JSON.stringify(opts.body):undefined
+  });
+  if(!r.ok){let e="HTTP "+r.status;try{const j=await r.json();if(j&&j.error)e=j.error;}catch(_){}
+  throw new Error(e);}
+  return r.json();
+}
+function guard(fn){return async(ev)=>{msg("");try{await fn(ev);}catch(e){msg(e.message,"err");}};}
+async function copyText(t){try{await navigator.clipboard.writeText(t);msg("已复制","ok");}catch(_){msg("复制失败,请手动选择复制","err");}}
+
+let lastProvision=null;
+function showProvision(r){
+  lastProvision=r;
+  $("provision-result").innerHTML=
+    '<div class="warn"><b>⚠️ Token 只显示这一次</b>,请立即把邀请链接或连接信息转交对方。</div>'+
+    '<p>访问地址:<a href="https://'+esc(r.hostname)+'" target="_blank" rel="noopener">'+esc(r.hostname)+'</a> '+
+    '邀请链接:<a href="'+esc(r.inviteUrl)+'" target="_blank" rel="noopener">'+esc(r.inviteUrl)+'</a></p>'+
+    '<p>TUNNEL_TOKEN:</p><pre><code>'+esc(r.token)+'</code></pre>'+
+    '<p><button id="p-copy-token">复制 Token</button> <button id="p-copy-prompt">复制 Agent 提示词</button> <button id="p-copy-url">复制邀请链接</button></p>'+
+    '<details><summary>Agent 提示词预览</summary><pre><code>'+esc(r.agentPrompt)+'</code></pre></details>';
+  $("p-copy-token").onclick=()=>copyText(lastProvision.token);
+  $("p-copy-prompt").onclick=()=>copyText(lastProvision.agentPrompt);
+  $("p-copy-url").onclick=()=>copyText(lastProvision.inviteUrl);
+}
+
+async function refresh(){
+  const data=await Promise.all([api("/api/admin/invites"),api("/api/admin/endpoints")]);
+  const invites=data[0].invites,endpoints=data[1].endpoints;
+  $("invites").innerHTML=invites.map((i)=>{
+    const url=location.origin+"/i/"+i.code;
+    const slugCell=i.status==="pending"
+      ?'<input size="12" id="slug-'+i.id+'" value="'+esc(i.slug||"")+'" placeholder="slug">'
+      :esc(i.slug||"");
+    const action=i.status==="pending"?'<button data-provision="'+i.id+'">开通</button>':"";
+    return '<tr><td>'+esc(i.email)+'</td><td>'+esc(i.invitee_label||"")+'</td><td>'+esc(i.status)+'</td><td>'+slugCell+'</td><td><a href="'+esc(url)+'" target="_blank" rel="noopener">链接</a></td><td>'+action+'</td></tr>';
+  }).join("");
+  for(const b of document.querySelectorAll("[data-provision]")){
+    b.onclick=guard(async()=>{
+      const input=$("slug-"+b.getAttribute("data-provision"));
+      const slug=input?input.value.trim():"";
+      const r=await api("/api/admin/invites/"+b.getAttribute("data-provision")+"/provision",{method:"POST",body:slug?{slug}:{}});
+      showProvision(r);
+      await refresh();
+    });
+  }
+  $("endpoints").innerHTML=endpoints.map((e)=>{
+    const action=e.status==="active"||e.status==="revoke_failed"?'<button data-revoke="'+e.id+'">吊销</button>':"";
+    return '<tr><td><a href="https://'+esc(e.hostname)+'" target="_blank" rel="noopener">'+esc(e.hostname)+'</a></td><td>'+esc(e.status)+'</td><td>'+esc(e.token_shown_at||"")+'</td><td>'+esc(e.created_at)+'</td><td>'+esc(e.revoked_at||"")+'</td><td>'+action+'</td></tr>';
+  }).join("");
+  for(const b of document.querySelectorAll("[data-revoke]")){
+    b.onclick=guard(async()=>{
+      if(!confirm("确认吊销?对方的远程访问将立即失效。"))return;
+      await api("/api/admin/endpoints/"+b.getAttribute("data-revoke")+"/revoke",{method:"POST",body:{}});
+      await refresh();
+    });
+  }
+}
+$("refresh").onclick=guard(refresh);
+$("create").onsubmit=guard(async(ev)=>{
+  ev.preventDefault();
+  const fd=new FormData(ev.target);
+  const body={email:fd.get("email")};
+  const label=String(fd.get("invitee_label")||"").trim();
+  const slug=String(fd.get("slug")||"").trim();
+  if(label)body.invitee_label=label;
+  if(slug)body.slug=slug;
+  const r=await api("/api/admin/invites",{method:"POST",body:body});
+  $("created").innerHTML='<p class="ok">已创建,邀请链接:<a href="'+esc(r.inviteUrl)+'" target="_blank" rel="noopener">'+esc(r.inviteUrl)+'</a></p>';
+  ev.target.reset();
+  await refresh();
+});
+if(tokenEl.value)guard(refresh)();
+</script>
+</body>
+</html>`;
+}

--- a/workers/scout-connect/src/html/admin-page.ts
+++ b/workers/scout-connect/src/html/admin-page.ts
@@ -93,9 +93,9 @@ async function refresh(){
   $("invites").innerHTML=invites.map((i)=>{
     const url=location.origin+"/i/"+i.code;
     const slugCell=i.status==="pending"
-      ?'<input size="12" id="slug-'+i.id+'" value="'+esc(i.slug||"")+'" placeholder="slug">'
+      ?'<input size="12" id="slug-'+esc(i.id)+'" value="'+esc(i.slug||"")+'" placeholder="slug">'
       :esc(i.slug||"");
-    const action=i.status==="pending"?'<button data-provision="'+i.id+'">开通</button>':"";
+    const action=i.status==="pending"?'<button data-provision="'+esc(i.id)+'">开通</button>':"";
     return '<tr><td>'+esc(i.email)+'</td><td>'+esc(i.invitee_label||"")+'</td><td>'+esc(i.status)+'</td><td>'+slugCell+'</td><td><a href="'+esc(url)+'" target="_blank" rel="noopener">链接</a></td><td>'+action+'</td></tr>';
   }).join("");
   for(const b of document.querySelectorAll("[data-provision]")){
@@ -108,7 +108,7 @@ async function refresh(){
     });
   }
   $("endpoints").innerHTML=endpoints.map((e)=>{
-    const action=e.status==="active"||e.status==="revoke_failed"?'<button data-revoke="'+e.id+'">吊销</button>':"";
+    const action=e.status==="active"||e.status==="revoke_failed"?'<button data-revoke="'+esc(e.id)+'">吊销</button>':"";
     return '<tr><td><a href="https://'+esc(e.hostname)+'" target="_blank" rel="noopener">'+esc(e.hostname)+'</a></td><td>'+esc(e.status)+'</td><td>'+esc(e.token_shown_at||"")+'</td><td>'+esc(e.created_at)+'</td><td>'+esc(e.revoked_at||"")+'</td><td>'+action+'</td></tr>';
   }).join("");
   for(const b of document.querySelectorAll("[data-revoke]")){

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -1,0 +1,23 @@
+export function homePage(): string {
+  return `<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Scout Connect</title>
+<style>
+body{font-family:system-ui,sans-serif;max-width:640px;margin:4rem auto;padding:0 1rem;color:#222;line-height:1.7}
+h1{font-size:1.6rem}
+a{color:#06c}
+</style>
+</head>
+<body>
+<main>
+<h1>Scout Connect</h1>
+<p lang="zh">Scout Connect 是自托管 Mediary Scout 的远程访问之门:通过 Cloudflare Tunnel 把你自己的实例安全地发布到一个专属域名,入口由 Cloudflare Access 邮箱验证把守。你的媒体内容与各类凭据始终留在你自己的机器上,这里只负责开门。</p>
+<p lang="en">Scout Connect is the remote access door for self-hosted Mediary Scout: it publishes your own instance to a dedicated hostname over a Cloudflare Tunnel, gated by Cloudflare Access email verification. Your content and credentials always stay on your own machines — this service only opens the door.</p>
+<p><a href="https://github.com/fancydirty/mediary-scout">github.com/fancydirty/mediary-scout</a></p>
+</main>
+</body>
+</html>`;
+}

--- a/workers/scout-connect/src/html/invite-page.ts
+++ b/workers/scout-connect/src/html/invite-page.ts
@@ -1,0 +1,131 @@
+export type InvitePageState =
+  | { kind: "not_found" }
+  | { kind: "waiting" }
+  | { kind: "revealed"; hostname: string }
+  | { kind: "ready"; code: string };
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+function shell(title: string, body: string): string {
+  return `<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)} · Scout Connect</title>
+<style>
+body{font-family:system-ui,sans-serif;max-width:640px;margin:3rem auto;padding:0 1rem;color:#222;line-height:1.7}
+a{color:#06c}
+pre{background:#f4f4f4;padding:.75rem;border-radius:6px;overflow-x:auto;word-break:break-all}
+code{background:#f4f4f4;padding:.1rem .3rem;border-radius:4px}
+pre code{background:none;padding:0}
+button{font:inherit;padding:.5rem 1rem;cursor:pointer}
+.warn{border:1px solid #e3b341;background:#fffbe6;padding:.75rem;border-radius:6px}
+</style>
+</head>
+<body>
+${body}
+</body>
+</html>`;
+}
+
+function readyBody(codeJson: string): string {
+  return `<h1>你的远程访问已就绪</h1>
+<div id="start">
+<p>点击下方按钮查看连接信息。<b>此信息只显示这一次</b>,请先准备好再点。</p>
+<p><button id="reveal">显示连接信息</button></p>
+</div>
+<div id="result" hidden>
+<p class="warn"><b>⚠️ 此信息只显示这一次</b>,刷新或关闭后将无法再次查看,请立即复制保存。</p>
+<p>访问地址:<a id="link" target="_blank" rel="noopener"></a></p>
+<p>TUNNEL_TOKEN:</p>
+<pre><code id="tok"></code></pre>
+<p><button id="copy-tok">复制 Token</button> <button id="copy-agent">复制给 Agent</button></p>
+<h2>手动配置步骤</h2>
+<ol>
+<li>进入 mediary-scout 部署目录(docker compose 项目根)。</li>
+<li>在 .env 中写入一行 <code>TUNNEL_TOKEN=<span class="tk"></span></code>(若已有旧值,先备份再替换)。</li>
+<li>可选:网络不稳定或 UDP 受限时,追加一行 <code>TUNNEL_TRANSPORT_PROTOCOL=http2</code>。</li>
+<li>执行 <code>docker compose --profile tunnel up -d</code>。</li>
+<li>执行 <code>docker compose logs -f cloudflared</code>,直到出现 Registered tunnel connection 字样。</li>
+<li>浏览器打开 <code>https://<span class="hn"></span></code>,先完成 Cloudflare Access 邮箱验证,通过后进入 Mediary Scout。</li>
+<li>若失败:检查 compose 服务名是否为 web、cloudflared 是否与 web 同网络、token 是否完整一行、防火墙是否拦截出站。</li>
+</ol>
+</div>
+<script type="module">
+const CODE=${codeJson};
+const $=(id)=>document.getElementById(id);
+let agentPrompt="";
+$("reveal").onclick=async()=>{
+  $("reveal").disabled=true;
+  let r=null;
+  try{r=await fetch("/api/i/"+encodeURIComponent(CODE)+"/reveal",{method:"POST"});}
+  catch(_){$("reveal").disabled=false;return;}
+  let d=null;
+  try{d=await r.json();}catch(_){}
+  // 409 未就绪 / 404 已失效 / 已显示过 → 回到服务端渲染的对应页面
+  if(!r.ok||d===null||typeof d.token!=="string"){location.reload();return;}
+  agentPrompt=d.agentPrompt;
+  const link=$("link");
+  link.href="https://"+d.hostname;
+  link.textContent="https://"+d.hostname;
+  $("tok").textContent=d.token;
+  const hns=document.querySelectorAll(".hn");
+  for(let i=0;i<hns.length;i++)hns[i].textContent=d.hostname;
+  const tks=document.querySelectorAll(".tk");
+  for(let i=0;i<tks.length;i++)tks[i].textContent=d.token;
+  $("start").hidden=true;
+  $("result").hidden=false;
+};
+$("copy-tok").onclick=()=>{navigator.clipboard.writeText($("tok").textContent);};
+$("copy-agent").onclick=()=>{navigator.clipboard.writeText(agentPrompt);};
+</script>`;
+}
+
+export function invitePage(state: InvitePageState): string {
+  switch (state.kind) {
+    case "not_found":
+      return shell(
+        "链接无效",
+        `<h1>链接无效</h1>
+<p>这个链接不存在或已失效。如有疑问,请联系邀请你的人。</p>`,
+      );
+    case "waiting":
+      return shell(
+        "请稍候",
+        `<h1>请稍候</h1>
+<p>作者尚未开通，请稍候。开通后刷新本页即可。</p>`,
+      );
+    case "revealed": {
+      const hn = escapeHtml(state.hostname);
+      return shell(
+        "连接信息已显示",
+        `<h1>连接信息已显示</h1>
+<p>你的访问地址:<a href="https://${hn}" target="_blank" rel="noopener">https://${hn}</a></p>
+<p>连接信息已显示过一次；如丢失请联系作者吊销重建。</p>`,
+      );
+    }
+    case "ready": {
+      // Interpolate the code into the inline script as a JSON string literal;
+      // escape "<" so an attacker-controlled code cannot break out of the
+      // <script> block.
+      const codeJson = JSON.stringify(state.code).replace(/</g, "\\u003c");
+      return shell("已就绪", readyBody(codeJson));
+    }
+  }
+}

--- a/workers/scout-connect/src/html/invite-page.ts
+++ b/workers/scout-connect/src/html/invite-page.ts
@@ -55,7 +55,7 @@ function readyBody(codeJson: string): string {
 <p>访问地址:<a id="link" target="_blank" rel="noopener"></a></p>
 <p>TUNNEL_TOKEN:</p>
 <pre><code id="tok"></code></pre>
-<p><button id="copy-tok">复制 Token</button> <button id="copy-agent">复制给 Agent</button></p>
+<p><button id="copy-tok" data-label="复制 Token">复制 Token</button> <button id="copy-agent" data-label="复制给 Agent">复制给 Agent</button></p>
 <h2>手动配置步骤</h2>
 <ol>
 <li>进入 mediary-scout 部署目录(docker compose 项目根)。</li>
@@ -71,11 +71,20 @@ function readyBody(codeJson: string): string {
 const CODE=${codeJson};
 const $=(id)=>document.getElementById(id);
 let agentPrompt="";
+async function copyText(btn,text){
+  try{await navigator.clipboard.writeText(text);btn.textContent="已复制 ✓";}
+  catch(_){btn.textContent="复制失败,请手动选择复制";}
+  setTimeout(()=>{btn.textContent=btn.dataset.label||btn.textContent;},2000);
+}
 $("reveal").onclick=async()=>{
   $("reveal").disabled=true;
   let r=null;
   try{r=await fetch("/api/i/"+encodeURIComponent(CODE)+"/reveal",{method:"POST"});}
-  catch(_){$("reveal").disabled=false;return;}
+  catch(_){
+    $("reveal").disabled=false;
+    $("reveal").textContent="网络错误,请重试";
+    return;
+  }
   let d=null;
   try{d=await r.json();}catch(_){}
   // 409 未就绪 / 404 已失效 / 已显示过 → 回到服务端渲染的对应页面
@@ -92,8 +101,8 @@ $("reveal").onclick=async()=>{
   $("start").hidden=true;
   $("result").hidden=false;
 };
-$("copy-tok").onclick=()=>{navigator.clipboard.writeText($("tok").textContent);};
-$("copy-agent").onclick=()=>{navigator.clipboard.writeText(agentPrompt);};
+$("copy-tok").onclick=()=>{copyText($("copy-tok"),$("tok").textContent);};
+$("copy-agent").onclick=()=>{copyText($("copy-agent"),agentPrompt);};
 </script>`;
 }
 

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -8,10 +8,13 @@ export class HttpError extends Error {
   }
 }
 
-export function json(data: unknown, status = 200): Response {
+export function json(data: unknown, status = 200, opts: { noStore?: boolean } = {}): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "content-type": "application/json; charset=utf-8" },
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...(opts.noStore === true ? { "cache-control": "no-store" } : {}),
+    },
   });
 }
 

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -18,7 +18,16 @@ export function json(data: unknown, status = 200): Response {
 export function htmlPage(body: string, status = 200): Response {
   return new Response(body, {
     status,
-    headers: { "content-type": "text/html; charset=utf-8" },
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      // Pages are fully self-contained (inline style/script only), so a strict
+      // CSP is free defense-in-depth for a page that carries a one-time token.
+      "content-security-policy":
+        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'self'",
+      "x-content-type-options": "nosniff",
+      "frame-ancestors": "'none'",
+      "referrer-policy": "no-referrer",
+    },
   });
 }
 

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -26,9 +26,11 @@ export function htmlPage(body: string, status = 200): Response {
       // Pages are fully self-contained (inline style/script only), so a strict
       // CSP is free defense-in-depth for a page that carries a one-time token.
       "content-security-policy":
-        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'self'",
+        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
       "x-content-type-options": "nosniff",
-      "frame-ancestors": "'none'",
+      // frame-ancestors only works as a CSP directive (above); x-frame-options
+      // is the legacy header that actually blocks framing in older browsers.
+      "x-frame-options": "DENY",
       "referrer-policy": "no-referrer",
     },
   });

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -1,0 +1,33 @@
+export class HttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
+export function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+export function htmlPage(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}
+
+// SECURITY: never leak stack traces or internal error text to the client —
+// only an HttpError's own deliberate message is exposed.
+export function handleError(e: unknown): Response {
+  if (e instanceof HttpError) {
+    return json({ error: e.message }, e.status);
+  }
+  console.error("unhandled route error", e);
+  return json({ error: "internal" }, 500);
+}

--- a/workers/scout-connect/src/ids.test.ts
+++ b/workers/scout-connect/src/ids.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { newId, newInviteCode } from "./ids.js";
+
+describe("ids", () => {
+  it("newId returns prefix underscore 16 hex chars", () => {
+    for (const prefix of ["inv", "ep", "aud"] as const) {
+      const id = newId(prefix);
+      expect(id.startsWith(`${prefix}_`)).toBe(true);
+      expect(id).toMatch(new RegExp(`^${prefix}_[0-9a-f]{16}$`));
+    }
+  });
+
+  it("newInviteCode returns 40 hex chars", () => {
+    expect(newInviteCode()).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("two calls differ", () => {
+    expect(newId("inv")).not.toBe(newId("inv"));
+    expect(newId("ep")).not.toBe(newId("ep"));
+    expect(newId("aud")).not.toBe(newId("aud"));
+    expect(newInviteCode()).not.toBe(newInviteCode());
+  });
+});

--- a/workers/scout-connect/src/ids.ts
+++ b/workers/scout-connect/src/ids.ts
@@ -1,32 +1,6 @@
-type RandomBytes = (size: number) => Uint8Array;
-
-const globalGetRandomValues =
-  typeof globalThis.crypto?.getRandomValues === "function"
-    ? globalThis.crypto.getRandomValues.bind(globalThis.crypto)
-    : undefined;
-
-// Fallback for runtimes without WebCrypto (e.g. some vitest environments).
-// Lazily imported only when needed so Workers never bundles node:crypto on
-// the hot path.
-const nodeRandomBytes: RandomBytes | undefined =
-  globalGetRandomValues !== undefined
-    ? undefined
-    : await import("node:crypto")
-        .then((m) => (m.randomBytes as unknown as RandomBytes))
-        .catch(() => undefined);
-
-function randomBytesSync(size: number): Uint8Array {
-  if (globalGetRandomValues !== undefined) {
-    return globalGetRandomValues(new Uint8Array(size));
-  }
-  if (nodeRandomBytes !== undefined) {
-    return nodeRandomBytes(size);
-  }
-  throw new Error("no CSPRNG available in this runtime");
-}
-
 function randomHex(hexLength: number): string {
-  const bytes = randomBytesSync(hexLength / 2);
+  const bytes = new Uint8Array(hexLength / 2);
+  crypto.getRandomValues(bytes);
   let hex = "";
   for (const byte of bytes) {
     hex += byte.toString(16).padStart(2, "0");

--- a/workers/scout-connect/src/ids.ts
+++ b/workers/scout-connect/src/ids.ts
@@ -1,0 +1,43 @@
+type RandomBytes = (size: number) => Uint8Array;
+
+const globalGetRandomValues =
+  typeof globalThis.crypto?.getRandomValues === "function"
+    ? globalThis.crypto.getRandomValues.bind(globalThis.crypto)
+    : undefined;
+
+// Fallback for runtimes without WebCrypto (e.g. some vitest environments).
+// Lazily imported only when needed so Workers never bundles node:crypto on
+// the hot path.
+const nodeRandomBytes: RandomBytes | undefined =
+  globalGetRandomValues !== undefined
+    ? undefined
+    : await import("node:crypto")
+        .then((m) => (m.randomBytes as unknown as RandomBytes))
+        .catch(() => undefined);
+
+function randomBytesSync(size: number): Uint8Array {
+  if (globalGetRandomValues !== undefined) {
+    return globalGetRandomValues(new Uint8Array(size));
+  }
+  if (nodeRandomBytes !== undefined) {
+    return nodeRandomBytes(size);
+  }
+  throw new Error("no CSPRNG available in this runtime");
+}
+
+function randomHex(hexLength: number): string {
+  const bytes = randomBytesSync(hexLength / 2);
+  let hex = "";
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+export function newId(prefix: "inv" | "ep" | "aud"): string {
+  return `${prefix}_${randomHex(16)}`;
+}
+
+export function newInviteCode(): string {
+  return randomHex(40);
+}

--- a/workers/scout-connect/src/index.ts
+++ b/workers/scout-connect/src/index.ts
@@ -1,0 +1,26 @@
+import { createCfApi } from "./cf-api.js";
+import { createD1ConnectDb } from "./db.js";
+import { newId, newInviteCode } from "./ids.js";
+import { handleRequest } from "./routes.js";
+import type { Env } from "./env.js";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return handleRequest(request, {
+      db: createD1ConnectDb(env.DB),
+      cf: createCfApi({
+        accountId: env.CF_ACCOUNT_ID,
+        zoneId: env.CF_ZONE_ID,
+        apiToken: env.CF_API_TOKEN,
+      }),
+      adminToken: env.ADMIN_TOKEN,
+      rootDomain: env.CONNECT_ROOT_DOMAIN,
+      tokenWrapKeyHex: env.TOKEN_WRAP_KEY,
+      now: () => new Date().toISOString(),
+      newInviteId: () => newId("inv"),
+      newEndpointId: () => newId("ep"),
+      newAuditId: () => newId("aud"),
+      newInviteCode,
+    });
+  },
+};

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -397,6 +397,43 @@ describe("provisionEndpoint", () => {
     expect(audits.some((a) => a.action === "provision.orphan")).toBe(true);
   });
 
+  it("insertAudit failure after invite flip: invite rolled back to pending, endpoint row gone, retry succeeds", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    // poison ONLY insertAudit — updateInviteStatus succeeds first
+    const inner = db;
+    const failingAuditDb: ConnectDb = {
+      ...inner,
+      async insertAudit() {
+        throw new Error("d1 audit boom");
+      },
+    };
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps: { ...deps, db: failingAuditDb } }),
+    ).rejects.toThrow(/d1 audit boom/);
+
+    // invite rolled back to pending (not stuck provisioned-without-endpoint)
+    const invite = await db.getInviteById("inv_1");
+    expect(invite?.status).toBe("pending");
+    expect(invite?.slug).toBeNull();
+    expect(invite?.provisioned_at).toBeNull();
+    // phantom endpoint row removed
+    expect(await db.listEndpoints()).toHaveLength(0);
+    // cf resources cleaned
+    expect(countCalls(calls, "del-dns:")).toBe(1);
+    expect(countCalls(calls, "del-access:")).toBe(1);
+    expect(countCalls(calls, "del-tunnel:")).toBe(1);
+
+    // retry works end-to-end
+    const retryDeps = { ...deps, newEndpointId: () => "ep_retry", newAuditId: () => "aud_retry" };
+    const retry = await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps: retryDeps });
+    expect(retry.hostname).toBe("alice.mediaryconnect.app");
+    expect(await db.listEndpoints()).toHaveLength(1);
+  });
+
   it("dns failure + deleteAccessApp also throws: tunnel still deleted via outer catch", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makePendingInvite());

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from "vitest";
+import { provisionEndpoint, type ProvisionDeps } from "./provision.js";
+import { createMemoryConnectDb, type ConnectDb, type InviteRow } from "./db.js";
+import type { CfApi } from "./cf-api.js";
+import { unwrapToken } from "./crypto-token.js";
+
+const NOW = "2026-07-24T10:00:00.000Z";
+const WRAP_KEY = "00".repeat(32);
+const PLAIN_TOKEN = "tok-plain-1";
+
+function makePendingInvite(overrides: Partial<InviteRow> = {}): InviteRow {
+  return {
+    id: "inv_1",
+    code: "code-abc",
+    invitee_label: "Alice",
+    email: "alice@example.com",
+    slug: null,
+    status: "pending",
+    created_at: "2026-07-24T00:00:00.000Z",
+    provisioned_at: null,
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+interface FakeCfOptions {
+  failOn?: "ingress" | "access" | "dns";
+}
+
+function makeFakeCf(calls: string[], opts: FakeCfOptions = {}): CfApi {
+  return {
+    async createTunnel(name) {
+      calls.push(`tunnel:${name}`);
+      return { tunnelId: "tid-1", token: PLAIN_TOKEN };
+    },
+    async putTunnelIngress(tunnelId, hostname) {
+      calls.push(`ingress:${tunnelId}:${hostname}`);
+      if (opts.failOn === "ingress") throw new Error("cf ingress boom");
+    },
+    async createAccessApp(input) {
+      calls.push(`access:${input.domain}:${input.email}`);
+      if (opts.failOn === "access") throw new Error("cf access boom");
+      return { appId: "app-1", policyId: "pol-1" };
+    },
+    async createDnsCname(slug, tunnelId) {
+      calls.push(`dns:${slug}:${tunnelId}`);
+      if (opts.failOn === "dns") throw new Error("cf dns boom");
+      return { recordId: "rec-1" };
+    },
+    async deleteTunnel(tunnelId) {
+      calls.push(`del-tunnel:${tunnelId}`);
+    },
+    async deleteDnsRecord(recordId) {
+      calls.push(`del-dns:${recordId}`);
+    },
+    async deleteAccessApp(appId) {
+      calls.push(`del-access:${appId}`);
+    },
+  };
+}
+
+function makeDeps(db: ConnectDb, cf: CfApi): ProvisionDeps {
+  return {
+    cf,
+    db,
+    rootDomain: "mediaryconnect.app",
+    tokenWrapKeyHex: WRAP_KEY,
+    now: () => NOW,
+    newEndpointId: () => "ep_test1",
+    newAuditId: () => "aud_test1",
+  };
+}
+
+function countCalls(calls: string[], prefix: string): number {
+  return calls.filter((c) => c.startsWith(prefix)).length;
+}
+
+describe("provisionEndpoint", () => {
+  it("happy path: ordered cf calls, persists endpoint/invite/audit, never persists plaintext token", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    const result = await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps });
+
+    expect(calls).toEqual([
+      "tunnel:scout-alice",
+      "ingress:tid-1:alice.mediaryconnect.app",
+      "access:alice.mediaryconnect.app:alice@example.com",
+      "dns:alice:tid-1",
+    ]);
+
+    expect(result.endpointId).toBe("ep_test1");
+    expect(result.inviteCode).toBe("code-abc");
+    expect(result.hostname).toBe("alice.mediaryconnect.app");
+    expect(result.token).toBe(PLAIN_TOKEN);
+    expect(result.agentPrompt).toContain("alice.mediaryconnect.app");
+
+    const endpoint = await db.getEndpointById("ep_test1");
+    expect(endpoint).not.toBeNull();
+    expect(endpoint?.status).toBe("active");
+    expect(endpoint?.token_ciphertext).toBeTruthy();
+    expect(endpoint?.token_shown_at).toBeNull();
+    expect(endpoint?.invite_id).toBe("inv_1");
+    expect(endpoint?.slug).toBe("alice");
+    expect(endpoint?.hostname).toBe("alice.mediaryconnect.app");
+    expect(endpoint?.cf_tunnel_id).toBe("tid-1");
+    expect(endpoint?.cf_access_app_id).toBe("app-1");
+    expect(endpoint?.cf_access_policy_id).toBe("pol-1");
+    expect(endpoint?.cf_dns_record_id).toBe("rec-1");
+    expect(endpoint?.created_at).toBe(NOW);
+    expect(endpoint?.revoked_at).toBeNull();
+
+    // The plaintext token must never touch the db.
+    expect(JSON.stringify(await db.listEndpoints())).not.toContain(PLAIN_TOKEN);
+
+    const invite = await db.getInviteById("inv_1");
+    expect(invite?.status).toBe("provisioned");
+    expect(invite?.slug).toBe("alice");
+    expect(invite?.provisioned_at).toBe(NOW);
+
+    const audits = await db.listAudits();
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.action).toBe("endpoint.provision");
+    expect(audits[0]?.actor).toBe("admin");
+    expect(audits[0]?.invite_id).toBe("inv_1");
+    expect(audits[0]?.endpoint_id).toBe("ep_test1");
+    expect(audits[0]?.detail_json ?? "").not.toContain(PLAIN_TOKEN);
+    expect(audits[0]?.detail_json ?? "").toContain("alice.mediaryconnect.app");
+  });
+
+  it("passes lowercased invite email to createAccessApp", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite({ email: "Alice@Example.COM" }));
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps });
+
+    expect(calls).toContain("access:alice.mediaryconnect.app:alice@example.com");
+  });
+
+  it("access failure: deletes tunnel exactly once, never touches dns/access deletes, persists nothing", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls, { failOn: "access" }));
+
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps }),
+    ).rejects.toThrow("cf access boom");
+
+    expect(countCalls(calls, "del-tunnel")).toBe(1);
+    expect(countCalls(calls, "del-access")).toBe(0);
+    expect(countCalls(calls, "del-dns")).toBe(0);
+    expect(await db.listEndpoints()).toHaveLength(0);
+    expect((await db.getInviteById("inv_1"))?.status).toBe("pending");
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+
+  it("dns failure: deletes access app once and tunnel exactly once, persists nothing", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls, { failOn: "dns" }));
+
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps }),
+    ).rejects.toThrow("cf dns boom");
+
+    expect(countCalls(calls, "del-access")).toBe(1);
+    expect(countCalls(calls, "del-tunnel")).toBe(1);
+    expect(countCalls(calls, "del-dns")).toBe(0);
+    expect(await db.listEndpoints()).toHaveLength(0);
+    expect((await db.getInviteById("inv_1"))?.status).toBe("pending");
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+
+  it("ingress failure: deletes tunnel exactly once, never creates access app or dns", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls, { failOn: "ingress" }));
+
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps }),
+    ).rejects.toThrow("cf ingress boom");
+
+    expect(countCalls(calls, "del-tunnel")).toBe(1);
+    expect(countCalls(calls, "del-access")).toBe(0);
+    expect(countCalls(calls, "del-dns")).toBe(0);
+    expect(countCalls(calls, "access:")).toBe(0);
+    expect(countCalls(calls, "dns:")).toBe(0);
+    expect(await db.listEndpoints()).toHaveLength(0);
+    expect((await db.getInviteById("inv_1"))?.status).toBe("pending");
+  });
+
+  it("throws when invite is not found, before any cf call", async () => {
+    const db = createMemoryConnectDb();
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    await expect(
+      provisionEndpoint({ inviteId: "missing", slug: "alice", deps }),
+    ).rejects.toThrow(/not found/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws when invite is not pending, before any cf call", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite({ status: "provisioned" }));
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps }),
+    ).rejects.toThrow(/not pending/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws on reserved slug, before any cf call", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "Admin", deps }),
+    ).rejects.toThrow(/reserved slug/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("stored ciphertext unwraps back to the returned token", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const deps = makeDeps(db, makeFakeCf([]));
+
+    const result = await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps });
+
+    const endpoint = await db.getEndpointById(result.endpointId);
+    if (endpoint === null || endpoint.token_ciphertext === null) {
+      throw new Error("expected persisted endpoint with ciphertext");
+    }
+    const unwrapped = await unwrapToken(endpoint.token_ciphertext, WRAP_KEY);
+    expect(unwrapped).toBe(result.token);
+  });
+});

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -267,8 +267,8 @@ describe("provisionEndpoint", () => {
     const calls: string[] = [];
     const deps = makeDeps(db, makeFakeCf(calls));
 
-    // first provision occupies the slug so the retry's insertEndpoint dies on
-    // the UNIQUE invite_id constraint after CF resources already exist
+    // first provision occupies the endpoint id so the retry's insertEndpoint
+    // dies on the endpoints.id PRIMARY KEY after CF resources already exist
     await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps });
 
     await db.insertInvite(makePendingInvite({ id: "inv_2", code: "code-def" }));
@@ -288,12 +288,15 @@ describe("provisionEndpoint", () => {
     expect(countCalls(calls, "del-access:")).toBe(1);
     expect(countCalls(calls, "del-tunnel:")).toBe(1);
 
-    // orphan audit row recorded, no plaintext token inside
+    // orphan audit row recorded, carrying cf ids for forensics, no plaintext token
     const audits = await db.listAudits();
     const orphan = audits.find((a) => a.action === "provision.orphan");
     expect(orphan).toBeDefined();
     expect(orphan?.actor).toBe("system");
     expect(orphan?.invite_id).toBe("inv_2");
+    expect(orphan?.detail_json).toContain("tid-1");
+    expect(orphan?.detail_json).toContain("app-1");
+    expect(orphan?.detail_json).toContain("rec-1");
     expect(JSON.stringify(orphan)).not.toContain(PLAIN_TOKEN);
 
     // invite stays pending so the admin can retry
@@ -338,5 +341,81 @@ describe("provisionEndpoint", () => {
     expect(calls).toContain("del-dns:boom");
     expect(calls).toContain("del-access:boom");
     expect(calls).toContain("del-tunnel:boom");
+  });
+
+  it("updateInviteStatus failure after successful insert: phantom row removed, cf cleaned, retry possible", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    // poison updateInviteStatus to fail once
+    const inner = db;
+    const failingDb: ConnectDb = {
+      ...inner,
+      async updateInviteStatus(id, patch) {
+        throw new Error("d1 update boom");
+      },
+    };
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps: { ...deps, db: failingDb } }),
+    ).rejects.toThrow(/d1 update boom/);
+
+    // phantom endpoint row removed
+    expect(await db.listEndpoints()).toHaveLength(0);
+    // full cf resource set cleaned
+    expect(countCalls(calls, "del-dns:")).toBe(1);
+    expect(countCalls(calls, "del-access:")).toBe(1);
+    expect(countCalls(calls, "del-tunnel:")).toBe(1);
+    // invite still pending, and a retry with the same slug now succeeds
+    expect((await db.getInviteById("inv_1"))?.status).toBe("pending");
+    const retryDeps = { ...deps, newEndpointId: () => "ep_retry", newAuditId: () => "aud_retry" };
+    const retry = await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps: retryDeps });
+    expect(retry.hostname).toBe("alice.mediaryconnect.app");
+    expect(await db.listEndpoints()).toHaveLength(1);
+  });
+
+  it("misconfigured wrap key: crypto failure inside persistence phase still cleans up cf resources", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = {
+      ...makeDeps(db, makeFakeCf(calls)),
+      tokenWrapKeyHex: "zz", // invalid hex — wrapToken throws
+    };
+
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps }),
+    ).rejects.toThrow();
+
+    expect(countCalls(calls, "tunnel:")).toBe(1);
+    expect(countCalls(calls, "del-dns:")).toBe(1);
+    expect(countCalls(calls, "del-access:")).toBe(1);
+    expect(countCalls(calls, "del-tunnel:")).toBe(1);
+    expect(await db.listEndpoints()).toHaveLength(0);
+    const audits = await db.listAudits();
+    expect(audits.some((a) => a.action === "provision.orphan")).toBe(true);
+  });
+
+  it("dns failure + deleteAccessApp also throws: tunnel still deleted via outer catch", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const base = makeFakeCf(calls, { failOn: "dns" });
+    const cf: CfApi = {
+      ...base,
+      async deleteAccessApp() {
+        calls.push("del-access:boom");
+        throw new Error("delete access boom");
+      },
+    };
+    const deps = makeDeps(db, cf);
+
+    // the thrown error is the delete's, not the original dns error — but the
+    // tunnel must still be cleaned up exactly once by the outer catch
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps }),
+    ).rejects.toThrow(/delete access boom/);
+    expect(countCalls(calls, "del-tunnel:")).toBe(1);
   });
 });

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -245,4 +245,98 @@ describe("provisionEndpoint", () => {
     const unwrapped = await unwrapToken(endpoint.token_ciphertext, WRAP_KEY);
     expect(unwrapped).toBe(result.token);
   });
+
+  it("rejects a slug already used by an existing endpoint before any cf call", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+    await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps });
+
+    await db.insertInvite(makePendingInvite({ id: "inv_2", code: "code-def" }));
+    await expect(
+      provisionEndpoint({ inviteId: "inv_2", slug: "alice", deps }),
+    ).rejects.toThrow(/already in use/);
+    // only the first provision's cf calls exist — no second tunnel was created
+    expect(countCalls(calls, "tunnel:")).toBe(1);
+  });
+
+  it("D1 write failure: best-effort deletes dns/access/tunnel and audits provision.orphan", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    // first provision occupies the slug so the retry's insertEndpoint dies on
+    // the UNIQUE invite_id constraint after CF resources already exist
+    await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps });
+
+    await db.insertInvite(makePendingInvite({ id: "inv_2", code: "code-def" }));
+    const otherDeps = {
+      ...makeDeps(db, makeFakeCf(calls)),
+      newEndpointId: () => "ep_test1", // collides with the existing row
+      newAuditId: () => "aud_test2",
+    };
+    await expect(
+      provisionEndpoint({ inviteId: "inv_2", slug: "bob", deps: otherDeps }),
+    ).rejects.toThrow(/UNIQUE/i);
+
+    // second tunnel's full resource set was cleaned up
+    const secondTunnelCalls = calls.filter((c) => c.startsWith("tunnel:")).length;
+    expect(secondTunnelCalls).toBe(2);
+    expect(countCalls(calls, "del-dns:")).toBe(1);
+    expect(countCalls(calls, "del-access:")).toBe(1);
+    expect(countCalls(calls, "del-tunnel:")).toBe(1);
+
+    // orphan audit row recorded, no plaintext token inside
+    const audits = await db.listAudits();
+    const orphan = audits.find((a) => a.action === "provision.orphan");
+    expect(orphan).toBeDefined();
+    expect(orphan?.actor).toBe("system");
+    expect(orphan?.invite_id).toBe("inv_2");
+    expect(JSON.stringify(orphan)).not.toContain(PLAIN_TOKEN);
+
+    // invite stays pending so the admin can retry
+    expect((await db.getInviteById("inv_2"))?.status).toBe("pending");
+  });
+
+  it("D1 failure compensation still throws the original error when cf deletes also fail", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const base = makeFakeCf(calls);
+    const failingDeletes: CfApi = {
+      ...base,
+      async deleteTunnel() {
+        calls.push("del-tunnel:boom");
+        throw new Error("delete tunnel boom");
+      },
+      async deleteDnsRecord() {
+        calls.push("del-dns:boom");
+        throw new Error("delete dns boom");
+      },
+      async deleteAccessApp() {
+        calls.push("del-access:boom");
+        throw new Error("delete access boom");
+      },
+    };
+    const deps = {
+      ...makeDeps(db, failingDeletes),
+      newEndpointId: () => "ep_test1",
+    };
+    // first, occupy the endpoint id so the insert fails
+    await provisionEndpoint({
+      inviteId: "inv_1",
+      slug: "alice",
+      deps: makeDeps(db, makeFakeCf([])),
+    });
+    await db.insertInvite(makePendingInvite({ id: "inv_2", code: "code-def" }));
+
+    await expect(
+      provisionEndpoint({ inviteId: "inv_2", slug: "bob", deps }),
+    ).rejects.toThrow(/UNIQUE/i);
+    expect(calls).toContain("del-dns:boom");
+    expect(calls).toContain("del-access:boom");
+    expect(calls).toContain("del-tunnel:boom");
+  });
 });

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -246,6 +246,35 @@ describe("provisionEndpoint", () => {
     expect(unwrapped).toBe(result.token);
   });
 
+  it("hostname conflict error names the hostname, not the slug", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+    // pre-seed an endpoint whose hostname collides but slug differs
+    await db.insertEndpoint({
+      id: "ep_other",
+      invite_id: "inv_other",
+      slug: "other",
+      hostname: "alice.mediaryconnect.app",
+      cf_tunnel_id: "tid-x",
+      cf_access_app_id: "app-x",
+      cf_access_policy_id: null,
+      cf_dns_record_id: "rec-x",
+      status: "active",
+      token_sha256: "x",
+      token_ciphertext: null,
+      token_shown_at: null,
+      created_at: NOW,
+      revoked_at: null,
+    });
+
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps }),
+    ).rejects.toThrow(/hostname already in use/);
+    expect(calls).toHaveLength(0);
+  });
+
   it("rejects a slug already used by an existing endpoint before any cf call", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makePendingInvite());

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -1,0 +1,130 @@
+import { assertSlug } from "./slug.js";
+import { sha256Hex, wrapToken } from "./crypto-token.js";
+import { buildAgentPrompt } from "./agent-prompt.js";
+import type { CfApi } from "./cf-api.js";
+import type { ConnectDb } from "./db.js";
+
+export interface ProvisionDeps {
+  cf: CfApi;
+  db: ConnectDb;
+  rootDomain: string; // e.g. "mediaryconnect.app"
+  tokenWrapKeyHex: string; // 64 hex chars
+  now: () => string; // ISO timestamp
+  newEndpointId: () => string;
+  newAuditId: () => string;
+}
+
+export interface ProvisionResult {
+  endpointId: string;
+  inviteCode: string;
+  hostname: string;
+  /** plaintext connector token — return value ONLY, never persisted */
+  token: string;
+  agentPrompt: string;
+}
+
+export async function provisionEndpoint(input: {
+  inviteId: string;
+  slug: string;
+  deps: ProvisionDeps;
+}): Promise<ProvisionResult> {
+  const { deps } = input;
+  const { cf, db } = deps;
+
+  const invite = await db.getInviteById(input.inviteId);
+  if (invite === null) {
+    throw new Error("invite not found");
+  }
+  if (invite.status !== "pending") {
+    throw new Error("invite not pending");
+  }
+
+  const slug = assertSlug(input.slug);
+  const hostname = `${slug}.${deps.rootDomain}`;
+
+  const { tunnelId, token } = await cf.createTunnel(`scout-${slug}`);
+
+  // Compensation invariant: deleteTunnel runs AT MOST once on any failure
+  // path. The inner dns catch deletes it, then rethrows into the outer catch,
+  // which must not delete it again.
+  let tunnelDeleted = false;
+  const deleteTunnelOnce = async (): Promise<void> => {
+    if (!tunnelDeleted) {
+      tunnelDeleted = true;
+      await cf.deleteTunnel(tunnelId);
+    }
+  };
+
+  // Order matters: Access BEFORE DNS, so the hostname never resolves to an
+  // unprotected origin.
+  let appId: string;
+  let policyId: string | undefined;
+  let recordId: string;
+  try {
+    await cf.putTunnelIngress(tunnelId, hostname);
+    const app = await cf.createAccessApp({
+      name: `scout-${slug}`,
+      domain: hostname,
+      email: invite.email.trim().toLowerCase(),
+    });
+    appId = app.appId;
+    policyId = app.policyId;
+    try {
+      ({ recordId } = await cf.createDnsCname(slug, tunnelId));
+    } catch (e) {
+      await cf.deleteAccessApp(appId);
+      await deleteTunnelOnce();
+      throw e;
+    }
+  } catch (e) {
+    await deleteTunnelOnce();
+    throw e;
+  }
+
+  // SECURITY: only ciphertext + sha256 persist. The plaintext token is
+  // returned to the caller once and never touches the db or the audit log.
+  const ciphertext = await wrapToken(token, deps.tokenWrapKeyHex);
+  const sha = await sha256Hex(token);
+  const endpointId = deps.newEndpointId();
+
+  await db.insertEndpoint({
+    id: endpointId,
+    invite_id: invite.id,
+    slug,
+    hostname,
+    cf_tunnel_id: tunnelId,
+    cf_access_app_id: appId,
+    cf_access_policy_id: policyId ?? null,
+    cf_dns_record_id: recordId,
+    status: "active",
+    token_sha256: sha,
+    token_ciphertext: ciphertext,
+    token_shown_at: null,
+    created_at: deps.now(),
+    revoked_at: null,
+  });
+
+  await db.updateInviteStatus(invite.id, {
+    status: "provisioned",
+    slug,
+    provisioned_at: deps.now(),
+  });
+
+  await db.insertAudit({
+    id: deps.newAuditId(),
+    at: deps.now(),
+    actor: "admin",
+    action: "endpoint.provision",
+    invite_id: invite.id,
+    endpoint_id: endpointId,
+    detail_json: JSON.stringify({ hostname }),
+  });
+
+  return {
+    endpointId,
+    inviteCode: invite.code,
+    hostname,
+    token,
+    agentPrompt: buildAgentPrompt({ hostname, tunnelToken: token }),
+  };
+}

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -42,12 +42,16 @@ export async function provisionEndpoint(input: {
   const slug = assertSlug(input.slug);
   const hostname = `${slug}.${deps.rootDomain}`;
 
-  // Slug-availability precheck: shrinks the window where a retry would burn a
-  // full set of CF resources only to die on a UNIQUE constraint at insert time.
-  for (const existing of await db.listEndpoints()) {
-    if (existing.slug === slug || existing.hostname === hostname) {
+  // Slug/hostname availability precheck: shrinks the window where a retry
+  // would burn a full set of CF resources only to die on a UNIQUE constraint
+  // at insert time. Targeted existence query; the UNIQUE constraints on
+  // endpoints.slug/hostname remain the final authority.
+  const conflict = await db.findEndpointBySlugOrHostname(slug, hostname);
+  if (conflict !== null) {
+    if (conflict.slug === slug) {
       throw new Error(`slug already in use: ${slug}`);
     }
+    throw new Error(`hostname already in use: ${hostname}`);
   }
 
   const { tunnelId, token } = await cf.createTunnel(`scout-${slug}`);

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -58,8 +58,10 @@ export async function provisionEndpoint(input: {
   let tunnelDeleted = false;
   const deleteTunnelOnce = async (): Promise<void> => {
     if (!tunnelDeleted) {
-      tunnelDeleted = true;
+      // Latch AFTER the await: a transient delete failure leaves the flag
+      // unset so a later catch can still retry (404-idempotent = safe).
       await cf.deleteTunnel(tunnelId);
+      tunnelDeleted = true;
     }
   };
 
@@ -143,6 +145,19 @@ export async function provisionEndpoint(input: {
       await db.deleteEndpoint(endpointId);
     } catch {
       // best-effort compensation — original error is what matters
+    }
+    // If updateInviteStatus already flipped the invite to `provisioned` before
+    // a later write (insertAudit) failed, the invite would be stuck forever
+    // (not pending → no re-provision; no endpoint → nothing to revoke). Roll
+    // it back so the admin can retry.
+    try {
+      await db.updateInviteStatus(invite.id, {
+        status: "pending",
+        slug: null,
+        provisioned_at: null,
+      });
+    } catch {
+      // D1 may be the failing component — nothing more we can do
     }
     try {
       await cf.deleteDnsRecord(recordId);

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -89,18 +89,20 @@ export async function provisionEndpoint(input: {
     throw e;
   }
 
-  // SECURITY: only ciphertext + sha256 persist. The plaintext token is
-  // returned to the caller once and never touches the db or the audit log.
-  const ciphertext = await wrapToken(token, deps.tokenWrapKeyHex);
-  const sha = await sha256Hex(token);
+  // Post-CF phase (crypto + persistence): all CF resources
+  // (tunnel/ingress/access/dns) exist now. If anything here fails — including
+  // a misconfigured wrap key — the resources would dangle, potentially with no
+  // db row (and thus unreachable by the revoke flow). Spec error-compensation
+  // row: best-effort delete of dns → access → tunnel, remove a partially
+  // inserted endpoint row, plus a best-effort `provision.orphan` audit row
+  // (which may itself fail if D1 is down).
   const endpointId = deps.newEndpointId();
-
-  // Post-CF persistence phase: all CF resources (tunnel/ingress/access/dns)
-  // exist now. If a D1 write fails, the resources would dangle with no db row
-  // (and thus be unreachable by the revoke flow) — spec error-compensation
-  // row: best-effort delete of dns → access → tunnel, plus a best-effort
-  // `provision.orphan` audit row (which may itself fail if D1 is down).
   try {
+    // SECURITY: only ciphertext + sha256 persist. The plaintext token is
+    // returned to the caller once and never touches the db or the audit log.
+    const ciphertext = await wrapToken(token, deps.tokenWrapKeyHex);
+    const sha = await sha256Hex(token);
+
     await db.insertEndpoint({
       id: endpointId,
       invite_id: invite.id,
@@ -134,6 +136,14 @@ export async function provisionEndpoint(input: {
       detail_json: JSON.stringify({ hostname }),
     });
   } catch (e) {
+    // A partially inserted endpoint row would be a phantom pointing at the
+    // (about-to-be-deleted) CF resources and would block any retry via UNIQUE
+    // constraints — remove it best-effort. Forensics live in the orphan audit.
+    try {
+      await db.deleteEndpoint(endpointId);
+    } catch {
+      // best-effort compensation — original error is what matters
+    }
     try {
       await cf.deleteDnsRecord(recordId);
     } catch {
@@ -157,7 +167,12 @@ export async function provisionEndpoint(input: {
         action: "provision.orphan",
         invite_id: invite.id,
         endpoint_id: endpointId,
-        detail_json: JSON.stringify({ hostname }),
+        detail_json: JSON.stringify({
+          hostname,
+          cf_tunnel_id: tunnelId,
+          cf_access_app_id: appId,
+          cf_dns_record_id: recordId,
+        }),
       });
     } catch {
       // D1 itself may be the failing component — nothing more we can do

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -42,6 +42,14 @@ export async function provisionEndpoint(input: {
   const slug = assertSlug(input.slug);
   const hostname = `${slug}.${deps.rootDomain}`;
 
+  // Slug-availability precheck: shrinks the window where a retry would burn a
+  // full set of CF resources only to die on a UNIQUE constraint at insert time.
+  for (const existing of await db.listEndpoints()) {
+    if (existing.slug === slug || existing.hostname === hostname) {
+      throw new Error(`slug already in use: ${slug}`);
+    }
+  }
+
   const { tunnelId, token } = await cf.createTunnel(`scout-${slug}`);
 
   // Compensation invariant: deleteTunnel runs AT MOST once on any failure
@@ -87,38 +95,75 @@ export async function provisionEndpoint(input: {
   const sha = await sha256Hex(token);
   const endpointId = deps.newEndpointId();
 
-  await db.insertEndpoint({
-    id: endpointId,
-    invite_id: invite.id,
-    slug,
-    hostname,
-    cf_tunnel_id: tunnelId,
-    cf_access_app_id: appId,
-    cf_access_policy_id: policyId ?? null,
-    cf_dns_record_id: recordId,
-    status: "active",
-    token_sha256: sha,
-    token_ciphertext: ciphertext,
-    token_shown_at: null,
-    created_at: deps.now(),
-    revoked_at: null,
-  });
+  // Post-CF persistence phase: all CF resources (tunnel/ingress/access/dns)
+  // exist now. If a D1 write fails, the resources would dangle with no db row
+  // (and thus be unreachable by the revoke flow) — spec error-compensation
+  // row: best-effort delete of dns → access → tunnel, plus a best-effort
+  // `provision.orphan` audit row (which may itself fail if D1 is down).
+  try {
+    await db.insertEndpoint({
+      id: endpointId,
+      invite_id: invite.id,
+      slug,
+      hostname,
+      cf_tunnel_id: tunnelId,
+      cf_access_app_id: appId,
+      cf_access_policy_id: policyId ?? null,
+      cf_dns_record_id: recordId,
+      status: "active",
+      token_sha256: sha,
+      token_ciphertext: ciphertext,
+      token_shown_at: null,
+      created_at: deps.now(),
+      revoked_at: null,
+    });
 
-  await db.updateInviteStatus(invite.id, {
-    status: "provisioned",
-    slug,
-    provisioned_at: deps.now(),
-  });
+    await db.updateInviteStatus(invite.id, {
+      status: "provisioned",
+      slug,
+      provisioned_at: deps.now(),
+    });
 
-  await db.insertAudit({
-    id: deps.newAuditId(),
-    at: deps.now(),
-    actor: "admin",
-    action: "endpoint.provision",
-    invite_id: invite.id,
-    endpoint_id: endpointId,
-    detail_json: JSON.stringify({ hostname }),
-  });
+    await db.insertAudit({
+      id: deps.newAuditId(),
+      at: deps.now(),
+      actor: "admin",
+      action: "endpoint.provision",
+      invite_id: invite.id,
+      endpoint_id: endpointId,
+      detail_json: JSON.stringify({ hostname }),
+    });
+  } catch (e) {
+    try {
+      await cf.deleteDnsRecord(recordId);
+    } catch {
+      // best-effort compensation — original error is what matters
+    }
+    try {
+      await cf.deleteAccessApp(appId);
+    } catch {
+      // best-effort compensation
+    }
+    try {
+      await deleteTunnelOnce();
+    } catch {
+      // best-effort compensation
+    }
+    try {
+      await db.insertAudit({
+        id: deps.newAuditId(),
+        at: deps.now(),
+        actor: "system",
+        action: "provision.orphan",
+        invite_id: invite.id,
+        endpoint_id: endpointId,
+        detail_json: JSON.stringify({ hostname }),
+      });
+    } catch {
+      // D1 itself may be the failing component — nothing more we can do
+    }
+    throw e;
+  }
 
   return {
     endpointId,

--- a/workers/scout-connect/src/reveal.test.ts
+++ b/workers/scout-connect/src/reveal.test.ts
@@ -224,4 +224,20 @@ describe("revealByCode", () => {
     expect(endpoint?.token_ciphertext).toBeNull();
     expect(await db.listAudits()).toHaveLength(0);
   });
+
+  it("concurrent reveals: exactly one wins, the other gets already_shown (atomic burn)", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await seedEndpointWithToken(db);
+    const deps = makeDeps(db);
+
+    // Fire two reveals back-to-back without awaiting the first — the atomic
+    // conditional burn in markTokenShown decides the winner.
+    const [a, b] = await Promise.all([
+      revealByCode({ code: "code-abc", deps }),
+      revealByCode({ code: "code-abc", deps: { ...deps, newAuditId: () => "aud_y" } }),
+    ]);
+    const kinds = [a.kind, b.kind].sort();
+    expect(kinds).toEqual(["already_shown", "revealed"]);
+  });
 });

--- a/workers/scout-connect/src/reveal.test.ts
+++ b/workers/scout-connect/src/reveal.test.ts
@@ -225,6 +225,21 @@ describe("revealByCode", () => {
     expect(await db.listAudits()).toHaveLength(0);
   });
 
+  it("revoked endpoint under a still-provisioned invite → not_found (no token, no validity leak)", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite()); // provisioned
+    await seedEndpointWithToken(db);
+    await db.markEndpointRevoked("ep_1", NOW);
+
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
+
+    expect(outcome).toEqual({ kind: "not_found" });
+    // ciphertext must NOT have been burned — admin forensics stay intact
+    const endpoint = await db.getEndpointById("ep_1");
+    expect(endpoint?.token_ciphertext).not.toBeNull();
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+
   it("concurrent reveals: exactly one wins, the other gets already_shown (atomic burn)", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makeInvite());

--- a/workers/scout-connect/src/reveal.test.ts
+++ b/workers/scout-connect/src/reveal.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import { revealByCode, type RevealDeps } from "./reveal.js";
+import {
+  createMemoryConnectDb,
+  type ConnectDb,
+  type EndpointRow,
+  type InviteRow,
+} from "./db.js";
+import { wrapToken } from "./crypto-token.js";
+
+const NOW = "2026-07-24T10:00:00.000Z";
+const WRAP_KEY = "00".repeat(32);
+const PLAIN_TOKEN = "tok-plain-secret-1";
+
+function makeInvite(overrides: Partial<InviteRow> = {}): InviteRow {
+  return {
+    id: "inv_1",
+    code: "code-abc",
+    invitee_label: "Alice",
+    email: "alice@example.com",
+    slug: "alice",
+    status: "provisioned",
+    created_at: "2026-07-24T00:00:00.000Z",
+    provisioned_at: "2026-07-24T01:00:00.000Z",
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+function makeEndpoint(overrides: Partial<EndpointRow> = {}): EndpointRow {
+  return {
+    id: "ep_1",
+    invite_id: "inv_1",
+    slug: "alice",
+    hostname: "alice.mediaryconnect.app",
+    cf_tunnel_id: "tid-1",
+    cf_access_app_id: "app-1",
+    cf_access_policy_id: "pol-1",
+    cf_dns_record_id: "rec-1",
+    status: "active",
+    token_sha256: "deadbeef",
+    token_ciphertext: null,
+    token_shown_at: null,
+    created_at: "2026-07-24T01:00:00.000Z",
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+function makeDeps(db: ConnectDb): RevealDeps {
+  return {
+    db,
+    tokenWrapKeyHex: WRAP_KEY,
+    now: () => NOW,
+    newAuditId: () => "aud_x",
+  };
+}
+
+/** Seeds an endpoint whose ciphertext is a real wrapToken(PLAIN_TOKEN). */
+async function seedEndpointWithToken(
+  db: ConnectDb,
+  overrides: Partial<EndpointRow> = {},
+): Promise<void> {
+  const ciphertext = await wrapToken(PLAIN_TOKEN, WRAP_KEY);
+  await db.insertEndpoint(makeEndpoint({ token_ciphertext: ciphertext, ...overrides }));
+}
+
+describe("revealByCode", () => {
+  it("unknown code → not_found", async () => {
+    const db = createMemoryConnectDb();
+    const outcome = await revealByCode({ code: "nope", deps: makeDeps(db) });
+    expect(outcome).toEqual({ kind: "not_found" });
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+
+  it("revoked invite → not_found, indistinguishable from never-existing (no leak)", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(
+      makeInvite({ status: "revoked", slug: null, revoked_at: "2026-07-24T05:00:00.000Z" }),
+    );
+    // ciphertext still present — a leak would surface as revealed/already_shown
+    await seedEndpointWithToken(db);
+
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
+
+    expect(outcome).toEqual({ kind: "not_found" });
+    expect(await db.listAudits()).toHaveLength(0);
+    // ciphertext untouched, token not burned
+    const endpoint = await db.getEndpointById("ep_1");
+    expect(endpoint?.token_ciphertext).not.toBeNull();
+    expect(endpoint?.token_shown_at).toBeNull();
+  });
+
+  it("pending invite → not_ready", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite({ status: "pending", slug: null, provisioned_at: null }));
+
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
+
+    expect(outcome).toEqual({ kind: "not_ready" });
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+
+  it("provisioned + ciphertext present → revealed with real unwrap roundtrip; burns ciphertext, audits hostname only", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await seedEndpointWithToken(db);
+
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
+
+    if (outcome.kind !== "revealed") {
+      throw new Error(`expected revealed, got ${outcome.kind}`);
+    }
+    expect(outcome.hostname).toBe("alice.mediaryconnect.app");
+    // real unwrap roundtrip — the exact plaintext that was wrapped
+    expect(outcome.token).toBe(PLAIN_TOKEN);
+    expect(outcome.agentPrompt).toContain("alice.mediaryconnect.app");
+    expect(outcome.agentPrompt).toContain(PLAIN_TOKEN);
+
+    // one-time burn: shown_at set AND ciphertext nulled atomically
+    const endpoint = await db.getEndpointById("ep_1");
+    expect(endpoint?.token_shown_at).toBe(NOW);
+    expect(endpoint?.token_ciphertext).toBeNull();
+
+    const audits = await db.listAudits();
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.action).toBe("token.reveal");
+    expect(audits[0]?.actor).toBe("invitee");
+    expect(audits[0]?.at).toBe(NOW);
+    expect(audits[0]?.invite_id).toBe("inv_1");
+    expect(audits[0]?.endpoint_id).toBe("ep_1");
+    expect(audits[0]?.detail_json).toContain("alice.mediaryconnect.app");
+    // the token must never be persisted anywhere
+    expect(audits[0]?.detail_json).not.toContain(PLAIN_TOKEN);
+    expect(JSON.stringify(await db.listEndpoints())).not.toContain(PLAIN_TOKEN);
+    expect(JSON.stringify(audits)).not.toContain(PLAIN_TOKEN);
+  });
+
+  it("second reveal → already_shown with hostname, no additional audit row, ciphertext stays null", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await seedEndpointWithToken(db);
+    const deps = makeDeps(db);
+
+    const first = await revealByCode({ code: "code-abc", deps });
+    expect(first.kind).toBe("revealed");
+
+    const second = await revealByCode({ code: "code-abc", deps });
+    expect(second).toEqual({
+      kind: "already_shown",
+      hostname: "alice.mediaryconnect.app",
+    });
+
+    // audit count unchanged — refresh must not spam the audit log
+    expect(await db.listAudits()).toHaveLength(1);
+    const endpoint = await db.getEndpointById("ep_1");
+    expect(endpoint?.token_ciphertext).toBeNull();
+    expect(endpoint?.token_shown_at).toBe(NOW);
+  });
+
+  it("provisioned invite but endpoint row missing → not_ready (half-done provisioning)", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite()); // provisioned, no endpoint row
+
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
+
+    expect(outcome).toEqual({ kind: "not_ready" });
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+
+  it("corrupt state (ciphertext null, shown_at null) → already_shown, no decrypt attempted", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    // ciphertext null AND shown_at null — unwrap would explode if attempted
+    await db.insertEndpoint(makeEndpoint());
+
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
+
+    expect(outcome).toEqual({
+      kind: "already_shown",
+      hostname: "alice.mediaryconnect.app",
+    });
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+
+  it("returns the exact plaintext that was wrapped, even with tricky characters", async () => {
+    const tricky = 'tok-with-"quotes"-\\-newline\n-unicode-✓';
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await db.insertEndpoint(
+      makeEndpoint({ token_ciphertext: await wrapToken(tricky, WRAP_KEY) }),
+    );
+
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
+
+    if (outcome.kind !== "revealed") {
+      throw new Error(`expected revealed, got ${outcome.kind}`);
+    }
+    expect(outcome.token).toBe(tricky);
+  });
+});

--- a/workers/scout-connect/src/reveal.test.ts
+++ b/workers/scout-connect/src/reveal.test.ts
@@ -198,4 +198,30 @@ describe("revealByCode", () => {
     }
     expect(outcome.token).toBe(tricky);
   });
+
+  it("audit insert failure after the burn still delivers the token (best-effort audit)", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await seedEndpointWithToken(db);
+    const inner = db;
+    const failingAuditDb = {
+      ...inner,
+      async insertAudit(): Promise<void> {
+        throw new Error("d1 audit boom");
+      },
+    };
+    const deps = { ...makeDeps(db), db: failingAuditDb };
+
+    const outcome = await revealByCode({ code: "code-abc", deps });
+
+    if (outcome.kind !== "revealed") {
+      throw new Error(`expected revealed, got ${outcome.kind}`);
+    }
+    expect(outcome.token).toBe(PLAIN_TOKEN);
+    // burn still happened — ciphertext is gone despite the lost audit
+    const endpoint = await db.getEndpointById("ep_1");
+    expect(endpoint?.token_shown_at).toBe(NOW);
+    expect(endpoint?.token_ciphertext).toBeNull();
+    expect(await db.listAudits()).toHaveLength(0);
+  });
 });

--- a/workers/scout-connect/src/reveal.ts
+++ b/workers/scout-connect/src/reveal.ts
@@ -48,8 +48,13 @@ export async function revealByCode(input: {
   // SECURITY: the plaintext token is returned to the caller ONLY — never
   // persisted, never written to the audit log (hostname only there).
   const token = await unwrapToken(endpoint.token_ciphertext, deps.tokenWrapKeyHex);
-  // Sets token_shown_at AND nulls the ciphertext atomically.
-  await db.markTokenShown(endpoint.id, deps.now());
+  // Atomic burn is the commit point: conditional UPDATE wins exactly one
+  // concurrent reveal. A loser gets already_shown and discards its decrypted
+  // copy — the "只显示这一次" promise holds even under racing requests.
+  const burned = await db.markTokenShown(endpoint.id, deps.now());
+  if (!burned) {
+    return { kind: "already_shown", hostname: endpoint.hostname };
+  }
   // Audit is best-effort: the ciphertext is already burned, so a failed audit
   // insert must never block delivery of the one-time token.
   try {

--- a/workers/scout-connect/src/reveal.ts
+++ b/workers/scout-connect/src/reveal.ts
@@ -50,15 +50,21 @@ export async function revealByCode(input: {
   const token = await unwrapToken(endpoint.token_ciphertext, deps.tokenWrapKeyHex);
   // Sets token_shown_at AND nulls the ciphertext atomically.
   await db.markTokenShown(endpoint.id, deps.now());
-  await db.insertAudit({
-    id: deps.newAuditId(),
-    at: deps.now(),
-    actor: "invitee",
-    action: "token.reveal",
-    invite_id: invite.id,
-    endpoint_id: endpoint.id,
-    detail_json: JSON.stringify({ hostname: endpoint.hostname }),
-  });
+  // Audit is best-effort: the ciphertext is already burned, so a failed audit
+  // insert must never block delivery of the one-time token.
+  try {
+    await db.insertAudit({
+      id: deps.newAuditId(),
+      at: deps.now(),
+      actor: "invitee",
+      action: "token.reveal",
+      invite_id: invite.id,
+      endpoint_id: endpoint.id,
+      detail_json: JSON.stringify({ hostname: endpoint.hostname }),
+    });
+  } catch {
+    // audit lost — delivering the token takes precedence
+  }
   return {
     kind: "revealed",
     hostname: endpoint.hostname,

--- a/workers/scout-connect/src/reveal.ts
+++ b/workers/scout-connect/src/reveal.ts
@@ -1,0 +1,68 @@
+import { unwrapToken } from "./crypto-token.js";
+import { buildAgentPrompt } from "./agent-prompt.js";
+import type { ConnectDb } from "./db.js";
+
+export interface RevealDeps {
+  db: ConnectDb;
+  tokenWrapKeyHex: string;
+  now: () => string;
+  newAuditId: () => string;
+}
+
+export type RevealOutcome =
+  | { kind: "not_found" } // unknown or revoked code — indistinguishable
+  | { kind: "not_ready" } // invite pending (no endpoint yet)
+  | { kind: "already_shown"; hostname: string } // token_shown_at already set (or ciphertext gone)
+  | { kind: "revealed"; hostname: string; token: string; agentPrompt: string };
+
+export async function revealByCode(input: {
+  code: string;
+  deps: RevealDeps;
+}): Promise<RevealOutcome> {
+  const { deps } = input;
+  const { db } = deps;
+
+  const invite = await db.getInviteByCode(input.code);
+  // Revoked invites must be indistinguishable from never-existing ones —
+  // do not leak that the code was ever valid.
+  if (invite === null || invite.status === "revoked") {
+    return { kind: "not_found" };
+  }
+  if (invite.status === "pending") {
+    return { kind: "not_ready" };
+  }
+
+  // provisioned
+  const endpoint = await db.getEndpointByInviteId(invite.id);
+  if (endpoint === null) {
+    // Edge: provisioning half-done (invite flipped, endpoint row missing).
+    return { kind: "not_ready" };
+  }
+  // One-time reveal: either already shown, or ciphertext gone (corrupt
+  // state — defensively refuse to attempt a decrypt). No audit row here:
+  // page refreshes must not spam the audit log unboundedly.
+  if (endpoint.token_shown_at !== null || endpoint.token_ciphertext === null) {
+    return { kind: "already_shown", hostname: endpoint.hostname };
+  }
+
+  // SECURITY: the plaintext token is returned to the caller ONLY — never
+  // persisted, never written to the audit log (hostname only there).
+  const token = await unwrapToken(endpoint.token_ciphertext, deps.tokenWrapKeyHex);
+  // Sets token_shown_at AND nulls the ciphertext atomically.
+  await db.markTokenShown(endpoint.id, deps.now());
+  await db.insertAudit({
+    id: deps.newAuditId(),
+    at: deps.now(),
+    actor: "invitee",
+    action: "token.reveal",
+    invite_id: invite.id,
+    endpoint_id: endpoint.id,
+    detail_json: JSON.stringify({ hostname: endpoint.hostname }),
+  });
+  return {
+    kind: "revealed",
+    hostname: endpoint.hostname,
+    token,
+    agentPrompt: buildAgentPrompt({ hostname: endpoint.hostname, tunnelToken: token }),
+  };
+}

--- a/workers/scout-connect/src/reveal.ts
+++ b/workers/scout-connect/src/reveal.ts
@@ -38,6 +38,12 @@ export async function revealByCode(input: {
     // Edge: provisioning half-done (invite flipped, endpoint row missing).
     return { kind: "not_ready" };
   }
+  // A revoked / revoke_failed endpoint must never hand out its (deleted)
+  // tunnel's token — and must not leak that the code was ever valid. Treat
+  // exactly like an unknown code, before any token logic.
+  if (endpoint.status !== "active") {
+    return { kind: "not_found" };
+  }
   // One-time reveal: either already shown, or ciphertext gone (corrupt
   // state — defensively refuse to attempt a decrypt). No audit row here:
   // page refreshes must not spam the audit log unboundedly.

--- a/workers/scout-connect/src/revoke.test.ts
+++ b/workers/scout-connect/src/revoke.test.ts
@@ -159,6 +159,25 @@ describe("revokeEndpoint", () => {
     expect((await db.getEndpointById("ep_1"))?.status).toBe("revoked");
   });
 
+  it("already revoked self-heals a stuck provisioned invite (crash window between the two D1 writes)", async () => {
+    const db = createMemoryConnectDb();
+    // Simulates isolate death between markEndpointRevoked and updateInviteStatus:
+    // endpoint revoked, invite still provisioned with slug set.
+    await db.insertInvite(makeInvite({ status: "provisioned", slug: "alice", provisioned_at: NOW }));
+    await db.insertEndpoint(makeEndpoint({ status: "revoked", revoked_at: NOW }));
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    const result = await revokeEndpoint({ endpointId: "ep_1", deps });
+
+    expect(result.hostname).toBe("alice.mediaryconnect.app");
+    expect(calls).toHaveLength(0); // still no cf calls
+    const invite = await db.getInviteById("inv_1");
+    expect(invite?.status).toBe("revoked");
+    expect(invite?.slug).toBeNull();
+    expect(invite?.revoked_at).toBe(NOW);
+  });
+
   it("access-app delete throws: dns+tunnel still attempted, revoke_failed, audit written, error rethrown, invite NOT revoked", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makeInvite());

--- a/workers/scout-connect/src/revoke.test.ts
+++ b/workers/scout-connect/src/revoke.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "vitest";
+import { revokeEndpoint, type RevokeDeps } from "./revoke.js";
+import {
+  createMemoryConnectDb,
+  type ConnectDb,
+  type EndpointRow,
+  type InviteRow,
+} from "./db.js";
+import type { CfApi } from "./cf-api.js";
+
+const NOW = "2026-07-24T10:00:00.000Z";
+
+function makeInvite(overrides: Partial<InviteRow> = {}): InviteRow {
+  return {
+    id: "inv_1",
+    code: "code-abc",
+    invitee_label: "Alice",
+    email: "alice@example.com",
+    slug: "alice",
+    status: "provisioned",
+    created_at: "2026-07-24T00:00:00.000Z",
+    provisioned_at: "2026-07-24T01:00:00.000Z",
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+function makeEndpoint(overrides: Partial<EndpointRow> = {}): EndpointRow {
+  return {
+    id: "ep_1",
+    invite_id: "inv_1",
+    slug: "alice",
+    hostname: "alice.mediaryconnect.app",
+    cf_tunnel_id: "tid-1",
+    cf_access_app_id: "app-1",
+    cf_access_policy_id: "pol-1",
+    cf_dns_record_id: "rec-1",
+    status: "active",
+    token_sha256: "deadbeef",
+    token_ciphertext: null,
+    token_shown_at: "2026-07-24T02:00:00.000Z",
+    created_at: "2026-07-24T01:00:00.000Z",
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+interface FakeCfOptions {
+  failOn?: "access" | "dns" | "tunnel";
+  /** when true, the configured failure happens only on the first attempt of that step */
+  failOnce?: boolean;
+}
+
+/**
+ * Records delete calls. Deletes on "already deleted" resources succeed (the
+ * real cf-api treats 404 as success), so a retry after a failOnce failure
+ * runs all three deletes cleanly.
+ */
+function makeFakeCf(calls: string[], opts: FakeCfOptions = {}): CfApi {
+  const attempts: Record<"access" | "dns" | "tunnel", number> = {
+    access: 0,
+    dns: 0,
+    tunnel: 0,
+  };
+  const shouldFail = (step: "access" | "dns" | "tunnel"): boolean => {
+    attempts[step] += 1;
+    if (opts.failOn !== step) return false;
+    return opts.failOnce !== true || attempts[step] === 1;
+  };
+  return {
+    async createTunnel() {
+      throw new Error("unexpected createTunnel call during revoke");
+    },
+    async putTunnelIngress() {
+      throw new Error("unexpected putTunnelIngress call during revoke");
+    },
+    async createDnsCname() {
+      throw new Error("unexpected createDnsCname call during revoke");
+    },
+    async createAccessApp() {
+      throw new Error("unexpected createAccessApp call during revoke");
+    },
+    async deleteAccessApp(appId) {
+      calls.push(`del-access:${appId}`);
+      if (shouldFail("access")) throw new Error("cf delete access boom");
+    },
+    async deleteDnsRecord(recordId) {
+      calls.push(`del-dns:${recordId}`);
+      if (shouldFail("dns")) throw new Error("cf delete dns boom");
+    },
+    async deleteTunnel(tunnelId) {
+      calls.push(`del-tunnel:${tunnelId}`);
+      if (shouldFail("tunnel")) throw new Error("cf delete tunnel boom");
+    },
+  };
+}
+
+function makeDeps(db: ConnectDb, cf: CfApi): RevokeDeps {
+  return {
+    cf,
+    db,
+    now: () => NOW,
+    newAuditId: () => "aud_x",
+  };
+}
+
+describe("revokeEndpoint", () => {
+  it("happy path: deletes access→dns→tunnel, revokes endpoint+invite, audits endpoint.revoke", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await db.insertEndpoint(makeEndpoint());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    const result = await revokeEndpoint({ endpointId: "ep_1", deps });
+
+    expect(result).toEqual({
+      endpointId: "ep_1",
+      hostname: "alice.mediaryconnect.app",
+    });
+    expect(calls).toEqual(["del-access:app-1", "del-dns:rec-1", "del-tunnel:tid-1"]);
+
+    const endpoint = await db.getEndpointById("ep_1");
+    expect(endpoint?.status).toBe("revoked");
+    expect(endpoint?.revoked_at).toBe(NOW);
+
+    const invite = await db.getInviteById("inv_1");
+    expect(invite?.status).toBe("revoked");
+    expect(invite?.slug).toBeNull();
+    expect(invite?.revoked_at).toBe(NOW);
+
+    const audits = await db.listAudits();
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.id).toBe("aud_x");
+    expect(audits[0]?.at).toBe(NOW);
+    expect(audits[0]?.action).toBe("endpoint.revoke");
+    expect(audits[0]?.actor).toBe("admin");
+    expect(audits[0]?.invite_id).toBe("inv_1");
+    expect(audits[0]?.endpoint_id).toBe("ep_1");
+    expect(audits[0]?.detail_json).toContain("alice.mediaryconnect.app");
+  });
+
+  it("already revoked: returns hostname with zero cf calls and zero new audit rows", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite({ status: "revoked", slug: null, revoked_at: NOW }));
+    await db.insertEndpoint(makeEndpoint({ status: "revoked", revoked_at: NOW }));
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    const result = await revokeEndpoint({ endpointId: "ep_1", deps });
+
+    expect(result).toEqual({
+      endpointId: "ep_1",
+      hostname: "alice.mediaryconnect.app",
+    });
+    expect(calls).toHaveLength(0);
+    expect(await db.listAudits()).toHaveLength(0);
+    // row untouched
+    expect((await db.getEndpointById("ep_1"))?.status).toBe("revoked");
+  });
+
+  it("access-app delete throws: dns+tunnel still attempted, revoke_failed, audit written, error rethrown, invite NOT revoked", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await db.insertEndpoint(makeEndpoint());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls, { failOn: "access" }));
+
+    await expect(revokeEndpoint({ endpointId: "ep_1", deps })).rejects.toThrow(
+      "cf delete access boom",
+    );
+
+    // all three deletes attempted despite the first one throwing
+    expect(calls).toEqual(["del-access:app-1", "del-dns:rec-1", "del-tunnel:tid-1"]);
+
+    const endpoint = await db.getEndpointById("ep_1");
+    expect(endpoint?.status).toBe("revoke_failed");
+    expect(endpoint?.revoked_at).toBeNull();
+
+    // invite must NOT be flipped to revoked — the admin retries later
+    const invite = await db.getInviteById("inv_1");
+    expect(invite?.status).toBe("provisioned");
+    expect(invite?.slug).toBe("alice");
+    expect(invite?.revoked_at).toBeNull();
+
+    const audits = await db.listAudits();
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.action).toBe("endpoint.revoke_failed");
+    expect(audits[0]?.actor).toBe("admin");
+    expect(audits[0]?.invite_id).toBe("inv_1");
+    expect(audits[0]?.endpoint_id).toBe("ep_1");
+    expect(audits[0]?.detail_json).toContain("alice.mediaryconnect.app");
+    expect(audits[0]?.detail_json).toContain("cf delete access boom");
+  });
+
+  it("tunnel delete throws: revoke_failed, then a retry succeeds because deletes are 404-idempotent", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makeInvite());
+    await db.insertEndpoint(makeEndpoint());
+    const calls: string[] = [];
+    // first tunnel delete throws; access/dns deletes succeed (and keep
+    // succeeding on the retry as "already deleted" → 404 → success)
+    const deps = makeDeps(db, makeFakeCf(calls, { failOn: "tunnel", failOnce: true }));
+
+    await expect(revokeEndpoint({ endpointId: "ep_1", deps })).rejects.toThrow(
+      "cf delete tunnel boom",
+    );
+    expect((await db.getEndpointById("ep_1"))?.status).toBe("revoke_failed");
+    expect((await db.getInviteById("inv_1"))?.status).toBe("provisioned");
+
+    // admin retries with the same (now healthy) cf — second run's deletes on
+    // already-deleted access/dns return success without throwing
+    const retryDeps = { ...deps, newAuditId: () => "aud_retry" };
+    const result = await revokeEndpoint({ endpointId: "ep_1", deps: retryDeps });
+
+    expect(result).toEqual({
+      endpointId: "ep_1",
+      hostname: "alice.mediaryconnect.app",
+    });
+    expect((await db.getEndpointById("ep_1"))?.status).toBe("revoked");
+    expect((await db.getEndpointById("ep_1"))?.revoked_at).toBe(NOW);
+    const invite = await db.getInviteById("inv_1");
+    expect(invite?.status).toBe("revoked");
+    expect(invite?.slug).toBeNull();
+
+    // both runs attempted the full delete set
+    expect(calls.filter((c) => c.startsWith("del-access:"))).toHaveLength(2);
+    expect(calls.filter((c) => c.startsWith("del-dns:"))).toHaveLength(2);
+    expect(calls.filter((c) => c.startsWith("del-tunnel:"))).toHaveLength(2);
+
+    const actions = (await db.listAudits()).map((a) => a.action);
+    expect(actions).toContain("endpoint.revoke_failed");
+    expect(actions).toContain("endpoint.revoke");
+  });
+
+  it("endpoint not found → throws, before any cf call", async () => {
+    const db = createMemoryConnectDb();
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    await expect(revokeEndpoint({ endpointId: "ep_missing", deps })).rejects.toThrow(
+      /not found/,
+    );
+    expect(calls).toHaveLength(0);
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+});

--- a/workers/scout-connect/src/revoke.ts
+++ b/workers/scout-connect/src/revoke.ts
@@ -1,0 +1,91 @@
+import type { CfApi } from "./cf-api.js";
+import type { ConnectDb } from "./db.js";
+
+export interface RevokeDeps {
+  cf: CfApi;
+  db: ConnectDb;
+  now: () => string;
+  newAuditId: () => string;
+}
+
+export interface RevokeResult {
+  endpointId: string;
+  hostname: string;
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+export async function revokeEndpoint(input: {
+  endpointId: string;
+  deps: RevokeDeps;
+}): Promise<RevokeResult> {
+  const { deps } = input;
+  const { cf, db } = deps;
+  const endpointId = input.endpointId;
+
+  const endpoint = await db.getEndpointById(endpointId);
+  if (endpoint === null) {
+    throw new Error("endpoint not found");
+  }
+  // Idempotent: already revoked → nothing to do. No cf calls, no audit row.
+  if (endpoint.status === "revoked") {
+    return { endpointId, hostname: endpoint.hostname };
+  }
+
+  // Delete order: access app → dns record → tunnel. A failure on one step
+  // must NOT prevent the remaining deletes from being attempted — e.g. a
+  // failed access-app delete still leaves a deletable tunnel. Failures are
+  // collected; the first one is what gets reported/rethrown.
+  const failures: unknown[] = [];
+  const attempt = async (fn: () => Promise<void>): Promise<void> => {
+    try {
+      await fn();
+    } catch (e) {
+      failures.push(e);
+    }
+  };
+
+  await attempt(() => cf.deleteAccessApp(endpoint.cf_access_app_id));
+  await attempt(() => cf.deleteDnsRecord(endpoint.cf_dns_record_id));
+  await attempt(() => cf.deleteTunnel(endpoint.cf_tunnel_id));
+
+  if (failures.length === 0) {
+    await db.markEndpointRevoked(endpointId, deps.now());
+    await db.updateInviteStatus(endpoint.invite_id, {
+      status: "revoked",
+      slug: null,
+      revoked_at: deps.now(),
+    });
+    await db.insertAudit({
+      id: deps.newAuditId(),
+      at: deps.now(),
+      actor: "admin",
+      action: "endpoint.revoke",
+      invite_id: endpoint.invite_id,
+      endpoint_id: endpointId,
+      detail_json: JSON.stringify({ hostname: endpoint.hostname }),
+    });
+    return { endpointId, hostname: endpoint.hostname };
+  }
+
+  // Partial failure: mark revoke_failed (NOT revoked) so the admin retries
+  // later. Retrying is safe because cf-api deletes are 404-idempotent —
+  // resources already deleted above simply come back as success.
+  const firstError = failures[0];
+  await db.markEndpointRevokeFailed(endpointId);
+  await db.insertAudit({
+    id: deps.newAuditId(),
+    at: deps.now(),
+    actor: "admin",
+    action: "endpoint.revoke_failed",
+    invite_id: endpoint.invite_id,
+    endpoint_id: endpointId,
+    detail_json: JSON.stringify({
+      hostname: endpoint.hostname,
+      error: errorMessage(firstError),
+    }),
+  });
+  throw firstError;
+}

--- a/workers/scout-connect/src/revoke.ts
+++ b/workers/scout-connect/src/revoke.ts
@@ -29,8 +29,20 @@ export async function revokeEndpoint(input: {
   if (endpoint === null) {
     throw new Error("endpoint not found");
   }
-  // Idempotent: already revoked → nothing to do. No cf calls, no audit row.
+  // Idempotent: already revoked → no cf calls, no audit row. But self-heal a
+  // partial crash window: if the isolate died between markEndpointRevoked and
+  // updateInviteStatus, the invite is stuck `provisioned` (slug set) forever —
+  // and revealByCode would still hand out the (deleted) tunnel's token. Flip
+  // the invite here when it's not already revoked.
   if (endpoint.status === "revoked") {
+    const invite = await db.getInviteById(endpoint.invite_id);
+    if (invite !== null && invite.status !== "revoked") {
+      await db.updateInviteStatus(invite.id, {
+        status: "revoked",
+        slug: null,
+        revoked_at: deps.now(),
+      });
+    }
     return { endpointId, hostname: endpoint.hostname };
   }
 
@@ -84,7 +96,7 @@ export async function revokeEndpoint(input: {
     endpoint_id: endpointId,
     detail_json: JSON.stringify({
       hostname: endpoint.hostname,
-      error: errorMessage(firstError),
+      errors: failures.map(errorMessage),
     }),
   });
   throw firstError;

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect } from "vitest";
+import { handleRequest, type RouteDeps } from "./routes.js";
+import { createMemoryConnectDb, type ConnectDb } from "./db.js";
+import type { CfApi } from "./cf-api.js";
+
+const BASE = "https://mediaryconnect.app";
+const ADMIN = "test-admin-token-fixture";
+const WRAP_KEY = "00".repeat(32);
+const NOW = "2026-07-24T10:00:00.000Z";
+const FIXTURE_TOKEN_1 = "fixture-tunnel-token-1";
+
+interface CfCall {
+  method: string;
+  args: unknown[];
+}
+
+function makeFakeCf(): { cf: CfApi; calls: CfCall[] } {
+  const calls: CfCall[] = [];
+  let tunnels = 0;
+  const rec = (method: string, ...args: unknown[]): void => {
+    calls.push({ method, args });
+  };
+  const cf: CfApi = {
+    async createTunnel(name) {
+      rec("createTunnel", name);
+      tunnels += 1;
+      return { tunnelId: `tid-${tunnels}`, token: `fixture-tunnel-token-${tunnels}` };
+    },
+    async putTunnelIngress(tunnelId, hostname) {
+      rec("putTunnelIngress", tunnelId, hostname);
+    },
+    async createDnsCname(slug, tunnelId) {
+      rec("createDnsCname", slug, tunnelId);
+      return { recordId: `rec-${slug}` };
+    },
+    async createAccessApp(input) {
+      rec("createAccessApp", input);
+      return { appId: `app-${input.domain}`, policyId: "pol-1" };
+    },
+    async deleteTunnel(tunnelId) {
+      rec("deleteTunnel", tunnelId);
+    },
+    async deleteDnsRecord(recordId) {
+      rec("deleteDnsRecord", recordId);
+    },
+    async deleteAccessApp(appId) {
+      rec("deleteAccessApp", appId);
+    },
+  };
+  return { cf, calls };
+}
+
+function makeDeps(db: ConnectDb, cf: CfApi): RouteDeps {
+  let n = 0;
+  const seq =
+    (prefix: string) =>
+    (): string => {
+      n += 1;
+      return `${prefix}_${n}`;
+    };
+  return {
+    db,
+    cf,
+    adminToken: ADMIN,
+    rootDomain: "mediaryconnect.app",
+    tokenWrapKeyHex: WRAP_KEY,
+    now: () => NOW,
+    newInviteId: seq("inv"),
+    newEndpointId: seq("ep"),
+    newAuditId: seq("aud"),
+    newInviteCode: seq("code"),
+  };
+}
+
+function setup(): { db: ConnectDb; calls: CfCall[]; deps: RouteDeps } {
+  const db = createMemoryConnectDb();
+  const { cf, calls } = makeFakeCf();
+  return { db, calls, deps: makeDeps(db, cf) };
+}
+
+function adminPost(path: string, body?: unknown): Request {
+  return new Request(`${BASE}${path}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${ADMIN}`, "content-type": "application/json" },
+    body: body === undefined ? "{}" : JSON.stringify(body),
+  });
+}
+
+function adminGet(path: string): Request {
+  return new Request(`${BASE}${path}`, {
+    headers: { authorization: `Bearer ${ADMIN}` },
+  });
+}
+
+async function createInviteViaApi(deps: RouteDeps, body: unknown): Promise<Response> {
+  return handleRequest(adminPost("/api/admin/invites", body), deps);
+}
+
+async function provisionViaApi(
+  deps: RouteDeps,
+  inviteId: string,
+  body?: unknown,
+): Promise<Response> {
+  return handleRequest(adminPost(`/api/admin/invites/${inviteId}/provision`, body), deps);
+}
+
+interface InviteCreated {
+  id: string;
+  code: string;
+  inviteUrl: string;
+}
+
+interface ProvisionOk {
+  hostname: string;
+  token: string;
+  agentPrompt: string;
+  inviteUrl: string;
+}
+
+/** Creates an invite (slug "alice") and provisions it through the HTTP routes. */
+async function seedProvisioned(deps: RouteDeps): Promise<InviteCreated & ProvisionOk> {
+  const createRes = await createInviteViaApi(deps, { email: "alice@example.com", slug: "alice" });
+  const created = (await createRes.json()) as InviteCreated;
+  const provRes = await provisionViaApi(deps, created.id);
+  const prov = (await provRes.json()) as ProvisionOk;
+  return { ...created, ...prov };
+}
+
+describe("handleRequest", () => {
+  it("GET / → 200 HTML containing Scout Connect", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/`), deps);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("Scout Connect");
+  });
+
+  it("GET /healthz → ok", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/healthz`), deps);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+
+  it("admin api without bearer → 401", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/api/admin/invites`), deps);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+
+  it("POST invite → 201 with lowercased email, inviteUrl, and audit row", async () => {
+    const { db, deps } = setup();
+    const res = await createInviteViaApi(deps, {
+      email: " Alice@Example.COM ",
+      invitee_label: "Alice",
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as InviteCreated;
+    expect(body.inviteUrl).toBe(`${BASE}/i/${body.code}`);
+
+    const invite = await db.getInviteById(body.id);
+    expect(invite?.email).toBe("alice@example.com");
+    expect(invite?.status).toBe("pending");
+    expect(invite?.invitee_label).toBe("Alice");
+    expect(invite?.created_at).toBe(NOW);
+
+    const audits = await db.listAudits();
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.action).toBe("invite.create");
+    expect(audits[0]?.actor).toBe("admin");
+    expect(audits[0]?.invite_id).toBe(body.id);
+    expect(audits[0]?.detail_json).toContain("alice@example.com");
+  });
+
+  it("POST invite with invalid email → 400, nothing persisted", async () => {
+    const { db, deps } = setup();
+    const res = await createInviteViaApi(deps, { email: "not-an-email" });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "invalid email" });
+    expect(await db.listInvites()).toHaveLength(0);
+    expect(await db.listAudits()).toHaveLength(0);
+  });
+
+  it("provision happy path → 200 with token; public endpoints list carries no token material", async () => {
+    const { db, deps } = setup();
+    const createRes = await createInviteViaApi(deps, {
+      email: "alice@example.com",
+      slug: "alice",
+    });
+    const created = (await createRes.json()) as InviteCreated;
+
+    const res = await provisionViaApi(deps, created.id);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ProvisionOk;
+    expect(body.hostname).toBe("alice.mediaryconnect.app");
+    expect(body.token).toBe(FIXTURE_TOKEN_1);
+    expect(body.agentPrompt).toContain(FIXTURE_TOKEN_1);
+    expect(body.inviteUrl).toBe(`${BASE}/i/${created.code}`);
+
+    const listRes = await handleRequest(adminGet("/api/admin/endpoints"), deps);
+    expect(listRes.status).toBe(200);
+    const list = (await listRes.json()) as { endpoints: Array<Record<string, unknown>> };
+    expect(list.endpoints).toHaveLength(1);
+    const ep = list.endpoints[0];
+    expect(ep?.hostname).toBe("alice.mediaryconnect.app");
+    expect(ep?.cf_tunnel_id).toBe("tid-1");
+    expect(ep && "token" in ep).toBe(false);
+    expect(ep && "token_ciphertext" in ep).toBe(false);
+    expect(ep && "token_sha256" in ep).toBe(false);
+    expect(JSON.stringify(list)).not.toContain("fixture-tunnel-token");
+
+    // db still holds the one-time ciphertext (not burned by listing)
+    const stored = await db.getEndpointByInviteId(created.id);
+    expect(stored?.token_ciphertext).not.toBeNull();
+    expect(stored?.token_shown_at).toBeNull();
+  });
+
+  it("provision without any slug → 400 slug required", async () => {
+    const { deps } = setup();
+    const createRes = await createInviteViaApi(deps, { email: "alice@example.com" });
+    const created = (await createRes.json()) as InviteCreated;
+
+    const res = await provisionViaApi(deps, created.id);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "slug required" });
+  });
+
+  it("provision unknown invite → 404", async () => {
+    const { deps } = setup();
+    const res = await provisionViaApi(deps, "inv_nope", { slug: "alice" });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "invite not found" });
+  });
+
+  it("revoke → 200 {hostname, revoked:true}, endpoint+invite flipped, cf deletes called", async () => {
+    const { db, calls, deps } = setup();
+    await seedProvisioned(deps);
+    const endpointId = (await db.listEndpoints())[0]?.id;
+    expect(endpointId).toBeDefined();
+
+    const res = await handleRequest(
+      adminPost(`/api/admin/endpoints/${endpointId ?? ""}/revoke`),
+      deps,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      hostname: "alice.mediaryconnect.app",
+      revoked: true,
+    });
+
+    const methods = calls.map((c) => c.method);
+    expect(methods).toContain("deleteAccessApp");
+    expect(methods).toContain("deleteDnsRecord");
+    expect(methods).toContain("deleteTunnel");
+
+    const endpoint = await db.getEndpointById(endpointId ?? "");
+    expect(endpoint?.status).toBe("revoked");
+    expect(endpoint?.revoked_at).toBe(NOW);
+    const invite = await db.getInviteById(endpoint?.invite_id ?? "");
+    expect(invite?.status).toBe("revoked");
+  });
+
+  it("GET /i/unknown → 链接无效 page", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/i/${"x".repeat(40)}`), deps);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toContain("链接无效");
+  });
+
+  it("GET /i/:code with pending invite → 作者尚未开通, no reveal button", async () => {
+    const { deps } = setup();
+    const createRes = await createInviteViaApi(deps, { email: "alice@example.com" });
+    const created = (await createRes.json()) as InviteCreated;
+
+    const res = await handleRequest(new Request(`${BASE}/i/${created.code}`), deps);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("作者尚未开通");
+    expect(html).not.toContain("显示连接信息");
+  });
+
+  it("GET /i/:code ready → 显示连接信息 button, but NOT the token", async () => {
+    const { deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    const res = await handleRequest(new Request(`${BASE}/i/${seeded.code}`), deps);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("显示连接信息");
+    expect(html).not.toContain(FIXTURE_TOKEN_1);
+  });
+
+  it("POST reveal → 200 with token; second reveal → 200 alreadyShown without token", async () => {
+    const { deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    const first = await handleRequest(
+      new Request(`${BASE}/api/i/${seeded.code}/reveal`, { method: "POST" }),
+      deps,
+    );
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as Record<string, unknown>;
+    expect(firstBody.hostname).toBe("alice.mediaryconnect.app");
+    expect(firstBody.token).toBe(FIXTURE_TOKEN_1);
+    expect(firstBody.agentPrompt).toBe(seeded.agentPrompt);
+
+    const second = await handleRequest(
+      new Request(`${BASE}/api/i/${seeded.code}/reveal`, { method: "POST" }),
+      deps,
+    );
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as Record<string, unknown>;
+    expect(secondBody).toEqual({
+      hostname: "alice.mediaryconnect.app",
+      alreadyShown: true,
+    });
+    expect("token" in secondBody).toBe(false);
+  });
+
+  it("POST reveal with unknown code → 404", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(
+      new Request(`${BASE}/api/i/${"y".repeat(40)}/reveal`, { method: "POST" }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not found" });
+  });
+
+  it("www.* hostname → 301 apex, preserving path", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request("https://www.mediaryconnect.app/i/abc"), deps);
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("https://mediaryconnect.app/i/abc");
+  });
+
+  it("unknown path → 404", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/nope`), deps);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not found" });
+  });
+});

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -292,6 +292,24 @@ describe("handleRequest", () => {
     expect(html).not.toContain(FIXTURE_TOKEN_1);
   });
 
+  it("GET ready page does not pre-burn: reveal afterwards still returns the token", async () => {
+    const { db, deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    await handleRequest(new Request(`${BASE}/i/${seeded.code}`), deps);
+    const invite = await db.getInviteByCode(seeded.code);
+    const ep = await db.getEndpointByInviteId(invite?.id ?? "");
+    expect(ep?.token_ciphertext).not.toBeNull();
+    expect(ep?.token_shown_at).toBeNull();
+
+    const reveal = await handleRequest(
+      new Request(`${BASE}/api/i/${seeded.code}/reveal`, { method: "POST" }),
+      deps,
+    );
+    expect(reveal.status).toBe(200);
+    expect(((await reveal.json()) as { token?: string }).token).toBe(FIXTURE_TOKEN_1);
+  });
+
   it("POST reveal → 200 with token; second reveal → 200 alreadyShown without token", async () => {
     const { deps } = setup();
     const seeded = await seedProvisioned(deps);

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -159,12 +159,23 @@ async function createInvite(request: Request, url: URL, deps: RouteDeps): Promis
   if (!email.includes("@")) {
     throw new HttpError(400, "invalid email");
   }
+  // Validate/normalize the slug at creation time so a bad slug fails fast
+  // (400 here) instead of later at provision.
+  const slugRaw = optString(body.slug);
+  let slug: string | null = null;
+  if (slugRaw !== null) {
+    try {
+      slug = assertSlug(slugRaw);
+    } catch (e) {
+      throw new HttpError(400, e instanceof Error ? e.message : "invalid slug");
+    }
+  }
   const invite = await deps.db.insertInvite({
     id: deps.newInviteId(),
     code: deps.newInviteCode(),
     invitee_label: optString(body.invitee_label),
     email,
-    slug: optString(body.slug),
+    slug,
     status: "pending",
     created_at: deps.now(),
     provisioned_at: null,
@@ -209,25 +220,40 @@ async function provisionInvite(
   if (invite.status !== "pending") {
     throw new HttpError(409, "invite not pending");
   }
-  const result = await provisionEndpoint({
-    inviteId: invite.id,
-    slug,
-    deps: {
-      cf: deps.cf,
-      db: deps.db,
-      rootDomain: deps.rootDomain,
-      tokenWrapKeyHex: deps.tokenWrapKeyHex,
-      now: deps.now,
-      newEndpointId: deps.newEndpointId,
-      newAuditId: deps.newAuditId,
+  let result;
+  try {
+    result = await provisionEndpoint({
+      inviteId: invite.id,
+      slug,
+      deps: {
+        cf: deps.cf,
+        db: deps.db,
+        rootDomain: deps.rootDomain,
+        tokenWrapKeyHex: deps.tokenWrapKeyHex,
+        now: deps.now,
+        newEndpointId: deps.newEndpointId,
+        newAuditId: deps.newAuditId,
+      },
+    });
+  } catch (e) {
+    // Domain conflicts (TOCTOU races past the pre-checks above) are client
+    // errors, not 500s. Everything else (CF/D1 failures) stays a 500.
+    const msg = e instanceof Error ? e.message : "";
+    if (msg.includes("invite not pending") || msg.includes("already in use")) {
+      throw new HttpError(409, msg);
+    }
+    throw e;
+  }
+  return json(
+    {
+      hostname: result.hostname,
+      token: result.token,
+      agentPrompt: result.agentPrompt,
+      inviteUrl: `${url.origin}/i/${result.inviteCode}`,
     },
-  });
-  return json({
-    hostname: result.hostname,
-    token: result.token,
-    agentPrompt: result.agentPrompt,
-    inviteUrl: `${url.origin}/i/${result.inviteCode}`,
-  });
+    200,
+    { noStore: true },
+  );
 }
 
 // Read-only mirror of revealByCode's state machine: a GET page render must
@@ -270,10 +296,14 @@ async function revealInvite(deps: RouteDeps, code: string): Promise<Response> {
     case "already_shown":
       return json({ hostname: outcome.hostname, alreadyShown: true });
     case "revealed":
-      return json({
-        hostname: outcome.hostname,
-        token: outcome.token,
-        agentPrompt: outcome.agentPrompt,
-      });
+      return json(
+        {
+          hostname: outcome.hostname,
+          token: outcome.token,
+          agentPrompt: outcome.agentPrompt,
+        },
+        200,
+        { noStore: true },
+      );
   }
 }

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -127,8 +127,14 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   const revokeMatch = path.match(/^\/api\/admin\/endpoints\/([^/]+)\/revoke$/);
   if (revokeMatch !== null && method === "POST") {
     requireAdmin(request, deps.adminToken);
+    const endpointId = decodeParam(revokeMatch[1] ?? "");
+    // 404 (not 500) for a missing endpoint — the admin client distinguishes
+    // "already gone" from "revoke failed".
+    if ((await deps.db.getEndpointById(endpointId)) === null) {
+      throw new HttpError(404, "endpoint not found");
+    }
     const result = await revokeEndpoint({
-      endpointId: decodeParam(revokeMatch[1] ?? ""),
+      endpointId,
       deps: { cf: deps.cf, db: deps.db, now: deps.now, newAuditId: deps.newAuditId },
     });
     return json({ hostname: result.hostname, revoked: true });

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -278,6 +278,11 @@ async function inviteState(deps: RouteDeps, code: string): Promise<InvitePageSta
     // provisioning half-done (invite flipped, endpoint row missing)
     return { kind: "waiting" };
   }
+  // Match revealByCode: a non-active endpoint is an invalid link — never show
+  // a hostname or ready/revealed state for a revoked/revoke_failed endpoint.
+  if (endpoint.status !== "active") {
+    return { kind: "not_found" };
+  }
   if (endpoint.token_shown_at !== null || endpoint.token_ciphertext === null) {
     return { kind: "revealed", hostname: endpoint.hostname };
   }

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -1,0 +1,279 @@
+import type { CfApi } from "./cf-api.js";
+import type { ConnectDb } from "./db.js";
+import { HttpError, handleError, htmlPage, json } from "./http.js";
+import { requireAdmin } from "./auth.js";
+import { provisionEndpoint } from "./provision.js";
+import { revokeEndpoint } from "./revoke.js";
+import { revealByCode } from "./reveal.js";
+import { assertSlug } from "./slug.js";
+import { homePage } from "./html/home-page.js";
+import { adminPage } from "./html/admin-page.js";
+import { invitePage, type InvitePageState } from "./html/invite-page.js";
+
+export interface RouteDeps {
+  db: ConnectDb;
+  cf: CfApi;
+  adminToken: string;
+  rootDomain: string;
+  tokenWrapKeyHex: string;
+  now: () => string;
+  newInviteId: () => string;
+  newEndpointId: () => string;
+  newAuditId: () => string;
+  newInviteCode: () => string;
+}
+
+export async function handleRequest(request: Request, deps: RouteDeps): Promise<Response> {
+  try {
+    return await route(request, deps);
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+async function readJsonBody(request: Request): Promise<Record<string, unknown>> {
+  const text = await request.text();
+  if (text.trim() === "") {
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new HttpError(400, "invalid json");
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new HttpError(400, "invalid body");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function optString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function decodeParam(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    throw new HttpError(400, "bad encoding");
+  }
+}
+
+async function route(request: Request, deps: RouteDeps): Promise<Response> {
+  const url = new URL(request.url);
+  const path = url.pathname;
+  const method = request.method;
+
+  // www.* → apex, preserving path (and query).
+  if (url.hostname.toLowerCase().startsWith("www.")) {
+    const target = new URL(url.toString());
+    target.hostname = url.hostname.slice("www.".length);
+    return Response.redirect(target.toString(), 301);
+  }
+
+  if (method === "GET" && path === "/") {
+    return htmlPage(homePage());
+  }
+  if (method === "GET" && path === "/healthz") {
+    return new Response("ok", {
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  }
+  if (method === "GET" && path === "/admin") {
+    return htmlPage(adminPage());
+  }
+
+  // ---- admin api (bearer required) ----
+  if (path === "/api/admin/invites") {
+    requireAdmin(request, deps.adminToken);
+    if (method === "GET") {
+      return json({ invites: await deps.db.listInvites() });
+    }
+    if (method === "POST") {
+      return await createInvite(request, url, deps);
+    }
+    throw new HttpError(404, "not found");
+  }
+
+  if (path === "/api/admin/endpoints" && method === "GET") {
+    requireAdmin(request, deps.adminToken);
+    // PUBLIC shape only — token_ciphertext / token_sha256 (and CF-internal
+    // resource ids besides the tunnel id) must never leave the server.
+    const endpoints = (await deps.db.listEndpoints()).map((ep) => ({
+      id: ep.id,
+      invite_id: ep.invite_id,
+      slug: ep.slug,
+      hostname: ep.hostname,
+      status: ep.status,
+      token_shown_at: ep.token_shown_at,
+      created_at: ep.created_at,
+      revoked_at: ep.revoked_at,
+      cf_tunnel_id: ep.cf_tunnel_id,
+    }));
+    return json({ endpoints });
+  }
+
+  const provisionMatch = path.match(/^\/api\/admin\/invites\/([^/]+)\/provision$/);
+  if (provisionMatch !== null && method === "POST") {
+    requireAdmin(request, deps.adminToken);
+    return await provisionInvite(request, url, deps, decodeParam(provisionMatch[1] ?? ""));
+  }
+
+  const revokeMatch = path.match(/^\/api\/admin\/endpoints\/([^/]+)\/revoke$/);
+  if (revokeMatch !== null && method === "POST") {
+    requireAdmin(request, deps.adminToken);
+    const result = await revokeEndpoint({
+      endpointId: decodeParam(revokeMatch[1] ?? ""),
+      deps: { cf: deps.cf, db: deps.db, now: deps.now, newAuditId: deps.newAuditId },
+    });
+    return json({ hostname: result.hostname, revoked: true });
+  }
+
+  // ---- invitee ----
+  const inviteMatch = path.match(/^\/i\/([^/]+)$/);
+  if (inviteMatch !== null && method === "GET") {
+    const state = await inviteState(deps, decodeParam(inviteMatch[1] ?? ""));
+    return htmlPage(invitePage(state));
+  }
+
+  const revealMatch = path.match(/^\/api\/i\/([^/]+)\/reveal$/);
+  if (revealMatch !== null && method === "POST") {
+    return await revealInvite(deps, decodeParam(revealMatch[1] ?? ""));
+  }
+
+  throw new HttpError(404, "not found");
+}
+
+async function createInvite(request: Request, url: URL, deps: RouteDeps): Promise<Response> {
+  const body = await readJsonBody(request);
+  const emailRaw = body.email;
+  if (typeof emailRaw !== "string") {
+    throw new HttpError(400, "email required");
+  }
+  const email = emailRaw.trim().toLowerCase();
+  if (!email.includes("@")) {
+    throw new HttpError(400, "invalid email");
+  }
+  const invite = await deps.db.insertInvite({
+    id: deps.newInviteId(),
+    code: deps.newInviteCode(),
+    invitee_label: optString(body.invitee_label),
+    email,
+    slug: optString(body.slug),
+    status: "pending",
+    created_at: deps.now(),
+    provisioned_at: null,
+    revoked_at: null,
+  });
+  await deps.db.insertAudit({
+    id: deps.newAuditId(),
+    at: deps.now(),
+    actor: "admin",
+    action: "invite.create",
+    invite_id: invite.id,
+    endpoint_id: null,
+    detail_json: JSON.stringify({ email }),
+  });
+  return json(
+    { id: invite.id, code: invite.code, inviteUrl: `${url.origin}/i/${invite.code}` },
+    201,
+  );
+}
+
+async function provisionInvite(
+  request: Request,
+  url: URL,
+  deps: RouteDeps,
+  inviteId: string,
+): Promise<Response> {
+  const invite = await deps.db.getInviteById(inviteId);
+  if (invite === null) {
+    throw new HttpError(404, "invite not found");
+  }
+  const body = await readJsonBody(request);
+  const slugRaw = optString(body.slug) ?? invite.slug;
+  if (slugRaw === null) {
+    throw new HttpError(400, "slug required");
+  }
+  let slug: string;
+  try {
+    slug = assertSlug(slugRaw);
+  } catch (e) {
+    throw new HttpError(400, e instanceof Error ? e.message : "invalid slug");
+  }
+  if (invite.status !== "pending") {
+    throw new HttpError(409, "invite not pending");
+  }
+  const result = await provisionEndpoint({
+    inviteId: invite.id,
+    slug,
+    deps: {
+      cf: deps.cf,
+      db: deps.db,
+      rootDomain: deps.rootDomain,
+      tokenWrapKeyHex: deps.tokenWrapKeyHex,
+      now: deps.now,
+      newEndpointId: deps.newEndpointId,
+      newAuditId: deps.newAuditId,
+    },
+  });
+  return json({
+    hostname: result.hostname,
+    token: result.token,
+    agentPrompt: result.agentPrompt,
+    inviteUrl: `${url.origin}/i/${result.inviteCode}`,
+  });
+}
+
+// Read-only mirror of revealByCode's state machine: a GET page render must
+// never burn the one-time ciphertext, so revealByCode is deliberately NOT
+// reused here — the state is queried directly from the db.
+async function inviteState(deps: RouteDeps, code: string): Promise<InvitePageState> {
+  const invite = await deps.db.getInviteByCode(code);
+  if (invite === null || invite.status === "revoked") {
+    return { kind: "not_found" };
+  }
+  if (invite.status === "pending") {
+    return { kind: "waiting" };
+  }
+  const endpoint = await deps.db.getEndpointByInviteId(invite.id);
+  if (endpoint === null) {
+    // provisioning half-done (invite flipped, endpoint row missing)
+    return { kind: "waiting" };
+  }
+  if (endpoint.token_shown_at !== null || endpoint.token_ciphertext === null) {
+    return { kind: "revealed", hostname: endpoint.hostname };
+  }
+  return { kind: "ready", code };
+}
+
+async function revealInvite(deps: RouteDeps, code: string): Promise<Response> {
+  const outcome = await revealByCode({
+    code,
+    deps: {
+      db: deps.db,
+      tokenWrapKeyHex: deps.tokenWrapKeyHex,
+      now: deps.now,
+      newAuditId: deps.newAuditId,
+    },
+  });
+  switch (outcome.kind) {
+    case "not_found":
+      throw new HttpError(404, "not found");
+    case "not_ready":
+      return json({ error: "not ready" }, 409);
+    case "already_shown":
+      return json({ hostname: outcome.hostname, alreadyShown: true });
+    case "revealed":
+      return json({
+        hostname: outcome.hostname,
+        token: outcome.token,
+        agentPrompt: outcome.agentPrompt,
+      });
+  }
+}

--- a/workers/scout-connect/src/slug.test.ts
+++ b/workers/scout-connect/src/slug.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { normalizeSlug, assertSlug, RESERVED_SLUGS } from "./slug.js";
+
+describe("slug", () => {
+  it("normalizes lowercases and trims", () => {
+    expect(normalizeSlug("  Alice-01 ")).toBe("alice-01");
+  });
+
+  it("accepts valid slugs", () => {
+    expect(() => assertSlug("alice")).not.toThrow();
+    expect(() => assertSlug("a7k2")).not.toThrow();
+    expect(() => assertSlug("a")).not.toThrow();
+  });
+
+  it("rejects reserved, bad charset, length, edge hyphens", () => {
+    expect(() => assertSlug("www")).toThrow(/reserved/i);
+    expect(() => assertSlug("Admin")).toThrow(/reserved/i);
+    expect(() => assertSlug("-ab")).toThrow();
+    expect(() => assertSlug("ab-")).toThrow();
+    expect(() => assertSlug("has_underscore")).toThrow();
+    expect(() => assertSlug("a".repeat(33))).toThrow();
+    for (const r of ["api", "admin", "mail", "connect", "status", "cdn", "static", "owner", "ftp"]) {
+      expect(RESERVED_SLUGS.has(r)).toBe(true);
+    }
+  });
+});

--- a/workers/scout-connect/src/slug.test.ts
+++ b/workers/scout-connect/src/slug.test.ts
@@ -23,4 +23,17 @@ describe("slug", () => {
       expect(RESERVED_SLUGS.has(r)).toBe(true);
     }
   });
+
+  it("returns the normalized slug", () => {
+    expect(assertSlug("  Alice-01 ")).toBe("alice-01");
+  });
+
+  it("rejects empty and whitespace-only input", () => {
+    expect(() => assertSlug("")).toThrow();
+    expect(() => assertSlug("   ")).toThrow();
+  });
+
+  it("accepts exactly 32 characters", () => {
+    expect(() => assertSlug("a".repeat(32))).not.toThrow();
+  });
 });

--- a/workers/scout-connect/src/slug.ts
+++ b/workers/scout-connect/src/slug.ts
@@ -21,13 +21,13 @@ export const RESERVED_SLUGS: ReadonlySet<string> = new Set([
 
 export const SLUG_RE = /^(?:[a-z0-9]|[a-z0-9][a-z0-9-]{0,30}[a-z0-9])$/;
 
-export const SLUG_MAX_LENGTH = 32;
+const SLUG_MAX_LENGTH = 32;
 
 export function normalizeSlug(input: string): string {
   return input.trim().toLowerCase();
 }
 
-export function assertSlug(input: string): void {
+export function assertSlug(input: string): string {
   const slug = normalizeSlug(input);
   if (slug.length < 1 || slug.length > SLUG_MAX_LENGTH) {
     throw new Error(
@@ -42,4 +42,5 @@ export function assertSlug(input: string): void {
   if (RESERVED_SLUGS.has(slug)) {
     throw new Error(`reserved slug: ${slug}`);
   }
+  return slug;
 }

--- a/workers/scout-connect/src/slug.ts
+++ b/workers/scout-connect/src/slug.ts
@@ -1,0 +1,45 @@
+export const RESERVED_SLUGS: ReadonlySet<string> = new Set([
+  "www",
+  "api",
+  "admin",
+  "mail",
+  "ftp",
+  "connect",
+  "status",
+  "cdn",
+  "static",
+  "owner",
+  "root",
+  "support",
+  "help",
+  "null",
+  "undefined",
+  "i",
+  "login",
+  "auth",
+]);
+
+export const SLUG_RE = /^(?:[a-z0-9]|[a-z0-9][a-z0-9-]{0,30}[a-z0-9])$/;
+
+export const SLUG_MAX_LENGTH = 32;
+
+export function normalizeSlug(input: string): string {
+  return input.trim().toLowerCase();
+}
+
+export function assertSlug(input: string): void {
+  const slug = normalizeSlug(input);
+  if (slug.length < 1 || slug.length > SLUG_MAX_LENGTH) {
+    throw new Error(
+      `invalid slug length: must be 1-${SLUG_MAX_LENGTH} characters`,
+    );
+  }
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(
+      "invalid slug: must be lowercase alphanumeric with optional inner hyphens, not starting or ending with a hyphen",
+    );
+  }
+  if (RESERVED_SLUGS.has(slug)) {
+    throw new Error(`reserved slug: ${slug}`);
+  }
+}

--- a/workers/scout-connect/tsconfig.json
+++ b/workers/scout-connect/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/scout-connect/wrangler.jsonc
+++ b/workers/scout-connect/wrangler.jsonc
@@ -8,7 +8,7 @@
     {
       "binding": "DB",
       "database_name": "scout-connect",
-      "database_id": "REPLACE_ME"
+      "database_id": "493fb312-2301-4a85-a22f-15e68460ed98"
     }
   ],
   "vars": {

--- a/workers/scout-connect/wrangler.jsonc
+++ b/workers/scout-connect/wrangler.jsonc
@@ -1,0 +1,17 @@
+{
+  "name": "scout-connect",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-06-01",
+  "workers_dev": false,
+  "routes": [{ "pattern": "mediaryconnect.app", "custom_domain": true }],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "scout-connect",
+      "database_id": "REPLACE_ME"
+    }
+  ],
+  "vars": {
+    "CONNECT_ROOT_DOMAIN": "mediaryconnect.app"
+  }
+}


### PR DESCRIPTION
## Summary

Invite-only remote access control plane at `mediaryconnect.app` (Workers + D1): admin provisions a Cloudflare Tunnel + public hostname + Access email-OTP gate per invitee; the home side just sets `TUNNEL_TOKEN` in `.env` and runs the existing compose tunnel profile.

- **`workers/scout-connect/`** — new deployable worker: slug/ids, AES-GCM token wrap, CF API client, D1 layer, provision/revoke/reveal orchestration, HTTP routes + admin & invite HTML pages.
- **Orchestration order is security-relevant:** tunnel → ingress (`http://web:3000`, fixed) → **Access app first** → DNS CNAME last, so a hostname never publicly resolves unprotected.
- **Token secrecy:** plaintext connector token returned to the caller exactly once (admin at provision, invitee at one-time reveal); D1 stores AES-GCM ciphertext pre-reveal, then only sha256 after burn. Atomic conditional burn makes the reveal once-only even under concurrent requests.
- **Compensation on every failure path:** CF rollback per orchestration step + D1-failure orphan cleanup (deletes CF resources, removes phantom row, rolls invite back to pending, audits `provision.orphan`).
- **Revoke is idempotent:** 404-tolerant deletes, collected-failure pattern, `revoke_failed` state, closes tunnel connections and retries CF error 1022, self-heals the isolate-death crash window.
- 104 unit tests (auto-discovered by root `vitest run`); CI typecheck added for the new worker.
- Docs: `workers/scout-connect/README.md` + `docs/deploy.md` 方式三.

**Deployed + live-verified end-to-end** on `mediaryconnect.app`: provision → home-side tunnel registered (4 connections) → hostname redirected to Access OTP → invite page ready/reveal/already-shown → revoke → CF resources fully cleaned. Production router `.env` was restored unchanged afterwards.

## Residual risks (accepted for invite-only MVP)

- Slugs are permanently single-use (endpoint rows kept for audit; slug/hostname UNIQUE forever).
- No rate limiting on `/i/:code` (mitigated by 160-bit code space; CF WAF is the future lever).
- `token_sha256` written but not yet read (future token-verification use).
- Worker types from `@types/node` + hand-written D1 ambient types (not `@cloudflare/workers-types`) — runtime proven by live e2e, tsc can't catch workerd drift.

## Test plan

- [x] `npx vitest run` — 1913 passed (104 new)
- [x] `npx tsc -p workers/scout-connect/tsconfig.json --noEmit` + all existing typechecks
- [x] `npm run lint`
- [x] Live e2e on production Cloudflare account (see above)