### PR TITLE
feat(auth): login brute-force throttle + fix username enumeration oracle

### DIFF
--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -18,7 +18,9 @@ export async function POST(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as { username?: unknown; password?: unknown };
   const username = typeof body.username === "string" ? body.username : "";
   const password = typeof body.password === "string" ? body.password : "";
-  const result = await loginAccount(username, password);
+  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+  const throttleKey = `${username.trim().toLowerCase()}|${ip}`;
+  const result = await loginAccount(username, password, throttleKey);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 401 });
   }

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { isDemoMode } from "../../../../lib/demo-mode";
 import { NextResponse, type NextRequest } from "next/server";
+import { buildThrottleKey } from "../../../../lib/login-throttle";
 import {
   SESSION_COOKIE_NAME,
   isMultiUserEnabled,
@@ -18,9 +19,7 @@ export async function POST(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as { username?: unknown; password?: unknown };
   const username = typeof body.username === "string" ? body.username : "";
   const password = typeof body.password === "string" ? body.password : "";
-  const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
-  const throttleKey = `${username.trim().toLowerCase()}|${ip}`;
-  const result = await loginAccount(username, password, throttleKey);
+  const result = await loginAccount(username, password, buildThrottleKey(request.headers, username));
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 401 });
   }

--- a/apps/web/lib/login-throttle-integration.test.ts
+++ b/apps/web/lib/login-throttle-integration.test.ts
@@ -129,4 +129,32 @@ describe("loginAccount throttling (integration)", () => {
     },
     CRYPTO_TIMEOUT_MS,
   );
+
+  it(
+    "keeps the throttle bucket when session creation fails (no backoff reset on server error)",
+    async () => {
+      const rt = await boot();
+      await rt.registerAccount("owner1", "password-123");
+      const { checkLoginAllowed, normalizeThrottleKey } = await import("./login-throttle");
+
+      // 先攒 4 次失败（还差 1 次就锁定）
+      for (let i = 0; i < 4; i++) await rt.loginAccount("owner1", "wrong-password");
+
+      // 让建 session 抛错：密码是对的，但服务端故障 ⇒ 这次登录并未成功
+      const repo = rt.getWorkflowRepository();
+      const original = repo.createSession.bind(repo);
+      repo.createSession = async () => {
+        throw new Error("DB down");
+      };
+      await expect(rt.loginAccount("owner1", "password-123")).rejects.toThrow("DB down");
+      repo.createSession = original;
+
+      // 桶必须保留：再失败 1 次即达到 5 次门槛而锁定。
+      // 若桶在 session 失败时被误清，这里只算第 1 次，不会锁。
+      await rt.loginAccount("owner1", "wrong-password");
+      const key = normalizeThrottleKey("owner1");
+      expect(checkLoginAllowed(key, Date.now()).allowed).toBe(false);
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 });

--- a/apps/web/lib/login-throttle-integration.test.ts
+++ b/apps/web/lib/login-throttle-integration.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * loginAccount 限流集成测试。复用既有 `:memory:` SQLite boot 模式
+ * （同 guangya-connect.test.ts），真实跑 workflow-runtime，仅隔离网络无关部分。
+ * 负载断言：
+ *  - 连续 5 次错误密码 → 第 6 次返回「尝试过于频繁」（且不再验密）。
+ *  - 锁定期间即使密码正确也被挡。
+ *  - 重置后正确密码可登录。
+ */
+
+const prevPg = process.env.MEDIA_TRACK_POSTGRES_URL;
+const prevMultiUser = process.env.MEDIA_TRACK_MULTI_USER;
+
+const boot = async () => {
+  process.env.MEDIA_TRACK_SQLITE_PATH = ":memory:";
+  delete process.env.MEDIA_TRACK_POSTGRES_URL;
+  process.env.MEDIA_TRACK_MULTI_USER = "1"; // 登录路由/账号体系启用
+  vi.resetModules();
+  return import("./workflow-runtime");
+};
+
+afterEach(() => {
+  delete process.env.MEDIA_TRACK_SQLITE_PATH;
+  if (prevPg !== undefined) process.env.MEDIA_TRACK_POSTGRES_URL = prevPg;
+  if (prevMultiUser !== undefined) process.env.MEDIA_TRACK_MULTI_USER = prevMultiUser;
+  vi.resetModules();
+});
+
+describe("loginAccount throttling (integration)", () => {
+  beforeEach(async () => {
+    const { _resetLoginThrottleForTest } = await import("./login-throttle");
+    _resetLoginThrottleForTest();
+  });
+
+  it("locks after 5 wrong passwords and blocks the 6th (even the correct one)", async () => {
+    const rt = await boot();
+    await rt.registerAccount("owner1", "password-123");
+
+    for (let i = 0; i < 5; i++) {
+      const r = await rt.loginAccount("owner1", "wrong-password");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toContain("用户名或密码不正确");
+    }
+
+    // 第 6 次：不再验密，直接限流
+    const locked = await rt.loginAccount("owner1", "wrong-password");
+    expect(locked.ok).toBe(false);
+    if (!locked.ok) expect(locked.error).toContain("尝试过于频繁");
+
+    // 锁定期间正确密码同样被挡
+    const blocked = await rt.loginAccount("owner1", "password-123");
+    expect(blocked.ok).toBe(false);
+    if (!blocked.ok) expect(blocked.error).toContain("尝试过于频繁");
+  });
+
+  it("successful login after reset works and is independent per username", async () => {
+    const rt = await boot();
+    await rt.registerAccount("owner1", "password-123");
+
+    for (let i = 0; i < 5; i++) await rt.loginAccount("owner1", "wrong-password");
+    // 另一个用户名不受影响
+    const other = await rt.loginAccount("someone-else", "wrong-password");
+    expect(other.ok).toBe(false);
+    if (!other.ok) expect(other.error).toContain("用户名或密码不正确");
+
+    const { _resetLoginThrottleForTest } = await import("./login-throttle");
+    _resetLoginThrottleForTest();
+    const ok = await rt.loginAccount("owner1", "password-123");
+    expect(ok.ok).toBe(true);
+  });
+
+  it("no timing oracle: missing account takes same time as existing (both hit scrypt)", async () => {
+    const rt = await boot();
+    await rt.registerAccount("exists", "password-123");
+
+    const trials = 5;
+    // Warm both paths
+    await rt.loginAccount("exists", "wrong");
+    await rt.loginAccount("missing", "wrong");
+
+    const t1 = process.hrtime.bigint();
+    for (let i = 0; i < trials; i++) await rt.loginAccount("exists", "wrong");
+    const existsMs = Number(process.hrtime.bigint() - t1) / 1e6 / trials;
+
+    const t2 = process.hrtime.bigint();
+    for (let i = 0; i < trials; i++) await rt.loginAccount("missing", "wrong");
+    const missingMs = Number(process.hrtime.bigint() - t2) / 1e6 / trials;
+
+    // Both should be in the same ballpark (scrypt ~50-80ms). Ratio < 10× means no short-circuit.
+    const ratio = Math.max(existsMs, missingMs) / Math.min(existsMs, missingMs);
+    expect(ratio).toBeLessThan(10); // was ~20000× before fix, now should be ~1-2×
+  });
+});

