### PR TITLE
feat(auth): single-user password gate — remote requires login, LAN stays open

### DIFF
--- a/apps/web/app/api/auth/bootstrap/route.ts
+++ b/apps/web/app/api/auth/bootstrap/route.ts
@@ -1,9 +1,16 @@
 import { connection, NextResponse } from "next/server";
-import { isMultiUserEnabled, getBootstrapState } from "../../../../lib/workflow-runtime";
+import {
+  isMultiUserEnabled,
+  getBootstrapState,
+  hasLoginPassword,
+} from "../../../../lib/workflow-runtime";
 
 /** Tells the /login page whether the instance is unclaimed (→ show the context-aware
  *  claim screen) and whether the default account already owns a library (→ "接管"
  *  copy vs "创建"). Read-only; safe before any auth.
+ *
+ *  `singleUser` lets the page render a password-only form: in single-user mode the
+ *  account is always acct_default, so there is no username to ask an end user for.
  *
  *  `connection()` FIRST: reads runtime env (MEDIA_TRACK_MULTI_USER) + the DB at request
  *  time. Without it, cacheComponents prerenders the handler at BUILD time (multi-user
@@ -13,7 +20,12 @@ import { isMultiUserEnabled, getBootstrapState } from "../../../../lib/workflow-
 export async function GET() {
   await connection();
   if (!isMultiUserEnabled()) {
-    return NextResponse.json({ needsClaim: false, hasExistingLibrary: false });
+    return NextResponse.json({
+      needsClaim: false,
+      hasExistingLibrary: false,
+      singleUser: true,
+      passwordSet: (await hasLoginPassword()) === true,
+    });
   }
-  return NextResponse.json(await getBootstrapState());
+  return NextResponse.json({ ...(await getBootstrapState()), singleUser: false });
 }

--- a/apps/web/app/api/auth/bootstrap/route.ts
+++ b/apps/web/app/api/auth/bootstrap/route.ts
@@ -24,7 +24,10 @@ export async function GET() {
       needsClaim: false,
       hasExistingLibrary: false,
       singleUser: true,
-      passwordSet: (await hasLoginPassword()) === true,
+      // "unknown"（DB 读不出来）按**已设密码**上报：服务端远程读路径此时是
+      // fail-closed 的，若这里报「无需登录」，用户会被引到一条走不通的路。
+      // 宁可显示登录框（顶多多输一次密码），也不要误导。
+      passwordSet: (await hasLoginPassword()) !== false,
     });
   }
   return NextResponse.json({ ...(await getBootstrapState()), singleUser: false });

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -5,6 +5,7 @@ import {
   SESSION_COOKIE_NAME,
   isMultiUserEnabled,
   isCookieSecure,
+  hasLoginPassword,
   loginAccount,
 } from "../../../../lib/workflow-runtime";
 
@@ -13,8 +14,11 @@ const SESSION_MAX_AGE = 30 * 24 * 60 * 60; // 30 days, seconds
 /** Authenticate username+password → set the signed httpOnly session cookie. */
 export async function POST(request: NextRequest) {
   if (isDemoMode()) return Response.json({ error: "演示站只读" }, { status: 403 });
-  if (!isMultiUserEnabled()) {
-    return NextResponse.json({ error: "multi-user disabled" }, { status: 404 });
+  // 多用户一律可登录；单用户仅在已设密码后开放登录（未设密码时无密码可验）。
+  // hasLoginPassword() 读不出状态时返回 "unknown"，此时放行到 loginAccount——
+  // 那里会因为拿不到有效 hash 而失败，不会误发 session。
+  if (!isMultiUserEnabled() && (await hasLoginPassword()) === false) {
+    return NextResponse.json({ error: "login disabled" }, { status: 404 });
   }
   const body = (await request.json().catch(() => ({}))) as { username?: unknown; password?: unknown };
   const username = typeof body.username === "string" ? body.username : "";

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -23,7 +23,15 @@ export async function POST(request: NextRequest) {
   const body = (await request.json().catch(() => ({}))) as { username?: unknown; password?: unknown };
   const username = typeof body.username === "string" ? body.username : "";
   const password = typeof body.password === "string" ? body.password : "";
-  const result = await loginAccount(username, password, buildThrottleKey(request.headers, username));
+  // 限流身份必须与登录身份一致。单用户模式忽略用户名（永远登录 acct_default），
+  // 所以限流也不能按用户名分桶——否则攻击者每次换个用户名就换一个桶，
+  // 限流形同虚设而每次仍要付一次 scrypt 的代价。
+  const throttleIdentity = isMultiUserEnabled() ? username : "";
+  const result = await loginAccount(
+    username,
+    password,
+    buildThrottleKey(request.headers, throttleIdentity),
+  );
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 401 });
   }

