### PR TITLE
feat(settings): remote-access tab — status card, password warning, waitlist form

### DIFF
--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -147,7 +147,7 @@ export default function SettingsPage({
               // visible before we know whether the viewer is the 站主.
               remote={
                 <Suspense fallback={null}>
-                  <RemoteAccessSection />
+                  <RemoteAccessSection searchParams={searchParams} />
                 </Suspense>
               }
             />

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -141,6 +141,9 @@ export default function SettingsPage({
                   </Suspense>
                 </>
               }
+              // Slot content lands in Task 3; until then the tab stays hidden by
+              // the same empty-slot observer that hides 账号 (nothing streams in).
+              remote={null}
             />
             </Suspense>
           </>

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -20,6 +20,7 @@ import { PatrolNowButton } from "../../components/patrol-now-button";
 import { SettingsTabs } from "../../components/settings-tabs";
 import { PasswordChangeForm } from "../../components/password-change-form";
 import { AccountAdminPanel } from "../../components/account-admin-panel";
+import { RemoteAccessSection } from "../../components/settings/remote-access-section";
 import { GitHubNameplate } from "../../components/github-nameplate";
 import { SettingsActionInbox } from "../../components/settings-action-inbox";
 import { loadSettingsAttentionSummary } from "../../lib/settings-attention-server";
@@ -141,9 +142,14 @@ export default function SettingsPage({
                   </Suspense>
                 </>
               }
-              // Slot content lands in Task 3; until then the tab stays hidden by
-              // the same empty-slot observer that hides 账号 (nothing streams in).
-              remote={null}
+              // Fallback is null, not a skeleton: a skeleton element would stream
+              // into the slot and the empty-slot observer would read the tab as
+              // visible before we know whether the viewer is the 站主.
+              remote={
+                <Suspense fallback={null}>
+                  <RemoteAccessSection />
+                </Suspense>
+              }
             />
             </Suspense>
           </>

--- a/apps/web/components/settings-tabs.tsx
+++ b/apps/web/components/settings-tabs.tsx
@@ -3,18 +3,27 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type ReactNode } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import {
+  OBSERVED_SETTINGS_TABS,
   SETTINGS_TABS,
   resolveSettingsTab,
   settingsTabQuery,
+  type ObservedSettingsTabId,
   type SettingsTabId,
+  type SettingsTabVisibility,
 } from "../lib/settings-tabs-model";
 
+/** 「内容为空即隐藏」的受观察 tab？（narrowing 供 ref map / 可见性查表用） */
+function isObserved(tab: SettingsTabId): tab is ObservedSettingsTabId {
+  return (OBSERVED_SETTINGS_TABS as readonly SettingsTabId[]).includes(tab);
+}
+
 /**
- * 设置页 tab 壳：五个 slot 常挂载（Suspense 流式照旧），按当前 tab 显隐。
+ * 设置页 tab 壳：六个 slot 常挂载（Suspense 流式照旧），按当前 tab 显隐。
  * - tab 状态 = ?tab=（router.replace 软导航，保留 ?w）。
- * - 「账号」tab 可见性不读服务端 flag（cacheComponents 会把 build 时的 env 值
- *   烤进静态壳，docker 镜像 build/run 环境不同——PasswordChangeSection 同款教训）：
- *   观察 account slot 是否真的流出了内容（多用户关时两个 section 都渲染 null）。
+ * - 「账号」「远程访问」两个 tab 的可见性不读服务端 flag（cacheComponents 会把
+ *   build 时的 env 值烤进静态壳，docker 镜像 build/run 环境不同——
+ *   PasswordChangeSection 同款教训）：观察对应 slot 是否真的流出了内容
+ *   （账号：多用户关时两个 section 都渲染 null；远程访问：非站主渲染 null）。
  */
 export function SettingsTabs(props: {
   drives: ReactNode;
@@ -22,11 +31,14 @@ export function SettingsTabs(props: {
   preferences: ReactNode;
   patrol: ReactNode;
   account: ReactNode;
+  remote: ReactNode;
 }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const accountRef = useRef<HTMLDivElement | null>(null);
-  const [accountVisible, setAccountVisible] = useState(false);
+  // 每个受观察 tab 一个 ref/可见性位。ref 存在 map 里而不是各自 useRef，
+  // 是为了让「加一个受观察 tab」只改 OBSERVED_SETTINGS_TABS 一处。
+  const observedRefs = useRef(new Map<ObservedSettingsTabId, HTMLDivElement | null>());
+  const [observedVisible, setObservedVisible] = useState<SettingsTabVisibility>({});
   const [hash, setHash] = useState<string | undefined>(undefined);
 
   useEffect(() => {
@@ -36,23 +48,30 @@ export function SettingsTabs(props: {
     const readHash = () => setHash(window.location.hash || undefined);
     readHash();
     window.addEventListener("hashchange", readHash);
-    const node = accountRef.current;
-    let observer: MutationObserver | undefined;
-    if (node) {
-      const check = () => setAccountVisible(node.childElementCount > 0);
+    const observers: MutationObserver[] = [];
+    for (const id of OBSERVED_SETTINGS_TABS) {
+      const node = observedRefs.current.get(id);
+      if (!node) continue;
+      // 函数式更新：多个 observer 各自异步触发，读闭包里的旧 state 会互相覆盖。
+      // 值未变时返回原对象，避免每次 mutation 都换引用触发无谓重渲染。
+      const check = () => {
+        const next = node.childElementCount > 0;
+        setObservedVisible((prev) => (prev[id] === next ? prev : { ...prev, [id]: next }));
+      };
       check();
-      observer = new MutationObserver(check);
-      // 只看直接子元素：account 两个 section 流出即成为 slot 的直接 child，
+      const observer = new MutationObserver(check);
+      // 只看直接子元素：section 流出即成为 slot 的直接 child，
       // subtree 只会放大无关触发。
       observer.observe(node, { childList: true });
+      observers.push(observer);
     }
     return () => {
       window.removeEventListener("hashchange", readHash);
-      observer?.disconnect();
+      for (const observer of observers) observer.disconnect();
     };
   }, []);
 
-  const active = resolveSettingsTab(searchParams.get("tab"), accountVisible, hash);
+  const active = resolveSettingsTab(searchParams.get("tab"), observedVisible, hash);
 
   const select = (tab: SettingsTabId) => {
     // 显式选 tab 即废弃 legacy hash 提示：replaceState 清 URL 片段但不触发
@@ -72,11 +91,14 @@ export function SettingsTabs(props: {
     { id: "preferences", content: props.preferences },
     { id: "patrol", content: props.patrol },
     { id: "account", content: props.account },
+    { id: "remote", content: props.remote },
   ];
 
   // WAI-ARIA tabs pattern: same-page state, not page navigation — so
   // tablist/tab/tabpanel + aria-selected (not aria-current), arrows move tabs.
-  const visibleTabs = SETTINGS_TABS.filter((tab) => tab.id !== "account" || accountVisible);
+  const visibleTabs = SETTINGS_TABS.filter(
+    (tab) => !isObserved(tab.id) || observedVisible[tab.id] === true,
+  );
   const onTablistKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") return;
     event.preventDefault();
@@ -116,7 +138,13 @@ export function SettingsTabs(props: {
           id={`settings-panel-${panel.id}`}
           role="tabpanel"
           aria-labelledby={`settings-tab-${panel.id}`}
-          ref={panel.id === "account" ? accountRef : undefined}
+          ref={
+            isObserved(panel.id)
+              ? (node) => {
+                  observedRefs.current.set(panel.id as ObservedSettingsTabId, node);
+                }
+              : undefined
+          }
           hidden={active !== panel.id}
         >
           {panel.content}

--- a/apps/web/components/settings/remote-access-section.tsx
+++ b/apps/web/components/settings/remote-access-section.tsx
@@ -1,7 +1,11 @@
 import { connection } from "next/server";
 import { Globe, ShieldAlert, TriangleAlert } from "lucide-react";
 import { getCurrentAccountSummary, hasLoginPassword } from "../../lib/workflow-runtime";
-import { instanceTunnelToken, resolveRemoteAccessState } from "../../lib/remote-access";
+import {
+  instanceTunnelToken,
+  resolveRemoteAccessState,
+  scoutConnectBaseUrl,
+} from "../../lib/remote-access";
 import { RemoteAccessWaitlistForm } from "./remote-access-waitlist";
 
 /**
@@ -39,7 +43,7 @@ export async function RemoteAccessSection() {
             </p>
           </div>
         </div>
-        <RemoteAccessWaitlistForm />
+        <RemoteAccessWaitlistForm workerBaseUrl={scoutConnectBaseUrl()} />
       </section>
     );
   }

--- a/apps/web/components/settings/remote-access-section.tsx
+++ b/apps/web/components/settings/remote-access-section.tsx
@@ -5,6 +5,7 @@ import {
   instanceTunnelToken,
   resolveRemoteAccessState,
   scoutConnectBaseUrl,
+  accountPasswordHref,
 } from "../../lib/remote-access";
 import { RemoteAccessWaitlistForm } from "./remote-access-waitlist";
 
@@ -17,7 +18,11 @@ import { RemoteAccessWaitlistForm } from "./remote-access-waitlist";
  * **必须**返回 `null` 而不是空 fragment/空 div（那会流出一个直接子元素，
  * observer 就把 tab 判成可见了）。
  */
-export async function RemoteAccessSection() {
+export async function RemoteAccessSection({
+  searchParams,
+}: {
+  searchParams: Promise<{ w?: string }>;
+}) {
   // connection() 必须是第一行：cacheComponents 下否则会在构建期预渲染，
   // 把 build 环境的 TUNNEL_TOKEN/账号状态烤成静态壳（PasswordChangeSection 同款教训）。
   // 本仓库禁用 `export const dynamic`，await connection() 是唯一手段。
@@ -26,6 +31,8 @@ export async function RemoteAccessSection() {
   if (!me?.isOwner) return null;
 
   // hostname 当前无本地来源，故不传（详见 lib/remote-access.ts 文件头）。
+  const { w } = await searchParams;
+  const passwordHref = accountPasswordHref(w);
   const state = await resolveRemoteAccessState({ token: instanceTunnelToken() });
 
   if (state.kind === "not_provisioned") {
@@ -89,7 +96,7 @@ export async function RemoteAccessSection() {
             <p className="panel-note" style={{ margin: "4px 0 8px" }}>
               任何知道你域名的人都能直接进入，读取整个媒体库、网盘凭据与 LLM Key。请立即设置密码。
             </p>
-            <a className="primary-button" href="/settings?tab=account#password">
+            <a className="primary-button" href={passwordHref}>
               去设置密码
             </a>
           </div>
@@ -102,7 +109,7 @@ export async function RemoteAccessSection() {
           <TriangleAlert size={12} aria-hidden style={{ verticalAlign: "-2px", marginRight: 4 }} />
           暂时无法确认登录密码是否已设置（数据库读取失败）。
           若你尚未设置，请到{" "}
-          <a href="/settings?tab=account#password">账号</a> 补上——远程访问下这是唯一的门禁。
+          <a href={passwordHref}>账号</a> 补上——远程访问下这是唯一的门禁。
         </p>
       ) : null}
 

--- a/apps/web/components/settings/remote-access-section.tsx
+++ b/apps/web/components/settings/remote-access-section.tsx
@@ -1,0 +1,120 @@
+import { connection } from "next/server";
+import { Globe, ShieldAlert, TriangleAlert } from "lucide-react";
+import { getCurrentAccountSummary, hasLoginPassword } from "../../lib/workflow-runtime";
+import { instanceTunnelToken, resolveRemoteAccessState } from "../../lib/remote-access";
+import { RemoteAccessWaitlistForm } from "./remote-access-waitlist";
+
+/**
+ * 「远程访问」设置 section。
+ *
+ * 非站主返回 `null` —— 与 `AccountManagementSection` 同款服务端判定
+ * （`getCurrentAccountSummary().isOwner`，不是藏 UI）。slot 空即触发
+ * `settings-tabs.tsx` 里的 MutationObserver 自动隐藏整个 tab，所以这里
+ * **必须**返回 `null` 而不是空 fragment/空 div（那会流出一个直接子元素，
+ * observer 就把 tab 判成可见了）。
+ */
+export async function RemoteAccessSection() {
+  // connection() 必须是第一行：cacheComponents 下否则会在构建期预渲染，
+  // 把 build 环境的 TUNNEL_TOKEN/账号状态烤成静态壳（PasswordChangeSection 同款教训）。
+  // 本仓库禁用 `export const dynamic`，await connection() 是唯一手段。
+  await connection();
+  const me = await getCurrentAccountSummary();
+  if (!me?.isOwner) return null;
+
+  // hostname 当前无本地来源，故不传（详见 lib/remote-access.ts 文件头）。
+  const state = await resolveRemoteAccessState({ token: instanceTunnelToken() });
+
+  if (state.kind === "not_provisioned") {
+    return (
+      <section className="panel" style={{ maxWidth: 720, marginTop: 24 }}>
+        <div className="panel-header">
+          <div>
+            <h2 className="panel-title">
+              <Globe size={16} aria-hidden style={{ verticalAlign: "-2px", marginRight: 8 }} />
+              远程访问
+            </h2>
+            <p className="panel-note">
+              从任何设备经加密隧道访问你的实例：不开端口、不需公网 IP、不需域名。
+              内容与凭据始终只在你自己的机器上。目前免费内测，席位有限。
+            </p>
+          </div>
+        </div>
+        <RemoteAccessWaitlistForm />
+      </section>
+    );
+  }
+
+  const passwordState = await hasLoginPassword();
+  // 三态：true / false / "unknown"（DB 读失败）。**不能**把 "unknown" 当 false，
+  // 那会在数据库抖动时凭空弹出一条「你没设密码」的假警告；也不能当 true，
+  // 那会在真没设密码时把唯一的警告吞掉。分开各说各话。
+  const showNoPasswordWarning = passwordState === false;
+  const showUnknownPasswordNote = passwordState === "unknown";
+
+  return (
+    <section className="panel" style={{ maxWidth: 720, marginTop: 24 }}>
+      <div className="panel-header">
+        <div>
+          <h2 className="panel-title">
+            <Globe size={16} aria-hidden style={{ verticalAlign: "-2px", marginRight: 8 }} />
+            远程访问
+          </h2>
+          <p className="panel-note">经 Cloudflare 隧道对外发布本实例；关掉隧道容器即可随时下线</p>
+        </div>
+        <span className={`hub-badge tone-${state.kind === "active" ? "green" : "amber"}`}>
+          {state.kind === "active" ? "已开启" : "状态未知"}
+        </span>
+      </div>
+
+      {showNoPasswordWarning ? (
+        <div
+          role="alert"
+          style={{
+            display: "flex",
+            gap: 10,
+            padding: "12px 14px",
+            marginBottom: 14,
+            borderRadius: 8,
+            border: "1px solid var(--danger, #e5484d)",
+            background: "color-mix(in srgb, var(--danger, #e5484d) 12%, transparent)",
+          }}
+        >
+          <ShieldAlert size={18} aria-hidden style={{ flexShrink: 0, marginTop: 1 }} />
+          <div>
+            <strong>远程访问已开启，但还没有设置登录密码。</strong>
+            <p className="panel-note" style={{ margin: "4px 0 8px" }}>
+              任何知道你域名的人都能直接进入，读取整个媒体库、网盘凭据与 LLM Key。请立即设置密码。
+            </p>
+            <a className="primary-button" href="/settings?tab=account#password">
+              去设置密码
+            </a>
+          </div>
+        </div>
+      ) : null}
+
+      {showUnknownPasswordNote ? (
+        // 读不出密码状态 ≠ 没设密码。只提示「没能确认」，不冒充安全结论。
+        <p className="panel-note" role="status" style={{ marginBottom: 12 }}>
+          <TriangleAlert size={12} aria-hidden style={{ verticalAlign: "-2px", marginRight: 4 }} />
+          暂时无法确认登录密码是否已设置（数据库读取失败）。
+          若你尚未设置，请到{" "}
+          <a href="/settings?tab=account#password">账号</a> 补上——远程访问下这是唯一的门禁。
+        </p>
+      ) : null}
+
+      {state.kind === "active" ? (
+        // 刻意不显示专属域名/链接：worker 的状态端点回 204 无 body（不泄露任何
+        // 端点元数据），而实例本地并没有存过自己的公网域名。臆造一个只会给出
+        // 点了 404 的链接。详见 lib/remote-access.ts 文件头注释。
+        <p className="panel-note" style={{ margin: 0 }}>
+          远程访问已开启，隧道连接正常。请使用开通时收到的专属地址访问（浏览器里收藏即可）。
+        </p>
+      ) : (
+        <p className="panel-note" style={{ margin: 0 }}>
+          远程访问已开启，但暂时联系不上控制面，无法确认隧道状态。
+          这通常是本机出站网络波动；不影响已建立的隧道，稍后刷新即可。
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/components/settings/remote-access-waitlist.tsx
+++ b/apps/web/components/settings/remote-access-waitlist.tsx
@@ -48,13 +48,20 @@ export function RemoteAccessWaitlistForm(props: { workerBaseUrl: string }) {
         | null;
 
       if (res.ok) {
-        // position 两条成功路径都有；万一缺了也别显示 "第 undefined 位"。
-        const position = typeof data?.position === "number" ? data.position : null;
-        const prefix = data?.already_exists ? "你已经在队列里" : "已登记";
-        setResult({
-          ok: true,
-          text: position === null ? `${prefix}。` : `${prefix}，当前排在第 ${position} 位。`,
-        });
+        // 光看 res.ok 不够：网关塞回来的 200 HTML、或空 body 让 json() 解析失败时，
+        // data 会是 null，用户却看到「已登记」——一次根本没发生的报名。
+        // 契约（README + addToWaitlist JSDoc）两条成功路径都必带 id:string 与
+        // position:number，所以拿它们当「这确实是 worker 的应答」的凭据。
+        const hasContract = typeof data?.id === "string" && typeof data?.position === "number";
+        if (!hasContract) {
+          setResult({
+            ok: false,
+            text: "提交后没收到有效回执，无法确认是否登记成功——请稍后重试一次。",
+          });
+          return;
+        }
+        const prefix = data.already_exists ? "你已经在队列里" : "已登记";
+        setResult({ ok: true, text: `${prefix}，当前排在第 ${data.position} 位。` });
         return;
       }
       setResult({ ok: false, text: waitlistErrorText(res.status, data?.error) });

--- a/apps/web/components/settings/remote-access-waitlist.tsx
+++ b/apps/web/components/settings/remote-access-waitlist.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { LoaderCircle } from "lucide-react";
+
+/**
+ * 内测 waitlist 登记表单。直接打 worker 的公开端点（`POST /waitlist`，
+ * 无鉴权），不经本实例的 API —— 未开通的实例没有任何凭据可代理这次请求。
+ *
+ * 契约见 `workers/scout-connect/README.md`：
+ *   201 `{ id, position }`               新登记
+ *   200 `{ already_exists, id, position }` 已在队列（position 是 201 的严格超集）
+ *   400 `{ error }`                      email required / invalid email / invalid json / invalid body
+ *   413 `{ error: "body too large" }`
+ *
+ * 两条成功路径都带 `position`，所以这里不按状态码分支取排名——重复提交
+ * （双击/刷新）正是用户想再看一眼排名的时刻。
+ */
+
+/** 与服务端同一个默认值（见 lib/remote-access.ts）。 */
+const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
+
+export function RemoteAccessWaitlistForm(props: { workerBaseUrl?: string }) {
+  const [email, setEmail] = useState("");
+  const [result, setResult] = useState<{ ok: boolean; text: string } | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const base = (props.workerBaseUrl?.trim() || DEFAULT_WORKER_BASE).replace(/\/+$/, "");
+
+  const submit = async () => {
+    setPending(true);
+    setResult(null);
+    try {
+      const res = await fetch(`${base}/waitlist`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      // 错误响应也可能不是 JSON（网关/反代插进来的 HTML 502），parse 失败
+      // 不能把整个 handler 炸成 unhandled rejection。
+      const data = (await res.json().catch(() => null)) as
+        | { id?: string; position?: number; already_exists?: boolean; error?: string }
+        | null;
+
+      if (res.ok) {
+        // position 两条成功路径都有；万一缺了也别显示 "第 undefined 位"。
+        const position = typeof data?.position === "number" ? data.position : null;
+        const prefix = data?.already_exists ? "你已经在队列里" : "已登记";
+        setResult({
+          ok: true,
+          text: position === null ? `${prefix}。` : `${prefix}，当前排在第 ${position} 位。`,
+        });
+        return;
+      }
+      setResult({ ok: false, text: waitlistErrorText(res.status, data?.error) });
+    } catch {
+      setResult({ ok: false, text: "网络异常，提交失败——请稍后再试。" });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!pending) void submit();
+      }}
+      style={{ maxWidth: 420, marginTop: 14 }}
+    >
+      <div className="setting-row" style={{ marginBottom: 10 }}>
+        <input
+          type="email"
+          required
+          className="setting-control"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="你的邮箱"
+          aria-label="用于接收内测邀请的邮箱"
+          autoComplete="email"
+        />
+      </div>
+      <button type="submit" className="primary-button" disabled={pending || email.trim() === ""}>
+        {pending ? <LoaderCircle size={14} className="spin" aria-hidden /> : "申请内测资格"}
+      </button>
+      {result ? (
+        <p
+          className="panel-note"
+          // 提交结果要被读屏播报：它是用户这次操作的唯一反馈。
+          role="status"
+          style={{ margin: "10px 0 0", color: result.ok ? "var(--accent)" : "var(--danger, #e5484d)" }}
+        >
+          {result.text}
+        </p>
+      ) : null}
+    </form>
+  );
+}
+
+/** worker 的 error 串是英文且面向调用方，直接展示对用户无意义——按状态码归类。 */
+function waitlistErrorText(status: number, error: string | undefined): string {
+  if (status === 400) {
+    // invalid json / invalid body 属于本表单自己发错了，不该怪用户的邮箱格式。
+    return error === "email required" || error === "invalid email"
+      ? "邮箱格式不正确，请检查后重试。"
+      : "提交内容有误，请刷新页面后重试。";
+  }
+  if (status === 413) return "邮箱地址过长，请换一个。";
+  if (status === 429) return "提交过于频繁，请稍后再试。";
+  if (status >= 500) return "服务暂时不可用，请稍后再试。";
+  return "提交失败，请稍后再试。";
+}

--- a/apps/web/components/settings/remote-access-waitlist.tsx
+++ b/apps/web/components/settings/remote-access-waitlist.tsx
@@ -85,7 +85,15 @@ export function RemoteAccessWaitlistForm(props: { workerBaseUrl: string }) {
           autoComplete="email"
         />
       </div>
-      <button type="submit" className="primary-button" disabled={pending || email.trim() === ""}>
+      <button
+        type="submit"
+        className="primary-button"
+        disabled={pending || email.trim() === ""}
+        // 提交中按钮内只剩 aria-hidden 的 spinner，读屏会念成无名「按钮」。
+        // 用 aria-label 补一个始终存在的可访问名称（仓库既有约定，见 login/page.tsx）。
+        aria-label={pending ? "正在提交内测申请" : "申请内测资格"}
+        aria-busy={pending}
+      >
         {pending ? <LoaderCircle size={14} className="spin" aria-hidden /> : "申请内测资格"}
       </button>
       {result ? (

--- a/apps/web/components/settings/remote-access-waitlist.tsx
+++ b/apps/web/components/settings/remote-access-waitlist.tsx
@@ -17,15 +17,20 @@ import { LoaderCircle } from "lucide-react";
  * （双击/刷新）正是用户想再看一眼排名的时刻。
  */
 
-/** 与服务端同一个默认值（见 lib/remote-access.ts）。 */
-const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
-
-export function RemoteAccessWaitlistForm(props: { workerBaseUrl?: string }) {
+/**
+ * `workerBaseUrl` 是**必填**且刻意没有本地默认值：唯一来源是服务端的
+ * `scoutConnectBaseUrl()`（见 lib/remote-access.ts），由调用方透传下来。
+ *
+ * 这里若留一个 `?:` + 本地兜底常量，某个将来忘记传参的调用点就会**静默**
+ * 退回生产 worker——把预发/自建实例的报名写进真实队列，正是上一个 commit
+ * 修掉的 bug。设成必填后，漏传是编译错误，不是线上脏数据。
+ */
+export function RemoteAccessWaitlistForm(props: { workerBaseUrl: string }) {
   const [email, setEmail] = useState("");
   const [result, setResult] = useState<{ ok: boolean; text: string } | null>(null);
   const [pending, setPending] = useState(false);
 
-  const base = (props.workerBaseUrl?.trim() || DEFAULT_WORKER_BASE).replace(/\/+$/, "");
+  const base = props.workerBaseUrl.trim().replace(/\/+$/, "");
 
   const submit = async () => {
     setPending(true);
@@ -87,7 +92,10 @@ export function RemoteAccessWaitlistForm(props: { workerBaseUrl?: string }) {
         <p
           className="panel-note"
           // 提交结果要被读屏播报：它是用户这次操作的唯一反馈。
-          role="status"
+          // 失败走 alert（assertive，立刻打断）——politeness 下的失败提示很容易
+          // 被用户完全错过，而这时表单看起来「什么都没发生」。成功走 status。
+          // 与 remote-access-section.tsx 的无密码警告同款约定。
+          role={result.ok ? "status" : "alert"}
           style={{ margin: "10px 0 0", color: result.ok ? "var(--accent)" : "var(--danger, #e5484d)" }}
         >
           {result.text}

--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -130,6 +130,31 @@ describe("resolveRemoteAccessState", () => {
   });
 });
 
+describe("心跳超时（SSR 渲染路径上的硬要求）", () => {
+  it("带 AbortSignal —— 项目硬规则「新外部 HTTP 一律带超时」", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await resolveRemoteAccessState({ token: "tok" });
+    const init = fetchMock.mock.calls[0]?.[1];
+    // 没有 signal 的话，worker「卡住但不报错」会把整个 /settings 渲染挂死
+    expect(init?.signal).toBeDefined();
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("超时被中止 → 降级，不向渲染路径抛错", async () => {
+    // AbortSignal.timeout 到期时 fetch 抛 TimeoutError；必须被吞成 degraded
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+      }),
+    );
+    await expect(resolveRemoteAccessState({ token: "tok" })).resolves.toEqual({
+      kind: "active_degraded",
+    });
+  });
+});
+
 describe("instanceTunnelToken", () => {
   it("读 TUNNEL_TOKEN 并 trim", () => {
     process.env.TUNNEL_TOKEN = "  tok  ";

--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   instanceTunnelToken,
   resolveRemoteAccessState,
+  scoutConnectBaseUrl,
   type RemoteAccessState,
 } from "./remote-access";
 
@@ -152,6 +153,29 @@ describe("心跳超时（SSR 渲染路径上的硬要求）", () => {
     await expect(resolveRemoteAccessState({ token: "tok" })).resolves.toEqual({
       kind: "active_degraded",
     });
+  });
+});
+
+describe("scoutConnectBaseUrl（心跳与 waitlist 表单的唯一来源）", () => {
+  it("默认生产域名；SCOUT_CONNECT_URL 可覆盖；去掉尾部斜杠", () => {
+    delete process.env.SCOUT_CONNECT_URL;
+    expect(scoutConnectBaseUrl()).toBe("https://mediaryconnect.app");
+    process.env.SCOUT_CONNECT_URL = "https://staging.example.com/";
+    expect(scoutConnectBaseUrl()).toBe("https://staging.example.com");
+    process.env.SCOUT_CONNECT_URL = "  https://staging.example.com///  ";
+    expect(scoutConnectBaseUrl()).toBe("https://staging.example.com");
+  });
+
+  it("心跳打的就是 scoutConnectBaseUrl —— 否则预发的报名会写进生产队列", async () => {
+    process.env.SCOUT_CONNECT_URL = "https://staging.example.com";
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await resolveRemoteAccessState({ token: "tok" });
+    // 表单拿的是同一个函数的返回值（见 remote-access-section.tsx 的透传），
+    // 所以只要这里对得上，两条路径就不会分叉。
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      `${scoutConnectBaseUrl()}/api/instance/status`,
+    );
   });
 });
 

--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -171,6 +171,17 @@ describe("心跳超时（SSR 渲染路径上的硬要求）", () => {
 });
 
 describe("scoutConnectBaseUrl（心跳与 waitlist 表单的唯一来源）", () => {
+  it("误配的 SCOUT_CONNECT_URL 回落默认，绝不退化成同源相对路径", () => {
+    // 仅 trim + 去尾斜杠的话，这些输入会变成空串或相对 URL，
+    // 心跳就静默打到实例自己身上，症状还只是「显示降级」，极难排查。
+    for (const bad of ["/", "////", "mediaryconnect.app", "://nope", "ftp://x.com"]) {
+      process.env.SCOUT_CONNECT_URL = bad;
+      const base = scoutConnectBaseUrl();
+      expect(base).toBe("https://mediaryconnect.app");
+      expect(`${base}/api/instance/status`.startsWith("https://")).toBe(true);
+    }
+  });
+
   it("默认生产域名；SCOUT_CONNECT_URL 可覆盖；去掉尾部斜杠", () => {
     delete process.env.SCOUT_CONNECT_URL;
     expect(scoutConnectBaseUrl()).toBe("https://mediaryconnect.app");

--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -3,6 +3,7 @@ import {
   instanceTunnelToken,
   resolveRemoteAccessState,
   scoutConnectBaseUrl,
+  accountPasswordHref,
   type RemoteAccessState,
 } from "./remote-access";
 
@@ -201,6 +202,22 @@ describe("scoutConnectBaseUrl（心跳与 waitlist 表单的唯一来源）", ()
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       `${scoutConnectBaseUrl()}/api/instance/status`,
     );
+  });
+});
+
+describe("accountPasswordHref（保留 ?w 工作区上下文）", () => {
+  it("无 w → 基础链接；有 w → 带上且仍以 #password 收尾", () => {
+    expect(accountPasswordHref()).toBe("/settings?tab=account#password");
+    const withW = accountPasswordHref("cs_abc");
+    expect(withW).toContain("w=cs_abc");
+    expect(withW).toContain("tab=account");
+    expect(withW.endsWith("#password")).toBe(true);
+  });
+
+  it("需要转义的值被正确编码（否则会截断或注入参数）", () => {
+    const href = accountPasswordHref("cs_a b&c");
+    expect(href).toContain("w=cs_a+b%26c");
+    expect(href.endsWith("#password")).toBe(true);
   });
 });
 

--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  instanceTunnelToken,
+  resolveRemoteAccessState,
+  type RemoteAccessState,
+} from "./remote-access";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.unstubAllGlobals();
+});
+
+describe("resolveRemoteAccessState", () => {
+  it("无 TUNNEL_TOKEN → not_provisioned，且**不发心跳**", async () => {
+    const sendHeartbeat = vi.fn(async () => true);
+    const state = await resolveRemoteAccessState({ token: undefined, sendHeartbeat });
+    expect(state).toEqual({ kind: "not_provisioned" });
+    // 没 token 就没身份可报——发了只会向 worker 暴露一台未开通实例的存在。
+    expect(sendHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it("空串 / 纯空白 token 视同未开通（.env 里 TUNNEL_TOKEN= 就是这形状）", async () => {
+    const sendHeartbeat = vi.fn(async () => true);
+    for (const token of ["", "   "]) {
+      expect(await resolveRemoteAccessState({ token, sendHeartbeat })).toEqual({
+        kind: "not_provisioned",
+      });
+    }
+    expect(sendHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it("心跳 204 → active（hostname 无本地来源时为 null，绝不臆造）", async () => {
+    const state = await resolveRemoteAccessState({
+      token: "tok",
+      sendHeartbeat: async () => true,
+    });
+    expect(state).toEqual({ kind: "active", hostname: null });
+  });
+
+  it("调用方能提供本地已知 hostname 时透传", async () => {
+    const state = await resolveRemoteAccessState({
+      token: "tok",
+      hostname: "s1.mediaryconnect.app",
+      sendHeartbeat: async () => true,
+    });
+    expect(state).toEqual({ kind: "active", hostname: "s1.mediaryconnect.app" });
+  });
+
+  it("心跳失败（非 204）→ active_degraded", async () => {
+    const state = await resolveRemoteAccessState({
+      token: "tok",
+      sendHeartbeat: async () => false,
+    });
+    expect(state).toEqual({ kind: "active_degraded" });
+  });
+
+  it("心跳抛错（网络不可达）→ active_degraded，不冒泡炸掉整页 SSR", async () => {
+    const state = await resolveRemoteAccessState({
+      token: "tok",
+      sendHeartbeat: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    expect(state).toEqual({ kind: "active_degraded" });
+  });
+
+  it("token 绝不出现在返回的 state 里（这东西会被序列化进 RSC 载荷）", async () => {
+    const token = "super-secret-connector-token";
+    const states: RemoteAccessState[] = [
+      await resolveRemoteAccessState({ token, sendHeartbeat: async () => true }),
+      await resolveRemoteAccessState({ token, sendHeartbeat: async () => false }),
+      await resolveRemoteAccessState({
+        token,
+        sendHeartbeat: async () => {
+          throw new Error(`failed for ${token}`); // 连报错串里的 token 也不能漏出去
+        },
+      }),
+    ];
+    for (const state of states) {
+      expect(JSON.stringify(state)).not.toContain(token);
+    }
+  });
+
+  it("默认心跳：Bearer 头 + POST + no-store，204 判成功", async () => {
+    process.env.SCOUT_CONNECT_URL = "https://connect.test";
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const state = await resolveRemoteAccessState({ token: "tok-abc" });
+
+    expect(state).toEqual({ kind: "active", hostname: null });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://connect.test/api/instance/status");
+    expect(init.method).toBe("POST");
+    expect(init.cache).toBe("no-store");
+    // 契约是 Authorization: Bearer <token> 头，不是 JSON body。
+    expect(new Headers(init.headers).get("authorization")).toBe("Bearer tok-abc");
+    expect(init.body).toBeUndefined();
+  });
+
+  it("默认心跳 base URL 缺省为生产 worker", async () => {
+    delete process.env.SCOUT_CONNECT_URL;
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await resolveRemoteAccessState({ token: "tok" });
+
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expect(url).toBe("https://mediaryconnect.app/api/instance/status");
+  });
+
+  it("默认心跳：401（token 已吊销）→ active_degraded", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 })));
+    expect(await resolveRemoteAccessState({ token: "revoked" })).toEqual({ kind: "active_degraded" });
+  });
+
+  it("默认心跳：200 也算失败——契约明确是 204 无 body", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 200 })));
+    expect(await resolveRemoteAccessState({ token: "tok" })).toEqual({ kind: "active_degraded" });
+  });
+
+  it("默认心跳：fetch 抛错 → active_degraded", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("network down");
+    }));
+    expect(await resolveRemoteAccessState({ token: "tok" })).toEqual({ kind: "active_degraded" });
+  });
+});
+
+describe("instanceTunnelToken", () => {
+  it("读 TUNNEL_TOKEN 并 trim", () => {
+    process.env.TUNNEL_TOKEN = "  tok  ";
+    expect(instanceTunnelToken()).toBe("tok");
+  });
+
+  it("未设 / 空串 / 纯空白 → undefined", () => {
+    delete process.env.TUNNEL_TOKEN;
+    expect(instanceTunnelToken()).toBeUndefined();
+    process.env.TUNNEL_TOKEN = "";
+    expect(instanceTunnelToken()).toBeUndefined();
+    process.env.TUNNEL_TOKEN = "   ";
+    expect(instanceTunnelToken()).toBeUndefined();
+  });
+});

--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -6,10 +6,24 @@ import {
   type RemoteAccessState,
 } from "./remote-access";
 
-const ORIGINAL_ENV = { ...process.env };
+// 只按 key 保存/还原本套件真正会改的两个变量。**不能**整体替换
+// `process.env`：那会换掉对象本体，任何在此之前拿到过旧引用的模块（含先加载的
+// 测试文件）会继续读一个已经不再更新的快照。
+const prevScoutConnectUrl = process.env.SCOUT_CONNECT_URL;
+const prevTunnelToken = process.env.TUNNEL_TOKEN;
 
 afterEach(() => {
-  process.env = { ...ORIGINAL_ENV };
+  // 原值为 undefined 时必须删除而非跳过，否则本套件设的值会泄漏给后续测试文件
+  if (prevScoutConnectUrl !== undefined) {
+    process.env.SCOUT_CONNECT_URL = prevScoutConnectUrl;
+  } else {
+    delete process.env.SCOUT_CONNECT_URL;
+  }
+  if (prevTunnelToken !== undefined) {
+    process.env.TUNNEL_TOKEN = prevTunnelToken;
+  } else {
+    delete process.env.TUNNEL_TOKEN;
+  }
   vi.unstubAllGlobals();
 });
 

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -51,8 +51,16 @@ const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
  * 这个值不敏感（就是个公开域名），可以安全下发给客户端组件。
  */
 export function scoutConnectBaseUrl(): string {
-  const raw = process.env.SCOUT_CONNECT_URL?.trim() || DEFAULT_WORKER_BASE;
-  return raw.replace(/\/+$/, "");
+  const raw = process.env.SCOUT_CONNECT_URL?.trim();
+  if (!raw) return DEFAULT_WORKER_BASE;
+  const trimmed = raw.replace(/\/+$/, "");
+  // 必须校验协议：仅 trim + 去尾斜杠的话，误配成 "/" 或 "////" 会规范化成空串，
+  // 而 "mediaryconnect.app"（漏了协议）也不是绝对 URL——两种情况都会让
+  // `${base}/api/instance/status` 变成**同源相对路径**，心跳静默打到实例自己身上，
+  // 而且症状是「远程访问显示降级」，排查时根本想不到是 env 配错了。
+  // 校验失败宁可回落到生产默认值（可用），也不要静默走错地址。
+  if (!/^https?:\/\/[^/]+/.test(trimmed)) return DEFAULT_WORKER_BASE;
+  return trimmed;
 }
 
 /**

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -45,6 +45,15 @@ const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
  * 构建期就被求值，把 build 环境的 env 值烤死进产物——docker 镜像 build/run
  * 环境不同，那样预发/自建实例改 `SCOUT_CONNECT_URL` 会失效。
  */
+/**
+ * 心跳超时。这次 fetch 发生在 `/settings` 的 **SSR 渲染路径**上——没有超时的话，
+ * worker 或网络「卡住但不报错」会把整个设置页的渲染一起挂死（不是慢，是永远不返回）。
+ * 遵守项目硬规则「新外部 HTTP 一律带超时」（见 `pan123-client.ts` 的同款注释）。
+ * 5s 与 `deployment-update-server.ts` 的探测保持一致：这只是个存活探针，
+ * 超时即按降级处理，反正降级态本来就是「拿不到状态」。
+ */
+const HEARTBEAT_TIMEOUT_MS = 5_000;
+
 async function defaultSendHeartbeat(token: string): Promise<boolean> {
   const base = process.env.SCOUT_CONNECT_URL?.trim() || DEFAULT_WORKER_BASE;
   const res = await fetch(`${base.replace(/\/+$/, "")}/api/instance/status`, {
@@ -52,6 +61,7 @@ async function defaultSendHeartbeat(token: string): Promise<boolean> {
     // 契约是 Bearer 头；worker 压根不读 body（大 body 都不会被读取）。
     headers: { authorization: `Bearer ${token}` },
     cache: "no-store",
+    signal: AbortSignal.timeout(HEARTBEAT_TIMEOUT_MS),
   });
   // 严格判 204：契约就是 204 无 body。放宽成 res.ok 会把任何反代/门禁塞回来的
   // 200 登录页当成「隧道健康」，那是最需要被显示为降级的场景。

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -45,7 +45,9 @@ const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
  * `SCOUT_CONNECT_URL` 指向预发/自建 worker 时，状态卡打到新 worker，
  * 而报名表单仍写进生产队列——测试数据污染真实名单。
  *
- * 在函数里读 env 而非模块顶层常量：`cacheComponents` 下顶层常量会被构建期烘死。
+ * 在函数里读 env 而非模块顶层常量：`cacheComponents` 下模块可能在构建期就被
+ * 求值，把 build 环境的 env 值烤死进产物——docker 镜像 build/run 环境不同，
+ * 那样预发/自建实例改 `SCOUT_CONNECT_URL` 会失效。
  * 这个值不敏感（就是个公开域名），可以安全下发给客户端组件。
  */
 export function scoutConnectBaseUrl(): string {
@@ -53,13 +55,6 @@ export function scoutConnectBaseUrl(): string {
   return raw.replace(/\/+$/, "");
 }
 
-/**
- * 心跳一次。`true` = worker 明确回了 204（契约里唯一的成功）。
- *
- * 注意读的是 `process.env`（而非模块顶层常量）：cacheComponents 下模块可能在
- * 构建期就被求值，把 build 环境的 env 值烤死进产物——docker 镜像 build/run
- * 环境不同，那样预发/自建实例改 `SCOUT_CONNECT_URL` 会失效。
- */
 /**
  * 心跳超时。这次 fetch 发生在 `/settings` 的 **SSR 渲染路径**上——没有超时的话，
  * worker 或网络「卡住但不报错」会把整个设置页的渲染一起挂死（不是慢，是永远不返回）。
@@ -69,6 +64,7 @@ export function scoutConnectBaseUrl(): string {
  */
 const HEARTBEAT_TIMEOUT_MS = 5_000;
 
+/** 心跳一次。`true` = worker 明确回了 204（契约里唯一的成功）。 */
 async function defaultSendHeartbeat(token: string): Promise<boolean> {
   const res = await fetch(`${scoutConnectBaseUrl()}/api/instance/status`, {
     method: "POST",

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -120,3 +120,17 @@ export async function resolveRemoteAccessState(opts: {
 export function instanceTunnelToken(): string | undefined {
   return process.env.TUNNEL_TOKEN?.trim() || undefined;
 }
+
+/**
+ * 「去设置密码」链接。
+ *
+ * 必须保留 `?w` 工作区深链参数：从非默认工作区进设置页时，硬编码
+ * `/settings?tab=account` 会把用户静默踢回默认工作区上下文。
+ * （`settings/page.tsx` 已经在 `SettingsSidebar` / `SettingsAttentionSection`
+ * 里透传同一个 `w`，这里跟随同一约定。）
+ */
+export function accountPasswordHref(w?: string): string {
+  const params = new URLSearchParams({ tab: "account" });
+  if (w) params.set("w", w);
+  return `/settings?${params.toString()}#password`;
+}

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -1,0 +1,94 @@
+/**
+ * 实例侧「远程访问」状态解析。纯逻辑 + 依赖注入，node 环境可测。
+ *
+ * ## 为什么状态里没有 hostname / connections
+ *
+ * Plan 3 落地的 worker 契约（见 `workers/scout-connect/src/routes.ts` 的
+ * `reportInstanceStatus` 与 `workers/scout-connect/README.md`）是：
+ *
+ *   POST /api/instance/status
+ *   Authorization: Bearer <TUNNEL_TOKEN>       ← 头，不是 JSON body
+ *   → 204 No Content（**无 body**）/ 401
+ *
+ * 204 无 body 是刻意的：即便持有有效 token 也拿不到任何端点元数据，
+ * 于是这个公开端点无法被当作「探测某 token 对应哪个域名」的预言机。
+ * 因此本模块把这次调用当作**心跳/存活探测**（它同时会在服务端更新
+ * `last_seen_at`，本身有价值），而不是数据源：
+ *
+ *  - `connections` 直接不要了。它是运维细节，用户不需要；要拿到它就得给
+ *    worker 新开一个返回元数据的端点，那等于把 Plan 3 刻意关掉的信息泄露面
+ *    重新打开。
+ *  - `hostname` 只可能来自**本地**。本仓库目前**没有**任何本地来源：
+ *    实例只被写入 `TUNNEL_TOKEN`（见 `.env.example` / `docker-compose.yml` 的
+ *    cloudflared 服务 / worker 那份 agent-prompt 生成的 .env 写入脚本——
+ *    它只写 `TUNNEL_TOKEN` 与 `TUNNEL_TRANSPORT_PROTOCOL`），公网域名只存在于
+ *    worker 侧的 D1 与用户自己的浏览器里。`MEDIA_TRACK_ALLOWED_ORIGINS` 是
+ *    构建期 CSRF 白名单（可为空、可多值、只在反代不透传 x-forwarded-host 时才
+ *    设），不是「本实例的公网域名」，拿它冒充会在多值/空值时显示错域名。
+ *    所以 hostname 是 `string | null`：拿不到就是 null，UI 显示「已开启」但
+ *    **不给链接**，绝不臆造一个用户点了会 404 的地址。
+ *    若将来实例侧真落地了自己的域名（配置项或隧道 setup 写入），
+ *    从 `resolveRemoteAccessState` 的 `hostname` 入参喂进来即可。
+ */
+
+export type RemoteAccessState =
+  | { kind: "not_provisioned" }
+  | { kind: "active"; hostname: string | null }
+  | { kind: "active_degraded" };
+
+const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
+
+/**
+ * 心跳一次。`true` = worker 明确回了 204（契约里唯一的成功）。
+ *
+ * 注意读的是 `process.env`（而非模块顶层常量）：cacheComponents 下模块可能在
+ * 构建期就被求值，把 build 环境的 env 值烤死进产物——docker 镜像 build/run
+ * 环境不同，那样预发/自建实例改 `SCOUT_CONNECT_URL` 会失效。
+ */
+async function defaultSendHeartbeat(token: string): Promise<boolean> {
+  const base = process.env.SCOUT_CONNECT_URL?.trim() || DEFAULT_WORKER_BASE;
+  const res = await fetch(`${base.replace(/\/+$/, "")}/api/instance/status`, {
+    method: "POST",
+    // 契约是 Bearer 头；worker 压根不读 body（大 body 都不会被读取）。
+    headers: { authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  // 严格判 204：契约就是 204 无 body。放宽成 res.ok 会把任何反代/门禁塞回来的
+  // 200 登录页当成「隧道健康」，那是最需要被显示为降级的场景。
+  return res.status === 204;
+}
+
+/**
+ * `token` 有值即视为已开通（本实例被发过连接凭据）；心跳只决定 active 还是降级。
+ *
+ * 心跳失败**不**回落成 not_provisioned：那会把「已开通但网络抖动」显示成
+ * 「未开通 + waitlist 表单」，等于劝一个已经付出配置成本的用户重新排队。
+ */
+export async function resolveRemoteAccessState(opts: {
+  token: string | undefined;
+  /** 本地已知的公网域名（当前无来源，见文件头注释）。 */
+  hostname?: string | null;
+  sendHeartbeat?: (token: string) => Promise<boolean>;
+}): Promise<RemoteAccessState> {
+  const token = opts.token?.trim();
+  if (!token) {
+    // 未开通就没身份可报——此处**必须**在心跳之前返回。
+    return { kind: "not_provisioned" };
+  }
+  const sendHeartbeat = opts.sendHeartbeat ?? defaultSendHeartbeat;
+  try {
+    // 捕获一切：这是在渲染路径上做的一次网络调用，worker 挂了不该炸掉设置页。
+    // 也刻意不把 error 放进返回值——报错串里可能带着 token（见测试）。
+    if (!(await sendHeartbeat(token))) {
+      return { kind: "active_degraded" };
+    }
+  } catch {
+    return { kind: "active_degraded" };
+  }
+  return { kind: "active", hostname: opts.hostname ?? null };
+}
+
+/** 服务端读实例隧道 token（docker-compose 需把 `TUNNEL_TOKEN` 也传给 web 服务）。 */
+export function instanceTunnelToken(): string | undefined {
+  return process.env.TUNNEL_TOKEN?.trim() || undefined;
+}

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -39,6 +39,21 @@ export type RemoteAccessState =
 const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
 
 /**
+ * 当前运行时的 worker base（唯一来源）。
+ *
+ * 服务端心跳与客户端 waitlist 表单**必须**用同一个值：否则把
+ * `SCOUT_CONNECT_URL` 指向预发/自建 worker 时，状态卡打到新 worker，
+ * 而报名表单仍写进生产队列——测试数据污染真实名单。
+ *
+ * 在函数里读 env 而非模块顶层常量：`cacheComponents` 下顶层常量会被构建期烘死。
+ * 这个值不敏感（就是个公开域名），可以安全下发给客户端组件。
+ */
+export function scoutConnectBaseUrl(): string {
+  const raw = process.env.SCOUT_CONNECT_URL?.trim() || DEFAULT_WORKER_BASE;
+  return raw.replace(/\/+$/, "");
+}
+
+/**
  * 心跳一次。`true` = worker 明确回了 204（契约里唯一的成功）。
  *
  * 注意读的是 `process.env`（而非模块顶层常量）：cacheComponents 下模块可能在
@@ -55,8 +70,7 @@ const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
 const HEARTBEAT_TIMEOUT_MS = 5_000;
 
 async function defaultSendHeartbeat(token: string): Promise<boolean> {
-  const base = process.env.SCOUT_CONNECT_URL?.trim() || DEFAULT_WORKER_BASE;
-  const res = await fetch(`${base.replace(/\/+$/, "")}/api/instance/status`, {
+  const res = await fetch(`${scoutConnectBaseUrl()}/api/instance/status`, {
     method: "POST",
     // 契约是 Bearer 头；worker 压根不读 body（大 body 都不会被读取）。
     headers: { authorization: `Bearer ${token}` },

--- a/apps/web/lib/settings-tabs-model.test.ts
+++ b/apps/web/lib/settings-tabs-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_SETTINGS_TAB,
+  OBSERVED_SETTINGS_TABS,
   SETTINGS_TABS,
   resolveSettingsTab,
   settingsTabQuery,
@@ -10,6 +11,25 @@ describe("resolveSettingsTab", () => {
   it("已知 tab 原样返回", () => {
     expect(resolveSettingsTab("patrol", false)).toBe("patrol");
     expect(resolveSettingsTab("services", false)).toBe("services");
+  });
+
+  it("remote 仅在远程访问 tab 可见时可达，否则回落默认", () => {
+    expect(resolveSettingsTab("remote", { remote: true })).toBe("remote");
+    expect(resolveSettingsTab("remote", { remote: false })).toBe("drives");
+    // 未给出 remote 可见性 → fail-closed（隐藏态与 tablist 一致）
+    expect(resolveSettingsTab("remote", {})).toBe("drives");
+  });
+
+  it("legacy 布尔第二参只表示「账号」tab 可见性，remote 仍 fail-closed", () => {
+    // 旧调用点传布尔即「账号可见」；它不该顺带把 remote 也放开。
+    expect(resolveSettingsTab("account", true)).toBe("account");
+    expect(resolveSettingsTab("remote", true)).toBe("drives");
+  });
+
+  it("两个受观察 tab 的可见性彼此独立", () => {
+    expect(resolveSettingsTab("account", { account: true, remote: false })).toBe("account");
+    expect(resolveSettingsTab("remote", { account: false, remote: true })).toBe("remote");
+    expect(resolveSettingsTab("account", { account: false, remote: true })).toBe("drives");
   });
 
   it("未知/缺失 → 默认 drives", () => {
@@ -42,8 +62,26 @@ describe("settingsTabQuery", () => {
 });
 
 describe("SETTINGS_TABS", () => {
-  it("五个 tab、顺序与标签固定", () => {
-    expect(SETTINGS_TABS.map((tab) => tab.id)).toEqual(["drives", "services", "preferences", "patrol", "account"]);
-    expect(SETTINGS_TABS.map((tab) => tab.label)).toEqual(["网盘", "资源与服务", "获取偏好", "巡检与通知", "账号"]);
+  it("六个 tab、顺序与标签固定", () => {
+    expect(SETTINGS_TABS.map((tab) => tab.id)).toEqual([
+      "drives",
+      "services",
+      "preferences",
+      "patrol",
+      "account",
+      "remote",
+    ]);
+    expect(SETTINGS_TABS.map((tab) => tab.label)).toEqual([
+      "网盘",
+      "资源与服务",
+      "获取偏好",
+      "巡检与通知",
+      "账号",
+      "远程访问",
+    ]);
+  });
+
+  it("受观察（内容为空即隐藏）的 tab 就是 account + remote", () => {
+    expect([...OBSERVED_SETTINGS_TABS]).toEqual(["account", "remote"]);
   });
 });

--- a/apps/web/lib/settings-tabs-model.ts
+++ b/apps/web/lib/settings-tabs-model.ts
@@ -6,6 +6,7 @@ export const SETTINGS_TABS = [
   { id: "preferences", label: "获取偏好" },
   { id: "patrol", label: "巡检与通知" },
   { id: "account", label: "账号" },
+  { id: "remote", label: "远程访问" },
 ] as const;
 
 export type SettingsTabId = (typeof SETTINGS_TABS)[number]["id"];
@@ -14,22 +15,50 @@ export const DEFAULT_SETTINGS_TAB: SettingsTabId = "drives";
 
 const TAB_IDS = new Set<string>(SETTINGS_TABS.map((tab) => tab.id));
 
+/**
+ * Tabs whose visibility is NOT derivable client-side and is instead observed
+ * from whether their slot actually streamed content (server-rendered `null`
+ * → hide). See the MutationObserver in `settings-tabs.tsx` for why the flag
+ * cannot simply be read from env at build time.
+ *
+ * Both members render `null` for the same class of reason (not the站主 /
+ * feature off), so they share one mechanism — but their visibility is
+ * INDEPENDENT: 多用户关时 account 隐藏而 remote 仍可显示。
+ */
+export const OBSERVED_SETTINGS_TABS = ["account", "remote"] as const;
+
+export type ObservedSettingsTabId = (typeof OBSERVED_SETTINGS_TABS)[number];
+
+/** 受观察 tab 的可见性映射。缺省 = 不可见（fail-closed，与 tablist 保持一致）。 */
+export type SettingsTabVisibility = Partial<Record<ObservedSettingsTabId, boolean>>;
+
 /** legacy 深链锚点（account-identity 菜单）→ 账号 tab。 */
 const ACCOUNT_HASHES = new Set(["#password", "#accounts"]);
 
+/**
+ * @param visible 受观察 tab 的可见性。为兼容旧调用点，传布尔时只表示
+ *   「账号 tab 可见」——它绝不顺带放开 remote，否则任一受观察 tab 的深链
+ *   就能借另一个 tab 的可见性绕过 fail-closed。
+ */
 export function resolveSettingsTab(
   param: string | null | undefined,
-  accountTabVisible: boolean,
+  visible: SettingsTabVisibility | boolean,
   hash?: string,
 ): SettingsTabId {
+  const visibility: SettingsTabVisibility =
+    typeof visible === "boolean" ? { account: visible } : visible;
   const candidate =
     param && TAB_IDS.has(param)
       ? (param as SettingsTabId)
       : !param && hash && ACCOUNT_HASHES.has(hash)
         ? "account"
         : DEFAULT_SETTINGS_TAB;
-  if (candidate === "account" && !accountTabVisible) return DEFAULT_SETTINGS_TAB;
+  if (isObservedTab(candidate) && visibility[candidate] !== true) return DEFAULT_SETTINGS_TAB;
   return candidate;
+}
+
+function isObservedTab(tab: SettingsTabId): tab is ObservedSettingsTabId {
+  return (OBSERVED_SETTINGS_TABS as readonly SettingsTabId[]).includes(tab);
 }
 
 /** 写回 URL query：保留其他参数（?w 工作区）；默认 tab 不留 tab 参数。 */

--- a/apps/web/lib/single-user-gate-wiring.test.ts
+++ b/apps/web/lib/single-user-gate-wiring.test.ts
@@ -45,106 +45,137 @@ afterEach(() => {
   vi.resetModules();
 });
 
+/**
+ * ⚠️ 超时：这些用例会调用 setSingleUserPassword / loginAccount，二者都跑
+ * memory-hard 的 scrypt（单次 ~50-80ms）。全量并行下与其它测试争抢 CPU 会远超
+ * vitest 默认的 5s。显式放宽到 30s——这不是「慢测试」，是密码学原语的固有成本。
+ */
+const CRYPTO_TIMEOUT_MS = 30_000;
+
 describe("single-user gate wiring (failure paths)", () => {
-  it("远程 + 密码状态读失败 → 必须 fail-closed（不得当作未设密码而放行）", async () => {
-    mockRemoteRequest();
-    const rt = await boot();
-    await rt.setSingleUserPassword("secret-123");
+  it(
+    "远程 + 密码状态读失败 → 必须 fail-closed（不得当作未设密码而放行）",
+    async () => {
+      mockRemoteRequest();
+      const rt = await boot();
+      await rt.setSingleUserPassword("secret-123");
 
-    // 让密码状态读不出来（DB 抖动/连接池耗尽/故障切换）
-    const repo = rt.getWorkflowRepository();
-    const original = repo.getAccountById.bind(repo);
-    repo.getAccountById = async () => {
-      throw new Error("DB down");
-    };
+      // 让密码状态读不出来（DB 抖动/连接池耗尽/故障切换）
+      const repo = rt.getWorkflowRepository();
+      const original = repo.getAccountById.bind(repo);
+      repo.getAccountById = async () => {
+        throw new Error("DB down");
+      };
 
-    const accountId = await rt.getCurrentAccountId();
-    repo.getAccountById = original;
+      const accountId = await rt.getCurrentAccountId();
+      repo.getAccountById = original;
 
-    // 读不到状态 ≠ 没设密码。远程匿名访客绝不能拿到 acct_default。
-    expect(accountId).toBe("acct_unauthenticated");
-  });
+      // 读不到状态 ≠ 没设密码。远程匿名访客绝不能拿到 acct_default。
+      expect(accountId).toBe("acct_unauthenticated");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("远程 + 密码状态读失败 → 写操作必须抛错", async () => {
-    mockRemoteRequest();
-    const rt = await boot();
-    await rt.setSingleUserPassword("secret-123");
+  it(
+    "远程 + 密码状态读失败 → 写操作必须抛错",
+    async () => {
+      mockRemoteRequest();
+      const rt = await boot();
+      await rt.setSingleUserPassword("secret-123");
 
-    const repo = rt.getWorkflowRepository();
-    const original = repo.getAccountById.bind(repo);
-    repo.getAccountById = async () => {
-      throw new Error("DB down");
-    };
+      const repo = rt.getWorkflowRepository();
+      const original = repo.getAccountById.bind(repo);
+      repo.getAccountById = async () => {
+        throw new Error("DB down");
+      };
 
-    await expect(rt.requireAuthenticatedAccountId()).rejects.toThrow();
-    repo.getAccountById = original;
-  });
+      await expect(rt.requireAuthenticatedAccountId()).rejects.toThrow();
+      repo.getAccountById = original;
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("远程 + session 读失败 → 已知是远程，必须 fail-closed", async () => {
-    mockRemoteRequest("forged.cookie");
-    const rt = await boot();
-    await rt.setSingleUserPassword("secret-123");
+  it(
+    "远程 + session 读失败 → 已知是远程，必须 fail-closed",
+    async () => {
+      mockRemoteRequest("forged.cookie");
+      const rt = await boot();
+      await rt.setSingleUserPassword("secret-123");
 
-    const repo = rt.getWorkflowRepository();
-    const original = repo.getSession.bind(repo);
-    repo.getSession = async () => {
-      throw new Error("session store down");
-    };
+      const repo = rt.getWorkflowRepository();
+      const original = repo.getSession.bind(repo);
+      repo.getSession = async () => {
+        throw new Error("session store down");
+      };
 
-    const accountId = await rt.getCurrentAccountId();
-    repo.getSession = original;
+      const accountId = await rt.getCurrentAccountId();
+      repo.getSession = original;
 
-    expect(accountId).toBe("acct_unauthenticated");
-  });
+      expect(accountId).toBe("acct_unauthenticated");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("远程 + 属于别的账号的有效 session → 不得落进单用户路径", async () => {
-    // 同一个库可能有多用户时期遗留的账号（MEDIA_TRACK_MULTI_USER 是运行时开关，
-    // 可以再切回单用户）。那些账号的 session 不该在单用户模式下被认作站主。
-    const rt = await boot();
-    // 纯函数层面就应该钉死：只有 acct_default 才算数
-    expect(
-      rt.resolveSingleUserAccount({
-        hasPassword: true,
-        isRemote: true,
-        sessionAccountId: "acct_someone_else",
-      }),
-    ).toBe("acct_unauthenticated");
-    expect(
-      rt.resolveSingleUserAccount({
-        hasPassword: true,
-        isRemote: true,
-        sessionAccountId: "acct_default",
-      }),
-    ).toBe("acct_default");
-  });
+  it(
+    "远程 + 属于别的账号的有效 session → 不得落进单用户路径",
+    async () => {
+      // 同一个库可能有多用户时期遗留的账号（MEDIA_TRACK_MULTI_USER 是运行时开关，
+      // 可以再切回单用户）。那些账号的 session 不该在单用户模式下被认作站主。
+      const rt = await boot();
+      // 纯函数层面就应该钉死：只有 acct_default 才算数
+      expect(
+        rt.resolveSingleUserAccount({
+          hasPassword: true,
+          isRemote: true,
+          sessionAccountId: "acct_someone_else",
+        }),
+      ).toBe("acct_unauthenticated");
+      expect(
+        rt.resolveSingleUserAccount({
+          hasPassword: true,
+          isRemote: true,
+          sessionAccountId: "acct_default",
+        }),
+      ).toBe("acct_default");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("LAN + 密码状态读失败 → 保持开放（不因读不到就把本地用户锁死）", async () => {
-    vi.doMock("next/headers", () => ({
-      headers: async () => new Headers({ "user-agent": "curl" }), // 无 CF 头 = LAN
-      cookies: async () => ({ get: () => undefined }),
-    }));
-    const rt = await boot();
-    await rt.setSingleUserPassword("secret-123");
+  it(
+    "LAN + 密码状态读失败 → 保持开放（不因读不到就把本地用户锁死）",
+    async () => {
+      vi.doMock("next/headers", () => ({
+        headers: async () => new Headers({ "user-agent": "curl" }), // 无 CF 头 = LAN
+        cookies: async () => ({ get: () => undefined }),
+      }));
+      const rt = await boot();
+      await rt.setSingleUserPassword("secret-123");
 
-    const repo = rt.getWorkflowRepository();
-    const original = repo.getAccountById.bind(repo);
-    repo.getAccountById = async () => {
-      throw new Error("DB down");
-    };
+      const repo = rt.getWorkflowRepository();
+      const original = repo.getAccountById.bind(repo);
+      repo.getAccountById = async () => {
+        throw new Error("DB down");
+      };
 
-    const accountId = await rt.getCurrentAccountId();
-    repo.getAccountById = original;
+      const accountId = await rt.getCurrentAccountId();
+      repo.getAccountById = original;
 
-    // 局域网是可信网段：读不到状态时维持现状行为，不制造运维事故
-    expect(accountId).toBe("acct_default");
-  });
+      // 局域网是可信网段：读不到状态时维持现状行为，不制造运维事故
+      expect(accountId).toBe("acct_default");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("无请求上下文（in-process worker）→ 直通 acct_default", async () => {
-    const rt = await boot();
-    await rt.setSingleUserPassword("secret-123");
-    // 未 mock next/headers ⇒ 取不到请求作用域，等同后台任务
-    expect(await rt.getCurrentAccountId()).toBe("acct_default");
-  });
+  it(
+    "无请求上下文（in-process worker）→ 直通 acct_default",
+    async () => {
+      const rt = await boot();
+      await rt.setSingleUserPassword("secret-123");
+      // 未 mock next/headers ⇒ 取不到请求作用域，等同后台任务
+      expect(await rt.getCurrentAccountId()).toBe("acct_default");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 });
 
 /**
@@ -160,71 +191,95 @@ describe("single-user gate wiring (failure paths)", () => {
  * 局域网维持开放（既定的可信网段设计）。
  */
 describe("未设密码 + 远程 = 必须 fail-closed（移除 Access 后的公网洞）", () => {
-  it("纯函数：未设密码 + 远程 + 无 session → 哨兵，绝不是 acct_default", async () => {
-    const rt = await boot();
-    expect(
-      rt.resolveSingleUserAccount({ hasPassword: false, isRemote: true, sessionAccountId: null }),
-    ).toBe("acct_unauthenticated");
-  });
+  it(
+    "纯函数：未设密码 + 远程 + 无 session → 哨兵，绝不是 acct_default",
+    async () => {
+      const rt = await boot();
+      expect(
+        rt.resolveSingleUserAccount({ hasPassword: false, isRemote: true, sessionAccountId: null }),
+      ).toBe("acct_unauthenticated");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("纯函数：未设密码 + 局域网 → 保持开放（可信网段设计不变）", async () => {
-    const rt = await boot();
-    expect(
-      rt.resolveSingleUserAccount({ hasPassword: false, isRemote: false, sessionAccountId: null }),
-    ).toBe("acct_default");
-  });
+  it(
+    "纯函数：未设密码 + 局域网 → 保持开放（可信网段设计不变）",
+    async () => {
+      const rt = await boot();
+      expect(
+        rt.resolveSingleUserAccount({ hasPassword: false, isRemote: false, sessionAccountId: null }),
+      ).toBe("acct_default");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("纯函数：状态未知/已设密码的既有组合不受影响", async () => {
-    const rt = await boot();
-    // LAN 一律开放
-    expect(
-      rt.resolveSingleUserAccount({ hasPassword: true, isRemote: false, sessionAccountId: null }),
-    ).toBe("acct_default");
-    expect(
-      rt.resolveSingleUserAccount({ hasPassword: "unknown", isRemote: false, sessionAccountId: null }),
-    ).toBe("acct_default");
-    // 远程：只认 acct_default 自己的 session
-    expect(
-      rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: null }),
-    ).toBe("acct_unauthenticated");
-    expect(
-      rt.resolveSingleUserAccount({ hasPassword: "unknown", isRemote: true, sessionAccountId: null }),
-    ).toBe("acct_unauthenticated");
-    expect(
-      rt.resolveSingleUserAccount({ hasPassword: false, isRemote: true, sessionAccountId: "acct_default" }),
-    ).toBe("acct_default");
-    expect(
-      rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: "acct_default" }),
-    ).toBe("acct_default");
-  });
+  it(
+    "纯函数：状态未知/已设密码的既有组合不受影响",
+    async () => {
+      const rt = await boot();
+      // LAN 一律开放
+      expect(
+        rt.resolveSingleUserAccount({ hasPassword: true, isRemote: false, sessionAccountId: null }),
+      ).toBe("acct_default");
+      expect(
+        rt.resolveSingleUserAccount({ hasPassword: "unknown", isRemote: false, sessionAccountId: null }),
+      ).toBe("acct_default");
+      // 远程：只认 acct_default 自己的 session
+      expect(
+        rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: null }),
+      ).toBe("acct_unauthenticated");
+      expect(
+        rt.resolveSingleUserAccount({ hasPassword: "unknown", isRemote: true, sessionAccountId: null }),
+      ).toBe("acct_unauthenticated");
+      expect(
+        rt.resolveSingleUserAccount({ hasPassword: false, isRemote: true, sessionAccountId: "acct_default" }),
+      ).toBe("acct_default");
+      expect(
+        rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: "acct_default" }),
+      ).toBe("acct_default");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
   /**
    * 接线测试，不可省。`getCurrentAccountId()` 自己也有一份
    * `if (hasPassword === false) return DEFAULT_ACCOUNT_ID` 的短路，位置在调用
    * 纯函数**之前**。只修纯函数会让上面那些断言全绿、而真实请求路径依旧裸奔。
    */
-  it("接线：未设密码 + 远程匿名请求 → getCurrentAccountId 必须返回哨兵", async () => {
-    mockRemoteRequest(); // 有 cf-ray，无 session cookie
-    const rt = await boot();
-    // 刻意不设密码：全新实例的真实状态
-    expect(await rt.hasLoginPassword()).toBe(false);
-    expect(await rt.getCurrentAccountId()).toBe("acct_unauthenticated");
-  });
+  it(
+    "接线：未设密码 + 远程匿名请求 → getCurrentAccountId 必须返回哨兵",
+    async () => {
+      mockRemoteRequest(); // 有 cf-ray，无 session cookie
+      const rt = await boot();
+      // 刻意不设密码：全新实例的真实状态
+      expect(await rt.hasLoginPassword()).toBe(false);
+      expect(await rt.getCurrentAccountId()).toBe("acct_unauthenticated");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("接线：未设密码 + 远程匿名请求 → 写路径必须抛错", async () => {
-    mockRemoteRequest();
-    const rt = await boot();
-    expect(await rt.hasLoginPassword()).toBe(false);
-    await expect(rt.requireAuthenticatedAccountId()).rejects.toThrow();
-  });
+  it(
+    "接线：未设密码 + 远程匿名请求 → 写路径必须抛错",
+    async () => {
+      mockRemoteRequest();
+      const rt = await boot();
+      expect(await rt.hasLoginPassword()).toBe(false);
+      await expect(rt.requireAuthenticatedAccountId()).rejects.toThrow();
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("接线：未设密码 + 局域网 → 仍然直通 acct_default（不得回归）", async () => {
-    vi.doMock("next/headers", () => ({
-      headers: async () => new Headers({ "user-agent": "curl" }), // 无 CF 头 = LAN
-      cookies: async () => ({ get: () => undefined }),
-    }));
-    const rt = await boot();
-    expect(await rt.hasLoginPassword()).toBe(false);
-    expect(await rt.getCurrentAccountId()).toBe("acct_default");
-  });
+  it(
+    "接线：未设密码 + 局域网 → 仍然直通 acct_default（不得回归）",
+    async () => {
+      vi.doMock("next/headers", () => ({
+        headers: async () => new Headers({ "user-agent": "curl" }), // 无 CF 头 = LAN
+        cookies: async () => ({ get: () => undefined }),
+      }));
+      const rt = await boot();
+      expect(await rt.hasLoginPassword()).toBe(false);
+      expect(await rt.getCurrentAccountId()).toBe("acct_default");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 });

--- a/apps/web/lib/single-user-password.test.ts
+++ b/apps/web/lib/single-user-password.test.ts
@@ -23,92 +23,131 @@ afterEach(() => {
   vi.resetModules();
 });
 
+/**
+ * ⚠️ 超时：这些用例会调用 setSingleUserPassword / loginAccount，二者都跑
+ * memory-hard 的 scrypt（单次 ~50-80ms）。全量并行下与其它测试争抢 CPU 会远超
+ * vitest 默认的 5s。显式放宽到 30s——这不是「慢测试」，是密码学原语的固有成本。
+ */
+const CRYPTO_TIMEOUT_MS = 30_000;
+
 describe("single-user password gate", () => {
-  it("未设密码时 hasLoginPassword=false", async () => {
-    const rt = await boot();
-    expect(await rt.hasLoginPassword()).toBe(false);
-  });
+  it(
+    "未设密码时 hasLoginPassword=false",
+    async () => {
+      const rt = await boot();
+      expect(await rt.hasLoginPassword()).toBe(false);
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("resolveSingleUserAccount：LAN 一律开放；远程一律需 session（与密码状态无关）", async () => {
-    const rt = await boot();
-    // 纯函数，覆盖全部内外/有无 session 组合（这是本 plan 的安全核心判定）
-    expect(rt.resolveSingleUserAccount({ hasPassword: false, isRemote: false, sessionAccountId: null })).toBe("acct_default");
-    // 未设密码 + 远程：曾经返回 acct_default —— 匿名公网访客直接拿到站主身份。
-    // Cloudflare Access 移除后这是活的公网洞，已收紧为哨兵。
-    expect(rt.resolveSingleUserAccount({ hasPassword: false, isRemote: true, sessionAccountId: null })).toBe("acct_unauthenticated");
-    expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: false, sessionAccountId: null })).toBe("acct_default"); // LAN 免登录
-    expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: null })).toBe("acct_unauthenticated"); // 远程无 session → 哨兵
-    expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: "acct_default" })).toBe("acct_default"); // 远程已登录 → 放行
-  });
+  it(
+    "resolveSingleUserAccount：LAN 一律开放；远程一律需 session（与密码状态无关）",
+    async () => {
+      const rt = await boot();
+      // 纯函数，覆盖全部内外/有无 session 组合（这是本 plan 的安全核心判定）
+      expect(rt.resolveSingleUserAccount({ hasPassword: false, isRemote: false, sessionAccountId: null })).toBe("acct_default");
+      // 未设密码 + 远程：曾经返回 acct_default —— 匿名公网访客直接拿到站主身份。
+      // Cloudflare Access 移除后这是活的公网洞，已收紧为哨兵。
+      expect(rt.resolveSingleUserAccount({ hasPassword: false, isRemote: true, sessionAccountId: null })).toBe("acct_unauthenticated");
+      expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: false, sessionAccountId: null })).toBe("acct_default"); // LAN 免登录
+      expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: null })).toBe("acct_unauthenticated"); // 远程无 session → 哨兵
+      expect(rt.resolveSingleUserAccount({ hasPassword: true, isRemote: true, sessionAccountId: "acct_default" })).toBe("acct_default"); // 远程已登录 → 放行
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("isRemoteRequest：任一 CF 头即远程（不只靠 cf-connecting-ip——它可被 zone 配置删除）", async () => {
-    const rt = await boot();
-    expect(rt.isRemoteRequest(new Headers({ "cf-ray": "8f3-abc" }))).toBe(true);
-    expect(rt.isRemoteRequest(new Headers({ "cdn-loop": "cloudflare" }))).toBe(true);
-    expect(rt.isRemoteRequest(new Headers({ "cf-connecting-ip": "1.2.3.4" }))).toBe(true);
-    expect(rt.isRemoteRequest(new Headers({ "user-agent": "curl" }))).toBe(false); // LAN 无 CF 头
-    expect(rt.isRemoteRequest(new Headers())).toBe(false);
-  });
+  it(
+    "isRemoteRequest：任一 CF 头即远程（不只靠 cf-connecting-ip——它可被 zone 配置删除）",
+    async () => {
+      const rt = await boot();
+      expect(rt.isRemoteRequest(new Headers({ "cf-ray": "8f3-abc" }))).toBe(true);
+      expect(rt.isRemoteRequest(new Headers({ "cdn-loop": "cloudflare" }))).toBe(true);
+      expect(rt.isRemoteRequest(new Headers({ "cf-connecting-ip": "1.2.3.4" }))).toBe(true);
+      expect(rt.isRemoteRequest(new Headers({ "user-agent": "curl" }))).toBe(false); // LAN 无 CF 头
+      expect(rt.isRemoteRequest(new Headers())).toBe(false);
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("单用户设密码后可用密码登录 acct_default（用户名任意/空均视为 default）", async () => {
-    const rt = await boot();
-    await rt.setSingleUserPassword("secret-123");
-    const bad = await rt.loginAccount("", "nope-nope");
-    expect(bad.ok).toBe(false);
-    const ok = await rt.loginAccount("", "secret-123");
-    expect(ok.ok).toBe(true);
-    if (ok.ok) expect(ok.accountId).toBe("acct_default");
-  });
+  it(
+    "单用户设密码后可用密码登录 acct_default（用户名任意/空均视为 default）",
+    async () => {
+      const rt = await boot();
+      await rt.setSingleUserPassword("secret-123");
+      const bad = await rt.loginAccount("", "nope-nope");
+      expect(bad.ok).toBe(false);
+      const ok = await rt.loginAccount("", "secret-123");
+      expect(ok.ok).toBe(true);
+      if (ok.ok) expect(ok.accountId).toBe("acct_default");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("单用户未设密码时不能登录（没有密码可验证，不该发出 session）", async () => {
-    const rt = await boot();
-    const r = await rt.loginAccount("", "anything");
-    expect(r.ok).toBe(false);
-  });
-
-  it("单用户登录同样受限流保护（连续失败后锁定）", async () => {
-    const rt = await boot();
-    const { _resetLoginThrottleForTest } = await import("./login-throttle");
-    _resetLoginThrottleForTest();
-    await rt.setSingleUserPassword("secret-123");
-    for (let i = 0; i < 5; i++) {
-      const r = await rt.loginAccount("", "wrong-password");
+  it(
+    "单用户未设密码时不能登录（没有密码可验证，不该发出 session）",
+    async () => {
+      const rt = await boot();
+      const r = await rt.loginAccount("", "anything");
       expect(r.ok).toBe(false);
-    }
-    const locked = await rt.loginAccount("", "secret-123"); // 正确密码也应被挡
-    expect(locked.ok).toBe(false);
-    if (!locked.ok) expect(locked.error).toContain("尝试过于频繁");
-  });
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-  it("单用户下换用户名不能绕过限流（用户名本就被忽略）", async () => {
-    // 曾经的漏洞：限流键含用户名，而单用户登录忽略用户名 ⇒ 每次换个名字
-    // 就换一个桶，限流形同虚设，且每次仍要付一次 memory-hard scrypt。
-    const rt = await boot();
-    const { _resetLoginThrottleForTest, buildThrottleKey } = await import("./login-throttle");
-    _resetLoginThrottleForTest();
-    await rt.setSingleUserPassword("secret-123");
-    const headers = new Headers({ "cf-connecting-ip": "9.9.9.9" });
+  it(
+    "单用户登录同样受限流保护（连续失败后锁定）",
+    async () => {
+      const rt = await boot();
+      const { _resetLoginThrottleForTest } = await import("./login-throttle");
+      _resetLoginThrottleForTest();
+      await rt.setSingleUserPassword("secret-123");
+      for (let i = 0; i < 5; i++) {
+        const r = await rt.loginAccount("", "wrong-password");
+        expect(r.ok).toBe(false);
+      }
+      const locked = await rt.loginAccount("", "secret-123"); // 正确密码也应被挡
+      expect(locked.ok).toBe(false);
+      if (!locked.ok) expect(locked.error).toContain("尝试过于频繁");
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 
-    let refusedByThrottle = 0;
-    for (let i = 0; i < 8; i++) {
-      // 模拟 route 的行为：单用户模式下身份为空串
-      const r = await rt.loginAccount(`bogus${i}`, "wrong", buildThrottleKey(headers, ""));
-      if (!r.ok && r.error.includes("尝试过于频繁")) refusedByThrottle++;
-    }
-    // 5 次失败即锁 ⇒ 后续几次必须被拦
-    expect(refusedByThrottle).toBeGreaterThan(0);
-  });
+  it(
+    "单用户下换用户名不能绕过限流（用户名本就被忽略）",
+    async () => {
+      // 曾经的漏洞：限流键含用户名，而单用户登录忽略用户名 ⇒ 每次换个名字
+      // 就换一个桶，限流形同虚设，且每次仍要付一次 memory-hard scrypt。
+      const rt = await boot();
+      const { _resetLoginThrottleForTest, buildThrottleKey } = await import("./login-throttle");
+      _resetLoginThrottleForTest();
+      await rt.setSingleUserPassword("secret-123");
+      const headers = new Headers({ "cf-connecting-ip": "9.9.9.9" });
 
-  it("库级调用（无显式 throttleKey）在单用户下也共用同一个桶", async () => {
-    const rt = await boot();
-    const { _resetLoginThrottleForTest } = await import("./login-throttle");
-    _resetLoginThrottleForTest();
-    await rt.setSingleUserPassword("secret-123");
-    let refused = 0;
-    for (let i = 0; i < 8; i++) {
-      const r = await rt.loginAccount(`name${i}`, "wrong"); // 不传 throttleKey
-      if (!r.ok && r.error.includes("尝试过于频繁")) refused++;
-    }
-    expect(refused).toBeGreaterThan(0);
-  });
+      let refusedByThrottle = 0;
+      for (let i = 0; i < 8; i++) {
+        // 模拟 route 的行为：单用户模式下身份为空串
+        const r = await rt.loginAccount(`bogus${i}`, "wrong", buildThrottleKey(headers, ""));
+        if (!r.ok && r.error.includes("尝试过于频繁")) refusedByThrottle++;
+      }
+      // 5 次失败即锁 ⇒ 后续几次必须被拦
+      expect(refusedByThrottle).toBeGreaterThan(0);
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
+
+  it(
+    "库级调用（无显式 throttleKey）在单用户下也共用同一个桶",
+    async () => {
+      const rt = await boot();
+      const { _resetLoginThrottleForTest } = await import("./login-throttle");
+      _resetLoginThrottleForTest();
+      await rt.setSingleUserPassword("secret-123");
+      let refused = 0;
+      for (let i = 0; i < 8; i++) {
+        const r = await rt.loginAccount(`name${i}`, "wrong"); // 不传 throttleKey
+        if (!r.ok && r.error.includes("尝试过于频繁")) refused++;
+      }
+      expect(refused).toBeGreaterThan(0);
+    },
+    CRYPTO_TIMEOUT_MS,
+  );
 });


### PR DESCRIPTION
免费 beta 闭环的最后一块（Plan 4）。设置页新增「远程访问」tab：未开通时是内测报名入口，已开通时显示状态并在未设登录密码时给出醒目警告。

## 与 Plan 3 的接口不匹配——已按实际契约实现，未按 plan 原文

plan 里的客户端假设 `POST /api/instance/status` 收 body `{token}`、返回 `{hostname, status, connections}`。**Plan 3（#175）实际交付的是** `Authorization: Bearer` 头鉴权、成功返回 **204 无 body**——有意为之，即便持有效 token 也不泄露任何端点元数据。

照 plan 原样写会让状态卡永远拿不到数据、全部降级。**决定不给 worker 加返回元数据的端点**（那会重新引入 Plan 3 刻意关掉的信息泄露面），改为：

- 状态机变为 `not_provisioned`（无 `TUNNEL_TOKEN`）｜`active`（心跳返回 204）｜`active_degraded`（心跳失败）
- **丢掉 `connections`**——隧道连接数是运维细节，用户不需要，为它开一个端点不划算
- **hostname 本地取，不问 worker**。实测确认：实例目前**没有任何本地来源**知道自己的公网域名（`.env.example`、`docker-compose.yml`、`next.config.ts`、各 `*_SETTING_KEY`、worker 的 agent-prompt `.env` writer 全查过；实例只拿到 `TUNNEL_TOKEN` 和 `TUNNEL_TRANSPORT_PROTOCOL`）。唯一近似的 `MEDIA_TRACK_ALLOWED_ORIGINS` 是构建期 CSRF 白名单、可多值，用它会显示错误的域名。所以 `hostname: string | null`，active 卡片不给链接，原因写在代码注释里，参数已预留给未来的本地来源。
- 心跳照发——它顺带更新 worker 侧 `last_seen_at`，当存活探测用。

## 子代理纠正了我 brief 里的一处关键错误

我告诉它「非 admin 隐藏依赖既有的 MutationObserver 机制，返回 `null` 即可」。**这是错的**——那套机制硬编码给账号 tab（单个 `accountRef`、`accountVisible` 布尔、`tab.id !== "account"` 字面量过滤）。只返回 `null` 什么也不会发生，**远程 tab 会对非 admin 永久可见**。已泛化为 `OBSERVED_SETTINGS_TABS` 列表 + ref map + 逐 tab 可见性记录。

顺手加固两处：
- `resolveSettingsTab` 第二参改为记录，但仍兼容旧的裸布尔——且该布尔**只表示「账号 tab 可见」**。否则 `?tab=remote` 能搭账号 tab 的可见性便车绕过 fail-closed 检查。已有测试钉死。
- 逐 tab 的 `check()` 改用函数式 `setState`，多个 observer 独立触发时不会因闭包过期互相覆盖。

另一处：waitlist 路径是 **`/waitlist`**，不是 plan 片段里写的 `/api/waitlist`。

## 安全细节

- `hasLoginPassword()` 现在是**三态**（`true | false | "unknown"`）。`"unknown"`（DB 读失败）**单独一个分支**：当成 `false` 会凭空捏造「你没设密码」的警告，当成 `true` 会吞掉真警告。现在 `false` → `role="alert"` 醒目警告；`"unknown"` → 「暂时无法确认」提示。
- section 返回**裸 `null`**（不是 `<></>`），Suspense fallback 也是 `null`——任何流式子元素都会让 observer 在「还不知道访客是不是 owner」之前就把 tab 判成可见。
- 心跳严格判 `204` 而非 `res.ok`：反向代理返回 200 登录页的情形必须读作 degraded。
- 错误一律吞掉、绝不进状态对象——错误串里可能含 token。测试里专门抛一个含 token 的错误，再断言 `JSON.stringify(state)` 不含它。
- `SCOUT_CONNECT_URL` 在函数内读取而非模块顶层常量——`cacheComponents` 下顶层常量会被构建期烘死。

## Verification

```
apps/web            426 passed (47 files)
全量              2069 passed（4 个失败是既存 flaky 四件套 guangya/pan123/quark/tianyi，单独跑通过）
tsc                 EXIT=0
build:web           EXIT=0（/settings 仍是 ◐ Partial Prerender）
```

顺带修：两个 single-user 测试套件在全量并行下因 scrypt 抢 CPU 超过默认 5s（6 次全是超时而非断言失败），按 #173 同款做法给了显式 30s 预算。现已不再出现在失败列表。

反向验证：把 `remote` 从 `OBSERVED_SETTINGS_TABS` 移除，两个测试立刻变红（证明非 admin 可见性真的被钉住）。

## ⚠️ 部署前置（本 PR 不含，属 ops 配置）

`docker-compose.yml` 目前只把 `TUNNEL_TOKEN` 传给 `cloudflared` 服务，`web` 服务看不到它——已开通的实例也会渲染成 `not_provisioned`。需要在 compose 里给 `web` 也传这个变量。