### PR TITLE
hotfix(settings): hide the waitlist entry until the backend is actually live

### DIFF
--- a/apps/web/components/settings/remote-access-section.tsx
+++ b/apps/web/components/settings/remote-access-section.tsx
@@ -5,6 +5,7 @@ import {
   instanceTunnelToken,
   resolveRemoteAccessState,
   scoutConnectBaseUrl,
+  isWaitlistOpen,
   accountPasswordHref,
 } from "../../lib/remote-access";
 import { RemoteAccessWaitlistForm } from "./remote-access-waitlist";
@@ -36,6 +37,11 @@ export async function RemoteAccessSection({
   const state = await resolveRemoteAccessState({ token: instanceTunnelToken() });
 
   if (state.kind === "not_provisioned") {
+    // 后端未就绪时**整个 tab 不渲染**（返回 null → tab 自动隐藏，与非站主同款机制）。
+    // 容器用户 git pull 就能吃到 main，所以「代码已合并」不等于「功能可用」：
+    // 生产 worker 上 POST /waitlist 目前返回 404，此时给出报名框只会让人白填一次。
+    // 开启条件见 lib/remote-access.ts 的 isWaitlistOpen()。
+    if (!isWaitlistOpen()) return null;
     return (
       <section className="panel" style={{ maxWidth: 720, marginTop: 24 }}>
         <div className="panel-header">

--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -4,6 +4,7 @@ import {
   resolveRemoteAccessState,
   scoutConnectBaseUrl,
   accountPasswordHref,
+  isWaitlistOpen,
   type RemoteAccessState,
 } from "./remote-access";
 
@@ -218,6 +219,21 @@ describe("accountPasswordHref（保留 ?w 工作区上下文）", () => {
     const href = accountPasswordHref("cs_a b&c");
     expect(href).toContain("w=cs_a+b%26c");
     expect(href.endsWith("#password")).toBe(true);
+  });
+});
+
+describe("isWaitlistOpen（默认关闭的发布开关）", () => {
+  it("未设 / 空 / 非 \"1\" → 关闭；只有 \"1\" 才开", () => {
+    delete process.env.MEDIA_TRACK_WAITLIST_OPEN;
+    expect(isWaitlistOpen()).toBe(false);
+    for (const v of ["", "  ", "0", "true", "yes", "on"]) {
+      process.env.MEDIA_TRACK_WAITLIST_OPEN = v;
+      expect(isWaitlistOpen()).toBe(false);
+    }
+    process.env.MEDIA_TRACK_WAITLIST_OPEN = "1";
+    expect(isWaitlistOpen()).toBe(true);
+    process.env.MEDIA_TRACK_WAITLIST_OPEN = "  1  ";
+    expect(isWaitlistOpen()).toBe(true);
   });
 });
 

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -134,3 +134,25 @@ export function accountPasswordHref(w?: string): string {
   if (w) params.set("w", w);
   return `/settings?${params.toString()}#password`;
 }
+
+/**
+ * 内测报名入口是否开放。**默认关闭。**
+ *
+ * 为什么要有这个开关：容器用户是 `git clone` + `docker compose up -d --build`
+ * 从源码构建，**没有 release 门槛——`git pull` 就吃到 main 上的一切**。
+ * 于是「代码合进 main」和「后端真的能用」之间存在一个窗口，窗口里用户会看到
+ * 一个点了必失败的报名框。
+ *
+ * 后端就绪的判据有两条，缺一不可：
+ *   1. Scout Connect worker 已部署到含 `POST /waitlist` 的版本（当前生产是
+ *      7-24 的版本，该端点返回 404）；
+ *   2. D1 迁移 0001 已执行（否则 waitlist 表不存在，插入必然失败），且
+ *      **admin 侧有读取名单的入口**——收得进却看不见等于没收。
+ *
+ * 两条都满足后，在实例 `.env` 里设 `MEDIA_TRACK_WAITLIST_OPEN=1` 开启。
+ * 不做成「探测端点可用性就自动开」是故意的：那会把一个产品发布决策
+ * 交给一次网络请求的结果，端点抖一下就自己开了。
+ */
+export function isWaitlistOpen(): boolean {
+  return process.env.MEDIA_TRACK_WAITLIST_OPEN?.trim() === "1";
+}


### PR DESCRIPTION
## 止血

容器用户走 `git clone` + `docker compose up -d --build`，**这条路径没有 release 门槛——`git pull` 就直接吃到 main**。所以 #176 一合并，设置页就出现了一个报名框，而它背后的后端并不存在：

```
POST https://mediaryconnect.app/waitlist → HTTP 404 {"error":"not found"}
```

生产 worker 最后部署于 **7-24**，`/waitlist` 是今天随 #175 合入的、**从未部署**。D1 迁移 0001 也没跑，waitlist 表不存在。而且就算这两步都做了，`listWaitlist()` 仍是**死代码**——没有 admin 路由、控制台没有区块，收上来的邮箱**看不到**。

对已经 `git pull` 的站主，实际后果是：看到邀请框 → 填 → 被告知失败。没有邮箱被捕获、也没有丢失，但这是设置页上的一个空头承诺。

## 做法

用 `MEDIA_TRACK_WAITLIST_OPEN` 门禁，**默认关闭**。关闭时 section 返回 `null`，tab 通过与「非站主」相同的机制自动隐藏——**不留任何死入口**，而不是留一个点了会失败的按钮。

不做成「探测端点可用就自动开」是刻意的：那等于把产品发布决策交给一次网络请求的结果，端点抖一下就自己开了。

开启需要同时满足三条：worker 已部署含 `/waitlist` 的版本、迁移 0001 已执行、admin 侧有读取名单的入口。

## 这是我的流程失误

Plan 3 是五个 plan 里**唯一一个我跳过了双审查子代理**的。plan 原文里明写了 `GET /api/admin/waitlist`，我漏实现，也没在 PR 描述和交接文档里标出这个缺口，还在 #176 的描述里把「免费 beta 闭环完成」当成了结论——而那个闭环实际是断的：收得进，看不见。

## Verification

```
apps/web  434 passed
tsc       EXIT=0
build:web EXIT=0
```

反向验证：把默认值改成 `true`，开关测试立刻变红。