### PR TITLE
fix(connect): post-Access coherence — agent prompt halt inversion, stale surfaces, race guard

### DIFF
--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -2,9 +2,11 @@
 
 Invite-only remote access for self-hosted Mediary Scout instances. The control
 plane provisions, per invitee, a Cloudflare Tunnel + public hostname
-(`<slug>.mediaryconnect.app`) + Cloudflare Access email-OTP gate, and hands the
-home side a one-time `TUNNEL_TOKEN`. Content and credentials never leave the
-user's own machines — this worker only brokers the tunnel/dns/access setup.
+(`<slug>.mediaryconnect.app`), and hands the home side a one-time
+`TUNNEL_TOKEN`. The entry gate is the app's own access password, set in the
+browser on first open (remote requests require login afterwards; LAN stays
+open). Content and credentials never leave the user's own machines — this
+worker only brokers the tunnel/dns setup.
 
 Deployed at `https://mediaryconnect.app` (custom domain).
 
@@ -15,8 +17,9 @@ admin ──► mediaryconnect.app (this worker)
             ├─ GET  /            intro
             ├─ GET  /admin       admin page (bearer token in sessionStorage)
             ├─ POST /api/admin/invites                     create invite
-            ├─ POST /api/admin/invites/:id/provision       tunnel+ingress+access+dns
-            ├─ POST /api/admin/endpoints/:id/revoke        delete all three
+            ├─ POST /api/admin/invites/:id/provision       tunnel+ingress+dns
+            ├─ POST /api/admin/endpoints/:id/revoke        delete dns+tunnel
+            │                                              (+Access app, legacy rows)
             ├─ GET  /i/:code     invitee page (state machine, never pre-burns)
             └─ POST /api/i/:code/reveal                    one-time token reveal
                  │
@@ -24,7 +27,6 @@ admin ──► mediaryconnect.app (this worker)
             tunnel (scout-<slug>, config_src=cloudflare)
             ingress → http://web:3000 (fixed) + catch-all 404
             DNS CNAME <slug> → <tunnel-id>.cfargotunnel.com
-            Access self_hosted app, email allow policy (OTP)
                  │
                  ▼ invitee home
             docker compose --profile tunnel up -d   (TUNNEL_TOKEN in .env)
@@ -61,7 +63,7 @@ sha256. After `token_shown_at` is set, the plaintext is unrecoverable.
 | Name | What |
 | --- | --- |
 | `ADMIN_TOKEN` | Bearer for all `/api/admin/*` + `/admin` page JS |
-| `CF_API_TOKEN` | Cloudflare API token — Tunnel:Edit, Access Apps & Policies:Edit (account), DNS:Edit (mediaryconnect.app zone only) |
+| `CF_API_TOKEN` | Cloudflare API token — Tunnel:Edit, Access Apps & Policies:Edit (account), DNS:Edit (mediaryconnect.app zone only). The Access scope is still required WHILE legacy rows with Access apps exist: revoke deletes them. Once no legacy rows remain (`SELECT COUNT(*) FROM endpoints WHERE cf_access_app_id IS NOT NULL` → 0), it can be dropped from the token. |
 | `CF_ACCOUNT_ID` | account holding Zero Trust / tunnels |
 | `CF_ZONE_ID` | mediaryconnect.app zone |
 | `TOKEN_WRAP_KEY` | `openssl rand -hex 32` — AES-256-GCM key for token-at-rest |
@@ -134,10 +136,12 @@ run deploy/secret commands as `env -u CF_API_TOKEN npx wrangler ...`.
    into their home `.env` as `TUNNEL_TOKEN=...`, then
    `docker compose --profile tunnel up -d`. The page offers a
    「复制给 Agent」 prompt that does this for them.
-4. Their `https://<slug>.mediaryconnect.app` is live behind Access email OTP.
+4. Their `https://<slug>.mediaryconnect.app` is live, gated by the app's own
+   access password (set-password page on first open).
 
-**Revoke**: admin page → 吊销. Deletes Access app + DNS + tunnel (connections
-closed first; CF error 1022 retried automatically). Idempotent.
+**Revoke**: admin page → 吊销. Deletes DNS + tunnel — plus the Access app for
+legacy rows provisioned before Access was removed (connections closed first;
+CF error 1022 retried automatically). Idempotent.
 
 **Home-side network issues**: if the tunnel won't register or keeps dropping
 on a UDP-restricted network, tell the invitee to add

--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -16,12 +16,16 @@ Deployed at `https://mediaryconnect.app` (custom domain).
 admin ──► mediaryconnect.app (this worker)
             ├─ GET  /            intro
             ├─ GET  /admin       admin page (bearer token in sessionStorage)