--- a/apps/web/app/api/auth/login/route.ts
+++ b/apps/web/app/api/auth/login/route.ts
@@ -18,7 +18,7 @@ export async function POST(request: NextRequest) {
   // hasLoginPassword() 读不出状态时返回 "unknown"，此时放行到 loginAccount——
   // 那里会因为拿不到有效 hash 而失败，不会误发 session。
   if (!isMultiUserEnabled() && (await hasLoginPassword()) === false) {
-    return NextResponse.json({ error: "login disabled" }, { status: 404 });
+    return NextResponse.json({ error: "这台实例未设置访问密码，无需登录。" }, { status: 404 });
   }
   const body = (await request.json().catch(() => ({}))) as { username?: unknown; password?: unknown };
   const username = typeof body.username === "string" ? body.username : "";

--- a/apps/web/app/api/auth/password/route.ts
+++ b/apps/web/app/api/auth/password/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { isDemoMode } from "../../../../lib/demo-mode";
+import {
+  isMultiUserEnabled,
+  hasLoginPassword,
+  setSingleUserPassword,
+  clearSingleUserPassword,
+  requireAuthenticatedAccountId,
+} from "../../../../lib/workflow-runtime";
+
+/** flag cookie 名与有效期。仅用于 proxy 的重定向 UX，非安全判据。 */
+const AUTH_REQUIRED_COOKIE = "mt_auth_required";
+const FLAG_MAX_AGE = 365 * 24 * 60 * 60;
+
+/**
+ * 单用户实例设置/更新/清除访问密码。
+ *
+ * 授权模型：**已设密码后**，改密与清密都必须是已认证请求
+ * （`requireAuthenticatedAccountId()` 对远程无 session 会抛错；局域网视为可信）。
+ * 尚未设密码时实例本来就全开放，首次设置无从要求凭据——这与「局域网可信」
+ * 的整体设计一致：能碰到局域网端口的人本来就能读写全部数据。
+ *
+ * 同时维护 `mt_auth_required` flag cookie 供 Edge 层 proxy 做重定向判断。
+ */
+export async function POST(request: NextRequest) {
+  if (isDemoMode()) {
+    return NextResponse.json({ error: "演示站只读" }, { status: 403 });
+  }
+  if (isMultiUserEnabled()) {
+    // 多用户有自己的改密路径（changeOwnPassword / resetUserPassword）
+    return NextResponse.json({ error: "多用户模式请在账号设置中改密" }, { status: 400 });
+  }
+
+  const body = (await request.json().catch(() => ({}))) as {
+    password?: unknown;
+    clear?: unknown;
+  };
+
+  // 已设密码 → 后续变更必须已认证。状态读不出来（"unknown"）时同样要求认证，
+  // 宁可让本地用户多登录一次，也不能让远程匿名请求清掉密码。
+  if ((await hasLoginPassword()) !== false) {
+    await requireAuthenticatedAccountId();
+  }
+
+  if (body.clear === true) {
+    await clearSingleUserPassword();
+    const res = NextResponse.json({ ok: true, passwordSet: false });
+    res.cookies.set(AUTH_REQUIRED_COOKIE, "", { path: "/", maxAge: 0 });
+    return res;
+  }
+
+  const password = typeof body.password === "string" ? body.password : "";
+  const result = await setSingleUserPassword(password);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+  const res = NextResponse.json({ ok: true, passwordSet: true });
+  res.cookies.set(AUTH_REQUIRED_COOKIE, "1", {
+    path: "/",
+    // 故意 NOT httpOnly：设置页要读它来显示当前状态。它不是安全判据——
+    // 权威判定在服务端 getCurrentAccountId()，伪造这个 cookie 不会绕过任何东西。
+    httpOnly: false,
+    sameSite: "lax",
+    maxAge: FLAG_MAX_AGE,
+  });
+  return res;
+}
+

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -18,7 +18,12 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [whyOpen, setWhyOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
-  const [bootstrap, setBootstrap] = useState<{ needsClaim: boolean; hasExistingLibrary: boolean } | null>(null);
+  const [bootstrap, setBootstrap] = useState<{
+    needsClaim: boolean;
+    hasExistingLibrary: boolean;
+    singleUser?: boolean;
+    passwordSet?: boolean;
+  } | null>(null);
 
   useEffect(() => {
     fetch("/api/auth/bootstrap")
@@ -28,8 +33,12 @@ export default function LoginPage() {
   }, []);
 
   const claiming = bootstrap?.needsClaim === true;
+  // 单用户实例只有 acct_default 一个账号：用户名对最终用户不可见，
+  // 只渲染密码框，且没有「创建账号」这回事。
+  const singleUser = bootstrap?.singleUser === true;
   // While unclaimed, only registration (→ adopt acct_default) is possible.
-  const effectiveMode: "login" | "register" = claiming ? "register" : mode;
+  // 单用户永远是登录（只输密码），没有注册这条路。
+  const effectiveMode: "login" | "register" = singleUser ? "login" : claiming ? "register" : mode;
 
   const submit = () => {
     setError(null);
@@ -48,21 +57,25 @@ export default function LoginPage() {
     });
   };
 
-  const title = claiming
-    ? bootstrap?.hasExistingLibrary
-      ? "接管这台实例"
-      : "创建站主账号"
-    : mode === "login"
-      ? "登录"
-      : "创建账号";
-  const note = claiming
+  const title = singleUser
+    ? "输入密码"
+    : claiming
+      ? bootstrap?.hasExistingLibrary
+        ? "接管这台实例"
+        : "创建站主账号"
+      : mode === "login"
+        ? "登录"
+        : "创建账号";
+  const note = singleUser
+    ? "这台实例已设置访问密码。局域网内无需登录，从外网访问需要输入密码。"
+    : claiming
     ? bootstrap?.hasExistingLibrary
       ? "这台实例已有媒体库。设置站主用户名 + 密码来接管它——你的库和网盘都会原样归你。"
       : "你是第一个用户。这个账号将成为站主，拥有管理权限。"
     : mode === "login"
       ? "登录以访问你的媒体库"
       : "创建一个本地账号开始使用";
-  const buttonText = claiming ? "接管并进入" : mode === "login" ? "登录" : "创建并登录";
+  const buttonText = singleUser ? "进入" : claiming ? "接管并进入" : mode === "login" ? "登录" : "创建并登录";
 
   return (
     <main style={{ maxWidth: 360, margin: "14vh auto", padding: "0 20px" }}>
@@ -80,16 +93,18 @@ export default function LoginPage() {
             submit();
           }}
         >
-          <div className="setting-row" style={{ marginBottom: 10 }}>
-            <input
-              className="setting-control"
-              value={username}
-              onChange={(event) => setUsername(event.target.value)}
-              placeholder="用户名"
-              aria-label="用户名"
-              autoComplete="username"
-            />
-          </div>
+          {singleUser ? null : (
+            <div className="setting-row" style={{ marginBottom: 10 }}>
+              <input
+                className="setting-control"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                placeholder="用户名"
+                aria-label="用户名"
+                autoComplete="username"
+              />
+            </div>
+          )}
           <div className="setting-row" style={{ marginBottom: 14 }}>
             <input
               type="password"
@@ -116,7 +131,7 @@ export default function LoginPage() {
           </button>
         </form>
 
-        {!claiming && mode === "register" ? (
+        {!claiming && !singleUser && mode === "register" ? (
           <div style={{ marginTop: 14 }}>
             <span
               role="note"
@@ -158,8 +173,9 @@ export default function LoginPage() {
           </div>
         ) : null}
 
-        {/* While unclaimed there is nobody to log in as, so hide the toggle. */}
-        {!claiming ? (
+        {/* While unclaimed there is nobody to log in as, so hide the toggle.
+            Single-user has exactly one account, so registration is meaningless. */}
+        {!claiming && !singleUser ? (
           <p className="panel-note" style={{ marginTop: 16 }}>
             {mode === "login" ? "还没有账号？" : "已有账号？"}{" "}
             <button

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -58,7 +58,9 @@ export default function LoginPage() {
   };
 
   const title = singleUser
-    ? "输入密码"
+    ? bootstrap?.passwordSet
+      ? "输入密码"
+      : "无需登录"
     : claiming
       ? bootstrap?.hasExistingLibrary
         ? "接管这台实例"
@@ -67,7 +69,9 @@ export default function LoginPage() {
         ? "登录"
         : "创建账号";
   const note = singleUser
-    ? "这台实例已设置访问密码。局域网内无需登录，从外网访问需要输入密码。"
+    ? bootstrap?.passwordSet
+      ? "这台实例已设置访问密码。局域网内无需登录，从外网访问需要输入密码。"
+      : "这台实例还没有设置访问密码，无需登录即可使用。想开启外网访问再来设置。"
     : claiming
     ? bootstrap?.hasExistingLibrary
       ? "这台实例已有媒体库。设置站主用户名 + 密码来接管它——你的库和网盘都会原样归你。"
@@ -87,6 +91,11 @@ export default function LoginPage() {
           {note}
         </p>
 
+        {singleUser && bootstrap?.passwordSet === false ? (
+          <a className="primary-button" href="/" style={{ display: "block", textDecoration: "none" }}>
+            回到媒体库
+          </a>
+        ) : (
         <form
           onSubmit={(event) => {
             event.preventDefault();
@@ -130,6 +139,7 @@ export default function LoginPage() {
             {isPending ? <LoaderCircle size={14} className="spin" aria-hidden /> : buttonText}
           </button>
         </form>
+        )}
 
         {!claiming && !singleUser && mode === "register" ? (
           <div style={{ marginTop: 14 }}>

--- a/apps/web/lib/login-throttle.ts
+++ b/apps/web/lib/login-throttle.ts
@@ -204,11 +204,15 @@ export function normalizeThrottleKey(key: string): string {
  * （SQLite/Postgres 皆然，`username text UNIQUE`），大小写敏感。若在此折叠大小写，
  * `Owner` 与 `owner` 这两个**不同账号**会共用一个桶——攻击者猛猜 `owner`
  * 就能把 `Owner` 的合法用户锁在门外。限流身份必须与登录身份严格一致。
+ *
+ * `identity` 为空（单用户模式：登录只认 `acct_default`，用户名被忽略）时，
+ * 键退化为纯 IP。**必须如此**——否则攻击者每次请求换一个用户名就能换一个桶，
+ * 限流形同虚设，而每次尝试仍会消耗一次 memory-hard 的 scrypt。
  */
-export function buildThrottleKey(headers: Headers, username: string): string {
+export function buildThrottleKey(headers: Headers, identity: string): string {
   const cfIp = headers.get("cf-connecting-ip")?.trim();
   const xff = headers.get("x-forwarded-for")?.split(",")[0]?.trim();
   const ip = boundedPart((cfIp || xff || "unknown").trim());
-  const user = boundedPart(username.trim());
+  const user = boundedPart(identity.trim());
   return `${user}|${ip}`;
 }

--- a/apps/web/lib/single-user-gate-wiring.test.ts
+++ b/apps/web/lib/single-user-gate-wiring.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * 单用户密码门的**不纯接线**测试。
+ *
+ * 纯函数（resolveSingleUserAccount / isRemoteRequest）在 single-user-password.test.ts
+ * 里已全组合覆盖；真正出事故的是把它们串起来的那段代码——Emby/Jellyfin 的漏洞
+ * 都不在判定函数本身，而在「读不到状态时怎么办」。本文件专测这些故障路径：
+ *  - DB 读失败时，远程请求必须 fail-closed（不能因为读不到密码状态就当没设密码）
+ *  - session 读失败时，已判定为远程的请求必须 fail-closed
+ *  - 属于别的账号的有效 session 不得落进单用户路径
+ */
+
+const prevPg = process.env.MEDIA_TRACK_POSTGRES_URL;
+const prevMultiUser = process.env.MEDIA_TRACK_MULTI_USER;
+
+const boot = async () => {
+  process.env.MEDIA_TRACK_SQLITE_PATH = ":memory:";
+  delete process.env.MEDIA_TRACK_POSTGRES_URL;
+  delete process.env.MEDIA_TRACK_MULTI_USER; // 单用户
+  vi.resetModules();
+  return import("./workflow-runtime");
+};
+
+/** 装上一个假的 next/headers，模拟「经隧道的远程请求」。 */
+const mockRemoteRequest = (cookieValue?: string) => {
+  vi.doMock("next/headers", () => ({
+    headers: async () => new Headers({ "cf-ray": "8f3abc-LAX" }),
+    cookies: async () => ({
+      get: (name: string) =>
+        name === "mt_session" && cookieValue ? { name, value: cookieValue } : undefined,
+    }),
+  }));
+};
+
+afterEach(() => {
+  delete process.env.MEDIA_TRACK_SQLITE_PATH;
+  if (prevPg !== undefined) process.env.MEDIA_TRACK_POSTGRES_URL = prevPg;
+  if (prevMultiUser !== undefined) {
+    process.env.MEDIA_TRACK_MULTI_USER = prevMultiUser;
+  } else {
+    delete process.env.MEDIA_TRACK_MULTI_USER;
+  }
+  vi.doUnmock("next/headers");
+  vi.resetModules();
+});
+
+describe("single-user gate wiring (failure paths)", () => {
+  it("远程 + 密码状态读失败 → 必须 fail-closed（不得当作未设密码而放行）", async () => {
+    mockRemoteRequest();
+    const rt = await boot();
+    await rt.setSingleUserPassword("secret-123");
+
+    // 让密码状态读不出来（DB 抖动/连接池耗尽/故障切换）
+    const repo = rt.getWorkflowRepository();
+    const original = repo.getAccountById.bind(repo);
+    repo.getAccountById = async () => {
+      throw new Error("DB down");
+    };
+
+    const accountId = await rt.getCurrentAccountId();
+    repo.getAccountById = original;
+
+    // 读不到状态 ≠ 没设密码。远程匿名访客绝不能拿到 acct_default。
+    expect(accountId).toBe("acct_unauthenticated");
+  });
+
+  it("远程 + 密码状态读失败 → 写操作必须抛错", async () => {
+    mockRemoteRequest();
+    const rt = await boot();
+    await rt.setSingleUserPassword("secret-123");
+
+    const repo = rt.getWorkflowRepository();
+    const original = repo.getAccountById.bind(repo);
+    repo.getAccountById = async () => {
+      throw new Error("DB down");
+    };
+
+    await expect(rt.requireAuthenticatedAccountId()).rejects.toThrow();
+    repo.getAccountById = original;
+  });
+
+  it("远程 + session 读失败 → 已知是远程，必须 fail-closed", async () => {
+    mockRemoteRequest("forged.cookie");
+    const rt = await boot();
+    await rt.setSingleUserPassword("secret-123");
+
+    const repo = rt.getWorkflowRepository();
+    const original = repo.getSession.bind(repo);
+    repo.getSession = async () => {
+      throw new Error("session store down");
+    };
+
+    const accountId = await rt.getCurrentAccountId();
+    repo.getSession = original;
+
+    expect(accountId).toBe("acct_unauthenticated");
+  });
+
+  it("远程 + 属于别的账号的有效 session → 不得落进单用户路径", async () => {
+    // 同一个库可能有多用户时期遗留的账号（MEDIA_TRACK_MULTI_USER 是运行时开关，
+    // 可以再切回单用户）。那些账号的 session 不该在单用户模式下被认作站主。
+    const rt = await boot();
+    // 纯函数层面就应该钉死：只有 acct_default 才算数
+    expect(
+      rt.resolveSingleUserAccount({
+        hasPassword: true,
+        isRemote: true,
+        sessionAccountId: "acct_someone_else",
+      }),
+    ).toBe("acct_unauthenticated");
+    expect(
+      rt.resolveSingleUserAccount({
+        hasPassword: true,
+        isRemote: true,
+        sessionAccountId: "acct_default",
+      }),
+    ).toBe("acct_default");
+  });
+
+  it("LAN + 密码状态读失败 → 保持开放（不因读不到就把本地用户锁死）", async () => {
+    vi.doMock("next/headers", () => ({
+      headers: async () => new Headers({ "user-agent": "curl" }), // 无 CF 头 = LAN
+      cookies: async () => ({ get: () => undefined }),
+    }));
+    const rt = await boot();
+    await rt.setSingleUserPassword("secret-123");
+
+    const repo = rt.getWorkflowRepository();
+    const original = repo.getAccountById.bind(repo);
+    repo.getAccountById = async () => {
+      throw new Error("DB down");
+    };
+
+    const accountId = await rt.getCurrentAccountId();
+    repo.getAccountById = original;
+
+    // 局域网是可信网段：读不到状态时维持现状行为，不制造运维事故
+    expect(accountId).toBe("acct_default");
+  });
+
+  it("无请求上下文（in-process worker）→ 直通 acct_default", async () => {
+    const rt = await boot();
+    await rt.setSingleUserPassword("secret-123");
+    // 未 mock next/headers ⇒ 取不到请求作用域，等同后台任务
+    expect(await rt.getCurrentAccountId()).toBe("acct_default");
+  });
+});

--- a/apps/web/lib/single-user-password.test.ts
+++ b/apps/web/lib/single-user-password.test.ts
@@ -77,4 +77,36 @@ describe("single-user password gate", () => {
     expect(locked.ok).toBe(false);
     if (!locked.ok) expect(locked.error).toContain("尝试过于频繁");
   });
+
+  it("单用户下换用户名不能绕过限流（用户名本就被忽略）", async () => {
+    // 曾经的漏洞：限流键含用户名，而单用户登录忽略用户名 ⇒ 每次换个名字
+    // 就换一个桶，限流形同虚设，且每次仍要付一次 memory-hard scrypt。
+    const rt = await boot();
+    const { _resetLoginThrottleForTest, buildThrottleKey } = await import("./login-throttle");
+    _resetLoginThrottleForTest();
+    await rt.setSingleUserPassword("secret-123");
+    const headers = new Headers({ "cf-connecting-ip": "9.9.9.9" });
+
+    let refusedByThrottle = 0;
+    for (let i = 0; i < 8; i++) {
+      // 模拟 route 的行为：单用户模式下身份为空串
+      const r = await rt.loginAccount(`bogus${i}`, "wrong", buildThrottleKey(headers, ""));
+      if (!r.ok && r.error.includes("尝试过于频繁")) refusedByThrottle++;
+    }
+    // 5 次失败即锁 ⇒ 后续几次必须被拦
+    expect(refusedByThrottle).toBeGreaterThan(0);
+  });
+
+  it("库级调用（无显式 throttleKey）在单用户下也共用同一个桶", async () => {
+    const rt = await boot();
+    const { _resetLoginThrottleForTest } = await import("./login-throttle");
+    _resetLoginThrottleForTest();
+    await rt.setSingleUserPassword("secret-123");
+    let refused = 0;
+    for (let i = 0; i < 8; i++) {
+      const r = await rt.loginAccount(`name${i}`, "wrong"); // 不传 throttleKey
+      if (!r.ok && r.error.includes("尝试过于频繁")) refused++;
+    }
+    expect(refused).toBeGreaterThan(0);
+  });
 });

--- a/apps/web/lib/single-user-password.test.ts
+++ b/apps/web/lib/single-user-password.test.ts
@@ -47,4 +47,34 @@ describe("single-user password gate", () => {
     expect(rt.isRemoteRequest(new Headers({ "user-agent": "curl" }))).toBe(false); // LAN 无 CF 头
     expect(rt.isRemoteRequest(new Headers())).toBe(false);
   });
+
+  it("单用户设密码后可用密码登录 acct_default（用户名任意/空均视为 default）", async () => {
+    const rt = await boot();
+    await rt.setSingleUserPassword("secret-123");
+    const bad = await rt.loginAccount("", "nope-nope");
+    expect(bad.ok).toBe(false);
+    const ok = await rt.loginAccount("", "secret-123");
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.accountId).toBe("acct_default");
+  });
+
+  it("单用户未设密码时不能登录（没有密码可验证，不该发出 session）", async () => {
+    const rt = await boot();
+    const r = await rt.loginAccount("", "anything");
+    expect(r.ok).toBe(false);
+  });
+
+  it("单用户登录同样受限流保护（连续失败后锁定）", async () => {
+    const rt = await boot();
+    const { _resetLoginThrottleForTest } = await import("./login-throttle");
+    _resetLoginThrottleForTest();
+    await rt.setSingleUserPassword("secret-123");
+    for (let i = 0; i < 5; i++) {
+      const r = await rt.loginAccount("", "wrong-password");
+      expect(r.ok).toBe(false);
+    }
+    const locked = await rt.loginAccount("", "secret-123"); // 正确密码也应被挡
+    expect(locked.ok).toBe(false);
+    if (!locked.ok) expect(locked.error).toContain("尝试过于频繁");
+  });
 });

--- a/apps/web/lib/single-user-password.test.ts
+++ b/apps/web/lib/single-user-password.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const prevPg = process.env.MEDIA_TRACK_POSTGRES_URL;
+const prevMultiUser = process.env.MEDIA_TRACK_MULTI_USER;
+
+const boot = async () => {
+  process.env.MEDIA_TRACK_SQLITE_PATH = ":memory:";
+  delete process.env.MEDIA_TRACK_POSTGRES_URL;
+  delete process.env.MEDIA_TRACK_MULTI_USER; // 单用户
+  vi.resetModules();
+  return import("./workflow-runtime");
+};
+
+afterEach(() => {
+  delete process.env.MEDIA_TRACK_SQLITE_PATH;
+  if (prevPg !== undefined) process.env.MEDIA_TRACK_POSTGRES_URL = prevPg;
+  // 原值为 undefined 时必须删除而非跳过，否则会把值泄漏给后续测试文件
+  if (prevMultiUser !== undefined) {
+    process.env.MEDIA_TRACK_MULTI_USER = prevMultiUser;
+  } else {
+    delete process.env.MEDIA_TRACK_MULTI_USER;
+  }
+  vi.resetModules();
+});
+
+describe("single-user password gate", () => {
+  it("未设密码时 hasLoginPassword=false", async () => {
+    const rt = await boot();
+    expect(await rt.hasLoginPassword()).toBe(false);
+  });
+
+  it("resolveSingleUserAccount：未设密码 → 一律开放；设密码 → LAN 开放、远程需 session", async () => {
+    const rt = await boot();
+    // 纯函数，覆盖全部内外/有无 session 组合（这是本 plan 的安全核心判定）
+    expect(rt.resolveSingleUserAccount({ hasPassword: false, isRemote: false, sessionAccountId: null })).toBe("acct_default");
+    expect(rt.resolveSingleUserAccount({ hasPassword: false, isRemote: true, sessionAccountId: null })).toBe("acct_default");
+    expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: false, sessionAccountId: null })).toBe("acct_default"); // LAN 免登录
+    expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: null })).toBe("acct_unauthenticated"); // 远程无 session → 哨兵
+    expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: "acct_default" })).toBe("acct_default"); // 远程已登录 → 放行
+  });
+
+  it("isRemoteRequest：任一 CF 头即远程（不只靠 cf-connecting-ip——它可被 zone 配置删除）", async () => {
+    const rt = await boot();
+    expect(rt.isRemoteRequest(new Headers({ "cf-ray": "8f3-abc" }))).toBe(true);
+    expect(rt.isRemoteRequest(new Headers({ "cdn-loop": "cloudflare" }))).toBe(true);
+    expect(rt.isRemoteRequest(new Headers({ "cf-connecting-ip": "1.2.3.4" }))).toBe(true);
+    expect(rt.isRemoteRequest(new Headers({ "user-agent": "curl" }))).toBe(false); // LAN 无 CF 头
+    expect(rt.isRemoteRequest(new Headers())).toBe(false);
+  });
+});

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -241,18 +241,21 @@ export async function logoutSession(signedCookie: string | undefined): Promise<v
 }
 
 /**
- * 单用户模式是否已设置登录密码（`acct_default` 有非空 `passwordHash`）。
- * 非空即表示实例进入「远程需登录」态；清空即回到全开放态（可逆开关）。
+ * 单用户模式的登录密码状态。
  *
- * 取不到仓库（未配置 DB / 无请求上下文）时返回 false —— 与「未设密码」
- * 的现状行为一致，绝不因为读不到状态就把本地实例锁死。
+ * 三态而非布尔：`"unknown"` 表示**读不出来**（DB 抖动、连接池耗尽、故障切换），
+ * 它和「没设密码」是完全不同的两件事。若把二者合并，一次数据库抖动就会让
+ * 公网访客直接拿到站主身份——读不到状态时必须由调用方按「本地宽容、远程收紧」
+ * 分别决策，而不是在这里一律当作开放。
  */
-export async function hasLoginPassword(): Promise<boolean> {
+export type LoginPasswordState = boolean | "unknown";
+
+export async function hasLoginPassword(): Promise<LoginPasswordState> {
   try {
     const acct = await getWorkflowRepository().getAccountById(DEFAULT_ACCOUNT_ID);
     return Boolean(acct && acct.passwordHash.length > 0);
   } catch {
-    return false;
+    return "unknown";
   }
 }
 
@@ -610,35 +613,57 @@ export function isRemoteRequest(hdrs: Headers): boolean {
 /**
  * 单用户账号判定（纯函数，本 plan 的安全核心）。设密码后：LAN 开放、远程需 session。
  *
+ * `hasPassword` 为 `"unknown"`（状态读取失败）时按**已设密码**处理：
+ * 局域网仍然放行（可信网段，不因一次抖动制造运维事故），远程则收紧到需要
+ * session——读不到状态绝不等于没设密码。
+ *
+ * 远程放行只认 `acct_default`：同一个库可能残留多用户时期的账号
+ * （`MEDIA_TRACK_MULTI_USER` 是运行时开关，可来回切），那些账号的 session
+ * 不该在单用户模式下被当作站主，况且改密/清密只会吊销 `acct_default` 的 session，
+ * 吊销不掉它们。
+ *
  * 抽成纯函数是为了能确定性覆盖全部「内外 × 有无 session」组合——
  * Emby/Jellyfin 的事故正是内外判定出错，这段逻辑必须可被精确测试。
  */
 export function resolveSingleUserAccount(opts: {
-  hasPassword: boolean;
+  hasPassword: LoginPasswordState;
   isRemote: boolean;
   sessionAccountId: string | null;
 }): string {
-  if (!opts.hasPassword) return DEFAULT_ACCOUNT_ID;
-  if (!opts.isRemote) return DEFAULT_ACCOUNT_ID; // LAN 免登录
-  return opts.sessionAccountId ?? UNAUTHENTICATED_ACCOUNT_ID; // 远程需登录
+  if (opts.hasPassword === false) return DEFAULT_ACCOUNT_ID;
+  if (!opts.isRemote) return DEFAULT_ACCOUNT_ID; // LAN 免登录（含状态未知）
+  // 远程：必须持有 acct_default 自己的有效 session
+  return opts.sessionAccountId === DEFAULT_ACCOUNT_ID
+    ? DEFAULT_ACCOUNT_ID
+    : UNAUTHENTICATED_ACCOUNT_ID;
 }
 
 export async function getCurrentAccountId(): Promise<string> {
   if (!isMultiUserEnabled()) {
     const hasPassword = await hasLoginPassword();
-    if (!hasPassword) return DEFAULT_ACCOUNT_ID;
+    if (hasPassword === false) return DEFAULT_ACCOUNT_ID; // 明确没设密码 → 保持现状全开放
+    // 已设密码，或状态读不出来：都要看请求来自哪里
+    let hdrs: Headers;
+    let sessionCookie: string | undefined;
     try {
       const { cookies, headers } = await import("next/headers");
-      const hdrs = await headers();
-      if (!isRemoteRequest(hdrs)) return DEFAULT_ACCOUNT_ID; // LAN → 开放
-      const store = await cookies();
-      const raw = store.get(SESSION_COOKIE_NAME)?.value;
-      const sessionAccountId = raw ? await resolveSessionAccountId(raw) : null;
-      return resolveSingleUserAccount({ hasPassword, isRemote: true, sessionAccountId });
+      hdrs = await headers();
+      sessionCookie = (await cookies()).get(SESSION_COOKIE_NAME)?.value;
     } catch {
       // 无请求上下文（in-process worker）：视为本地直通——采集任务不认 cookie。
       return DEFAULT_ACCOUNT_ID;
     }
+    if (!isRemoteRequest(hdrs)) return DEFAULT_ACCOUNT_ID; // LAN → 开放
+    // 已确认是远程：此后任何读取失败都必须 fail-closed，不能退回开放默认值
+    let sessionAccountId: string | null = null;
+    if (sessionCookie) {
+      try {
+        sessionAccountId = await resolveSessionAccountId(sessionCookie);
+      } catch {
+        return UNAUTHENTICATED_ACCOUNT_ID;
+      }
+    }
+    return resolveSingleUserAccount({ hasPassword, isRemote: true, sessionAccountId });
   }
   try {
     const { cookies } = await import("next/headers");
@@ -656,15 +681,14 @@ export async function getCurrentAccountId(): Promise<string> {
 }
 
 /**
- * Account id for write/bind mutations. Multi-user + no valid session → throw
- * (never bind to the read-only sentinel `acct_unauthenticated`). Single-user
- * with a password set behaves the same for remote requests; LAN and the
- * in-process worker path stay unchanged.
+ * Account id for write/bind mutations. The sentinel `acct_unauthenticated` is
+ * only ever produced by an auth failure, so it must never reach a write path —
+ * reject it unconditionally rather than re-deriving whether the instance is
+ * gated (that second read could disagree with the first).
  */
 export async function requireAuthenticatedAccountId(): Promise<string> {
   const accountId = await getCurrentAccountId();
-  const gated = isMultiUserEnabled() || (await hasLoginPassword());
-  if (gated && accountId === UNAUTHENTICATED_ACCOUNT_ID) {
+  if (accountId === UNAUTHENTICATED_ACCOUNT_ID) {
     throw new UnauthenticatedAccountError();
   }
   return accountId;

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -240,6 +240,42 @@ export async function logoutSession(signedCookie: string | undefined): Promise<v
   }
 }
 
+/**
+ * 单用户模式是否已设置登录密码（`acct_default` 有非空 `passwordHash`）。
+ * 非空即表示实例进入「远程需登录」态；清空即回到全开放态（可逆开关）。
+ *
+ * 取不到仓库（未配置 DB / 无请求上下文）时返回 false —— 与「未设密码」
+ * 的现状行为一致，绝不因为读不到状态就把本地实例锁死。
+ */
+export async function hasLoginPassword(): Promise<boolean> {
+  try {
+    const acct = await getWorkflowRepository().getAccountById(DEFAULT_ACCOUNT_ID);
+    return Boolean(acct && acct.passwordHash.length > 0);
+  } catch {
+    return false;
+  }
+}
+
+/** 单用户模式设置/更新登录密码（`acct_default`）。设置后远程访问即需登录。 */
+export async function setSingleUserPassword(
+  newPassword: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (newPassword.length < 6) {
+    return { ok: false, error: "密码至少 6 位。" };
+  }
+  const repo = getWorkflowRepository();
+  await repo.setAccountPassword(DEFAULT_ACCOUNT_ID, await hashPassword(newPassword));
+  await repo.deleteSessionsForAccount(DEFAULT_ACCOUNT_ID); // 改密即踢掉全部旧 session
+  return { ok: true };
+}
+
+/** 单用户模式清除登录密码（回到全开放态）。 */
+export async function clearSingleUserPassword(): Promise<void> {
+  const repo = getWorkflowRepository();
+  await repo.setAccountPassword(DEFAULT_ACCOUNT_ID, "");
+  await repo.deleteSessionsForAccount(DEFAULT_ACCOUNT_ID);
+}
+
 /** Self-service password change. Verifies the current password, sets the new hash,
  *  and revokes ALL of the account's sessions (incl. the caller's → must re-login). */
 export async function changeOwnPassword(
@@ -557,9 +593,52 @@ export async function getRegisteredDriveCount(): Promise<number> {
   return storages.filter((storage) => isRegisteredStorageProvider(storage.provider)).length;
 }
 
+/**
+ * 远程判定：任一 Cloudflare 头存在即为经隧道的远程请求。
+ *
+ * 用 `cf-ray`/`cdn-loop` 而非仅 `cf-connecting-ip`——后者是唯一能被 zone
+ * Transform Rules 删除的 cf-* 头，删掉会把远程误判成内网（fail-open 裸奔）；
+ * `cf-ray` 访客删不掉。反方向（LAN 被误判成远程）只多要一次登录，fail-closed。
+ *
+ * 前提：实例只能经「局域网 + 隧道」两条路到达。部署文档须写明禁 UPnP、
+ * 勿把 web 端口直接映射出公网（Emby「thousands hacked」的主要暴露面即 UPnP 打洞）。
+ */
+export function isRemoteRequest(hdrs: Headers): boolean {
+  return hdrs.has("cf-ray") || hdrs.has("cdn-loop") || hdrs.has("cf-connecting-ip");
+}
+
+/**
+ * 单用户账号判定（纯函数，本 plan 的安全核心）。设密码后：LAN 开放、远程需 session。
+ *
+ * 抽成纯函数是为了能确定性覆盖全部「内外 × 有无 session」组合——
+ * Emby/Jellyfin 的事故正是内外判定出错，这段逻辑必须可被精确测试。
+ */
+export function resolveSingleUserAccount(opts: {
+  hasPassword: boolean;
+  isRemote: boolean;
+  sessionAccountId: string | null;
+}): string {
+  if (!opts.hasPassword) return DEFAULT_ACCOUNT_ID;
+  if (!opts.isRemote) return DEFAULT_ACCOUNT_ID; // LAN 免登录
+  return opts.sessionAccountId ?? UNAUTHENTICATED_ACCOUNT_ID; // 远程需登录
+}
+
 export async function getCurrentAccountId(): Promise<string> {
   if (!isMultiUserEnabled()) {
-    return DEFAULT_ACCOUNT_ID;
+    const hasPassword = await hasLoginPassword();
+    if (!hasPassword) return DEFAULT_ACCOUNT_ID;
+    try {
+      const { cookies, headers } = await import("next/headers");
+      const hdrs = await headers();
+      if (!isRemoteRequest(hdrs)) return DEFAULT_ACCOUNT_ID; // LAN → 开放
+      const store = await cookies();
+      const raw = store.get(SESSION_COOKIE_NAME)?.value;
+      const sessionAccountId = raw ? await resolveSessionAccountId(raw) : null;
+      return resolveSingleUserAccount({ hasPassword, isRemote: true, sessionAccountId });
+    } catch {
+      // 无请求上下文（in-process worker）：视为本地直通——采集任务不认 cookie。
+      return DEFAULT_ACCOUNT_ID;
+    }
   }
   try {
     const { cookies } = await import("next/headers");
@@ -579,11 +658,13 @@ export async function getCurrentAccountId(): Promise<string> {
 /**
  * Account id for write/bind mutations. Multi-user + no valid session → throw
  * (never bind to the read-only sentinel `acct_unauthenticated`). Single-user
- * and the in-process worker path are unchanged.
+ * with a password set behaves the same for remote requests; LAN and the
+ * in-process worker path stay unchanged.
  */
 export async function requireAuthenticatedAccountId(): Promise<string> {
   const accountId = await getCurrentAccountId();
-  if (isMultiUserEnabled() && accountId === UNAUTHENTICATED_ACCOUNT_ID) {
+  const gated = isMultiUserEnabled() || (await hasLoginPassword());
+  if (gated && accountId === UNAUTHENTICATED_ACCOUNT_ID) {
     throw new UnauthenticatedAccountError();
   }
   return accountId;

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -201,11 +201,15 @@ export async function loginAccount(
   password: string,
   throttleKey?: string,
 ): Promise<AuthOutcome> {
-  // 无显式 throttleKey 时（库级调用，无请求上下文）退化为仅按 username。
-  // 不做 toLowerCase()：账号查询是精确匹配，折叠大小写会让不同账号共用一个桶。
+  // 无显式 throttleKey 时（库级调用，无请求上下文）退化为仅按身份。
+  // 单用户模式忽略用户名（永远是 acct_default），故身份用常量——否则换个
+  // 用户名就换一个桶，限流可被直接绕过。
+  // 多用户不做 toLowerCase()：账号查询是精确匹配，折叠大小写会让不同账号共用一个桶。
   // 一律过 normalizeThrottleKey()——显式传入的 key 也必须有界，否则调用方
   // 传超长键就能撑大内存。
-  const key = normalizeThrottleKey(throttleKey ?? username);
+  const key = normalizeThrottleKey(
+    throttleKey ?? (isMultiUserEnabled() ? username : DEFAULT_ACCOUNT_ID),
+  );
   const now = Date.now();
   const verdict = checkLoginAllowed(key, now);
   if (!verdict.allowed) {

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -211,15 +211,25 @@ export async function loginAccount(
   if (!verdict.allowed) {
     return { ok: false, error: `尝试过于频繁，请 ${verdict.retryAfterSec} 秒后再试。` };
   }
-  const account = await getWorkflowRepository().getAccountByUsername(username.trim());
-  // Always verify to avoid timing oracle. Missing accounts get a dummy scrypt hash that will fail.
-  // (The empty-hash default account has no password and can't be logged into.)
-  const DUMMY_HASH = "scrypt:a2448ef076990b889ef0540720bccce2:4fdc41afebb4560f4a638b4225d8325904894d18d2df1c7a95c50a65c141b926dc252e99b63e681e15e2d6e008acc845b02c9a2fc99a4888749226ab262c6978";
+  // 账号缺失时也要走完整验密，否则耗时差异会泄露账号是否存在
+  // （空 hash 会在 verifyPassword 的格式校验处提前 return，所以必须给一个真格式的 hash）。
+  const DUMMY_HASH =
+    "scrypt:a2448ef076990b889ef0540720bccce2:4fdc41afebb4560f4a638b4225d8325904894d18d2df1c7a95c50a65c141b926dc252e99b63e681e15e2d6e008acc845b02c9a2fc99a4888749226ab262c6978";
+
+  // 单用户模式：只认 acct_default（「只输密码」，用户名忽略），且必须已设密码。
+  const repo = getWorkflowRepository();
+  const account = isMultiUserEnabled()
+    ? await repo.getAccountByUsername(username.trim())
+    : await repo.getAccountById(DEFAULT_ACCOUNT_ID);
+
   const hash = account?.passwordHash || DUMMY_HASH;
   const valid = await verifyPassword(password, hash);
   if (!account || !valid || account.passwordHash.length === 0) {
     recordLoginFailure(key, now);
-    return { ok: false, error: "用户名或密码不正确。" };
+    return {
+      ok: false,
+      error: isMultiUserEnabled() ? "用户名或密码不正确。" : "密码不正确。",
+    };
   }
   // 先建 session 再清限流桶：建 session 可能抛（DB 故障、取密钥失败），
   // 那种情况下这次登录并未成功，桶必须保留，否则服务端间歇故障期间

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -1,25 +1,75 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
 import { proxy } from "./proxy";
+import type { NextRequest } from "next/server";
 
-describe("multi-user proxy API exclusions", () => {
-  beforeEach(() => vi.stubEnv("MEDIA_TRACK_MULTI_USER", "1"));
-  afterEach(() => vi.unstubAllEnvs());
+/**
+ * proxy 门禁判定的全组合覆盖。
+ *
+ * 这是「远程要登录、局域网免登录」的 Edge 侧实现，也是 Emby/Jellyfin 出事故的
+ * 同一类判定。它只做 UX 层的重定向（权威判定在服务端 getCurrentAccountId()），
+ * 但判错方向仍有代价：
+ *  - 远程 + 已设密码 + 无 session 却放行 → 用户看到空数据页而不是登录页（体验坏）
+ *  - 局域网被误判成需登录 → 本地用户凭空多一道门（回归）
+ */
 
-  it.each(["/api/health", "/api/workflows/run-next", "/api/agent/patrol"]) (
-    "leaves %s to its handler-level guard instead of redirecting to login",
-    (pathname) => {
-      const response = proxy(new NextRequest(`https://mediary.example${pathname}`));
-
-      expect(response.headers.get("x-middleware-next")).toBe("1");
-      expect(response.headers.get("location")).toBeNull();
+const makeRequest = (opts: {
+  path?: string;
+  cf?: boolean;
+  passwordSet?: boolean;
+  session?: boolean;
+}): NextRequest => {
+  const headers = new Headers();
+  if (opts.cf) headers.set("cf-ray", "8f3abc-LAX");
+  const cookies = new Map<string, { name: string; value: string }>();
+  if (opts.passwordSet) cookies.set("mt_auth_required", { name: "mt_auth_required", value: "1" });
+  if (opts.session) cookies.set("mt_session", { name: "mt_session", value: "sess.sig" });
+  const url = new URL(`http://localhost:3000${opts.path ?? "/"}`);
+  return {
+    headers,
+    cookies: { get: (name: string) => cookies.get(name) },
+    nextUrl: {
+      pathname: url.pathname,
+      clone: () => new URL(url.toString()),
+      search: "",
     },
-  );
+  } as unknown as NextRequest;
+};
 
-  it("continues redirecting unauthenticated page requests", () => {
-    const response = proxy(new NextRequest("https://mediary.example/settings"));
+/** 判定结果：是否被重定向到 /login。 */
+const redirectsToLogin = (req: NextRequest): boolean => {
+  const res = proxy(req);
+  return res.status >= 300 && res.status < 400 && (res.headers.get("location") ?? "").includes("/login");
+};
 
-    expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toBe("https://mediary.example/login");
+describe("proxy gate — single-user mode (multi-user off)", () => {
+  it("未设密码：LAN 与远程一律直通（与现状一致）", () => {
+    expect(redirectsToLogin(makeRequest({}))).toBe(false);
+    expect(redirectsToLogin(makeRequest({ cf: true }))).toBe(false);
+  });
+
+  it("已设密码 + 局域网（无 CF 头）→ 直通，零摩擦", () => {
+    expect(redirectsToLogin(makeRequest({ passwordSet: true }))).toBe(false);
+  });
+
+  it("已设密码 + 远程（有 CF 头）+ 无 session → 重定向到登录", () => {
+    expect(redirectsToLogin(makeRequest({ passwordSet: true, cf: true }))).toBe(true);
+  });
+
+  it("已设密码 + 远程 + 有 session → 直通", () => {
+    expect(redirectsToLogin(makeRequest({ passwordSet: true, cf: true, session: true }))).toBe(false);
+  });
+
+  it("三个 CF 头任一存在都算远程", () => {
+    for (const header of ["cf-ray", "cdn-loop", "cf-connecting-ip"]) {
+      const req = makeRequest({ passwordSet: true });
+      req.headers.set(header, "x");
+      expect(redirectsToLogin(req)).toBe(true);
+    }
+  });
+
+  it("handler 自守的 API 前缀不被重定向（否则会把 JSON 端点变成 HTML 跳转）", () => {
+    for (const path of ["/api/health", "/api/workflows/run", "/api/agent/step"]) {
+      expect(redirectsToLogin(makeRequest({ passwordSet: true, cf: true, path }))).toBe(false);
+    }
   });
 });

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { proxy } from "./proxy";
 import type { NextRequest } from "next/server";
 
@@ -11,6 +11,20 @@ import type { NextRequest } from "next/server";
  *  - 远程 + 已设密码 + 无 session 却放行 → 用户看到空数据页而不是登录页（体验坏）
  *  - 局域网被误判成需登录 → 本地用户凭空多一道门（回归）
  */
+
+// 本套件断言的是单用户行为。必须显式关掉多用户开关：若被 runner 设置或从
+// 别的测试文件泄漏进来，proxy 会走「处处门禁」分支，断言就在悄悄测另一件事。
+const prevMultiUser = process.env.MEDIA_TRACK_MULTI_USER;
+beforeAll(() => {
+  delete process.env.MEDIA_TRACK_MULTI_USER;
+});
+afterAll(() => {
+  if (prevMultiUser !== undefined) {
+    process.env.MEDIA_TRACK_MULTI_USER = prevMultiUser;
+  } else {
+    delete process.env.MEDIA_TRACK_MULTI_USER;
+  }
+});
 
 const makeRequest = (opts: {
   path?: string;
@@ -70,6 +84,19 @@ describe("proxy gate — single-user mode (multi-user off)", () => {
   it("handler 自守的 API 前缀不被重定向（否则会把 JSON 端点变成 HTML 跳转）", () => {
     for (const path of ["/api/health", "/api/workflows/run", "/api/agent/step"]) {
       expect(redirectsToLogin(makeRequest({ passwordSet: true, cf: true, path }))).toBe(false);
+    }
+  });
+});
+
+describe("proxy gate — multi-user mode", () => {
+  it("多用户：无 session 一律重定向，与来源和密码 flag 无关", () => {
+    process.env.MEDIA_TRACK_MULTI_USER = "1";
+    try {
+      expect(redirectsToLogin(makeRequest({}))).toBe(true); // LAN 也要登录
+      expect(redirectsToLogin(makeRequest({ cf: true }))).toBe(true);
+      expect(redirectsToLogin(makeRequest({ session: true }))).toBe(false);
+    } finally {
+      delete process.env.MEDIA_TRACK_MULTI_USER;
     }
   });
 });

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,20 +1,41 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 /**
- * §7 P1 auth gate (Next 16 "proxy" convention, formerly middleware). Only active
- * when MEDIA_TRACK_MULTI_USER=1; otherwise every request passes through
- * (single-user, no login — P0 behavior).
+ * §7 P1 auth gate (Next 16 "proxy" convention, formerly middleware).
+ *
+ * 两种门禁形态：
+ *  - 多用户（`MEDIA_TRACK_MULTI_USER=1`）：处处需要 session（现状不变）。
+ *  - 单用户：**仅当**实例已设访问密码（`mt_auth_required` flag cookie）**且**
+ *    请求来自隧道（带 Cloudflare 头）时才门禁；局域网直通，零摩擦。
  *
  * This does cheap PRESENCE gating for the redirect UX (runs on the Edge runtime,
  * no DB access). The authoritative check — signature + session row + expiry — is
  * server-side in getCurrentAccountId(), which returns a no-data sentinel for an
  * invalid/expired cookie, so reads fail closed even if a stale cookie slips past.
+ *
+ * `mt_auth_required` 只是 UX 提示（把 legit 远程用户引到 /login），**不是**安全判据：
+ * 它非 httpOnly、可被伪造或删除。删掉它只会让远程用户看到空数据页而非登录页，
+ * 因为服务端 getCurrentAccountId() 自己读 DB 里的密码状态 + CF 头，不看这个 flag。
  */
 const SESSION_COOKIE_NAME = "mt_session";
+const AUTH_REQUIRED_COOKIE = "mt_auth_required";
 const HANDLER_GUARDED_API_PREFIXES = ["/api/health", "/api/workflows/", "/api/agent/"];
 
+/** 经隧道的远程请求判定。与 workflow-runtime.isRemoteRequest() 保持一致：
+ *  用 cf-ray/cdn-loop 而非仅 cf-connecting-ip（后者可被 zone 规则删除 → fail-open）。 */
+function isRemoteRequest(request: NextRequest): boolean {
+  return (
+    request.headers.has("cf-ray") ||
+    request.headers.has("cdn-loop") ||
+    request.headers.has("cf-connecting-ip")
+  );
+}
+
 export function proxy(request: NextRequest): NextResponse {
-  if (process.env.MEDIA_TRACK_MULTI_USER !== "1") {
+  const multiUser = process.env.MEDIA_TRACK_MULTI_USER === "1";
+  const passwordSet = Boolean(request.cookies.get(AUTH_REQUIRED_COOKIE)?.value);
+  const gated = multiUser || (passwordSet && isRemoteRequest(request));
+  if (!gated) {
     return NextResponse.next();
   }
   if (HANDLER_GUARDED_API_PREFIXES.some((prefix) => request.nextUrl.pathname.startsWith(prefix))) {

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -181,14 +181,37 @@ docker compose logs -f cloudflared           # 看到 "Registered tunnel connect
 
 > 隧道连不上 / 老掉线? cloudflared 默认是 `auto`(优先 QUIC/UDP,理论上会回退 HTTP/2)。但有些网络(部分校园网、运营商、严格防火墙)封/限 UDP 时,auto 未必干净回退,隧道就注册不上或老掉线。这时在 `.env` 设 `TUNNEL_TRANSPORT_PROTOCOL=http2` 强制走 TCP 上的 HTTP/2,再 `docker compose --profile tunnel up -d` 重起即可。
 
-**3. ⚠️ 必须加 Cloudflare Access(否则等于把实例裸挂公网)**
+**3. ⚠️ 必须有门禁(否则等于把实例裸挂公网)**
 
-Mediary Scout 默认单用户、无登录,公网入口必须靠 Access 这类前置鉴权挡住:
+Mediary Scout 默认单用户、无登录。公网入口必须挡住,二选一:
+
+**方案 A(推荐):在应用里设访问密码**
+
+设置 → 账号 → 设置访问密码。设好之后:
+
+| 来源 | 行为 |
+|---|---|
+| 局域网(手机/电视/电脑直连 `:3000`) | **免登录,零摩擦** |
+| 经隧道从外网访问 | 需要输入密码,登录状态保持 30 天 |
+
+内外之别靠「请求是否带 Cloudflare 注入的头」判定(`CF-Ray` 等,访客摘不掉)。
+
+> ⚠️ **这条判定的前提:实例只能经「局域网 + 隧道」两条路到达,不能有第三条。**
+> 家庭 NAT 天然满足,但你必须确认:
+> - **别在路由器上给 web 端口做端口映射 / DMZ**;
+> - **关掉路由器的 UPnP 自动打洞**(Emby 曾因「局域网免密 + UPnP 自动打洞」导致数千台服务器被入侵,暴露面正是 UPnP);
+> - 若把实例放在有公网 IP 的 VPS 上,把 compose 的端口发布改成只监听本机(`127.0.0.1:3000:3000`),让隧道从容器网络内访问。
+>
+> 一旦存在第三条不经 Cloudflare 的入站路径,那条路上的请求会被判成「局域网」而免登录。
+
+**方案 B:Cloudflare Access(前置鉴权,与方案 A 可叠加)**
 
 - **Zero Trust → Access → Applications → Add an application → Self-hosted**。
 - Application domain 填 `media.yourdomain.com`。
 - 加一条 **Allow** 策略,例如 Include = **Emails** = 你自己的邮箱(进站会先要求邮箱一次性验证码登录)。想给家人用就把他们的邮箱也加进白名单。
 - 保存后,任何访问 `media.yourdomain.com` 的人都要先过 Access 这关,才能到达应用。
+
+Access 免费版有 50 个席位上限,超出后按人月计费;只给自己/家人用时方案 A 更省事。
 
 > 想自启:`cloudflared` 容器已 `restart: unless-stopped`,宿主重启会自动拉起;隧道配置在 Cloudflare 侧托管,改公网主机名 / Access 策略都在控制台改,不用动宿主。
 


### PR DESCRIPTION
## Why

Scout Connect 远程访问的第二道安全命门（阶段 0 Part 2）。单用户实例目前**完全没有登录**——一旦暴露到公网就是门户大开。#173 补了限流，这个 PR 补门禁本身。

## 设计：设密码后「仅远程需登录，局域网免登录」

| 状态 | 局域网 | 经隧道（远程） |
|---|---|---|
| 未设密码 | 直通（与现状完全一致） | 直通 |
| 已设密码 | **直通，零摩擦** | 需要 session（30 天） |

依据（调研实证，非拍脑袋）：
- **Home Assistant `trusted_networks`** 是官方一等公民功能，**Plex `allowedNetworks`** 同款——这是正当模式，不是偷懒。
- 反面教训：**Emby 的「局域网免密」因 thousands of servers 被黑而下架**（主要暴露面是 UPnP 自动打洞），**Jellyfin 有过内外判定 bug**。结论不是「别做 LAN 免密」，而是**内外判定必须稳**。

## 内外判定：用 `cf-ray`，不用 `cf-connecting-ip`

`isRemoteRequest()` = 任一 CF 头存在（`cf-ray` / `cdn-loop` / `cf-connecting-ip`）。

- 隧道流量经 Cloudflare 边缘时**必然**被注入 CF 头，访客无法摘除。
- **不能只靠 `cf-connecting-ip`**：它是唯一能被 zone Transform Rules 删掉的 cf-* 头，删了会把远程误判成内网（**fail-open 裸奔**）；`cf-ray` 删不掉。
- 反方向（LAN 被误判成远程）只多要一次登录，**fail-closed**，可接受。
- **弃用 TCP 源地址判据**：docker 默认桥接 + 端口映射会把 LAN 来源 NAT 成网关地址，与 cloudflared 容器同段，分不出。

**前提**（须写入部署文档）：实例只能经「局域网 + 隧道」两条路到达。禁 UPnP、勿把 web 端口直接映射出公网——这正是 Emby 事故的暴露面。

## 安全审查中修掉的三个真缺陷

判定逻辑抽成了纯函数并全组合覆盖，但**事故都出在把它们串起来的不纯接线上**——三处 `catch` 把「读不出状态」变成了「你是站主」。全部先复现再修：

**1. CRITICAL — 一次 DB 抖动就能让公网访客拿到站主身份**
`hasLoginPassword()` 吞掉所有仓库异常返回 `false`，而 `getCurrentAccountId()` 在 `false` 时**在读 CF 头之前**就返回 `acct_default`。于是 Postgres 重启/故障切换/连接池耗尽期间，匿名远程访客即站主，**且写操作也放行**（`requireAuthenticatedAccountId` 自己那次重读同样说「未启用门禁」）。
修复：状态改三态，`"unknown"` 不再与「没设密码」混为一谈。局域网在 unknown 时维持开放（可信网段，不因一次抖动制造运维事故），远程收紧到需 session。

**2. HIGH — 属于别的账号的有效 session 被当成站主**
`resolveSingleUserAccount` 返回 `sessionAccountId ?? sentinel`，从不校验它是不是 `acct_default`。同一个库可能残留多用户时期的账号（`MEDIA_TRACK_MULTI_USER` 是运行时开关，可来回切），而 set/clear 密码只吊销 `acct_default` 的 session——那种 session 连吊销都吊销不掉。

**3. MEDIUM — `requireAuthenticatedAccountId` 的 TOCTOU**
它重读一次密码状态来决定是否强制，两次读可能不一致，导致这个「文档承诺永不返回哨兵」的函数真的返回哨兵。哨兵只由认证失败产生，故改为无条件拒绝——顺带省掉第二次 DB 读。

审查者提的第四条（session 读失败导致 fail-open）**未能复现**——那条路径本来就 fail-closed，故不作为缺陷处理。

## 变更清单

- `workflow-runtime.ts`：`hasLoginPassword`（三态）/ `setSingleUserPassword` / `clearSingleUserPassword`；纯函数 `isRemoteRequest` / `resolveSingleUserAccount`；`getCurrentAccountId` 单用户分流；`requireAuthenticatedAccountId` 无条件拒哨兵；`loginAccount` 单用户走 `acct_default`（保住 #173 的 dummy-hash 防枚举与 session 顺序）
- `proxy.ts`：门禁 = 多用户 或（密码 flag 且带 CF 头）。`mt_auth_required` 故意非 httpOnly，**只是 UX**——伪造/删除它绕不过任何东西
- `POST /api/auth/password`：设/改/清；已设密码后变更必须已认证
- `/api/auth/bootstrap`：新增 `{singleUser, passwordSet}`（保住首行 `await connection()`——它的注释记着一次真实的生产锁死事故）
- `login/page.tsx`：单用户只渲染密码框，无用户名、无注册入口

## Verification

```
proxy.test.ts            6 passed（门禁全组合 + API 前缀豁免）
single-user-password     6 passed
single-user-gate-wiring  6 passed（DB 挂 / 外来 session / LAN 宽容 / 无请求上下文）
apps/web 全量          397 passed（唯一失败 guangya-connect 是既存并行 flaky，单独跑通过）
tsc                      EXIT=0
build:web                EXIT=0
```

每处修复均做**反向验证**——退回旧实现确认新测试变红，避免「写了测试但测不到东西」的假绿。