### PR TITLE
feat(connect): admin waitlist visibility + seat cap + dead-code surface guard

### DIFF
--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -39,6 +39,7 @@ admin ──► mediaryconnect.app (this worker)
 | 201 | `{ id, position }` — new signup |
 | 200 | `{ already_exists: true, id, position }` — email already queued |
 | 400 | `{ error }` — `email required` / `invalid email` (or `invalid json` / `invalid body` from the shared body reader) |
+| 409 | `{ error: "本批内测席位已满" }` — founding batch is capped at 100 seats; **new** emails only, emails already queued keep their 200 position lookup |
 | 413 | `{ error: "body too large" }` |
 
 `position` is 1-based within the batch and is returned on **both** success

--- a/workers/scout-connect/src/db-surface.test.ts
+++ b/workers/scout-connect/src/db-surface.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+/**
+ * Dead-code guard: every method on the ConnectDb interface must have at least
+ * one call site in NON-TEST source under src/.
+ *
+ * Why this exists: `listWaitlist()` shipped in PR #175 fully implemented and
+ * tested, but with zero production call sites — there was no admin read path,
+ * and the gap was discovered by a human audit, not by CI. "Implemented but
+ * never wired" must fail the build, not wait for a user to notice.
+ *
+ * Method names are scraped from the interface declaration in db.ts itself, so
+ * adding a method to ConnectDb automatically brings it under this guard —
+ * there is no hardcoded list to keep in sync. db.ts is excluded from the
+ * call-site scan because it holds the DEFINITIONS (interface + two
+ * implementations), which are not call sites; the `.<name>(` shape it never
+ * contains.
+ */
+
+const SRC_DIR = fileURLToPath(new URL(".", import.meta.url));
+
+/** All .ts files under src/ (recursively), excluding test files. */
+function nonTestSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...nonTestSourceFiles(full));
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Method names declared on `export interface ConnectDb` in db.ts. */
+function connectDbMethodNames(): string[] {
+  const dbSource = readFileSync(path.join(SRC_DIR, "db.ts"), "utf8");
+  const iface = dbSource.match(/export interface ConnectDb \{([\s\S]*?)\n\}/);
+  if (iface === null || iface[1] === undefined) {
+    throw new Error("ConnectDb interface not found in db.ts — guard cannot run");
+  }
+  // Members are declared one per line at exactly two-space indent:
+  //   methodName(args): Promise<...>;
+  // JSDoc/comment lines cannot match (they start with `/` or `*`).
+  return [...iface[1].matchAll(/^ {2}([a-zA-Z]+)\(/gm)]
+    .map((m) => m[1])
+    .filter((n): n is string => n !== undefined);
+}
+
+describe("ConnectDb surface guard", () => {
+  it("scrapes a sane method list from the interface (guard is not vacuous)", () => {
+    const names = connectDbMethodNames();
+    // A broken regex that scrapes 0 methods would make the call-site
+    // assertion below pass on an empty set — pin that the scrape works.
+    expect(names.length).toBeGreaterThan(15);
+    expect(names).toContain("insertInvite");
+    expect(names).toContain("listWaitlist");
+  });
+
+  it("every ConnectDb method has at least one call site in non-test source", () => {
+    const names = connectDbMethodNames();
+    const nonTestSource = nonTestSourceFiles(SRC_DIR)
+      // db.ts holds the interface + the D1/memory implementations — the
+      // definition sites, never call sites.
+      .filter((f) => path.basename(f) !== "db.ts")
+      .map((f) => readFileSync(f, "utf8"))
+      .join("\n");
+
+    const dead = names.filter((name) => !nonTestSource.includes(`.${name}(`));
+
+    expect(
+      dead,
+      `ConnectDb methods with no production call site (implemented but never wired): ${dead.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/workers/scout-connect/src/db-surface.test.ts
+++ b/workers/scout-connect/src/db-surface.test.ts
@@ -46,7 +46,10 @@ function connectDbMethodNames(): string[] {
   // Members are declared one per line at exactly two-space indent:
   //   methodName(args): Promise<...>;
   // JSDoc/comment lines cannot match (they start with `/` or `*`).
-  return [...iface[1].matchAll(/^ {2}([a-zA-Z]+)\(/gm)]
+  // Character class must include digits: getEndpointByTokenSha256 contains
+  // "256" and a letters-only class would silently exclude it from the guard —
+  // the exact kind of gap this file exists to catch. (Copilot PR #179.)
+  return [...iface[1].matchAll(/^ {2}([a-zA-Z0-9]+)\(/gm)]
     .map((m) => m[1])
     .filter((n): n is string => n !== undefined);
 }
@@ -59,6 +62,8 @@ describe("ConnectDb surface guard", () => {
     expect(names.length).toBeGreaterThan(15);
     expect(names).toContain("insertInvite");
     expect(names).toContain("listWaitlist");
+    // 含数字的方法名也在守护范围内——letters-only 的正则会把它漏掉
+    expect(names).toContain("getEndpointByTokenSha256");
   });
 
   it("every ConnectDb method has at least one call site in non-test source", () => {

--- a/workers/scout-connect/src/html/admin-page.ts
+++ b/workers/scout-connect/src/html/admin-page.ts
@@ -51,6 +51,13 @@ h1{font-size:1.3rem}h2{font-size:1.05rem;margin-top:2rem}
 <tbody id="endpoints"></tbody>
 </table>
 
+<h2>内测报名列表</h2>
+<p><button id="copy-waitlist">复制全部邮箱</button>（每行一个,便于在自己邮箱里批量粘贴发送邀请链接）</p>
+<table>
+<thead><tr><th>名次</th><th>邮箱</th><th>状态</th><th>报名时间</th></tr></thead>
+<tbody id="waitlist"></tbody>
+</table>
+
 <script type="module">
 const $=(id)=>document.getElementById(id);
 const esc=(s)=>String(s).replace(/[&<>"']/g,(c)=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
@@ -87,9 +94,11 @@ function showProvision(r){
   $("p-copy-url").onclick=()=>copyText(lastProvision.inviteUrl);
 }
 
+let lastWaitlist=[];
 async function refresh(){
-  const data=await Promise.all([api("/api/admin/invites"),api("/api/admin/endpoints")]);
+  const data=await Promise.all([api("/api/admin/invites"),api("/api/admin/endpoints"),api("/api/admin/waitlist")]);
   const invites=data[0].invites,endpoints=data[1].endpoints;
+  lastWaitlist=data[2].waitlist;
   $("invites").innerHTML=invites.map((i)=>{
     const url=location.origin+"/i/"+i.code;
     const slugCell=i.status==="pending"
@@ -118,7 +127,16 @@ async function refresh(){
       await refresh();
     });
   }
+  $("waitlist").innerHTML=lastWaitlist.length===0
+    ?'<tr><td colspan="4">暂无报名</td></tr>'
+    :lastWaitlist.map((w,i)=>{
+      return '<tr><td>'+(i+1)+'</td><td>'+esc(w.email)+'</td><td>'+esc(w.status)+'</td><td>'+esc(w.created_at)+'</td></tr>';
+    }).join("");
 }
+$("copy-waitlist").onclick=guard(async()=>{
+  if(lastWaitlist.length===0){msg("暂无报名可复制","err");return;}
+  await copyText(lastWaitlist.map((w)=>w.email).join("\n"));
+});
 $("refresh").onclick=guard(refresh);
 $("create").onsubmit=guard(async(ev)=>{
   ev.preventDefault();

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -677,6 +677,24 @@ describe("GET /api/admin/waitlist", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ waitlist: [] });
   });
+
+  it("GET /admin console page renders the waitlist section wired to the route", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/admin`), deps);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Section with the four required columns.
+    expect(html).toContain("内测报名列表");
+    expect(html).toContain("名次");
+    expect(html).toContain("邮箱");
+    expect(html).toContain("报名时间");
+    // The copy-all-emails export (the project has no email-sending capability).
+    expect(html).toContain("复制全部邮箱");
+    // Actually wired to fetch the route, like the other sections.
+    expect(html).toContain("/api/admin/waitlist");
+    // Empty-state copy.
+    expect(html).toContain("暂无报名");
+  });
 });
 
 describe("POST /waitlist hardening", () => {

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -619,6 +619,66 @@ describe("handleRequest", () => {
   });
 });
 