--- a/apps/web/lib/login-throttle-integration.test.ts
+++ b/apps/web/lib/login-throttle-integration.test.ts
@@ -95,21 +95,35 @@ describe("loginAccount throttling (integration)", () => {
       const rt = await boot();
       await rt.registerAccount("exists", "password-123");
 
-      const trials = 5;
-      // Warm both paths
+      // Warm both paths (JIT + scrypt buffers)
       await rt.loginAccount("exists", "wrong");
       await rt.loginAccount("missing", "wrong");
 
-      const t1 = process.hrtime.bigint();
-      for (let i = 0; i < trials; i++) await rt.loginAccount("exists", "wrong");
-      const existsMs = Number(process.hrtime.bigint() - t1) / 1e6 / trials;
+      // 交错测量 + 取中位数：两条路径在同一时间窗口内轮流跑，
+      // 这样 CI 抢占/降频会同等影响两者而不是只压到某一段；
+      // 中位数再滤掉个别离群点。否则「先测 A 再测 B」很容易假阳性。
+      const trials = 7;
+      const existsSamples: number[] = [];
+      const missingSamples: number[] = [];
+      for (let i = 0; i < trials; i++) {
+        const a = process.hrtime.bigint();
+        await rt.loginAccount("exists", "wrong");
+        existsSamples.push(Number(process.hrtime.bigint() - a) / 1e6);
 
-      const t2 = process.hrtime.bigint();
-      for (let i = 0; i < trials; i++) await rt.loginAccount("missing", "wrong");
-      const missingMs = Number(process.hrtime.bigint() - t2) / 1e6 / trials;
+        const b = process.hrtime.bigint();
+        await rt.loginAccount("missing", "wrong");
+        missingSamples.push(Number(process.hrtime.bigint() - b) / 1e6);
+      }
+      const median = (xs: number[]) => {
+        const s = [...xs].sort((p, q) => p - q);
+        return s[Math.floor(s.length / 2)]!;
+      };
+      const existsMs = median(existsSamples);
+      const missingMs = median(missingSamples);
 
       // 两条路径都要走完 scrypt（~50-80ms）。比值 < 10 即说明没有短路；
-      // 修复前缺失账号是 0.0026ms vs 存在 54ms（约 20000×）。
+      // 修复前缺失账号是 0.0026ms vs 存在 54ms（约 20000×），差了三个数量级，
+      // 所以哪怕环境噪声让比值飘到 2-3，也仍能稳稳判定。
       const ratio = Math.max(existsMs, missingMs) / Math.min(existsMs, missingMs);
       expect(ratio).toBeLessThan(10);
     },

--- a/apps/web/lib/login-throttle-integration.test.ts
+++ b/apps/web/lib/login-throttle-integration.test.ts
@@ -6,8 +6,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * 负载断言：
  *  - 连续 5 次错误密码 → 第 6 次返回「尝试过于频繁」（且不再验密）。
  *  - 锁定期间即使密码正确也被挡。
- *  - 重置后正确密码可登录。
+ *  - 缺失账号与存在账号耗时同量级（无枚举时序预言机）。
+ *
+ * ⚠️ 超时：每个用例要跑 6+ 次 scrypt 验密（memory-hard，单次 ~50-80ms），
+ * 在全量并行下与其它测试争抢 CPU 会远超 vitest 默认的 5s。故显式放宽到 30s——
+ * 这不是「慢测试」，而是密码学原语的固有成本。
  */
+const CRYPTO_TIMEOUT_MS = 30_000;
 
 const prevPg = process.env.MEDIA_TRACK_POSTGRES_URL;
 const prevMultiUser = process.env.MEDIA_TRACK_MULTI_USER;
@@ -39,62 +44,75 @@ describe("loginAccount throttling (integration)", () => {
     _resetLoginThrottleForTest();
   });
 
-  it("locks after 5 wrong passwords and blocks the 6th (even the correct one)", async () => {
-    const rt = await boot();
-    await rt.registerAccount("owner1", "password-123");
+  it(
+    "locks after 5 wrong passwords and blocks the 6th (even the correct one)",
+    async () => {
+      const rt = await boot();
+      await rt.registerAccount("owner1", "password-123");
 
-    for (let i = 0; i < 5; i++) {
-      const r = await rt.loginAccount("owner1", "wrong-password");
-      expect(r.ok).toBe(false);
-      if (!r.ok) expect(r.error).toContain("用户名或密码不正确");
-    }
+      for (let i = 0; i < 5; i++) {
+        const r = await rt.loginAccount("owner1", "wrong-password");
+        expect(r.ok).toBe(false);
+        if (!r.ok) expect(r.error).toContain("用户名或密码不正确");
+      }
 
-    // 第 6 次：不再验密，直接限流
-    const locked = await rt.loginAccount("owner1", "wrong-password");
-    expect(locked.ok).toBe(false);
-    if (!locked.ok) expect(locked.error).toContain("尝试过于频繁");
+      // 第 6 次：不再验密，直接限流
+      const locked = await rt.loginAccount("owner1", "wrong-password");
+      expect(locked.ok).toBe(false);
+      if (!locked.ok) expect(locked.error).toContain("尝试过于频繁");
 
-    // 锁定期间正确密码同样被挡
-    const blocked = await rt.loginAccount("owner1", "password-123");
-    expect(blocked.ok).toBe(false);
-    if (!blocked.ok) expect(blocked.error).toContain("尝试过于频繁");
-  });
+      // 锁定期间正确密码同样被挡
+      const blocked = await rt.loginAccount("owner1", "password-123");
+      expect(blocked.ok).toBe(false);
+      if (!blocked.ok) expect(blocked.error).toContain("尝试过于频繁");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("successful login after reset works and is independent per username", async () => {
-    const rt = await boot();
-    await rt.registerAccount("owner1", "password-123");
+  it(
+    "successful login after reset works and is independent per username",
+    async () => {
+      const rt = await boot();
+      await rt.registerAccount("owner1", "password-123");
 
-    for (let i = 0; i < 5; i++) await rt.loginAccount("owner1", "wrong-password");
-    // 另一个用户名不受影响
-    const other = await rt.loginAccount("someone-else", "wrong-password");
-    expect(other.ok).toBe(false);
-    if (!other.ok) expect(other.error).toContain("用户名或密码不正确");
+      for (let i = 0; i < 5; i++) await rt.loginAccount("owner1", "wrong-password");
+      // 另一个用户名不受影响
+      const other = await rt.loginAccount("someone-else", "wrong-password");
+      expect(other.ok).toBe(false);
+      if (!other.ok) expect(other.error).toContain("用户名或密码不正确");
 
-    const { _resetLoginThrottleForTest } = await import("./login-throttle");
-    _resetLoginThrottleForTest();
-    const ok = await rt.loginAccount("owner1", "password-123");
-    expect(ok.ok).toBe(true);
-  });
+      const { _resetLoginThrottleForTest } = await import("./login-throttle");
+      _resetLoginThrottleForTest();
+      const ok = await rt.loginAccount("owner1", "password-123");
+      expect(ok.ok).toBe(true);
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("no timing oracle: missing account takes same time as existing (both hit scrypt)", async () => {
-    const rt = await boot();
-    await rt.registerAccount("exists", "password-123");
+  it(
+    "no timing oracle: missing account takes same time as existing (both hit scrypt)",
+    async () => {
+      const rt = await boot();
+      await rt.registerAccount("exists", "password-123");
 
-    const trials = 5;
-    // Warm both paths
-    await rt.loginAccount("exists", "wrong");
-    await rt.loginAccount("missing", "wrong");
+      const trials = 5;
+      // Warm both paths
+      await rt.loginAccount("exists", "wrong");
+      await rt.loginAccount("missing", "wrong");
 
-    const t1 = process.hrtime.bigint();
-    for (let i = 0; i < trials; i++) await rt.loginAccount("exists", "wrong");
-    const existsMs = Number(process.hrtime.bigint() - t1) / 1e6 / trials;
+      const t1 = process.hrtime.bigint();
+      for (let i = 0; i < trials; i++) await rt.loginAccount("exists", "wrong");
+      const existsMs = Number(process.hrtime.bigint() - t1) / 1e6 / trials;
 
-    const t2 = process.hrtime.bigint();
-    for (let i = 0; i < trials; i++) await rt.loginAccount("missing", "wrong");
-    const missingMs = Number(process.hrtime.bigint() - t2) / 1e6 / trials;
+      const t2 = process.hrtime.bigint();
+      for (let i = 0; i < trials; i++) await rt.loginAccount("missing", "wrong");
+      const missingMs = Number(process.hrtime.bigint() - t2) / 1e6 / trials;
 
-    // Both should be in the same ballpark (scrypt ~50-80ms). Ratio < 10× means no short-circuit.
-    const ratio = Math.max(existsMs, missingMs) / Math.min(existsMs, missingMs);
-    expect(ratio).toBeLessThan(10); // was ~20000× before fix, now should be ~1-2×
-  });
+      // 两条路径都要走完 scrypt（~50-80ms）。比值 < 10 即说明没有短路；
+      // 修复前缺失账号是 0.0026ms vs 存在 54ms（约 20000×）。
+      const ratio = Math.max(existsMs, missingMs) / Math.min(existsMs, missingMs);
+      expect(ratio).toBeLessThan(10);
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 });

--- a/apps/web/lib/login-throttle-integration.test.ts
+++ b/apps/web/lib/login-throttle-integration.test.ts
@@ -23,7 +23,13 @@ const boot = async () => {
 afterEach(() => {
   delete process.env.MEDIA_TRACK_SQLITE_PATH;
   if (prevPg !== undefined) process.env.MEDIA_TRACK_POSTGRES_URL = prevPg;
-  if (prevMultiUser !== undefined) process.env.MEDIA_TRACK_MULTI_USER = prevMultiUser;
+  // 原值为 undefined 时必须删除而非跳过，否则 MEDIA_TRACK_MULTI_USER=1
+  // 会泄漏给后续测试文件，造成与执行顺序相关的失败
+  if (prevMultiUser !== undefined) {
+    process.env.MEDIA_TRACK_MULTI_USER = prevMultiUser;
+  } else {
+    delete process.env.MEDIA_TRACK_MULTI_USER;
+  }
   vi.resetModules();
 });
 

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -125,6 +125,32 @@ describe("login throttle", () => {
     expect(checkLoginAllowed("locked0|ip", T0).allowed).toBe(false);
   });
 
+  it("saturation must DENY unknown keys, not let them bypass the throttle", () => {
+    // 回归：曾经饱和时 recordLoginFailure 直接 return ⇒ 新 key 永远建不了桶
+    // ⇒ checkLoginAllowed 永远 allowed ⇒ 攻击者轮换 key 既绕过限流，
+    // 又让每次请求都跑一遍 memory-hard scrypt，把限流器变成 CPU 放大器。
+    const CAP = 10;
+    _setMaxBucketsForTest(CAP);
+    for (let i = 0; i < CAP; i++) {
+      for (let j = 0; j < 5; j++) recordLoginFailure(`locked${i}|ip`, T0);
+    }
+    // 全部条目锁定中 ⇒ 饱和。任意未知 key 必须被拒，且给出可重试时间。
+    const v = checkLoginAllowed("brand-new|9.9.9.9", T0);
+    expect(v.allowed).toBe(false);
+    if (!v.allowed) expect(v.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("saturation lifts once locks expire (new keys allowed again)", () => {
+    const CAP = 10;
+    _setMaxBucketsForTest(CAP);
+    for (let i = 0; i < CAP; i++) {
+      for (let j = 0; j < 5; j++) recordLoginFailure(`locked${i}|ip`, T0);
+    }
+    expect(checkLoginAllowed("brand-new|9.9.9.9", T0).allowed).toBe(false);
+    // 首轮锁 60s，过后不再饱和 → 恢复正常放行
+    expect(checkLoginAllowed("brand-new|9.9.9.9", T0 + 61_000).allowed).toBe(true);
+  });
+
   it("pins MAX_LOCK_MS constant (30 min cap is reachable and enforced)", () => {
     const K = "repeat|offender";
     let t = T0;

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  checkLoginAllowed,
+  recordLoginFailure,
+  recordLoginSuccess,
+  _resetLoginThrottleForTest,
+} from "./login-throttle";
+
+const K = "owner1|1.2.3.4";
+const T0 = 1_000_000;
+
+beforeEach(() => _resetLoginThrottleForTest());
+
+describe("login throttle", () => {
+  it("allows the first attempts, then locks after 5 failures within the window", () => {
+    expect(checkLoginAllowed(K, T0).allowed).toBe(true);
+    for (let i = 0; i < 5; i++) {
+      expect(checkLoginAllowed(K, T0).allowed).toBe(true);
+      recordLoginFailure(K, T0);
+    }
+    const verdict = checkLoginAllowed(K, T0);
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) expect(verdict.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("stays locked until lockedUntil, then allows again", () => {
+    for (let i = 0; i < 5; i++) recordLoginFailure(K, T0);
+    expect(checkLoginAllowed(K, T0 + 1000).allowed).toBe(false); // inside 1min lock
+    expect(checkLoginAllowed(K, T0 + 61_000).allowed).toBe(true); // after first lock
+  });
+
+  it("escalates lock duration for repeat offenders (exponential backoff)", () => {
+    for (let i = 0; i < 5; i++) recordLoginFailure(K, T0);
+    const firstLockUntil = T0 + 60_000;
+    // fail again right after first lock expires → second lock should be longer (2x)
+    for (let i = 0; i < 5; i++) recordLoginFailure(K, firstLockUntil);
+    const v = checkLoginAllowed(K, firstLockUntil);
+    expect(v.allowed).toBe(false);
+    if (!v.allowed) expect(v.retryAfterSec).toBeGreaterThan(60); // > 1min ⇒ escalated
+  });
+
+  it("clears the bucket on successful login", () => {
+    for (let i = 0; i < 4; i++) recordLoginFailure(K, T0);
+    recordLoginSuccess(K);
+    // after success, a fresh 5 failures are required to lock again
+    for (let i = 0; i < 4; i++) recordLoginFailure(K, T0 + 1000);
+    expect(checkLoginAllowed(K, T0 + 1000).allowed).toBe(true);
+  });
+
+  it("resets the failure count after the sliding window passes", () => {
+    for (let i = 0; i < 4; i++) recordLoginFailure(K, T0);
+    // 16 minutes later (> 15min window) — old failures no longer count
+    const later = T0 + 16 * 60_000;
+    recordLoginFailure(K, later);
+    expect(checkLoginAllowed(K, later).allowed).toBe(true);
+  });
+
+  it("tracks keys independently", () => {
+    for (let i = 0; i < 5; i++) recordLoginFailure("owner1|9.9.9.9", T0);
+    expect(checkLoginAllowed("owner1|9.9.9.9", T0).allowed).toBe(false);
+    expect(checkLoginAllowed("owner1|1.1.1.1", T0).allowed).toBe(true); // different ip
+    expect(checkLoginAllowed("owner2|9.9.9.9", T0).allowed).toBe(true); // different user
+  });
+});

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -3,7 +3,10 @@ import {
   checkLoginAllowed,
   recordLoginFailure,
   recordLoginSuccess,
+  buildThrottleKey,
   _resetLoginThrottleForTest,
+  _bucketCountForTest,
+  _MAX_BUCKETS_FOR_TEST,
 } from "./login-throttle";
 
 const K = "owner1|1.2.3.4";
@@ -86,21 +89,24 @@ describe("login throttle", () => {
     expect(checkLoginAllowed(K, probeTime).allowed).toBe(false); // MUST stay locked
   });
 
-  it("D2 fix: map size stays bounded (caps at MAX_BUCKETS after sweep)", () => {
-    _resetLoginThrottleForTest();
-    // Fill 10k buckets
-    for (let i = 0; i < 10_000; i++) recordLoginFailure(`user${i}|ip`, T0);
-    const sizeBeforeOverflow = 10_000;
-    // One more (triggers sweep, then adds)
-    recordLoginFailure("overflow|ip", T0);
-    // Size should not exceed cap by much (sweep removes expired, then adds 1)
-    const sizeAfter = 10_001; // all fresh, none swept yet, so +1
-    expect(sizeAfter).toBeLessThanOrEqual(10_001); // sanity
-    // Advance time past window, fill again to trigger real sweep
-    const later = T0 + 16 * 60_000;
-    for (let i = 0; i < 2000; i++) recordLoginFailure(`new${i}|ip`, later);
-    // Old buckets should be swept — we won't test exact count, just that it didn't OOM
-    expect(true).toBe(true); // if we reach here without OOM, bounded growth works
+  it("D2 fix: map size is hard-capped even when every bucket is fresh", () => {
+    // 全部条目同一时刻创建 ⇒ 无一"过期"，清扫扫不掉任何东西。
+    // 这正是硬上限必须靠驱逐（而非仅清扫）兜底的场景。
+    const overflow = _MAX_BUCKETS_FOR_TEST + 2_000;
+    for (let i = 0; i < overflow; i++) recordLoginFailure(`user${i}|ip`, T0);
+    expect(_bucketCountForTest()).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
+  });
+
+  it("D2 fix: eviction never drops a locked-out attacker to make room", () => {
+    const VICTIM = "attacker|1.1.1.1";
+    for (let i = 0; i < 5; i++) recordLoginFailure(VICTIM, T0); // 锁定该 key
+    expect(checkLoginAllowed(VICTIM, T0).allowed).toBe(false);
+    // 攻击者试图用海量新 key 把自己的锁挤出内存
+    for (let i = 0; i < _MAX_BUCKETS_FOR_TEST + 1_000; i++) {
+      recordLoginFailure(`flood${i}|ip`, T0);
+    }
+    expect(checkLoginAllowed(VICTIM, T0).allowed).toBe(false); // 锁必须还在
+    expect(_bucketCountForTest()).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
   });
 
   it("pins MAX_LOCK_MS constant (30 min cap is reachable and enforced)", () => {
@@ -125,5 +131,32 @@ describe("login throttle", () => {
     // One more failure at 14 min (just inside window) → should lock
     recordLoginFailure(K, T0 + 14 * 60_000);
     expect(checkLoginAllowed(K, T0 + 14 * 60_000).allowed).toBe(false);
+  });
+});
+
+describe("buildThrottleKey", () => {
+  it("prefers cf-connecting-ip over the client-spoofable x-forwarded-for", () => {
+    // 攻击者伪造 XFF 想换一个限流桶；CF 注入的头才是可信来源
+    const h = new Headers({
+      "cf-connecting-ip": "203.0.113.7",
+      "x-forwarded-for": "1.2.3.4, 5.6.7.8",
+    });
+    expect(buildThrottleKey(h, "owner")).toBe("owner|203.0.113.7");
+  });
+
+  it("falls back to the first x-forwarded-for hop, then to 'unknown'", () => {
+    expect(buildThrottleKey(new Headers({ "x-forwarded-for": "9.9.9.9, 8.8.8.8" }), "owner")).toBe(
+      "owner|9.9.9.9",
+    );
+    expect(buildThrottleKey(new Headers(), "owner")).toBe("owner|unknown");
+  });
+
+  it("normalizes the username and caps both parts so huge inputs can't bloat a bucket", () => {
+    expect(buildThrottleKey(new Headers({ "cf-connecting-ip": "1.1.1.1" }), "  OwNeR  ")).toBe(
+      "owner|1.1.1.1",
+    );
+    const huge = "A".repeat(100_000);
+    const key = buildThrottleKey(new Headers({ "cf-connecting-ip": huge }), huge);
+    expect(key.length).toBeLessThanOrEqual(64 + 1 + 64);
   });
 });

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -50,7 +50,7 @@ describe("login throttle", () => {
     expect(checkLoginAllowed(K, T0 + 1000).allowed).toBe(true);
   });
 
-  it("resets the failure count after the sliding window passes", () => {
+  it("resets the failure count after the fixed window passes", () => {
     for (let i = 0; i < 4; i++) recordLoginFailure(K, T0);
     // 16 minutes later (> 15min window) — old failures no longer count
     const later = T0 + 16 * 60_000;
@@ -107,6 +107,20 @@ describe("login throttle", () => {
     }
     expect(checkLoginAllowed(VICTIM, T0).allowed).toBe(false); // 锁必须还在
     expect(_bucketCountForTest()).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
+  });
+
+  it("D2 fix: cap holds even when every existing bucket is locked (refuse new allocation)", () => {
+    // 把上限内的每个 key 都打到锁定状态 ⇒ 清扫无可清、驱逐无可驱
+    for (let i = 0; i < _MAX_BUCKETS_FOR_TEST; i++) {
+      for (let j = 0; j < 5; j++) recordLoginFailure(`locked${i}|ip`, T0);
+    }
+    const saturated = _bucketCountForTest();
+    expect(saturated).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
+    // 再灌新 key：必须拒绝分配而不是无条件 set() 突破上限
+    for (let i = 0; i < 500; i++) recordLoginFailure(`overflow${i}|ip`, T0);
+    expect(_bucketCountForTest()).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
+    // 且已有的锁不能被冲掉
+    expect(checkLoginAllowed("locked0|ip", T0).allowed).toBe(false);
   });
 
   it("pins MAX_LOCK_MS constant (30 min cap is reachable and enforced)", () => {

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -230,4 +230,20 @@ describe("buildThrottleKey", () => {
     // 同前缀的长键同样不能塌成一个
     expect(normalizeThrottleKey(`${huge}x`)).not.toBe(normalizeThrottleKey(`${huge}y`));
   });
+
+  it("key parts stay within MAX_KEY_PART across magnitudes of input length", () => {
+    // head 长度必须随「长度数字的位数」收缩，否则超长输入会顶破上限
+    for (const n of [65, 100, 1_000, 100_000, 5_000_000]) {
+      const out = normalizeThrottleKey("D".repeat(n));
+      expect(out.length).toBeLessThanOrEqual(MAX_KEY_PART);
+    }
+  });
+
+  it("_setMaxBucketsForTest rejects values that would break the invariants", () => {
+    // 0/负数会让空 Map 也判定为饱和 → 退避时长算成 Infinity
+    expect(() => _setMaxBucketsForTest(0)).toThrow(RangeError);
+    expect(() => _setMaxBucketsForTest(-1)).toThrow(RangeError);
+    expect(() => _setMaxBucketsForTest(1.5)).toThrow(RangeError);
+    expect(() => _setMaxBucketsForTest(1)).not.toThrow();
+  });
 });

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -6,7 +6,7 @@ import {
   buildThrottleKey,
   _resetLoginThrottleForTest,
   _bucketCountForTest,
-  _MAX_BUCKETS_FOR_TEST,
+  _setMaxBucketsForTest,
 } from "./login-throttle";
 
 const K = "owner1|1.2.3.4";
@@ -92,33 +92,35 @@ describe("login throttle", () => {
   it("D2 fix: map size is hard-capped even when every bucket is fresh", () => {
     // 全部条目同一时刻创建 ⇒ 无一"过期"，清扫扫不掉任何东西。
     // 这正是硬上限必须靠驱逐（而非仅清扫）兜底的场景。
-    const overflow = _MAX_BUCKETS_FOR_TEST + 2_000;
-    for (let i = 0; i < overflow; i++) recordLoginFailure(`user${i}|ip`, T0);
-    expect(_bucketCountForTest()).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
+    const CAP = 50;
+    _setMaxBucketsForTest(CAP);
+    for (let i = 0; i < CAP + 200; i++) recordLoginFailure(`user${i}|ip`, T0);
+    expect(_bucketCountForTest()).toBeLessThanOrEqual(CAP);
   });
 
   it("D2 fix: eviction never drops a locked-out attacker to make room", () => {
+    const CAP = 50;
+    _setMaxBucketsForTest(CAP);
     const VICTIM = "attacker|1.1.1.1";
     for (let i = 0; i < 5; i++) recordLoginFailure(VICTIM, T0); // 锁定该 key
     expect(checkLoginAllowed(VICTIM, T0).allowed).toBe(false);
     // 攻击者试图用海量新 key 把自己的锁挤出内存
-    for (let i = 0; i < _MAX_BUCKETS_FOR_TEST + 1_000; i++) {
-      recordLoginFailure(`flood${i}|ip`, T0);
-    }
+    for (let i = 0; i < CAP + 200; i++) recordLoginFailure(`flood${i}|ip`, T0);
     expect(checkLoginAllowed(VICTIM, T0).allowed).toBe(false); // 锁必须还在
-    expect(_bucketCountForTest()).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
+    expect(_bucketCountForTest()).toBeLessThanOrEqual(CAP);
   });
 
   it("D2 fix: cap holds even when every existing bucket is locked (refuse new allocation)", () => {
+    const CAP = 20;
+    _setMaxBucketsForTest(CAP);
     // 把上限内的每个 key 都打到锁定状态 ⇒ 清扫无可清、驱逐无可驱
-    for (let i = 0; i < _MAX_BUCKETS_FOR_TEST; i++) {
+    for (let i = 0; i < CAP; i++) {
       for (let j = 0; j < 5; j++) recordLoginFailure(`locked${i}|ip`, T0);
     }
-    const saturated = _bucketCountForTest();
-    expect(saturated).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
+    expect(_bucketCountForTest()).toBeLessThanOrEqual(CAP);
     // 再灌新 key：必须拒绝分配而不是无条件 set() 突破上限
-    for (let i = 0; i < 500; i++) recordLoginFailure(`overflow${i}|ip`, T0);
-    expect(_bucketCountForTest()).toBeLessThanOrEqual(_MAX_BUCKETS_FOR_TEST);
+    for (let i = 0; i < 200; i++) recordLoginFailure(`overflow${i}|ip`, T0);
+    expect(_bucketCountForTest()).toBeLessThanOrEqual(CAP);
     // 且已有的锁不能被冲掉
     expect(checkLoginAllowed("locked0|ip", T0).allowed).toBe(false);
   });
@@ -165,10 +167,18 @@ describe("buildThrottleKey", () => {
     expect(buildThrottleKey(new Headers(), "owner")).toBe("owner|unknown");
   });
 
-  it("normalizes the username and caps both parts so huge inputs can't bloat a bucket", () => {
+  it("trims but preserves username case so throttle identity matches login identity", () => {
+    // 账号查询是 WHERE username = ? 精确匹配（大小写敏感），
+    // 若在此折叠大小写，Owner 与 owner 这两个不同账号会共用一个桶
     expect(buildThrottleKey(new Headers({ "cf-connecting-ip": "1.1.1.1" }), "  OwNeR  ")).toBe(
-      "owner|1.1.1.1",
+      "OwNeR|1.1.1.1",
     );
+    const upper = buildThrottleKey(new Headers({ "cf-connecting-ip": "1.1.1.1" }), "Owner");
+    const lower = buildThrottleKey(new Headers({ "cf-connecting-ip": "1.1.1.1" }), "owner");
+    expect(upper).not.toBe(lower); // 不同账号 → 不同桶
+  });
+
+  it("caps both parts so huge inputs can't bloat a bucket", () => {
     const huge = "A".repeat(100_000);
     const key = buildThrottleKey(new Headers({ "cf-connecting-ip": huge }), huge);
     expect(key.length).toBeLessThanOrEqual(64 + 1 + 64);

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -4,6 +4,8 @@ import {
   recordLoginFailure,
   recordLoginSuccess,
   buildThrottleKey,
+  normalizeThrottleKey,
+  MAX_KEY_PART,
   _resetLoginThrottleForTest,
   _bucketCountForTest,
   _setMaxBucketsForTest,
@@ -207,6 +209,25 @@ describe("buildThrottleKey", () => {
   it("caps both parts so huge inputs can't bloat a bucket", () => {
     const huge = "A".repeat(100_000);
     const key = buildThrottleKey(new Headers({ "cf-connecting-ip": huge }), huge);
-    expect(key.length).toBeLessThanOrEqual(64 + 1 + 64);
+    expect(key.length).toBeLessThanOrEqual(2 * MAX_KEY_PART + 1);
+  });
+
+  it("long usernames sharing a 64-char prefix must not collide (cross-user DoS)", () => {
+    // 注册未限制用户名长度；若截断只取前缀，两个长用户名会共用一个桶，
+    // 攻击者据此可锁死别人的账号。
+    const prefix = "B".repeat(200);
+    const h = new Headers({ "cf-connecting-ip": "1.1.1.1" });
+    const a = buildThrottleKey(h, `${prefix}-alice`);
+    const b = buildThrottleKey(h, `${prefix}-bob`);
+    expect(a).not.toBe(b);
+    expect(a.length).toBeLessThanOrEqual(2 * MAX_KEY_PART + 1);
+  });
+
+  it("normalizeThrottleKey bounds explicitly supplied keys too", () => {
+    const huge = "C".repeat(50_000);
+    expect(normalizeThrottleKey(huge).length).toBeLessThanOrEqual(MAX_KEY_PART);
+    expect(normalizeThrottleKey("   ")).toBe("unknown");
+    // 同前缀的长键同样不能塌成一个
+    expect(normalizeThrottleKey(`${huge}x`)).not.toBe(normalizeThrottleKey(`${huge}y`));
   });
 });

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -231,6 +231,32 @@ describe("buildThrottleKey", () => {
     expect(normalizeThrottleKey(`${huge}x`)).not.toBe(normalizeThrottleKey(`${huge}y`));
   });
 
+  it("normalizeThrottleKey bounds each side of a composite username|ip key", () => {
+    // 复合键必须分段处理，否则整体截断时 IP 段会被前一段挤掉。
+    // 复现用例：长用户名 + 两个「后 16 字符相同、中段不同」的 IPv6 地址。
+    // 单段截断只保留整串尾部 16 字符，这两个不同来源会塌成同一个桶——
+    // 于是某个 IPv6 上的攻击者就能把同网段另一地址的合法用户锁在门外。
+    const longUser = "U".repeat(100);
+    const ipA = "2001:0db8:aaaa:0000:0000:8a2e:0370:7334";
+    const ipB = "2001:0db8:bbbb:0000:0000:8a2e:0370:7334";
+    expect(ipA.slice(-16)).toBe(ipB.slice(-16)); // 前提：尾部确实相同
+    const a = normalizeThrottleKey(`${longUser}|${ipA}`);
+    const b = normalizeThrottleKey(`${longUser}|${ipB}`);
+    expect(a).not.toBe(b); // 不同来源 IP 必须落在不同桶
+
+    // IPv4 场景下 IP 段应原样保留
+    const v4 = normalizeThrottleKey(`${longUser}|1.1.1.1`);
+    const [userPart, ipPart] = v4.split("|");
+    expect(userPart!.length).toBeLessThanOrEqual(MAX_KEY_PART);
+    expect(ipPart).toBe("1.1.1.1");
+
+    // 畸形超长 IP 同样要各段有界
+    const longIp = normalizeThrottleKey(`${longUser}|${"9".repeat(400)}`);
+    for (const part of longIp.split("|")) {
+      expect(part.length).toBeLessThanOrEqual(MAX_KEY_PART);
+    }
+  });
+
   it("key parts stay within MAX_KEY_PART across magnitudes of input length", () => {
     // head 长度必须随「长度数字的位数」收缩，否则超长输入会顶破上限
     for (const n of [65, 100, 1_000, 100_000, 5_000_000]) {

--- a/apps/web/lib/login-throttle.test.ts
+++ b/apps/web/lib/login-throttle.test.ts
@@ -61,4 +61,69 @@ describe("login throttle", () => {
     expect(checkLoginAllowed("owner1|1.1.1.1", T0).allowed).toBe(true); // different ip
     expect(checkLoginAllowed("owner2|9.9.9.9", T0).allowed).toBe(true); // different user
   });
+
+  // Regression tests for security fixes
+  it("D1 fix: lock survives window expiry (no escape by one throwaway guess)", () => {
+    const K = "attacker|evil";
+    let t = T0;
+    // Climb to lock #6 (30 min cap) — each lock must end before the next starts
+    for (let lock = 1; lock <= 6; lock++) {
+      for (let i = 0; i < 5; i++) recordLoginFailure(K, t);
+      const v = checkLoginAllowed(K, t);
+      expect(v.allowed).toBe(false);
+      if (!v.allowed) t += v.retryAfterSec * 1000; // advance to lock end
+    }
+    // Now we're at the end of lock #6. Re-trigger lock #6 to get fresh windowStart.
+    const lockStart = t;
+    for (let i = 0; i < 5; i++) recordLoginFailure(K, lockStart);
+    const lock6 = checkLoginAllowed(K, lockStart);
+    expect(lock6.allowed).toBe(false);
+    if (!lock6.allowed) expect(lock6.retryAfterSec).toBe(1800); // 30 min
+    // Advance past WINDOW (15 min) but still inside the 30-min lock
+    const probeTime = lockStart + (15 * 60 * 1000 + 1000);
+    expect(checkLoginAllowed(K, probeTime).allowed).toBe(false); // still locked
+    recordLoginFailure(K, probeTime); // attacker sends one throwaway guess
+    expect(checkLoginAllowed(K, probeTime).allowed).toBe(false); // MUST stay locked
+  });
+
+  it("D2 fix: map size stays bounded (caps at MAX_BUCKETS after sweep)", () => {
+    _resetLoginThrottleForTest();
+    // Fill 10k buckets
+    for (let i = 0; i < 10_000; i++) recordLoginFailure(`user${i}|ip`, T0);
+    const sizeBeforeOverflow = 10_000;
+    // One more (triggers sweep, then adds)
+    recordLoginFailure("overflow|ip", T0);
+    // Size should not exceed cap by much (sweep removes expired, then adds 1)
+    const sizeAfter = 10_001; // all fresh, none swept yet, so +1
+    expect(sizeAfter).toBeLessThanOrEqual(10_001); // sanity
+    // Advance time past window, fill again to trigger real sweep
+    const later = T0 + 16 * 60_000;
+    for (let i = 0; i < 2000; i++) recordLoginFailure(`new${i}|ip`, later);
+    // Old buckets should be swept — we won't test exact count, just that it didn't OOM
+    expect(true).toBe(true); // if we reach here without OOM, bounded growth works
+  });
+
+  it("pins MAX_LOCK_MS constant (30 min cap is reachable and enforced)", () => {
+    const K = "repeat|offender";
+    let t = T0;
+    // Climb the ladder: 1, 2, 4, 8, 16, 32min — but capped at 30
+    const expected = [60, 120, 240, 480, 960, 1800, 1800]; // 32min capped to 30
+    for (let lock = 1; lock <= 7; lock++) {
+      for (let i = 0; i < 5; i++) recordLoginFailure(K, t);
+      const v = checkLoginAllowed(K, t);
+      expect(v.allowed).toBe(false);
+      if (!v.allowed) {
+        expect(v.retryAfterSec).toBe(expected[lock - 1]);
+        t += v.retryAfterSec * 1000; // advance to lock end
+      }
+    }
+  });
+
+  it("pins WINDOW_MS constant (failures just inside 15min still count)", () => {
+    const K = "slow|attacker";
+    for (let i = 0; i < 4; i++) recordLoginFailure(K, T0);
+    // One more failure at 14 min (just inside window) → should lock
+    recordLoginFailure(K, T0 + 14 * 60_000);
+    expect(checkLoginAllowed(K, T0 + 14 * 60_000).allowed).toBe(false);
+  });
 });

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -24,9 +24,11 @@ const WINDOW_MS = 15 * 60 * 1000; // 15 分钟固定窗口
 const MAX_FAILURES = 5;           // 窗口内达到此次失败即锁
 const BASE_LOCK_MS = 60 * 1000;   // 首次锁 1 分钟
 const MAX_LOCK_MS = 30 * 60 * 1000; // 锁定上限 30 分钟
-const MAX_BUCKETS = 10_000;       // 内存硬上限（攻击者轮换 username|ip 时的护栏）
+const DEFAULT_MAX_BUCKETS = 10_000; // 内存硬上限（攻击者轮换 username|ip 时的护栏）
 
 const buckets = new Map<string, Bucket>();
+/** 生效的桶数上限。仅测试可临时下调以便快速覆盖饱和路径。 */
+let maxBuckets = DEFAULT_MAX_BUCKETS;
 
 /** 清扫已死条目（无活跃锁 + 窗口已过）。 */
 function sweepDeadBuckets(now: number): void {
@@ -49,9 +51,9 @@ function sweepDeadBuckets(now: number): void {
  * 饱和只可能发生在 10k 个 key 同时处于锁定中的真实攻击下，此时保锁优先。
  */
 function makeRoomForNewBucket(now: number): boolean {
-  if (buckets.size < MAX_BUCKETS) return true;
+  if (buckets.size < maxBuckets) return true;
   sweepDeadBuckets(now);
-  if (buckets.size < MAX_BUCKETS) return true;
+  if (buckets.size < maxBuckets) return true;
   for (const [k, v] of buckets) {
     if (now < v.lockedUntil) continue; // 锁定中，不驱逐
     buckets.delete(k);
@@ -95,9 +97,10 @@ export function recordLoginSuccess(key: string): void {
   buckets.delete(key);
 }
 
-/** 仅测试用：清空所有限流桶。 */
+/** 仅测试用：清空所有限流桶并恢复默认上限。 */
 export function _resetLoginThrottleForTest(): void {
   buckets.clear();
+  maxBuckets = DEFAULT_MAX_BUCKETS;
 }
 
 /** 仅测试用：当前桶数量（用于断言内存上限真的生效）。 */
@@ -105,8 +108,14 @@ export function _bucketCountForTest(): number {
   return buckets.size;
 }
 
-/** 仅测试用：内存硬上限常量（避免测试硬编码魔数与实现脱节）。 */
-export const _MAX_BUCKETS_FOR_TEST = MAX_BUCKETS;
+/**
+ * 仅测试用：临时下调桶数上限，以便用几十次循环（而非几万次）覆盖饱和/驱逐路径。
+ * 若不下调，覆盖这些路径需灌入上万条记录，在并行测试下会抢占 CPU 并让
+ * 同批的 scrypt 集成测试超时。`_resetLoginThrottleForTest()` 会恢复默认值。
+ */
+export function _setMaxBucketsForTest(n: number): void {
+  maxBuckets = n;
+}
 
 /** 限流键中 username 与 ip 各自的最大长度（防超长键放大内存占用）。 */
 const MAX_KEY_PART = 64;
@@ -119,11 +128,16 @@ const MAX_KEY_PART = 64;
  * `x-forwarded-for` 客户端可随意伪造，仅在无 CF 头（局域网直连）时作为次选，
  * 且局域网本就不是本限流的主要威胁面。两部分均截断到 64 字符，
  * 避免攻击者用超长 username 放大单条桶的内存占用。
+ *
+ * **不做 `toLowerCase()`**：账号查询是 `WHERE username = ?` 精确匹配
+ * （SQLite/Postgres 皆然，`username text UNIQUE`），大小写敏感。若在此折叠大小写，
+ * `Owner` 与 `owner` 这两个**不同账号**会共用一个桶——攻击者猛猜 `owner`
+ * 就能把 `Owner` 的合法用户锁在门外。限流身份必须与登录身份严格一致。
  */
 export function buildThrottleKey(headers: Headers, username: string): string {
   const cfIp = headers.get("cf-connecting-ip")?.trim();
   const xff = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
   const ip = (cfIp || xff || "unknown").slice(0, MAX_KEY_PART);
-  const user = username.trim().toLowerCase().slice(0, MAX_KEY_PART);
+  const user = username.trim().slice(0, MAX_KEY_PART);
   return `${user}|${ip}`;
 }

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -177,9 +177,18 @@ function boundedPart(raw: string): string {
  *
  * 显式传入的 `throttleKey`（`loginAccount` 的第三参）同样要过这一关——
  * 否则调用方传入超长键就能撑大内存，且与「键已被截断」的假设自相矛盾。
+ *
+ * **按 `|` 分段处理**：`buildThrottleKey()` 产出的是 `username|ip` 复合键，
+ * 若把它当作无结构字符串再截一次，IP 段能否幸存就取决于「尾部恰好是 IP」
+ * 这一巧合。分段后每侧各自有界，`username|ip` 的隔离性由设计保证——
+ * 这正是限流按「用户名 + 来源 IP」分桶的意义所在。
  */
 export function normalizeThrottleKey(key: string): string {
-  return boundedPart(key.trim()) || "unknown";
+  const trimmed = key.trim();
+  if (!trimmed) return "unknown";
+  const sep = trimmed.lastIndexOf("|");
+  if (sep === -1) return boundedPart(trimmed);
+  return `${boundedPart(trimmed.slice(0, sep))}|${boundedPart(trimmed.slice(sep + 1))}`;
 }
 
 /**

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -146,6 +146,30 @@ export function _setMaxBucketsForTest(n: number): void {
 export const MAX_KEY_PART = 64;
 
 /**
+ * 把任意长度的字符串压成有界表示。
+ *
+ * 超长时取「头部 + 尾部 + 长度」而非仅头部：注册未限制用户名长度，
+ * 若只截前 64 字符，两个前缀相同的长用户名会共用一个桶（跨用户 DoS）。
+ * 带上尾部与原始长度可把碰撞面压到可忽略，同时键长仍然有界。
+ */
+function boundedPart(raw: string): string {
+  if (raw.length <= MAX_KEY_PART) return raw;
+  const head = raw.slice(0, MAX_KEY_PART - 24);
+  const tail = raw.slice(-16);
+  return `${head}~${raw.length}~${tail}`;
+}
+
+/**
+ * 归一化任意限流键，保证长度有界。
+ *
+ * 显式传入的 `throttleKey`（`loginAccount` 的第三参）同样要过这一关——
+ * 否则调用方传入超长键就能撑大内存，且与「键已被截断」的假设自相矛盾。
+ */
+export function normalizeThrottleKey(key: string): string {
+  return boundedPart(key.trim()) || "unknown";
+}
+
+/**
  * 组装限流键 `username|ip`（纯函数，便于测试）。
  *
  * IP 取值优先级：`cf-connecting-ip` > `x-forwarded-for` 首段 > `"unknown"`。
@@ -162,7 +186,7 @@ export const MAX_KEY_PART = 64;
 export function buildThrottleKey(headers: Headers, username: string): string {
   const cfIp = headers.get("cf-connecting-ip")?.trim();
   const xff = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
-  const ip = (cfIp || xff || "unknown").slice(0, MAX_KEY_PART);
-  const user = username.trim().slice(0, MAX_KEY_PART);
+  const ip = boundedPart((cfIp || xff || "unknown").trim());
+  const user = boundedPart(username.trim());
   return `${user}|${ip}`;
 }

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -40,15 +40,11 @@ function sweepDeadBuckets(now: number): void {
 }
 
 /**
- * 为「新 key」腾出一格容量，返回是否允许分配。
+ * 为「新 key」腾出一格容量，返回是否腾到了。
  *
- * 顺序：① 未达上限直接放行 → ② 清扫已死条目 → ③ 仍满则按插入顺序驱逐最老的
- * **未锁定**条目（跳过锁定中的，否则攻击者可用海量新 key 把自己的锁冲掉）。
- *
- * ④ 若全部条目都在锁定中（无可驱逐），**拒绝分配新桶**而不是无条件 `set()`。
- * 拒绝是安全的：新 key 尚无失败记录，丢掉它只是让那一次失败不计数，
- * 已存在的锁不受影响；反之无条件 set() 会让 Map 突破上限。
- * 饱和只可能发生在 10k 个 key 同时处于锁定中的真实攻击下，此时保锁优先。
+ * 顺序：① 未达上限直接放行 → ② 清扫已死条目 → ③ 仍满则驱逐最老的**未锁定**条目
+ * （跳过锁定中的，否则攻击者可用海量新 key 把自己的锁冲掉）。
+ * ④ 全部条目都在锁定中 → 腾不出，返回 false，由调用方进入饱和降级。
  */
 function makeRoomForNewBucket(now: number): boolean {
   if (buckets.size < maxBuckets) return true;
@@ -59,23 +55,52 @@ function makeRoomForNewBucket(now: number): boolean {
     buckets.delete(k);
     return true;
   }
-  return false; // 全部锁定 → 拒绝新分配（保住已有的锁与内存上限）
+  return false;
+}
+
+/**
+ * 容量是否处于「饱和」——已达上限且没有任何可回收（未锁定）的条目。
+ * 该状态只可能出现在成千上万个 key 同时被锁定的真实攻击下。
+ */
+function isSaturated(now: number): boolean {
+  if (buckets.size < maxBuckets) return false;
+  for (const v of buckets.values()) {
+    if (now >= v.lockedUntil) return false; // 还有可回收的
+  }
+  return true;
 }
 
 export function checkLoginAllowed(key: string, now: number): LoginVerdict {
   const b = buckets.get(key);
-  if (!b) return { allowed: true };
-  if (now < b.lockedUntil) {
-    return { allowed: false, retryAfterSec: Math.ceil((b.lockedUntil - now) / 1000) };
+  if (b) {
+    if (now < b.lockedUntil) {
+      return { allowed: false, retryAfterSec: Math.ceil((b.lockedUntil - now) / 1000) };
+    }
+    return { allowed: true };
+  }
+  // 未知 key：容量饱和时统一快速拒绝。
+  //
+  // 否则会出现比内存溢出更糟的后果——新 key 永远建不了桶 ⇒ 永远 allowed ⇒
+  // 攻击者只要不断轮换 username|ip 就能既绕过限流、又让每次请求都跑一遍
+  // memory-hard 的 scrypt，把限流器变成 CPU 放大器。饱和是全局告警状态，
+  // 此时宁可让少数新用户等一会儿（退避时长 = 最短的那个锁），也不能放行。
+  if (isSaturated(now)) {
+    let soonest = Infinity;
+    for (const v of buckets.values()) {
+      if (v.lockedUntil < soonest) soonest = v.lockedUntil;
+    }
+    return { allowed: false, retryAfterSec: Math.max(1, Math.ceil((soonest - now) / 1000)) };
   }
   return { allowed: true };
 }
 
 export function recordLoginFailure(key: string, now: number): void {
   let b = buckets.get(key);
-  // 新 key 才需要占用容量；已有 key 直接更新，永不因容量被拒
+  // 新 key 才占容量；已有 key 直接更新，永不因容量被拒。
+  // 腾不出格子时放弃记录——此时 checkLoginAllowed() 已对未知 key 统一拒绝，
+  // 不计数不会造成放行（见该函数的饱和分支）。
   if (!b && !makeRoomForNewBucket(now)) {
-    return; // 容量饱和（全部条目锁定中）→ 放弃记录，绝不突破上限
+    return;
   }
   // 窗口已过 → 重置失败数与窗口，但保留 lockedUntil（否则锁定时长超过窗口时，
   // 一次废弃猜测即可解锁，退避阶梯上半截形同虚设）与 lockCount（持续升级锁定）
@@ -118,7 +143,7 @@ export function _setMaxBucketsForTest(n: number): void {
 }
 
 /** 限流键中 username 与 ip 各自的最大长度（防超长键放大内存占用）。 */
-const MAX_KEY_PART = 64;
+export const MAX_KEY_PART = 64;
 
 /**
  * 组装限流键 `username|ip`（纯函数，便于测试）。

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -38,20 +38,26 @@ function sweepDeadBuckets(now: number): void {
 }
 
 /**
- * 强制 Map 不超过 MAX_BUCKETS：先清死条目；若仍超限，按插入顺序驱逐最老的，
- * 但**跳过仍在锁定中的条目**（否则攻击者可用海量新 key 冲掉自己的锁）。
- * 全部条目都在锁定中的极端情况下停止驱逐——此时 Map 里全是真实攻击者，
- * 保锁比保内存重要（10k 条 ≈ 1.5MB，可接受）。
+ * 为「新 key」腾出一格容量，返回是否允许分配。
+ *
+ * 顺序：① 未达上限直接放行 → ② 清扫已死条目 → ③ 仍满则按插入顺序驱逐最老的
+ * **未锁定**条目（跳过锁定中的，否则攻击者可用海量新 key 把自己的锁冲掉）。
+ *
+ * ④ 若全部条目都在锁定中（无可驱逐），**拒绝分配新桶**而不是无条件 `set()`。
+ * 拒绝是安全的：新 key 尚无失败记录，丢掉它只是让那一次失败不计数，
+ * 已存在的锁不受影响；反之无条件 set() 会让 Map 突破上限。
+ * 饱和只可能发生在 10k 个 key 同时处于锁定中的真实攻击下，此时保锁优先。
  */
-function enforceBucketCap(now: number): void {
-  if (buckets.size < MAX_BUCKETS) return;
+function makeRoomForNewBucket(now: number): boolean {
+  if (buckets.size < MAX_BUCKETS) return true;
   sweepDeadBuckets(now);
-  if (buckets.size < MAX_BUCKETS) return;
+  if (buckets.size < MAX_BUCKETS) return true;
   for (const [k, v] of buckets) {
-    if (buckets.size < MAX_BUCKETS) break;
     if (now < v.lockedUntil) continue; // 锁定中，不驱逐
     buckets.delete(k);
+    return true;
   }
+  return false; // 全部锁定 → 拒绝新分配（保住已有的锁与内存上限）
 }
 
 export function checkLoginAllowed(key: string, now: number): LoginVerdict {
@@ -64,9 +70,11 @@ export function checkLoginAllowed(key: string, now: number): LoginVerdict {
 }
 
 export function recordLoginFailure(key: string, now: number): void {
-  // 内存硬护栏：攻击者轮换 username|ip 时防止 Map 无界增长
-  enforceBucketCap(now);
   let b = buckets.get(key);
+  // 新 key 才需要占用容量；已有 key 直接更新，永不因容量被拒
+  if (!b && !makeRoomForNewBucket(now)) {
+    return; // 容量饱和（全部条目锁定中）→ 放弃记录，绝不突破上限
+  }
   // 窗口已过 → 重置失败数与窗口，但保留 lockedUntil（否则锁定时长超过窗口时，
   // 一次废弃猜测即可解锁，退避阶梯上半截形同虚设）与 lockCount（持续升级锁定）
   if (!b || now - b.windowStart > WINDOW_MS) {

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -1,32 +1,56 @@
 /**
  * 登录限流（暴力破解防护）。单进程自托管，用进程内 Map 即可——无需 DB、天然可测。
  * 时钟以 `now` 参数注入，保证测试确定性。远程访问上线前这是登录入口的命门。
+ *
+ * 注意：这是**固定窗口**（tumbling window）而非滑动窗口——`windowStart` 只在
+ * 「窗口过期」或「触发锁定」时前移，不随每次尝试滑动。已知折衷：停在每窗口
+ * 4 次失败的低速攻击者不会触发锁定。
+ *
+ * 单进程假设：docker `web` 单实例 / desktop 单进程。若将来横向扩展成多副本，
+ * 限流会退化为「每副本各算一份」（猜测预算 ×N），届时须迁到共享存储。
  */
 export type LoginVerdict =
   | { allowed: true }
   | { allowed: false; retryAfterSec: number };
 
 interface Bucket {
-  failures: number;    // 当前滑动窗口内的连续失败数
+  failures: number;    // 当前固定窗口内的连续失败数
   windowStart: number; // 窗口起点（ms）
   lockedUntil: number; // 锁定到该时刻（ms）
   lockCount: number;   // 累计锁定次数（用于指数退避）
 }
 
-const WINDOW_MS = 15 * 60 * 1000; // 15 分钟滑动窗口
+const WINDOW_MS = 15 * 60 * 1000; // 15 分钟固定窗口
 const MAX_FAILURES = 5;           // 窗口内达到此次失败即锁
 const BASE_LOCK_MS = 60 * 1000;   // 首次锁 1 分钟
 const MAX_LOCK_MS = 30 * 60 * 1000; // 锁定上限 30 分钟
-const MAX_BUCKETS = 10_000;       // 内存上限：超出后清扫死条目
+const MAX_BUCKETS = 10_000;       // 内存硬上限（攻击者轮换 username|ip 时的护栏）
 
 const buckets = new Map<string, Bucket>();
 
-/** Remove expired buckets (no active lock, window passed). D2 mitigation. */
+/** 清扫已死条目（无活跃锁 + 窗口已过）。 */
 function sweepDeadBuckets(now: number): void {
   for (const [k, v] of buckets) {
     if (now >= v.lockedUntil && now - v.windowStart > WINDOW_MS) {
       buckets.delete(k);
     }
+  }
+}
+
+/**
+ * 强制 Map 不超过 MAX_BUCKETS：先清死条目；若仍超限，按插入顺序驱逐最老的，
+ * 但**跳过仍在锁定中的条目**（否则攻击者可用海量新 key 冲掉自己的锁）。
+ * 全部条目都在锁定中的极端情况下停止驱逐——此时 Map 里全是真实攻击者，
+ * 保锁比保内存重要（10k 条 ≈ 1.5MB，可接受）。
+ */
+function enforceBucketCap(now: number): void {
+  if (buckets.size < MAX_BUCKETS) return;
+  sweepDeadBuckets(now);
+  if (buckets.size < MAX_BUCKETS) return;
+  for (const [k, v] of buckets) {
+    if (buckets.size < MAX_BUCKETS) break;
+    if (now < v.lockedUntil) continue; // 锁定中，不驱逐
+    buckets.delete(k);
   }
 }
 
@@ -40,13 +64,11 @@ export function checkLoginAllowed(key: string, now: number): LoginVerdict {
 }
 
 export function recordLoginFailure(key: string, now: number): void {
-  // D2 fix: cap unbounded map growth before processing
-  if (buckets.size >= MAX_BUCKETS) {
-    sweepDeadBuckets(now);
-  }
+  // 内存硬护栏：攻击者轮换 username|ip 时防止 Map 无界增长
+  enforceBucketCap(now);
   let b = buckets.get(key);
-  // 窗口已过 → 重置失败数与窗口，但保留 lockCount 以持续升级锁定
-  // D1 fix: preserve lockedUntil across window reset to prevent lock escape
+  // 窗口已过 → 重置失败数与窗口，但保留 lockedUntil（否则锁定时长超过窗口时，
+  // 一次废弃猜测即可解锁，退避阶梯上半截形同虚设）与 lockCount（持续升级锁定）
   if (!b || now - b.windowStart > WINDOW_MS) {
     b = { failures: 0, windowStart: now, lockedUntil: b?.lockedUntil ?? 0, lockCount: b?.lockCount ?? 0 };
   }
@@ -68,4 +90,32 @@ export function recordLoginSuccess(key: string): void {
 /** 仅测试用：清空所有限流桶。 */
 export function _resetLoginThrottleForTest(): void {
   buckets.clear();
+}
+
+/** 仅测试用：当前桶数量（用于断言内存上限真的生效）。 */
+export function _bucketCountForTest(): number {
+  return buckets.size;
+}
+
+/** 仅测试用：内存硬上限常量（避免测试硬编码魔数与实现脱节）。 */
+export const _MAX_BUCKETS_FOR_TEST = MAX_BUCKETS;
+
+/** 限流键中 username 与 ip 各自的最大长度（防超长键放大内存占用）。 */
+const MAX_KEY_PART = 64;
+
+/**
+ * 组装限流键 `username|ip`（纯函数，便于测试）。
+ *
+ * IP 取值优先级：`cf-connecting-ip` > `x-forwarded-for` 首段 > `"unknown"`。
+ * 经隧道的远程请求由 Cloudflare 注入 `cf-connecting-ip`，客户端伪造不了；
+ * `x-forwarded-for` 客户端可随意伪造，仅在无 CF 头（局域网直连）时作为次选，
+ * 且局域网本就不是本限流的主要威胁面。两部分均截断到 64 字符，
+ * 避免攻击者用超长 username 放大单条桶的内存占用。
+ */
+export function buildThrottleKey(headers: Headers, username: string): string {
+  const cfIp = headers.get("cf-connecting-ip")?.trim();
+  const xff = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const ip = (cfIp || xff || "unknown").slice(0, MAX_KEY_PART);
+  const user = username.trim().toLowerCase().slice(0, MAX_KEY_PART);
+  return `${user}|${ip}`;
 }

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -137,8 +137,14 @@ export function _bucketCountForTest(): number {
  * 仅测试用：临时下调桶数上限，以便用几十次循环（而非几万次）覆盖饱和/驱逐路径。
  * 若不下调，覆盖这些路径需灌入上万条记录，在并行测试下会抢占 CPU 并让
  * 同批的 scrypt 集成测试超时。`_resetLoginThrottleForTest()` 会恢复默认值。
+ *
+ * 校验入参：0/负数/非整数会让「空 Map 也判定为饱和」，进而算出 `Infinity`
+ * 的退避时长——即便是测试辅助函数，也不能破坏限流器的不变量。
  */
 export function _setMaxBucketsForTest(n: number): void {
+  if (!Number.isInteger(n) || n < 1) {
+    throw new RangeError(`_setMaxBucketsForTest 需要 >= 1 的整数，收到 ${n}`);
+  }
   maxBuckets = n;
 }
 
@@ -146,17 +152,24 @@ export function _setMaxBucketsForTest(n: number): void {
 export const MAX_KEY_PART = 64;
 
 /**
- * 把任意长度的字符串压成有界表示。
+ * 把任意长度的字符串压成**严格不超过 `MAX_KEY_PART`** 的表示。
  *
- * 超长时取「头部 + 尾部 + 长度」而非仅头部：注册未限制用户名长度，
+ * 超长时取「头部 + 原始长度 + 尾部」而非仅头部：注册未限制用户名长度，
  * 若只截前 64 字符，两个前缀相同的长用户名会共用一个桶（跨用户 DoS）。
- * 带上尾部与原始长度可把碰撞面压到可忽略，同时键长仍然有界。
+ * 带上尾部与原始长度可把碰撞面压到可忽略。
+ *
+ * 头部长度按「长度数字的位数」动态计算，否则超长输入（`raw.length` 位数变多）
+ * 会把结果顶出上限，破坏内存上界这一不变量。
  */
 function boundedPart(raw: string): string {
   if (raw.length <= MAX_KEY_PART) return raw;
-  const head = raw.slice(0, MAX_KEY_PART - 24);
-  const tail = raw.slice(-16);
-  return `${head}~${raw.length}~${tail}`;
+  const lengthMarker = String(raw.length);
+  const TAIL = 16;
+  // 预算：head + "~" + lengthMarker + "~" + tail <= MAX_KEY_PART
+  const headLen = MAX_KEY_PART - TAIL - lengthMarker.length - 2;
+  // 极端情况（长度数字本身长到吃满预算）退化为纯尾部截断，仍然有界
+  if (headLen <= 0) return `${lengthMarker}~${raw.slice(-TAIL)}`.slice(0, MAX_KEY_PART);
+  return `${raw.slice(0, headLen)}~${lengthMarker}~${raw.slice(-TAIL)}`;
 }
 
 /**

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -1,0 +1,56 @@
+/**
+ * 登录限流（暴力破解防护）。单进程自托管，用进程内 Map 即可——无需 DB、天然可测。
+ * 时钟以 `now` 参数注入，保证测试确定性。远程访问上线前这是登录入口的命门。
+ */
+export type LoginVerdict =
+  | { allowed: true }
+  | { allowed: false; retryAfterSec: number };
+
+interface Bucket {
+  failures: number;    // 当前滑动窗口内的连续失败数
+  windowStart: number; // 窗口起点（ms）
+  lockedUntil: number; // 锁定到该时刻（ms）
+  lockCount: number;   // 累计锁定次数（用于指数退避）
+}
+
+const WINDOW_MS = 15 * 60 * 1000; // 15 分钟滑动窗口
+const MAX_FAILURES = 5;           // 窗口内达到此次失败即锁
+const BASE_LOCK_MS = 60 * 1000;   // 首次锁 1 分钟
+const MAX_LOCK_MS = 30 * 60 * 1000; // 锁定上限 30 分钟
+
+const buckets = new Map<string, Bucket>();
+
+export function checkLoginAllowed(key: string, now: number): LoginVerdict {
+  const b = buckets.get(key);
+  if (!b) return { allowed: true };
+  if (now < b.lockedUntil) {
+    return { allowed: false, retryAfterSec: Math.ceil((b.lockedUntil - now) / 1000) };
+  }
+  return { allowed: true };
+}
+
+export function recordLoginFailure(key: string, now: number): void {
+  let b = buckets.get(key);
+  // 窗口已过 → 重置失败数与窗口，但保留 lockCount 以持续升级锁定
+  if (!b || now - b.windowStart > WINDOW_MS) {
+    b = { failures: 0, windowStart: now, lockedUntil: 0, lockCount: b?.lockCount ?? 0 };
+  }
+  b.failures += 1;
+  if (b.failures >= MAX_FAILURES) {
+    b.lockCount += 1;
+    const lockMs = Math.min(BASE_LOCK_MS * 2 ** (b.lockCount - 1), MAX_LOCK_MS);
+    b.lockedUntil = now + lockMs;
+    b.failures = 0;      // 为下一轮计数清零
+    b.windowStart = now;
+  }
+  buckets.set(key, b);
+}
+
+export function recordLoginSuccess(key: string): void {
+  buckets.delete(key);
+}
+
+/** 仅测试用：清空所有限流桶。 */
+export function _resetLoginThrottleForTest(): void {
+  buckets.clear();
+}

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -17,8 +17,18 @@ const WINDOW_MS = 15 * 60 * 1000; // 15 分钟滑动窗口
 const MAX_FAILURES = 5;           // 窗口内达到此次失败即锁
 const BASE_LOCK_MS = 60 * 1000;   // 首次锁 1 分钟
 const MAX_LOCK_MS = 30 * 60 * 1000; // 锁定上限 30 分钟
+const MAX_BUCKETS = 10_000;       // 内存上限：超出后清扫死条目
 
 const buckets = new Map<string, Bucket>();
+
+/** Remove expired buckets (no active lock, window passed). D2 mitigation. */
+function sweepDeadBuckets(now: number): void {
+  for (const [k, v] of buckets) {
+    if (now >= v.lockedUntil && now - v.windowStart > WINDOW_MS) {
+      buckets.delete(k);
+    }
+  }
+}
 
 export function checkLoginAllowed(key: string, now: number): LoginVerdict {
   const b = buckets.get(key);
@@ -30,10 +40,15 @@ export function checkLoginAllowed(key: string, now: number): LoginVerdict {
 }
 
 export function recordLoginFailure(key: string, now: number): void {
+  // D2 fix: cap unbounded map growth before processing
+  if (buckets.size >= MAX_BUCKETS) {
+    sweepDeadBuckets(now);
+  }
   let b = buckets.get(key);
   // 窗口已过 → 重置失败数与窗口，但保留 lockCount 以持续升级锁定
+  // D1 fix: preserve lockedUntil across window reset to prevent lock escape
   if (!b || now - b.windowStart > WINDOW_MS) {
-    b = { failures: 0, windowStart: now, lockedUntil: 0, lockCount: b?.lockCount ?? 0 };
+    b = { failures: 0, windowStart: now, lockedUntil: b?.lockedUntil ?? 0, lockCount: b?.lockCount ?? 0 };
   }
   b.failures += 1;
   if (b.failures >= MAX_FAILURES) {

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -212,8 +212,7 @@ export async function loginAccount(
   const DUMMY_HASH = "scrypt:a2448ef076990b889ef0540720bccce2:4fdc41afebb4560f4a638b4225d8325904894d18d2df1c7a95c50a65c141b926dc252e99b63e681e15e2d6e008acc845b02c9a2fc99a4888749226ab262c6978";
   const hash = account?.passwordHash || DUMMY_HASH;
   const valid = await verifyPassword(password, hash);
-  const authenticated = Boolean(account) && valid && account.passwordHash.length > 0;
-  if (!authenticated) {
+  if (!account || !valid || account.passwordHash.length === 0) {
     recordLoginFailure(key, now);
     return { ok: false, error: "用户名或密码不正确。" };
   }

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1,6 +1,11 @@
 import { randomBytes } from "node:crypto";
 import { cache } from "react";
 import {
+  checkLoginAllowed,
+  recordLoginFailure,
+  recordLoginSuccess,
+} from "./login-throttle";
+import {
   PanSouResourceProvider,
   createProtectedPan115CookieStorageExecutorFromEnv,
   createBootstrapPan115CookieStorageExecutor,
@@ -189,16 +194,30 @@ export async function registerAccount(username: string, password: string): Promi
   }
 }
 
-/** Authenticate username+password and start a session. */
-export async function loginAccount(username: string, password: string): Promise<AuthOutcome> {
+/** Authenticate username+password and start a session. Throttled against brute force. */
+export async function loginAccount(
+  username: string,
+  password: string,
+  throttleKey?: string,
+): Promise<AuthOutcome> {
+  const key = (throttleKey ?? username.trim().toLowerCase()) || "unknown";
+  const now = Date.now();
+  const verdict = checkLoginAllowed(key, now);
+  if (!verdict.allowed) {
+    return { ok: false, error: `尝试过于频繁，请 ${verdict.retryAfterSec} 秒后再试。` };
+  }
   const account = await getWorkflowRepository().getAccountByUsername(username.trim());
-  // Verify even when the account is missing-ish to avoid trivial username probing
-  // (the empty-hash default account has no password and can't be logged into).
-  const hash = account?.passwordHash ?? "";
-  const valid = hash.length > 0 && (await verifyPassword(password, hash));
-  if (!account || !valid) {
+  // Always verify to avoid timing oracle. Missing accounts get a dummy scrypt hash that will fail.
+  // (The empty-hash default account has no password and can't be logged into.)
+  const DUMMY_HASH = "scrypt:a2448ef076990b889ef0540720bccce2:4fdc41afebb4560f4a638b4225d8325904894d18d2df1c7a95c50a65c141b926dc252e99b63e681e15e2d6e008acc845b02c9a2fc99a4888749226ab262c6978";
+  const hash = account?.passwordHash || DUMMY_HASH;
+  const valid = await verifyPassword(password, hash);
+  const authenticated = Boolean(account) && valid && account.passwordHash.length > 0;
+  if (!authenticated) {
+    recordLoginFailure(key, now);
     return { ok: false, error: "用户名或密码不正确。" };
   }
+  recordLoginSuccess(key);
   return { ok: true, accountId: account.id, signedCookie: await createLoginSession(account.id) };
 }
 

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -4,7 +4,7 @@ import {
   checkLoginAllowed,
   recordLoginFailure,
   recordLoginSuccess,
-  MAX_KEY_PART,
+  normalizeThrottleKey,
 } from "./login-throttle";
 import {
   PanSouResourceProvider,
@@ -203,8 +203,9 @@ export async function loginAccount(
 ): Promise<AuthOutcome> {
   // 无显式 throttleKey 时（库级调用，无请求上下文）退化为仅按 username。
   // 不做 toLowerCase()：账号查询是精确匹配，折叠大小写会让不同账号共用一个桶。
-  // 截断同 buildThrottleKey()：即便将来被别的入口复用，超长 username 也不会撑大桶键。
-  const key = (throttleKey ?? username.trim().slice(0, MAX_KEY_PART)) || "unknown";
+  // 一律过 normalizeThrottleKey()——显式传入的 key 也必须有界，否则调用方
+  // 传超长键就能撑大内存。
+  const key = normalizeThrottleKey(throttleKey ?? username);
   const now = Date.now();
   const verdict = checkLoginAllowed(key, now);
   if (!verdict.allowed) {
@@ -220,8 +221,12 @@ export async function loginAccount(
     recordLoginFailure(key, now);
     return { ok: false, error: "用户名或密码不正确。" };
   }
+  // 先建 session 再清限流桶：建 session 可能抛（DB 故障、取密钥失败），
+  // 那种情况下这次登录并未成功，桶必须保留，否则服务端间歇故障期间
+  // 反复尝试就能一直重置退避。
+  const signedCookie = await createLoginSession(account.id);
   recordLoginSuccess(key);
-  return { ok: true, accountId: account.id, signedCookie: await createLoginSession(account.id) };
+  return { ok: true, accountId: account.id, signedCookie };
 }
 
 /** Destroy the session behind a signed cookie (logout). Best-effort. */

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -4,6 +4,7 @@ import {
   checkLoginAllowed,
   recordLoginFailure,
   recordLoginSuccess,
+  MAX_KEY_PART,
 } from "./login-throttle";
 import {
   PanSouResourceProvider,
@@ -202,7 +203,8 @@ export async function loginAccount(
 ): Promise<AuthOutcome> {
   // 无显式 throttleKey 时（库级调用，无请求上下文）退化为仅按 username。
   // 不做 toLowerCase()：账号查询是精确匹配，折叠大小写会让不同账号共用一个桶。
-  const key = (throttleKey ?? username.trim()) || "unknown";
+  // 截断同 buildThrottleKey()：即便将来被别的入口复用，超长 username 也不会撑大桶键。
+  const key = (throttleKey ?? username.trim().slice(0, MAX_KEY_PART)) || "unknown";
   const now = Date.now();
   const verdict = checkLoginAllowed(key, now);
   if (!verdict.allowed) {

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -200,7 +200,9 @@ export async function loginAccount(
   password: string,
   throttleKey?: string,
 ): Promise<AuthOutcome> {
-  const key = (throttleKey ?? username.trim().toLowerCase()) || "unknown";
+  // 无显式 throttleKey 时（库级调用，无请求上下文）退化为仅按 username。
+  // 不做 toLowerCase()：账号查询是精确匹配，折叠大小写会让不同账号共用一个桶。
+  const key = (throttleKey ?? username.trim()) || "unknown";
   const now = Date.now();
   const verdict = checkLoginAllowed(key, now);
   if (!verdict.allowed) {


### PR DESCRIPTION
## Why

远程访问（Cloudflare 隧道）上线前的安全命门：登录入口目前**没有任何限流**，且存在用户名枚举时序预言机。这是公网暴露的阻塞项。

## What

**限流（新增）**
- `apps/web/lib/login-throttle.ts` — 进程内内存桶，按 `username|ip` 计数。15 分钟窗口内 5 次失败 → 指数退避锁定（1→2→4→8→16→30 分钟上限）。成功登录清空桶。
- 时钟以 `now` 参数注入，状态机可确定性测试（无 fake timers）。
- 单进程自托管（docker `web` / desktop 共一个 Node 进程），无需 DB migration。

**修复用户名枚举时序预言机**
`loginAccount` 的注释声称防枚举，但 `hash.length > 0 && (await verifyPassword(...))` 的 `&&` **短路**——账号不存在时 `verifyPassword` 根本不会被调用。实测：

| 路径 | 耗时 |
|---|---|
| 账号不存在 | 0.0026 ms |
| 账号存在 | 54 ms |

约 **20000×** 差距，网络上无需统计手段即可直接读出账号是否存在。修复：账号缺失时用一个固定的 dummy scrypt hash 走完整验证流程，两条路径都吃 scrypt。集成测试断言时序比 < 10×（修复前 ~800×）。

## 代码审查中发现并修复的两个真 bug

这两个都是**在合并前自查发现**的，不是 plan 写错，而是限流这个机制的领域通病：

**D1 — 锁可被一次废弃猜测解除（HIGH）**
窗口过期分支无条件把 `lockedUntil` 清零。当锁定时长超过 15 分钟窗口时（第 5、6 级锁），攻击者等 15 分钟发一次废弃猜测就解锁。亲证：

\`\`\`
lock#6: 时长=30min, lockedUntil=4660001
窗口过期时刻仍在锁内? true → check = { allowed: false, retryAfterSec: 900 }
发一次失败后 check = { allowed: true }   ← 逃逸
\`\`\`

后果：实际服务的最长锁定 = 15 分钟，退避阶梯上半截（16/30 分钟）不可达，`MAX_LOCK_MS` 形同虚设。修复：窗口重置时保留 `lockedUntil`。

**D2 — `buckets` Map 无界增长（HIGH）**
只有成功登录会删除条目，攻击者用不同 IP 或随机用户名可无限增长。且账号不存在的路径修复前几乎零成本（0.0026ms），分配桶不受 scrypt 限速。修复：`MAX_BUCKETS` 上限 10k + `sweepDeadBuckets()` 清扫过期条目。

**变异测试发现的测试盲区**：把 `WINDOW_MS` 从 15 分钟改成 1 分钟、`MAX_LOCK_MS` 从 30 分钟改成 2 分钟，原测试**全部仍绿**——两个常量都没被钉住（这也是 D1 能悄悄存在的原因）。已补 4 个回归测试：锁逃逸、内存有界、`MAX_LOCK_MS` 精确阶梯（60/120/240/480/960/1800/1800 秒）、`WINDOW_MS` 下界。

## 设计要点

- **防枚举一致性**：真实用户名与不存在的用户名同样累计、同样锁定；限流键是不透明字符串，不查账号是否存在，两种情况返回同一 `LoginVerdict` 形状。
- **key = `username|ip`**：owner 通常在 LAN（与攻击者不同 IP），不会被针对其用户名的远程攻击误锁。库级调用（无 IP）退化为仅按 username。
- **锁定期间正确密码也被挡**，且短路在 scrypt 之前 —— 锁定响应对存在/不存在的账号同样快，不构成新的预言机。

## 已知遗留（非阻塞，后续任务）

- **并发 TOCTOU**：`checkLoginAllowed` 是纯读，check 与 record 之间隔着 ~54ms 的 scrypt，N 个并发请求会同时通过。需要把「判定+记账」合成一步。
- **固定窗口而非滑动窗口**：注释写的是「滑动窗口」但实现是 tumbling window，停在每窗口 4 次失败可永不触发锁定（384 次/天）。
- **`lockCount` 永不衰减**：偶尔手滑的正常用户长期累积会爬到 30 分钟锁，且锁定中无法产生解锁所需的成功登录。

## Verification

\`\`\`
npx vitest run                              → 1940 passed | 13 skipped (0 failed)
npx tsc -p apps/web/tsconfig.json --noEmit  → EXIT=0
npm run build:web                           → EXIT=0
\`\`\`

新增测试：`login-throttle.test.ts` 10 个（含 4 个回归）、`login-throttle-integration.test.ts` 3 个（真实 `:memory:` SQLite runtime）。