### PR TITLE
fix(compose): pass TUNNEL_TOKEN to web so the remote-access tab works

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,11 @@ services:
       # queue (获取 stuck "排队", category dirs never provisioned). Must be vercel-ai.
       MEDIA_TRACK_AGENT_ADAPTER: vercel-ai
       MEDIA_TRACK_DEMO_SEED: "0"
+      # 隧道 token 也给 web:设置页「远程访问」用它作实例身份，向 Scout Connect
+      # 报到查状态(仅发 Bearer 头做存活探针,不回传任何端点信息)。不传的话已开通
+      # 的实例会把自己显示成「未开通」。cloudflared 那边同样需要它,两处读同一个
+      # .env 变量。未设时为空 → tab 显示未开通,这正是自建/未开通实例的正确状态。
+      TUNNEL_TOKEN: ${TUNNEL_TOKEN:-}
       # 可观测性:完整有序的 agent 逐步轨迹始终落 agent_steps 表(psql 即可复盘)。
       # 额外把每一步打到 stdout(docker compose logs web)是 OPT-IN —— 它会把工具参数
       # (搜索关键词 / 候选 id / 文件 id)写进容器日志与日志聚合器,默认不开。需要排障时
@@ -99,7 +104,9 @@ services:
   #      NOT localhost), and copy the connector token.
   #   2. Put TUNNEL_TOKEN=<token> in .env  (compose reads .env for interpolation).
   #   3. docker compose --profile tunnel up -d
-  #   4. ⚠️ Put Cloudflare Access in front of the hostname — this app has no login.
+  #   4. ⚠️ Gate the hostname: set an access password in 设置 → 账号 (remote requests
+  #      then require login while the LAN stays open), or put Cloudflare Access in front.
+  #      See docs/deploy.md → 「必须有门禁」. Do NOT expose it with neither.
   # See docs/deploy.md → 「方式二:Cloudflare Tunnel」 for the full walkthrough.
   cloudflared:
     image: cloudflare/cloudflared:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,8 @@ services:
   #   3. docker compose --profile tunnel up -d
   #   4. ⚠️ Gate the hostname: set an access password in 设置 → 账号 (remote requests
   #      then require login while the LAN stays open), or put Cloudflare Access in front.
-  #      See docs/deploy.md → 「必须有门禁」. Do NOT expose it with neither.
+  #      See docs/deploy.md → 「必须有门禁」. Never expose the hostname unless at
+  #      least one of those two gates is in place.
   # See docs/deploy.md → 「方式二:Cloudflare Tunnel」 for the full walkthrough.
   cloudflared:
     image: cloudflare/cloudflared:latest


### PR DESCRIPTION
#176 合并后暴露的部署前置：设置页「远程访问」tab 用 `TUNNEL_TOKEN` 作实例身份向 Scout Connect 报到，但 compose **只把它传给了 `cloudflared`**，`web` 服务看不到——于是**已开通的实例会把自己显示成「未开通」**，整条链路在真机上不通。

## 变更

1. `web` 服务也读同一个 `.env` 变量。未设时插值为空串，这正是自建/未开通实例的正确状态（tab 显示未开通 + 报名入口）。
2. 更正一条已过时的注释——它让运维「必须在前面放 Cloudflare Access，因为这个应用没有登录」。**现在有了**（#173 限流 + #174 密码门：远程需登录、局域网免登录），且 Access 不再是唯一选择。改为指向 deploy.md 里同时记录两种方案的那一节，并明确「两个都不做就别暴露」。

安全说明：这个 token 只用于**存活探针**——`POST /api/instance/status` 发 Bearer 头，worker 返回 204 无 body，不回传任何端点信息（这是 #175 有意的设计）。它不是新的凭据面：cloudflared 本来就持有同一个 token，而且它就是隧道本身的凭据。

## 验证

用 `docker compose config` 真跑插值解析，不靠眼看：

```
默认 profile：      web → TUNNEL_TOKEN: test-tok-123     ✅
--profile tunnel：  web + cloudflared 两处都拿到          ✅
未设该变量：        web → TUNNEL_TOKEN: ""（不报错）      ✅
```