+describe("GET /api/admin/waitlist", () => {
+  it("→ 401 without admin token", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/api/admin/waitlist`), deps);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+
+  it("→ 200 with rows in queue order ((created_at, id) ascending) for a seeded list", async () => {
+    const { db, deps } = setup();
+    // Insert OUT of order to prove the response is sorted by the queue
+    // composite (created_at, id), not insertion order.
+    await db.insertWaitlist({
+      id: "wl_c",
+      email: "c@example.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-24T10:00:02.000Z",
+    });
+    await db.insertWaitlist({
+      id: "wl_a",
+      email: "a@example.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-24T10:00:00.000Z",
+    });
+    await db.insertWaitlist({
+      id: "wl_b",
+      email: "b@example.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-24T10:00:01.000Z",
+    });
+
+    const res = await handleRequest(adminGet("/api/admin/waitlist"), deps);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      waitlist: Array<{ id: string; email: string; status: string; created_at: string }>;
+    };
+    expect(body.waitlist.map((r) => r.email)).toEqual([
+      "a@example.com",
+      "b@example.com",
+      "c@example.com",
+    ]);
+    expect(body.waitlist[0]).toMatchObject({
+      id: "wl_a",
+      status: "pending",
+      created_at: "2026-07-24T10:00:00.000Z",
+    });
+  });
+
+  it("→ 200 { waitlist: [] } when the batch is empty", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(adminGet("/api/admin/waitlist"), deps);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ waitlist: [] });
+  });
+});
+
 describe("POST /waitlist hardening", () => {
   function waitlistPost(email: unknown): Request {
     return new Request(`${BASE}/waitlist`, {

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -697,6 +697,54 @@ describe("GET /api/admin/waitlist", () => {
   });
 });
 
+describe("GET /api/admin/audits", () => {
+  it("→ 401 without admin token", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/api/admin/audits`), deps);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+
+  it("→ 200 with audit rows, newest first", async () => {
+    const { db, deps } = setup();
+    // Insert OUT of order to prove the response is sorted (at DESC, id DESC).
+    await db.insertAudit({
+      id: "aud_old",
+      at: "2026-07-24T09:00:00.000Z",
+      actor: "admin",
+      action: "invite.create",
+      invite_id: "inv_1",
+      endpoint_id: null,
+      detail_json: JSON.stringify({ email: "a@example.com" }),
+    });
+    await db.insertAudit({
+      id: "aud_new",
+      at: "2026-07-24T11:00:00.000Z",
+      actor: "admin",
+      action: "invite.create",
+      invite_id: "inv_2",
+      endpoint_id: null,
+      detail_json: JSON.stringify({ email: "b@example.com" }),
+    });
+
+    const res = await handleRequest(adminGet("/api/admin/audits"), deps);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      audits: Array<{ id: string; action: string; at: string }>;
+    };
+    expect(body.audits.map((r) => r.id)).toEqual(["aud_new", "aud_old"]);
+    expect(body.audits[0]).toMatchObject({ action: "invite.create", at: "2026-07-24T11:00:00.000Z" });
+  });
+
+  it("→ 200 { audits: [] } when nothing has happened yet", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(adminGet("/api/admin/audits"), deps);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ audits: [] });
+  });
+});
+
 describe("POST /waitlist hardening", () => {
   function waitlistPost(email: unknown): Request {
     return new Request(`${BASE}/waitlist`, {
@@ -1019,6 +1067,79 @@ describe("POST /waitlist hardening", () => {
     await handleRequest(waitlistPost("lit@example.com"), deps);
     const row = await db.getWaitlistByEmail("lit@example.com", 1);
     expect(row?.status).toBe("pending");
+  });
+});
+
+describe("POST /waitlist seat cap (founding batch = 100)", () => {
+  function waitlistPost(email: unknown): Request {
+    return new Request(`${BASE}/waitlist`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+  }
+
+  /**
+   * Seeds `n` pending rows directly into batch 1, bypassing the route.
+   * Distinct, ascending created_at values (all BEFORE the frozen NOW) so the
+   * (created_at, id) queue order is chronological and positions are
+   * deterministic: seed i holds position i regardless of the random id the
+   * route assigns to a new signup.
+   */
+  async function seedBatch(db: ConnectDb, n: number): Promise<void> {
+    for (let i = 1; i <= n; i++) {
+      const mm = String(Math.floor(i / 60)).padStart(2, "0");
+      const ss = String(i % 60).padStart(2, "0");
+      await db.insertWaitlist({
+        id: `wl_seed_${i}`,
+        email: `seed${i}@example.com`,
+        batch: 1,
+        status: "pending",
+        created_at: `2026-07-24T09:${mm}:${ss}.000Z`,
+      });
+    }
+  }
+
+  it("99 entries → the 100th new email still succeeds (201)", async () => {
+    const { db, deps } = setup();
+    await seedBatch(db, 99);
+
+    const res = await handleRequest(waitlistPost("last-seat@example.com"), deps);
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string; position: number };
+    expect(body.id).toMatch(/^wl_/);
+    expect(body.position).toBe(100);
+    expect(await db.countWaitlist(1)).toBe(100);
+  });
+
+  it("100 entries → a NEW email → 409 本批内测席位已满, nothing inserted", async () => {
+    const { db, deps } = setup();
+    await seedBatch(db, 100);
+
+    const res = await handleRequest(waitlistPost("too-late@example.com"), deps);
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "本批内测席位已满" });
+    expect(await db.countWaitlist(1)).toBe(100);
+    expect(await db.getWaitlistByEmail("too-late@example.com", 1)).toBeNull();
+  });
+
+  it("at capacity, an EXISTING email still gets 200 with its position", async () => {
+    const { db, deps } = setup();
+    await seedBatch(db, 100);
+
+    const res = await handleRequest(waitlistPost("seed42@example.com"), deps);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      already_exists: boolean;
+      id: string;
+      position: number;
+    };
+    expect(body.already_exists).toBe(true);
+    expect(body.id).toBe("wl_seed_42");
+    expect(body.position).toBe(42);
   });
 });
 

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -226,6 +226,14 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
     return json({ waitlist: await deps.db.listWaitlist(WAITLIST_BATCH) });
   }
 