+            ├─ GET  /api/admin/invites                     list invites
             ├─ POST /api/admin/invites                     create invite
             ├─ POST /api/admin/invites/:id/provision       tunnel+ingress+dns
+            ├─ GET  /api/admin/endpoints                   list endpoints (public
+            │                                              shape, incl. last_seen_at)
             ├─ POST /api/admin/endpoints/:id/revoke        delete dns+tunnel
             │                                              (+Access app, legacy rows)
             ├─ GET  /i/:code     invitee page (state machine, never pre-burns)
-            └─ POST /api/i/:code/reveal                    one-time token reveal
+            ├─ POST /api/i/:code/reveal                    one-time token reveal
+            └─ POST /api/instance/status                   heartbeat (see below)
                  │
                  ▼ Cloudflare API
             tunnel (scout-<slug>, config_src=cloudflare)
@@ -52,6 +56,16 @@ re-display the rank, so clients never have to branch on status code to find it.
 Ranking counts every row in the batch regardless of `waitlist.status`. Only
 `'pending'` exists today and nothing reads the column; if that changes, see the
 TRIPWIRE tests in `src/schema.test.ts` and `src/db.test.ts`.
+
+### Instance heartbeat (connector-token auth)
+
+`POST /api/instance/status` — the home instance's liveness beat.
+`Authorization: Bearer <connector token>` (the same `TUNNEL_TOKEN` handed out
+at provision/reveal — NOT the admin token). The token's sha256 must match an
+`active` endpoint; on success the worker stamps `endpoints.last_seen_at`
+(surfaced on `GET /api/admin/endpoints` and the admin page's 最近心跳 column)
+and returns `204 No Content`. Unknown or revoked token → `401`. The body is
+never read, so it needs no size cap.
 
 Token secrecy: the connector token is returned to the caller exactly once (at
 provision to the admin, or at `/api/i/:code/reveal` to the invitee). D1 stores

--- a/workers/scout-connect/src/agent-prompt.test.ts
+++ b/workers/scout-connect/src/agent-prompt.test.ts
@@ -104,8 +104,44 @@ describe("buildAgentPrompt", () => {
     expect(out).toContain('cp "$RESTORE_FROM" .env');
     // not "restart" (restart doesn't re-read .env)
     expect(out).toContain("restart 不会重读 .env");
-    // Access verification is done by the human, not the agent
+    // Gate verification is done by the human, not the agent
     expect(out).toContain("不要自行声称验证结果");
+  });
+
+  it("describes the app-login gate, not a Cloudflare Access OTP gate", () => {
+    const out = buildAgentPrompt(INPUT);
+    // Post-#175 there is no Access app: referencing it sends the invitee's
+    // agent looking for a verification page that can never appear.
+    expect(out).not.toContain("Cloudflare Access");
+    expect(out).not.toContain("Access 验证页");
+    // The gate is the app's own access password, set in the browser on first
+    // open (remote requests then require login; LAN stays open).
+    expect(out).toContain("设置访问密码");
+  });
+
+  it("halts ONLY when the app is reachable with no login page at all", () => {
+    const out = buildAgentPrompt(INPUT);
+    // The old halt condition fired on the now-normal success path (app
+    // visible, no Access page) — every new provision ended in a bogus halt.
+    expect(out).not.toContain("无 Access 页");
+    // The genuinely broken state post-#175: app reachable with NO gate —
+    // that means the login gate didn't deploy.
+    expect(out).toContain("没有任何登录/设密码页,立刻停止");
+  });
+
+  it("report template asks about the login/set-password page, not an Access page", () => {
+    const out = buildAgentPrompt(INPUT);
+    expect(out).not.toContain("Access 验证页是否");
+    expect(out).toContain("登录/设密码页是否(由用户确认)出现");
+  });
+
+  it("manual fallback also cites the app-login gate", () => {
+    const manual = buildAgentPromptOrManual({
+      hostname: "h.example.com",
+      tunnelToken: "a\nb",
+    });
+    expect(manual).not.toContain("Cloudflare Access");
+    expect(manual).toContain("访问密码");
   });
 
   it("braces every shell var that precedes a non-ASCII char", () => {

--- a/workers/scout-connect/src/agent-prompt.ts
+++ b/workers/scout-connect/src/agent-prompt.ts
@@ -37,7 +37,7 @@ export function buildAgentPrompt(input: {
 
 目标:让用户的自托管实例经 Cloudflare Tunnel 发布到:
   https://${input.hostname}
-门禁是 Cloudflare Access 邮箱 OTP(浏览器打开时先要求邮箱验证码,通过后才进应用)。
+门禁是应用自身的访问密码(浏览器首次打开时会要求设置访问密码;设置后远程访问必须登录,局域网直连不受影响)。
 不要修改获取/网盘/LLM 业务逻辑。
 
 安全红线:
@@ -257,16 +257,16 @@ ${TOKEN_HEREDOC_MARKER}
 
 第 5 步·验证门禁(由人来完成,不是 agent):
 - 请用户在自己的设备浏览器打开 https://${input.hostname}
-- 应先到 Cloudflare Access 邮箱验证页(输入受邀邮箱收验证码;若没收到,查垃圾邮件)
-- 通过后进入 Mediary Scout 面板
+- 应看到 Mediary Scout 的登录页(全新实例首次打开是设置访问密码的页面)
+- 请用户设置访问密码 — 这就是门禁:设置后远程访问必须登录,之后进入 Mediary Scout 面板
 - 你(agent)不要自行声称验证结果;让用户告诉你看到了什么。
-- 若用户直接看到应用而无 Access 页,立刻停止并提示(门禁没生效,需作者检查)。
+- 若用户直接看到应用主界面而没有任何登录/设密码页,立刻停止并提示(门禁没生效,需作者检查)。
 
 第 6 步·收尾(告诉用户):
 - https://${input.hostname} 现在可从任何设备访问;token 页面只显示一次,但 token 本身长期有效,重启容器/宿主不影响。
 - 以后若无法访问,先 \`docker compose logs cloudflared --tail 30\` 看隧道是否还活着。
 
-完成后用简短中文汇报三项:隧道是否 Registered、Access 验证页是否(由用户确认)出现、能否进入面板。
+完成后用简短中文汇报三项:隧道是否 Registered、登录/设密码页是否(由用户确认)出现、能否进入面板。
 若卡在某步,说明卡在哪、日志关键行、你的下一步建议。
 `;
 }
@@ -293,7 +293,7 @@ export function buildAgentPromptOrManual(input: {
 在此之前可以先确认环境:
 1. \`docker info\` 能跑通(装了 Docker / OrbStack)。
 2. \`docker compose ls\` 找到 mediary-scout 部署目录。
-3. 目标地址是 https://${input.hostname},门禁为 Cloudflare Access 邮箱 OTP。
+3. 目标地址是 https://${input.hostname},门禁为应用自身的访问密码(首次打开时设置)。
 
 安全红线:
 - TUNNEL_TOKEN 是机密。不提交 git、不写进文档/截图/issue、不打印日志。

--- a/workers/scout-connect/src/html/admin-page.ts
+++ b/workers/scout-connect/src/html/admin-page.ts
@@ -109,6 +109,9 @@ async function refresh(){
   }).join("");
   for(const b of document.querySelectorAll("[data-provision]")){
     b.onclick=guard(async()=>{
+      // Disable on click: a double-click fires two provisions for the same
+      // invite (the loser dies on UNIQUE endpoints.invite_id server-side).
+      b.disabled=true;
       const input=$("slug-"+b.getAttribute("data-provision"));
       const slug=input?input.value.trim():"";
       const r=await api("/api/admin/invites/"+b.getAttribute("data-provision")+"/provision",{method:"POST",body:slug?{slug}:{}});

--- a/workers/scout-connect/src/html/admin-page.ts
+++ b/workers/scout-connect/src/html/admin-page.ts
@@ -47,7 +47,7 @@ h1{font-size:1.3rem}h2{font-size:1.05rem;margin-top:2rem}
 
 <h2>端点列表</h2>
 <table>
-<thead><tr><th>hostname</th><th>状态</th><th>token 显示时间</th><th>创建时间</th><th>吊销时间</th><th>操作</th></tr></thead>
+<thead><tr><th>hostname</th><th>状态</th><th>token 显示时间</th><th>最近心跳</th><th>创建时间</th><th>吊销时间</th><th>操作</th></tr></thead>
 <tbody id="endpoints"></tbody>
 </table>
 
@@ -121,7 +121,7 @@ async function refresh(){
   }
   $("endpoints").innerHTML=endpoints.map((e)=>{
     const action=e.status==="active"||e.status==="revoke_failed"?'<button data-revoke="'+esc(e.id)+'">吊销</button>':"";
-    return '<tr><td><a href="https://'+esc(e.hostname)+'" target="_blank" rel="noopener">'+esc(e.hostname)+'</a></td><td>'+esc(e.status)+'</td><td>'+esc(e.token_shown_at||"")+'</td><td>'+esc(e.created_at)+'</td><td>'+esc(e.revoked_at||"")+'</td><td>'+action+'</td></tr>';
+    return '<tr><td><a href="https://'+esc(e.hostname)+'" target="_blank" rel="noopener">'+esc(e.hostname)+'</a></td><td>'+esc(e.status)+'</td><td>'+esc(e.token_shown_at||"")+'</td><td>'+esc(e.last_seen_at||"从未报到")+'</td><td>'+esc(e.created_at)+'</td><td>'+esc(e.revoked_at||"")+'</td><td>'+action+'</td></tr>';
   }).join("");
   for(const b of document.querySelectorAll("[data-revoke]")){
     b.onclick=guard(async()=>{

--- a/workers/scout-connect/src/html/admin-page.ts
+++ b/workers/scout-connect/src/html/admin-page.ts
@@ -114,9 +114,17 @@ async function refresh(){
       b.disabled=true;
       const input=$("slug-"+b.getAttribute("data-provision"));
       const slug=input?input.value.trim():"";
-      const r=await api("/api/admin/invites/"+b.getAttribute("data-provision")+"/provision",{method:"POST",body:slug?{slug}:{}});
-      showProvision(r);
-      await refresh();
+      try {
+        const r=await api("/api/admin/invites/"+b.getAttribute("data-provision")+"/provision",{method:"POST",body:slug?{slug}:{}});
+        showProvision(r);
+        await refresh();
+      } catch(e) {
+        // Failure leaves the DOM untouched (no refresh), so re-enable for retry —
+        // the success path doesn't need this because refresh() re-renders the
+        // table and the provisioned invite no longer gets a 开通 button at all.
+        b.disabled=false;
+        throw e;
+      }
     });
   }
   $("endpoints").innerHTML=endpoints.map((e)=>{

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -14,8 +14,8 @@ a{color:#06c}
 <body>
 <main>
 <h1>Scout Connect</h1>
-<p lang="zh">Scout Connect 是自托管 Mediary Scout 的远程访问之门:通过 Cloudflare Tunnel 把你自己的实例安全地发布到一个专属域名,入口由 Cloudflare Access 邮箱验证把守。你的媒体内容与各类凭据始终留在你自己的机器上,这里只负责开门。</p>
-<p lang="en">Scout Connect is the remote access door for self-hosted Mediary Scout: it publishes your own instance to a dedicated hostname over a Cloudflare Tunnel, gated by Cloudflare Access email verification. Your content and credentials always stay on your own machines — this service only opens the door.</p>
+<p lang="zh">Scout Connect 是自托管 Mediary Scout 的远程访问之门:通过 Cloudflare Tunnel 把你自己的实例安全地发布到一个专属域名,入口由应用自身的访问密码把守(首次打开时设置)。你的媒体内容与各类凭据始终留在你自己的机器上,这里只负责开门。</p>
+<p lang="en">Scout Connect is the remote access door for self-hosted Mediary Scout: it publishes your own instance to a dedicated hostname over a Cloudflare Tunnel, gated by the app's own access password (set on first open). Your content and credentials always stay on your own machines — this service only opens the door.</p>
 <p><a href="https://github.com/fancydirty/mediary-scout">github.com/fancydirty/mediary-scout</a></p>
 </main>
 </body>

--- a/workers/scout-connect/src/html/invite-page.ts
+++ b/workers/scout-connect/src/html/invite-page.ts
@@ -101,7 +101,7 @@ function readyBody(codeJson: string): string {
 <li>可选:网络不稳定或 UDP 受限时,追加一行 <code>TUNNEL_TRANSPORT_PROTOCOL=http2</code>。</li>
 <li>执行 <code>docker compose --profile tunnel up -d</code>。</li>
 <li>执行 <code>docker compose logs -f cloudflared</code>,直到出现 Registered tunnel connection 字样。</li>
-<li>浏览器打开 <code>https://<span class="hn"></span></code>,先完成 Cloudflare Access 邮箱验证,通过后进入 Mediary Scout。</li>
+<li>浏览器打开 <code>https://<span class="hn"></span></code>,首次打开先设置访问密码(这就是门禁),之后登录进入 Mediary Scout。</li>
 <li>若失败:检查 compose 服务名是否为 web、cloudflared 是否与 web 同网络、token 是否完整一行、防火墙是否拦截出站。</li>
 </ol>
 </div>

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -324,6 +324,57 @@ describe("provisionEndpoint", () => {
     expect((await db.getInviteById("inv_2"))?.status).toBe("pending");
   });
 
+  // Same-invite double-provision race (admin double-clicks 开通 — the button
+  // was never disabled): both requests pass the prechecks while the invite is
+  // still pending, both create CF resources, the winner commits, and the loser
+  // dies on `UNIQUE … endpoints.invite_id`. The loser's compensation must NOT
+  // flip the invite back to pending — that would orphan the winner's live
+  // endpoint (invite page shows "waiting" forever, reveal 409s, re-provision
+  // 500s on UNIQUE). The existing race tests above use a DIFFERENT invite;
+  // this one pins the same-invite case.
+  it("same-invite race: loser's compensation leaves the winner's invite provisioned", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    // Winner runs to completion.
+    await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps });
+    expect((await db.getInviteById("inv_1"))?.status).toBe("provisioned");
+
+    // Loser: its precheck reads happened BEFORE the winner committed — model
+    // the race window with stale reads (invite still pending, slug still free).
+    // Everything else goes to the real db, so the INSERT hits the winner's row.
+    const staleDb: ConnectDb = {
+      ...db,
+      async getInviteById(id) {
+        const row = await db.getInviteById(id);
+        return row === null ? null : { ...row, status: "pending" };
+      },
+      async findEndpointBySlugOrHostname() {
+        return null;
+      },
+    };
+    const loserDeps = {
+      ...makeDeps(db, makeFakeCf(calls)),
+      newEndpointId: () => "ep_loser",
+      newAuditId: () => "aud_loser",
+    };
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps: { ...loserDeps, db: staleDb } }),
+    ).rejects.toThrow(/UNIQUE/i);
+
+    // The winner's state must survive the loser's compensation untouched.
+    const invite = await db.getInviteById("inv_1");
+    expect(invite?.status).toBe("provisioned");
+    expect(invite?.slug).toBe("alice");
+    expect(invite?.provisioned_at).toBe(NOW);
+    expect(await db.getEndpointByInviteId("inv_1")).not.toBeNull();
+    // The loser's own CF resources were still cleaned up.
+    expect(countCalls(calls, "del-dns:")).toBe(1);
+    expect(countCalls(calls, "del-tunnel:")).toBe(1);
+  });
+
   it("D1 failure compensation still throws the original error when cf deletes also fail", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makePendingInvite());

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -466,6 +466,45 @@ describe("provisionEndpoint", () => {
     expect(audits.some((a) => a.action === "provision.orphan")).toBe(true);
   });
 
+  it("insertAudit fails AND deleteEndpoint also fails: invite STILL rolls back (phantom row is revocable)", async () => {
+    // The rollback guard exists to protect the RACE WINNER's row (a different
+    // endpointId). It must not protect OUR OWN attempt's row: when our own
+    // deleteEndpoint compensation fails, the surviving row points at CF
+    // resources the compensation is about to delete — leaving the invite
+    // provisioned would let reveal hand out a token for a dead tunnel.
+    // Rolling the invite back is strictly better: the phantom row stays
+    // visible in the admin endpoints list and revoke is 404-idempotent.
+    const db = createMemoryConnectDb();
+    await db.insertInvite(makePendingInvite());
+    const calls: string[] = [];
+    const deps = makeDeps(db, makeFakeCf(calls));
+
+    const inner = db;
+    const failingDb: ConnectDb = {
+      ...inner,
+      async insertAudit() {
+        throw new Error("d1 audit boom");
+      },
+      async deleteEndpoint() {
+        throw new Error("d1 delete boom");
+      },
+    };
+    await expect(
+      provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps: { ...deps, db: failingDb } }),
+    ).rejects.toThrow(/d1 audit boom/);
+
+    // invite rolled back (NOT stuck provisioned pointing at deleted resources)
+    const invite = await db.getInviteById("inv_1");
+    expect(invite?.status).toBe("pending");
+    expect(invite?.slug).toBeNull();
+    expect(invite?.provisioned_at).toBeNull();
+    // our own phantom row survives (delete failed) — visible, revocable later
+    expect(await db.listEndpoints()).toHaveLength(1);
+    // cf resources still cleaned up
+    expect(countCalls(calls, "del-dns:")).toBe(1);
+    expect(countCalls(calls, "del-tunnel:")).toBe(1);
+  });
+
   it("insertAudit failure after invite flip: invite rolled back to pending, endpoint row gone, retry succeeds", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makePendingInvite());

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -158,13 +158,19 @@ export async function provisionEndpoint(input: {
     // If updateInviteStatus already flipped the invite to `provisioned` before
     // a later write (insertAudit) failed, the invite would be stuck forever
     // (not pending → no re-provision; no endpoint → nothing to revoke). Roll
-    // it back so the admin can retry.
+    // it back so the admin can retry — but ONLY when no endpoint row survives
+    // for this invite. In a same-invite double-provision race (admin
+    // double-clicks 开通) the winner's row IS still there; reverting the
+    // invite to pending would orphan a live endpoint: the invitee link shows
+    // "waiting" forever, reveal 409s, and re-provision dies on UNIQUE.
     try {
-      await db.updateInviteStatus(invite.id, {
-        status: "pending",
-        slug: null,
-        provisioned_at: null,
-      });
+      if ((await db.getEndpointByInviteId(invite.id)) === null) {
+        await db.updateInviteStatus(invite.id, {
+          status: "pending",
+          slug: null,
+          provisioned_at: null,
+        });
+      }
     } catch {
       // D1 may be the failing component — nothing more we can do
     }

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -158,13 +158,19 @@ export async function provisionEndpoint(input: {
     // If updateInviteStatus already flipped the invite to `provisioned` before
     // a later write (insertAudit) failed, the invite would be stuck forever
     // (not pending → no re-provision; no endpoint → nothing to revoke). Roll
-    // it back so the admin can retry — but ONLY when no endpoint row survives
-    // for this invite. In a same-invite double-provision race (admin
-    // double-clicks 开通) the winner's row IS still there; reverting the
-    // invite to pending would orphan a live endpoint: the invitee link shows
-    // "waiting" forever, reveal 409s, and re-provision dies on UNIQUE.
+    // it back so the admin can retry — but ONLY when the surviving endpoint
+    // row is NOT ours. In a same-invite double-provision race (admin
+    // double-clicks 开通) the winner's row has a different endpointId; reverting
+    // the invite would orphan that live endpoint (invitee link shows "waiting"
+    // forever, reveal 409s, re-provision dies on UNIQUE). When the survivor is
+    // OUR OWN row (our deleteEndpoint compensation failed above), roll back
+    // anyway: the row points at CF resources the compensation below is about
+    // to delete, so a provisioned invite would let reveal hand out a token for
+    // a dead tunnel. The phantom row stays visible in the admin endpoints list
+    // and revoke is 404-idempotent.
     try {
-      if ((await db.getEndpointByInviteId(invite.id)) === null) {
+      const surviving = await db.getEndpointByInviteId(invite.id);
+      if (surviving === null || surviving.id === endpointId) {
         await db.updateInviteStatus(invite.id, {
           status: "pending",
           slug: null,

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -280,7 +280,11 @@ describe("handleRequest", () => {
     };
     const res = await provisionViaApi({ ...deps, db: racing }, created.id);
     expect(res.status).toBe(409);
-    expect(((await res.json()) as { error: string }).error).toContain("endpoints.slug");
+    const body = (await res.json()) as { error: string };
+    // User-facing message, NOT the raw "UNIQUE constraint failed: …" string —
+    // echoing internal schema text to the client violates this file's contract.
+    expect(body.error).toBe("slug already in use");
+    expect(body.error).not.toContain("UNIQUE");
   });
 
   it("provision losing a same-invite race (UNIQUE endpoints.invite_id) → 409, not 500", async () => {
@@ -302,7 +306,9 @@ describe("handleRequest", () => {
     };
     const res = await provisionViaApi({ ...deps, db: racing }, seeded.id);
     expect(res.status).toBe(409);
-    expect(((await res.json()) as { error: string }).error).toContain("endpoints.invite_id");
+    const body2 = (await res.json()) as { error: string };
+    expect(body2.error).toBe("invite already provisioned");
+    expect(body2.error).not.toContain("UNIQUE");
     // …and the winner's invite was not rolled back by the loser's compensation.
     expect((await db.getInviteById(seeded.id))?.status).toBe("provisioned");
   });

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -217,6 +217,32 @@ describe("handleRequest", () => {
     expect(stored?.token_shown_at).toBeNull();
   });
 
+  // The heartbeat's only output was unobservable: POST /api/instance/status
+  // wrote endpoints.last_seen_at, but the admin list shape stripped it.
+  it("GET /api/admin/endpoints exposes last_seen_at (null before, ISO after a heartbeat)", async () => {
+    const { deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    const beforeRes = await handleRequest(adminGet("/api/admin/endpoints"), deps);
+    const before = (await beforeRes.json()) as { endpoints: Array<Record<string, unknown>> };
+    expect(before.endpoints).toHaveLength(1);
+    expect(before.endpoints[0] && "last_seen_at" in before.endpoints[0]).toBe(true);
+    expect(before.endpoints[0]?.last_seen_at).toBeNull();
+
+    const beat = await handleRequest(
+      new Request(`${BASE}/api/instance/status`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${seeded.token}` },
+      }),
+      deps,
+    );
+    expect(beat.status).toBe(204);
+
+    const afterRes = await handleRequest(adminGet("/api/admin/endpoints"), deps);
+    const after = (await afterRes.json()) as { endpoints: Array<Record<string, unknown>> };
+    expect(after.endpoints[0]?.last_seen_at).toBe(NOW);
+  });
+
   it("provision without any slug → 400 slug required", async () => {
     const { deps } = setup();
     const createRes = await createInviteViaApi(deps, { email: "alice@example.com" });

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -283,7 +283,7 @@ describe("handleRequest", () => {
     const body = (await res.json()) as { error: string };
     // User-facing message, NOT the raw "UNIQUE constraint failed: …" string —
     // echoing internal schema text to the client violates this file's contract.
-    expect(body.error).toBe("slug already in use");
+    expect(body.error).toBe("slug already in use: alice");
     expect(body.error).not.toContain("UNIQUE");
   });
 

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -234,6 +234,53 @@ describe("handleRequest", () => {
     expect(await res.json()).toEqual({ error: "invite not found" });
   });
 
+  // The TOCTOU window past the slug precheck dies on the UNIQUE constraint,
+  // whose message ("UNIQUE constraint failed: endpoints.slug") matched NEITHER
+  // of the old 409 patterns ("already in use" / "invite not pending") and so
+  // surfaced as an opaque 500. A lost race is a client conflict, not an outage.
+  it("provision losing a slug race (UNIQUE endpoints.slug) → 409, not 500", async () => {
+    const { db, deps } = setup();
+    await seedProvisioned(deps); // alice.mediaryconnect.app endpoint exists
+    const createRes = await createInviteViaApi(deps, { email: "bob@example.com", slug: "alice" });
+    const created = (await createRes.json()) as InviteCreated;
+
+    // Blind ONLY the availability precheck: the winner's row was not visible
+    // when the loser checked, but is by the time the INSERT runs.
+    const racing: ConnectDb = {
+      ...db,
+      async findEndpointBySlugOrHostname() {
+        return null;
+      },
+    };
+    const res = await provisionViaApi({ ...deps, db: racing }, created.id);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toContain("endpoints.slug");
+  });
+
+  it("provision losing a same-invite race (UNIQUE endpoints.invite_id) → 409, not 500", async () => {
+    const { db, deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    // The loser's invite read happened before the winner committed: stale
+    // pending snapshot + a blinded availability precheck, then the INSERT
+    // dies on the winner's row.
+    const racing: ConnectDb = {
+      ...db,
+      async getInviteById(id) {
+        const row = await db.getInviteById(id);
+        return row === null ? null : { ...row, status: "pending" as const };
+      },
+      async findEndpointBySlugOrHostname() {
+        return null;
+      },
+    };
+    const res = await provisionViaApi({ ...deps, db: racing }, seeded.id);
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toContain("endpoints.invite_id");
+    // …and the winner's invite was not rolled back by the loser's compensation.
+    expect((await db.getInviteById(seeded.id))?.status).toBe("provisioned");
+  });
+
   it("revoke → 200 {hostname, revoked:true}, endpoint+invite flipped, cf deletes called", async () => {
     const { db, calls, deps } = setup();
     await seedProvisioned(deps);

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -211,6 +211,7 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
       hostname: ep.hostname,
       status: ep.status,
       token_shown_at: ep.token_shown_at,
+      last_seen_at: ep.last_seen_at,
       created_at: ep.created_at,
       revoked_at: ep.revoked_at,
       cf_tunnel_id: ep.cf_tunnel_id,

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -383,11 +383,13 @@ async function provisionInvite(
     // "UNIQUE constraint failed: endpoints.<column>" string would leak internal
     // schema details to the client (this file's contract is to never leak
     // internal error text) and make the response brittle across runtimes.
+    // Messages match the pre-check path's format ("…: <value>") so callers see
+    // the same text whether the conflict was caught by the pre-check or the race.
     if (msg.includes("UNIQUE constraint failed: endpoints.slug")) {
-      throw new HttpError(409, "slug already in use");
+      throw new HttpError(409, `slug already in use: ${slug}`);
     }
     if (msg.includes("UNIQUE constraint failed: endpoints.hostname")) {
-      throw new HttpError(409, "hostname already in use");
+      throw new HttpError(409, `hostname already in use: ${slug}.${deps.rootDomain}`);
     }
     if (msg.includes("UNIQUE constraint failed: endpoints.invite_id")) {
       throw new HttpError(409, "invite already provisioned");

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -370,8 +370,15 @@ async function provisionInvite(
   } catch (e) {
     // Domain conflicts (TOCTOU races past the pre-checks above) are client
     // errors, not 500s. Everything else (CF/D1 failures) stays a 500.
+    // The actual race loser dies on the UNIQUE constraint — "UNIQUE
+    // constraint failed: endpoints.slug" (same wording in D1 and the memory
+    // mock) — which contains neither pre-check message, so map it explicitly.
     const msg = e instanceof Error ? e.message : "";
-    if (msg.includes("invite not pending") || msg.includes("already in use")) {
+    if (
+      msg.includes("invite not pending") ||
+      msg.includes("already in use") ||
+      /UNIQUE constraint failed: endpoints\.(slug|hostname|invite_id)/.test(msg)
+    ) {
       throw new HttpError(409, msg);
     }
     throw e;

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -375,12 +375,22 @@ async function provisionInvite(
     // constraint failed: endpoints.slug" (same wording in D1 and the memory
     // mock) — which contains neither pre-check message, so map it explicitly.
     const msg = e instanceof Error ? e.message : "";
-    if (
-      msg.includes("invite not pending") ||
-      msg.includes("already in use") ||
-      /UNIQUE constraint failed: endpoints\.(slug|hostname|invite_id)/.test(msg)
-    ) {
+    if (msg.includes("invite not pending") || msg.includes("already in use")) {
       throw new HttpError(409, msg);
+    }
+    // The actual race loser dies on the UNIQUE constraint — same wording in D1
+    // and the memory mock. Translate to user-facing text: echoing the raw
+    // "UNIQUE constraint failed: endpoints.<column>" string would leak internal
+    // schema details to the client (this file's contract is to never leak
+    // internal error text) and make the response brittle across runtimes.
+    if (msg.includes("UNIQUE constraint failed: endpoints.slug")) {
+      throw new HttpError(409, "slug already in use");
+    }
+    if (msg.includes("UNIQUE constraint failed: endpoints.hostname")) {
+      throw new HttpError(409, "hostname already in use");
+    }
+    if (msg.includes("UNIQUE constraint failed: endpoints.invite_id")) {
+      throw new HttpError(409, "invite already provisioned");
     }
     throw e;
   }


### PR DESCRIPTION
#175 摘掉 CF Access 时只改了 provision/revoke 的**机制**，没改谈论它的**表面**——二次审计逐项发现，逐条修复：

## NEW-1（HIGH，100% 触发的线上 bug）：agent prompt 让受邀者的部署 agent 在成功路径上强制停下

`agent-prompt.ts` 仍告诉受邀者的 agent：门禁是 Access 邮箱 OTP，应先到 Access 验证页，**「若用户直接看到应用而无 Access 页，立刻停止并提示门禁没生效」**。而 #175 之后，成功路径恰恰就是直达应用（应用自己的登录门：新装实例显示设密码页）。即每次新开通的最后一步，agent 都会按指示停下来报告「配置错误」。

修复：改写成应用登录门（首开 → 设密码页 → 设密码即是门禁）。**停机条件反转**：现在「连登录/设密码页都没有就能进应用」才是真正的事故态。4 个新测试钉住。

## NEW-3：公开页陈旧文案
home-page 与 invite-page 仍在描述 Access 邮箱验证。改为应用登录门。

## NEW-4：README 架构叙述 + 失效 token 权限
README 五处仍把 Access 写成架构一部分，且要求 `CF_API_TOKEN` 带 Access Apps & Policies:Edit 权限。该权限在**老数据清完前仍需要**（revoke 要删遗留 Access app）——已按此事实改写，并给出可删除权限的检查 SQL。

## NEW-5（状态机漏洞）：同邀请并发开通，失败方的补偿把成功方写好的状态抹掉
`provision.ts` 的回滚是无条件的。admin 双击「开通」→ 两个请求都过预检 → 赢家建好 endpoint 并把邀请翻成 provisioned → 输家撞 `UNIQUE endpoints.invite_id` 后，补偿把邀请**又翻回 pending**。结果：隧道活着、endpoint 在，但邀请永远显示等待中，reveal 409，重试 500。

修复：回滚前检查 `getEndpointByInviteId(invite.id) === null`，有存活 endpoint 就不回滚。新增同邀请竞态测试（既有竞态测试用的是不同邀请，从没覆盖到），**反向验证通过**；admin 的开通按钮点击即禁用，从源头降低触发率。

## NEW-6：TOCTOU 竞态实际报 500 而非声称的 409
`routes.ts` 把 "already in use" 映射 409，但真实竞态死于 `UNIQUE constraint failed: endpoints.slug`，不匹配任何模式，吐出不透明 500。补上对 endpoints 三个 UNIQUE 列的映射 + 路由级测试。

## NEW-7：心跳写了没人看
`last_seen_at` 每次心跳都写，但 admin 端点列表不返回、控制台没列。补上响应字段 + 「最近心跳」列（从未报到显示占位）。

## NEW-10：README 路由清单补齐心跳与 admin 列表路由

210 tests 全绿，tsc 干净。每处逻辑修复均反向验证。

（CORS 与限流两条刻意未动：内嵌表单将随设计改为跳转链接而整体删除，CORS 问题连根消失；限流属部署期 zone 层配置，上线时处理。）