+  if (path === "/api/admin/audits" && method === "GET") {
+    requireAdmin(request, deps.adminToken);
+    // Operator-facing read of the audit log (newest first, from the db).
+    // detail_json may carry invitee emails — same sensitivity as the invites
+    // list, and this route sits behind the same admin bearer as that one.
+    return json({ audits: await deps.db.listAudits() });
+  }
+
   const provisionMatch = path.match(/^\/api\/admin\/invites\/([^/]+)\/provision$/);
   if (provisionMatch !== null && method === "POST") {
     requireAdmin(request, deps.adminToken);
@@ -439,6 +447,14 @@ async function revealInvite(deps: RouteDeps, code: string): Promise<Response> {
 
 const WAITLIST_BATCH = 1; // Fixed batch for 阶段 1.
 
+/**
+ * Founding-batch seat cap. 阶段 1 admits at most 100 signups; new emails past
+ * the cap get 409. A module constant (like WAITLIST_BATCH), not an env var:
+ * the cap is a product decision tied to the fixed batch, and making it
+ * deploy-configurable would invite changing it without a code review.
+ */
+const WAITLIST_SEAT_CAP = 100;
+
 /** The status literal for a queued signup. Must match schema.sql's DEFAULT. */
 const WAITLIST_PENDING = "pending";
 
@@ -462,6 +478,8 @@ function isUniqueViolation(e: unknown): boolean {
  *   400 `{ error: "email required" | "invalid email" }`
  *       (plus "invalid json" / "invalid body" from the
  *        shared body reader)
+ *   409 `{ error: "本批内测席位已满" }` — founding batch at WAITLIST_SEAT_CAP;
+ *       NEW emails only, repeats still get their 200 below
  *   413 `{ error: "body too large" }`
  *
  * The 200 body is a strict superset of `{ already_exists, id }`. Any doc that
@@ -509,6 +527,19 @@ async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Respons
       { already_exists: true, id: existing.id, position: await waitlistPosition(deps, existing) },
       200,
     );
+  }
+
+  // Founding-batch seat cap — checked AFTER the repeat-submit fast path, so
+  // an email already on the list keeps its 200 position lookup even when the
+  // batch is full; only NEW emails are turned away.
+  //
+  // Like the email pre-check above, this count-then-insert pair is not
+  // atomic: concurrent signups at cap-1 can all pass and overshoot the cap by
+  // a little. Tolerable for a soft product cap (the founding batch is
+  // hand-invited from the admin console anyway); the one hard invariant —
+  // one row per (email, batch) — stays with the UNIQUE index below.
+  if ((await deps.db.countWaitlist(batch)) >= WAITLIST_SEAT_CAP) {
+    throw new HttpError(409, "本批内测席位已满");
   }
 
   const row = {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -218,6 +218,14 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
     return json({ endpoints });
   }
 
+  if (path === "/api/admin/waitlist" && method === "GET") {
+    requireAdmin(request, deps.adminToken);
+    // Queue order straight from the db — (created_at, id) ascending, the same
+    // composite waitlistRankOf counts under, so the 1-based array index here
+    // IS the position POST /waitlist reported to the user.
+    return json({ waitlist: await deps.db.listWaitlist(WAITLIST_BATCH) });
+  }
+
   const provisionMatch = path.match(/^\/api\/admin\/invites\/([^/]+)\/provision$/);
   if (provisionMatch !== null && method === "POST") {
     requireAdmin(request, deps.adminToken);


### PR DESCRIPTION
补齐 #175 漏掉的 operator 可见性（plan Task 4 明写但未实现），并加一道防线让「实现了但没接线」从此在 CI 就炸出来。

## 变更

1. **`GET /api/admin/waitlist`**（admin 认证，复用 `requireAdmin`）——返回队列顺序的完整名单。至此邮箱不再是「收得进、看不见」。
2. **admin 控制台 waitlist 区块**——名次 / 邮箱 / 状态 / 报名时间四列，空态「暂无报名」，**「复制全部邮箱」按钮**（项目无发信能力，邀请靠运营手工发，这就是导出机制）。
3. **席位上限 100（founding batch）**：满员后新邮箱返回 `409 {error: "本批内测席位已满"}`，已在队列中的重复提交仍正常返回 200 + 名次。cap 是模块常量而非 env——席位是产品决策，不该可部署配置。
4. **`GET /api/admin/audits`**——守卫测试抓出 `listAudits()` 也是死代码（审计日志只写不读），一并接线。
5. **`db-surface.test.ts` 防线**：断言 `ConnectDb` 接口的**每个方法都至少有一个非测试调用点**。这正是 #175 漏掉 admin 路由的那类问题——以后「实现了但没接线」直接 CI 红，不靠人发现。

## 验证

- 202 tests 全绿（+12：waitlist API ×3、控制台 ×1、cap ×3、audits ×3、守卫 ×2）
- tsc 干净
- 全部反向验证过：删路由→API 测试红；删 cap→409 测试红；cap 100→99→边界测试红（无 off-by-one）；断控制台 fetch→页面测试红；断 audits 路由→守卫红（证明守卫非摆设）
- cap 边界测试的 seed 用递增时间戳——同秒 seed 下随机 hex id 的字典序会让名次断言不确定（这是个真坑，已绕开并注释）