### PR TITLE
feat(connect): beta signup site at /beta — marketing page + optional survey

### DIFF
--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -15,6 +15,8 @@ Deployed at `https://mediaryconnect.app` (custom domain).
 ```
 admin ──► mediaryconnect.app (this worker)
             ├─ GET  /            intro
+            ├─ GET  /beta        beta signup page (two-step: email → optional
+            │                    survey; also served on beta.mediaryconnect.app)
             ├─ GET  /admin       admin page (bearer token in sessionStorage)
             ├─ GET  /api/admin/invites                     list invites
             ├─ POST /api/admin/invites                     create invite
@@ -56,6 +58,24 @@ re-display the rank, so clients never have to branch on status code to find it.
 Ranking counts every row in the batch regardless of `waitlist.status`. Only
 `'pending'` exists today and nothing reads the column; if that changes, see the
 TRIPWIRE tests in `src/schema.test.ts` and `src/db.test.ts`.
+
+`POST /waitlist/survey` — the optional post-signup survey offered by
+`GET /beta` after a successful signup. Body
+`{ id, willing_to_pay?, price_point?, use_cases?, donate?, feedback? }`.
+
+| Status | Body |
+| --- | --- |
+| 204 | stored (or nothing to store); no body |
+| 400 | `{ error: "id required" }` (or `invalid json` / `invalid body` from the shared body reader) |
+| 404 | `{ error: "waitlist entry not found" }` |
+| 413 | `{ error: "body too large" }` |
+
+Only answered keys are persisted, as a JSON object in `waitlist.survey_json`
+(added by `migrations/0002-waitlist-survey.sql`; NULL until answered): unknown
+keys and wrong-typed values are dropped, `feedback` is capped at 500 chars
+server-side (the page's textarea has `maxlength="500"`), and a submit with
+zero answered fields returns 204 **without** touching `survey_json`, so an
+empty re-submit never clobbers stored answers.
 
 ### Instance heartbeat (connector-token auth)
 
@@ -116,6 +136,7 @@ npx wrangler deploy
 | Migration | What / why |
 | --- | --- |
 | `0001-drop-access-notnull-add-last-seen.sql` | Drops the `cf_access_app_id NOT NULL` (post-Access `provision.ts` writes `NULL`; the old table rejected it, so **every provision 500'd** after creating and then rolling back the tunnel/DNS). Adds `last_seen_at` for `POST /api/instance/status`. Adds `idx_endpoints_token_sha256` + `idx_waitlist_batch_created` (both paths were full table scans). Realigns `waitlist.status` default `'waiting'` → `'pending'`. |
+| `0002-waitlist-survey.sql` | Adds nullable `waitlist.survey_json TEXT` for `POST /waitlist/survey`. Single additive `ALTER` (no rebuild; pre-existing rows read back NULL). Must run before deploy: `insertWaitlist` binds the column, so **every new signup 500s** on an unmigrated instance, not just survey submits. |
 
 Notes on writing migrations here:
 

--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -69,6 +69,7 @@ TRIPWIRE tests in `src/schema.test.ts` and `src/db.test.ts`.
 | 400 | `{ error: "id required" }` (or `invalid json` / `invalid body` from the shared body reader) |
 | 404 | `{ error: "waitlist entry not found" }` |
 | 413 | `{ error: "body too large" }` |
+| 503 | `{ error: "survey temporarily unavailable" }` — migration window only (survey_json column missing); other db errors stay a generic 500 |
 
 Only answered keys are persisted, as a JSON object in `waitlist.survey_json`
 (added by `migrations/0002-waitlist-survey.sql`; NULL until answered): unknown
@@ -136,7 +137,7 @@ npx wrangler deploy
 | Migration | What / why |
 | --- | --- |
 | `0001-drop-access-notnull-add-last-seen.sql` | Drops the `cf_access_app_id NOT NULL` (post-Access `provision.ts` writes `NULL`; the old table rejected it, so **every provision 500'd** after creating and then rolling back the tunnel/DNS). Adds `last_seen_at` for `POST /api/instance/status`. Adds `idx_endpoints_token_sha256` + `idx_waitlist_batch_created` (both paths were full table scans). Realigns `waitlist.status` default `'waiting'` → `'pending'`. |
-| `0002-waitlist-survey.sql` | Adds nullable `waitlist.survey_json TEXT` for `POST /waitlist/survey`. Single additive `ALTER` (no rebuild; pre-existing rows read back NULL). Must run before deploy: `insertWaitlist` binds the column, so **every new signup 500s** on an unmigrated instance, not just survey submits. |
+| `0002-waitlist-survey.sql` | Adds nullable `waitlist.survey_json TEXT` for `POST /waitlist/survey`. Single additive `ALTER` (no rebuild; pre-existing rows read back NULL). Migrate before deploying. Wrong order no longer takes the funnel down — `insertWaitlist` falls back to the legacy column list and the survey route answers 503 — but degraded means exactly that: signups land without the column and their survey submits fail until this runs. |
 
 Notes on writing migrations here:
 

--- a/workers/scout-connect/migrations/0002-waitlist-survey.sql
+++ b/workers/scout-connect/migrations/0002-waitlist-survey.sql
@@ -2,11 +2,11 @@
 -- survey served by GET /beta and stored by POST /waitlist/survey.
 --
 -- ⚠️ RUN THIS BEFORE DEPLOYING the Worker version that reads/writes
--- survey_json. It is not optional:
---   * insertWaitlist binds survey_json, so EVERY new POST /waitlist signup
---     fails with `no column named survey_json` on an unmigrated instance —
---     not just survey submits.
---   * POST /waitlist/survey's UPDATE targets the same missing column.
+-- survey_json. As a safety net the code degrades in the wrong order —
+-- insertWaitlist falls back to the legacy column list, and the survey route
+-- answers 503 — but degraded means exactly that: signups land WITHOUT the
+-- survey column (their later survey submit fails) until this migration runs.
+-- Correct order is always: migrate first, deploy second.
 --
 -- How to run:
 --   cd workers/scout-connect

--- a/workers/scout-connect/migrations/0002-waitlist-survey.sql
+++ b/workers/scout-connect/migrations/0002-waitlist-survey.sql
@@ -1,0 +1,42 @@
+-- Migration 0002 — add waitlist.survey_json for the optional post-signup
+-- survey served by GET /beta and stored by POST /waitlist/survey.
+--
+-- ⚠️ RUN THIS BEFORE DEPLOYING the Worker version that reads/writes
+-- survey_json. It is not optional:
+--   * insertWaitlist binds survey_json, so EVERY new POST /waitlist signup
+--     fails with `no column named survey_json` on an unmigrated instance —
+--     not just survey submits.
+--   * POST /waitlist/survey's UPDATE targets the same missing column.
+--
+-- How to run:
+--   cd workers/scout-connect
+--   npx wrangler d1 execute scout-connect --local \
+--     --file=./migrations/0002-waitlist-survey.sql
+--   npx wrangler d1 execute scout-connect --remote \
+--     --file=./migrations/0002-waitlist-survey.sql
+--   # then, and only then:
+--   npx wrangler deploy
+--
+-- (If CF_API_TOKEN is exported in your shell, prefix with `env -u CF_API_TOKEN`
+-- — see README. There is no `migrations_dir` / `d1 migrations apply` wiring for
+-- this Worker; the file is applied explicitly with `d1 execute --file`.)
+--
+-- On transactions: this file deliberately has NO explicit transaction
+-- statements. D1 rejects them outright. `wrangler d1 execute --file` already
+-- applies the statements as one atomic unit: a mid-file failure leaves the
+-- database untouched.
+--
+-- Do NOT write the two words BEGIN and TRANSACTION adjacently anywhere in this
+-- file, including inside a comment: wrangler's SQL splitter string-matches for
+-- them and refuses the file with "contains several transactions" before any SQL
+-- is parsed. schema.test.ts pins this.
+--
+-- On re-running: SQLite has no `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, so
+-- this migration is abort-safe rather than idempotent. A second application
+-- fails with "duplicate column name: survey_json" and, because the file is
+-- atomic, changes nothing.
+
+-- Additive only: nullable, no default — most signups never answer the survey,
+-- and rows queued before this migration must read back NULL. Being additive,
+-- no table rebuild is needed and existing rows are untouched.
+ALTER TABLE waitlist ADD COLUMN survey_json TEXT;

--- a/workers/scout-connect/schema.sql
+++ b/workers/scout-connect/schema.sql
@@ -59,7 +59,12 @@ CREATE TABLE waitlist (
   -- counts every row in a batch regardless of status — if you add a second
   -- status value, see the TRIPWIRE tests in src/schema.test.ts.
   status TEXT NOT NULL DEFAULT 'pending',
-  created_at TEXT NOT NULL
+  created_at TEXT NOT NULL,
+  -- Optional post-signup survey answers (a JSON object holding only the keys
+  -- the user actually filled), written by POST /waitlist/survey. NULL until
+  -- then, and always NULL for rows queued before
+  -- migrations/0002-waitlist-survey.sql. Appended last to mirror the ALTER.
+  survey_json TEXT
 );
 CREATE UNIQUE INDEX idx_waitlist_email_batch ON waitlist(email, batch);
 -- Backs the per-batch count on the POST /waitlist path (was a full scan).

--- a/workers/scout-connect/schema.sql
+++ b/workers/scout-connect/schema.sql
@@ -62,8 +62,9 @@ CREATE TABLE waitlist (
   created_at TEXT NOT NULL,
   -- Optional post-signup survey answers (a JSON object holding only the keys
   -- the user actually filled), written by POST /waitlist/survey. NULL until
-  -- then, and always NULL for rows queued before
-  -- migrations/0002-waitlist-survey.sql. Appended last to mirror the ALTER.
+  -- the user answers; rows queued before migrations/0002-waitlist-survey.sql
+  -- START as NULL after the ALTER but can be updated by a later survey submit.
+  -- Appended last to mirror the ALTER.
   survey_json TEXT
 );
 CREATE UNIQUE INDEX idx_waitlist_email_batch ON waitlist(email, batch);

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -336,6 +336,17 @@ describe("D1 ConnectDb SQL", () => {
     expect(calls[0]?.query).not.toContain("willing_to_pay");
     expect(calls[0]?.binds).toContain(`{"willing_to_pay":"愿意"}`);
   });
+
+  it("updateWaitlistSurvey binds the JSON without leaking it into SQL text", async () => {
+    const { d1, calls } = createSpyD1();
+    const db = createD1ConnectDb(d1);
+    await db.updateWaitlistSurvey("w1", `{"feedback":"加长版"}`);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("run");
+    expect(calls[0]?.query).toBe("UPDATE waitlist SET survey_json = ? WHERE id = ?");
+    expect(calls[0]?.query).not.toContain("加长版");
+    expect(calls[0]?.binds).toEqual([`{"feedback":"加长版"}`, "w1"]);
+  });
 });
 
 describe("waitlist", () => {
@@ -375,6 +386,45 @@ describe("waitlist", () => {
     });
     expect(await db.getWaitlistByEmail("b@y.com", 1)).toMatchObject({ email: "b@y.com" });
     expect(await db.getWaitlistByEmail("missing@z.com", 1)).toBeNull();
+  });
+
+  it("getWaitlistById 返回匹配行或 null", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertWaitlist({
+      id: "w1",
+      email: "b@y.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-25T00:00:00Z",
+      survey_json: null,
+    });
+    expect(await db.getWaitlistById("w1")).toMatchObject({ id: "w1", email: "b@y.com" });
+    expect(await db.getWaitlistById("missing")).toBeNull();
+  });
+
+  it("updateWaitlistSurvey persists survey_json and overwrites on re-submit", async () => {
+    const db = createMemoryConnectDb();
+    await db.insertWaitlist({
+      id: "w1",
+      email: "b@y.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-25T00:00:00Z",
+      survey_json: null,
+    });
+    expect((await db.getWaitlistById("w1"))?.survey_json).toBeNull();
+
+    await db.updateWaitlistSurvey("w1", `{"donate":true}`);
+    expect((await db.getWaitlistById("w1"))?.survey_json).toBe(`{"donate":true}`);
+
+    await db.updateWaitlistSurvey("w1", `{"donate":false,"feedback":"x"}`);
+    expect((await db.getWaitlistById("w1"))?.survey_json).toBe(`{"donate":false,"feedback":"x"}`);
+  });
+
+  it("updateWaitlistSurvey on a nonexistent id is a silent no-op (D1 UPDATE parity)", async () => {
+    const db = createMemoryConnectDb();
+    await expect(db.updateWaitlistSurvey("nope", `{}`)).resolves.toBeUndefined();
+    expect(await db.getWaitlistById("nope")).toBeNull();
   });
 
   // The memory backend must rank identically to the D1 backend, or route tests

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -607,6 +607,36 @@ describe("insertWaitlist 迁移窗口降级", () => {
     expect(calls[1]!.binds).toEqual(["w1", "a@x.com", 1, "pending", "2026-07-25T00:00:00Z"]);
   });
 
+  it("另一种缺列措辞（no column named）同样触发降级", async () => {
+    // SQLite/D1 不同版本的报错文案可能是 "no such column" 或 "no column named"——
+    // 匹配过窄会让降级在它唯一存在的窗口期失灵（Copilot PR #181 round 4）。
+    const calls: string[] = [];
+    const d1: D1Database = {
+      prepare(query: string): D1PreparedStatement {
+        const stmt: D1PreparedStatement = {
+          bind() { return stmt; },
+          async first<T>(): Promise<T | null> { return null as T | null; },
+          async all<T>(): Promise<{ results: T[] }> { return { results: [] as T[] }; },
+          async run(): Promise<unknown> {
+            calls.push(query);
+            if (query.includes("survey_json")) {
+              throw new Error("no column named survey_json");
+            }
+            return {};
+          },
+        };
+        return stmt;
+      },
+    };
+    const db = createD1ConnectDb(d1);
+    const row = await db.insertWaitlist({
+      id: "w1", email: "a@x.com", batch: 1, status: "pending",
+      created_at: "t", survey_json: null,
+    });
+    expect(row.id).toBe("w1");
+    expect(calls).toHaveLength(2);
+  });
+
   it("其它错误（如 UNIQUE 冲突）原样上抛，绝不降级吞掉", async () => {
     const d1: D1Database = {
       prepare(): D1PreparedStatement {

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -319,6 +319,23 @@ describe("D1 ConnectDb SQL", () => {
     expect(calls[0]?.query).not.toContain("s3cret-ciphertext");
     expect(calls[0]?.binds).toContain("s3cret-ciphertext");
   });
+
+  it("insertWaitlist binds survey_json without leaking it into SQL text", async () => {
+    const { d1, calls } = createSpyD1();
+    const db = createD1ConnectDb(d1);
+    await db.insertWaitlist({
+      id: "w1",
+      email: "a@x.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-26T00:00:00.000Z",
+      survey_json: `{"willing_to_pay":"愿意"}`,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.query).toContain("survey_json");
+    expect(calls[0]?.query).not.toContain("willing_to_pay");
+    expect(calls[0]?.binds).toContain(`{"willing_to_pay":"愿意"}`);
+  });
 });
 
 describe("waitlist", () => {
@@ -330,6 +347,7 @@ describe("waitlist", () => {
       batch: 1,
       status: "pending",
       created_at: "2026-07-25T00:00:00Z",
+      survey_json: null,
     });
     await expect(
       db.insertWaitlist({
@@ -338,6 +356,7 @@ describe("waitlist", () => {
         batch: 1,
         status: "pending",
         created_at: "2026-07-25T00:00:01Z",
+        survey_json: null,
       }),
     ).rejects.toThrow(/UNIQUE/);
     expect(await db.countWaitlist(1)).toBe(1);
@@ -352,6 +371,7 @@ describe("waitlist", () => {
       batch: 1,
       status: "pending",
       created_at: "2026-07-25T00:00:00Z",
+      survey_json: null,
     });
     expect(await db.getWaitlistByEmail("b@y.com", 1)).toMatchObject({ email: "b@y.com" });
     expect(await db.getWaitlistByEmail("missing@z.com", 1)).toBeNull();
@@ -369,7 +389,7 @@ describe("waitlist", () => {
       { id: "wl_c", email: "c@x.com" },
       { id: "wl_a", email: "a@x.com" },
     ]) {
-      await db.insertWaitlist({ id, email, batch: 1, status: "pending", created_at: ts });
+      await db.insertWaitlist({ id, email, batch: 1, status: "pending", created_at: ts, survey_json: null });
     }
 
     const ranks = await Promise.all(
@@ -386,6 +406,7 @@ describe("waitlist", () => {
       batch: 1,
       status: "pending",
       created_at: "2026-07-25T00:00:00.000Z",
+      survey_json: null,
     });
     await db.insertWaitlist({
       id: "wl_late",
@@ -393,6 +414,7 @@ describe("waitlist", () => {
       batch: 1,
       status: "pending",
       created_at: "2026-07-27T00:00:00.000Z",
+      survey_json: null,
     });
     await db.insertWaitlist({
       id: "wl_zzz_other",
@@ -400,6 +422,7 @@ describe("waitlist", () => {
       batch: 2,
       status: "pending",
       created_at: "2026-07-25T00:00:00.000Z",
+      survey_json: null,
     });
 
     expect(await db.waitlistRankOf(1, "2026-07-25T00:00:00.000Z", "wl_early")).toBe(1);
@@ -421,6 +444,7 @@ describe("waitlist", () => {
       batch: 1,
       status: "removed",
       created_at: "2026-07-25T00:00:00.000Z",
+      survey_json: null,
     });
     await db.insertWaitlist({
       id: "wl_here",
@@ -428,6 +452,7 @@ describe("waitlist", () => {
       batch: 1,
       status: "pending",
       created_at: TS,
+      survey_json: null,
     });
 
     expect(await db.waitlistRankOf(1, TS, "wl_here")).toBe(2);
@@ -447,7 +472,7 @@ describe("waitlist", () => {
       { id: "wl_a", email: "a@x.com" },
       { id: "wl_b", email: "b@x.com" },
     ]) {
-      await db.insertWaitlist({ id, email, batch: 1, status: "pending", created_at: TS });
+      await db.insertWaitlist({ id, email, batch: 1, status: "pending", created_at: TS, survey_json: null });
     }
   }
 
@@ -479,7 +504,7 @@ describe("waitlist", () => {
       { id: "wl_a", email: "a@x.com", created_at: TS, batch: 1 },
       { id: "wl_aaa_other", email: "o@x.com", created_at: TS, batch: 2 },
     ]) {
-      await db.insertWaitlist({ id, email, batch, status: "pending", created_at });
+      await db.insertWaitlist({ id, email, batch, status: "pending", created_at, survey_json: null });
     }
 
     const rows = await db.listWaitlist(1);

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -565,6 +565,30 @@ describe("waitlist", () => {
   });
 });
 
+describe("waitlist survey_json 兼容", () => {
+  it("老 schema（无 survey_json 列）的行映射为 null 而非 undefined", async () => {
+    // 迁移 0002 执行前的窗口期：老表 SELECT * 根本不会返回 survey_json 列。
+    // 用 spy D1 直接喂一个「缺键」的原始行（memory backend 测不到这条路径——
+    // 它的行总是带键）。映射必须落成 null：undefined 会破坏 WaitlistRow 契约，
+    // 且 JSON.stringify 会把整个键丢掉（API 响应形状在迁移前后不一致）。
+    const legacyRow = {
+      id: "w1",
+      email: "a@x.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-25T00:00:00Z",
+      // 故意没有 survey_json 键 —— 这就是迁移前的行形状
+    };
+    const { d1 } = createSpyD1({ first: legacyRow });
+    const db = createD1ConnectDb(d1);
+    const row = await db.getWaitlistByEmail("a@x.com", 1);
+    expect(row).not.toBeNull();
+    expect(row!.survey_json).toBeNull(); // 不是 undefined
+    expect("survey_json" in row!).toBe(true);
+    expect(JSON.parse(JSON.stringify(row))).toHaveProperty("survey_json", null);
+  });
+});
+
 describe("endpoint cf_access_app_id 可空", () => {
   // NOTE: this only pins the in-memory ConnectDb contract. createMemoryConnectDb
   // is a plain Map with no constraint engine, so a green result here says

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -565,6 +565,72 @@ describe("waitlist", () => {
   });
 });
 
+describe("insertWaitlist 迁移窗口降级", () => {
+  /** D1 stub：含 survey_json 的 INSERT 抛 "no such column"，legacy INSERT 放行。 */
+  function createPreMigrationD1() {
+    const calls: { query: string; binds: unknown[] }[] = [];
+    const d1: D1Database = {
+      prepare(query: string): D1PreparedStatement {
+        const binds: unknown[] = [];
+        const stmt: D1PreparedStatement = {
+          bind(...values: unknown[]) {
+            binds.push(...values);
+            return stmt;
+          },
+          async first<T>(): Promise<T | null> { return null as T | null; },
+          async all<T>(): Promise<{ results: T[] }> { return { results: [] as T[] }; },
+          async run(): Promise<unknown> {
+            calls.push({ query, binds: [...binds] });
+            if (query.includes("survey_json")) {
+              throw new Error("no such column: survey_json");
+            }
+            return {};
+          },
+        };
+        return stmt;
+      },
+    };
+    return { d1, calls };
+  }
+
+  it("列不存在时退化为 legacy INSERT，报名不挂", async () => {
+    const { d1, calls } = createPreMigrationD1();
+    const db = createD1ConnectDb(d1);
+    const row = await db.insertWaitlist({
+      id: "w1", email: "a@x.com", batch: 1, status: "pending",
+      created_at: "2026-07-25T00:00:00Z", survey_json: null,
+    });
+    expect(row.id).toBe("w1");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.query).toContain("survey_json");
+    expect(calls[1]!.query).not.toContain("survey_json");
+    expect(calls[1]!.binds).toEqual(["w1", "a@x.com", 1, "pending", "2026-07-25T00:00:00Z"]);
+  });
+
+  it("其它错误（如 UNIQUE 冲突）原样上抛，绝不降级吞掉", async () => {
+    const d1: D1Database = {
+      prepare(): D1PreparedStatement {
+        const stmt: D1PreparedStatement = {
+          bind() { return stmt; },
+          async first<T>(): Promise<T | null> { return null as T | null; },
+          async all<T>(): Promise<{ results: T[] }> { return { results: [] as T[] }; },
+          async run(): Promise<unknown> {
+            throw new Error("UNIQUE constraint failed: waitlist.email");
+          },
+        };
+        return stmt;
+      },
+    };
+    const db = createD1ConnectDb(d1);
+    await expect(
+      db.insertWaitlist({
+        id: "w1", email: "a@x.com", batch: 1, status: "pending",
+        created_at: "t", survey_json: null,
+      }),
+    ).rejects.toThrow(/UNIQUE/);
+  });
+});
+
 describe("waitlist survey_json 兼容", () => {
   it("老 schema（无 survey_json 列）的行映射为 null 而非 undefined", async () => {
     // 迁移 0002 执行前的窗口期：老表 SELECT * 根本不会返回 survey_json 列。

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -180,7 +180,10 @@ function mapWaitlist(row: RawRow): WaitlistRow {
     batch: row.batch as number,
     status: row.status as string,
     created_at: row.created_at as string,
-    survey_json: row.survey_json as string | null,
+    // Coalesce, don't cast: against a pre-0002 schema (migration not yet run),
+    // SELECT * returns no survey_json column at all → `undefined`, which would
+    // break the `string | null` contract and silently vanish from JSON responses.
+    survey_json: (row.survey_json as string | null | undefined) ?? null,
   };
 }
 

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -378,11 +378,17 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
         // migrations/0002-waitlist-survey.sql ran, the column doesn't exist and
         // every signup would 500 — a public-funnel outage caused by deploy order.
         // Degrade to the legacy column list instead (survey silently off until
-        // the migration runs; updateWaitlistSurvey will fail loudly if someone
-        // actually submits a survey in that window, which is the right trade).
-        // Only this exact schema-mismatch error falls back — UNIQUE violations
-        // and real outages must propagate unchanged.
-        if (!(e instanceof Error) || !e.message.includes("no such column: survey_json")) {
+        // the migration runs). Match BOTH phrasings of the missing-column error:
+        // "no such column: x" and "no column named x" — the exact wording varies
+        // across SQLite/D1 versions, and a too-narrow match would silently
+        // disable the fallback in exactly the window it exists for.
+        // Only schema-mismatch errors fall back — UNIQUE violations and real
+        // outages must propagate unchanged.
+        const msg = e instanceof Error ? e.message : "";
+        const isMissingColumn =
+          msg.includes("survey_json") &&
+          (msg.includes("no such column") || msg.includes("no column named"));
+        if (!isMissingColumn) {
           throw e;
         }
         await d1

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -44,6 +44,8 @@ export interface WaitlistRow {
   batch: number;
   status: string;
   created_at: string;
+  /** Optional post-signup survey answers as a JSON string; null until answered. */
+  survey_json: string | null;
 }
 
 export interface InviteStatusPatch {
@@ -171,6 +173,7 @@ function mapWaitlist(row: RawRow): WaitlistRow {
     batch: row.batch as number,
     status: row.status as string,
     created_at: row.created_at as string,
+    survey_json: row.survey_json as string | null,
   };
 }
 
@@ -354,9 +357,10 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
     async insertWaitlist(row) {
       await d1
         .prepare(
-          `INSERT INTO waitlist (id, email, batch, status, created_at) VALUES (?, ?, ?, ?, ?)`,
+          `INSERT INTO waitlist (id, email, batch, status, created_at, survey_json)
+           VALUES (?, ?, ?, ?, ?, ?)`,
         )
-        .bind(row.id, row.email, row.batch, row.status, row.created_at)
+        .bind(row.id, row.email, row.batch, row.status, row.created_at, row.survey_json)
         .run();
       return row;
     },

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -365,13 +365,34 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
     },
 
     async insertWaitlist(row) {
-      await d1
-        .prepare(
-          `INSERT INTO waitlist (id, email, batch, status, created_at, survey_json)
-           VALUES (?, ?, ?, ?, ?, ?)`,
-        )
-        .bind(row.id, row.email, row.batch, row.status, row.created_at, row.survey_json)
-        .run();
+      try {
+        await d1
+          .prepare(
+            `INSERT INTO waitlist (id, email, batch, status, created_at, survey_json)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          )
+          .bind(row.id, row.email, row.batch, row.status, row.created_at, row.survey_json)
+          .run();
+      } catch (e) {
+        // Migration-window fallback: if the worker got deployed BEFORE
+        // migrations/0002-waitlist-survey.sql ran, the column doesn't exist and
+        // every signup would 500 — a public-funnel outage caused by deploy order.
+        // Degrade to the legacy column list instead (survey silently off until
+        // the migration runs; updateWaitlistSurvey will fail loudly if someone
+        // actually submits a survey in that window, which is the right trade).
+        // Only this exact schema-mismatch error falls back — UNIQUE violations
+        // and real outages must propagate unchanged.
+        if (!(e instanceof Error) || !e.message.includes("no such column: survey_json")) {
+          throw e;
+        }
+        await d1
+          .prepare(
+            `INSERT INTO waitlist (id, email, batch, status, created_at)
+             VALUES (?, ?, ?, ?, ?)`,
+          )
+          .bind(row.id, row.email, row.batch, row.status, row.created_at)
+          .run();
+      }
       return row;
     },
 

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -81,6 +81,13 @@ export interface ConnectDb {
   listAudits(): Promise<AuditRow[]>;
   insertWaitlist(row: WaitlistRow): Promise<WaitlistRow>;
   getWaitlistByEmail(email: string, batch: number): Promise<WaitlistRow | null>;
+  getWaitlistById(id: string): Promise<WaitlistRow | null>;
+  /**
+   * Stores the optional post-signup survey (a JSON string) on the row.
+   * UPDATE semantics: a nonexistent id is a silent no-op — the route is
+   * responsible for the 404 precheck.
+   */
+  updateWaitlistSurvey(id: string, surveyJson: string): Promise<void>;
   countWaitlist(batch: number): Promise<number>;
   /**
    * 1-based queue position of the row identified by (`batch`, `createdAt`,
@@ -373,6 +380,21 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
       return row ? mapWaitlist(row) : null;
     },
 
+    async getWaitlistById(id) {
+      const row = await d1
+        .prepare(`SELECT * FROM waitlist WHERE id = ?`)
+        .bind(id)
+        .first<RawRow>();
+      return row ? mapWaitlist(row) : null;
+    },
+
+    async updateWaitlistSurvey(id, surveyJson) {
+      await d1
+        .prepare(`UPDATE waitlist SET survey_json = ? WHERE id = ?`)
+        .bind(surveyJson, id)
+        .run();
+    },
+
     async countWaitlist(batch) {
       const row = await d1
         .prepare(`SELECT COUNT(*) as cnt FROM waitlist WHERE batch = ?`)
@@ -612,6 +634,18 @@ export function createMemoryConnectDb(): ConnectDb {
         }
       }
       return null;
+    },
+
+    async getWaitlistById(id) {
+      const row = waitlist.get(id);
+      return row === undefined ? null : { ...row };
+    },
+
+    async updateWaitlistSurvey(id, surveyJson) {
+      const row = waitlist.get(id);
+      if (row !== undefined) {
+        row.survey_json = surveyJson;
+      }
     },
 
     async countWaitlist(batch) {

--- a/workers/scout-connect/src/html/beta-page.test.ts
+++ b/workers/scout-connect/src/html/beta-page.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { betaPage } from "./beta-page.js";
+
+const page = betaPage();
+
+describe("betaPage", () => {
+  it("is a self-contained zh HTML document with the beta title", () => {
+    expect(page.startsWith("<!doctype html>")).toBe(true);
+    expect(page).toContain('<html lang="zh">');
+    expect(page).toContain('<meta charset="utf-8">');
+    expect(page).toContain("<title>Scout Connect 远程访问 · 内测 · Mediary Scout Connect</title>");
+  });
+
+  it("renders the honest marketing copy (what it is, pricing, 100 seats)", () => {
+    expect(page).toContain("Scout Connect 远程访问 · 内测");
+    expect(page).toContain("在外网也能打开家里实例的浏览器界面");
+    expect(page).toContain("经 Cloudflare 加密隧道，不开端口、不要公网 IP、不需要域名");
+    expect(page).toContain("内容与凭据始终只在你自己的机器上");
+    expect(page).toContain("内测期免费");
+    expect(page).toContain("创始批 100 席");
+    expect(page).toContain("¥19/月 或 ¥199/年");
+    expect(page).toContain("创始价 ¥149/年");
+    expect(page).toContain("先填邮箱，开通时邮件通知");
+    // Honesty guardrail: 转存到用户自己的网盘, never "download to our server"
+    // or streaming/viewing claims.
+    expect(page).not.toMatch(/在线看|在线播放| streaming|下载到服务器/);
+  });
+
+  it("step 1: email form posts same-origin to /waitlist with the a11y contract", () => {
+    expect(page).toContain('<form id="signup"');
+    expect(page).toContain('<label for="email">');
+    expect(page).toContain('type="email"');
+    expect(page).toContain("required");
+    expect(page).toContain('autocomplete="email"');
+    // The button keeps an accessible name while pending (aria-label + aria-busy,
+    // mirroring apps/web's remote-access-waitlist.tsx pattern).
+    expect(page).toMatch(/<button[^>]*id="join"[^>]*aria-label="申请内测席位"[^>]*aria-busy="false"/);
+    expect(page).toContain("申请内测席位");
+    // Error line is announced assertively.
+    expect(page).toMatch(/<p[^>]*id="err"[^>]*role="alert"/);
+    // Same-origin relative fetch — no CORS, no absolute URL.
+    expect(page).toContain('fetch("/waitlist",');
+    expect(page).not.toMatch(/fetch\("https?:/);
+  });
+
+  it("step 2: survey section is hidden until signup succeeds; position slot exists", () => {
+    expect(page).toMatch(/<section[^>]*id="step-survey"[^>]*hidden/);
+    expect(page).not.toMatch(/<section[^>]*id="step-signup"[^>]*hidden/);
+    // 你是第 N 位 — N is filled client-side via textContent into #pos.
+    expect(page).toContain("你是第 ");
+    expect(page).toContain('id="pos"');
+    expect(page).toContain("顺便帮个忙（可跳过）");
+  });
+
+  it("survey fields: all optional, every input labelled, feedback capped at 500", () => {
+    // 愿意付费吗 — radios
+    expect(page).toContain("愿意付费吗");
+    for (const v of ["willing", "free", "depends"]) {
+      expect(page).toContain(`name="willing_to_pay" value="${v}"`);
+    }
+    expect(page).toContain("愿意");
+    expect(page).toContain("只想免费");
+    expect(page).toContain("看情况");
+    // 心理价位 — radios
+    expect(page).toContain("心理价位");
+    for (const v of ["9", "19", "29", "year149", "unsure"]) {
+      expect(page).toContain(`name="price_point" value="${v}"`);
+    }
+    for (const label of ["¥9/月", "¥29/月", "年付 ¥149", "说不好"]) {
+      expect(page).toContain(label);
+    }
+    // 场景 — checkboxes
+    expect(page).toContain("你会在哪些场景用它");
+    for (const v of ["progress", "newtask", "config", "all"]) {
+      expect(page).toContain(`name="use_cases" value="${v}"`);
+    }
+    for (const label of ["查进度", "下新任务", "改配置", "都有"]) {
+      expect(page).toContain(label);
+    }
+    // 打赏 + 其他想说的
+    expect(page).toContain('name="donate"');
+    expect(page).toContain("如果喜欢这个项目，我愿意打赏作者");
+    expect(page).toContain('<label for="feedback">');
+    expect(page).toMatch(/<textarea[^>]*maxlength="500"/);
+    // Buttons
+    expect(page).toContain("提交（可选）");
+    expect(page).toContain("跳过");
+    // Group labels exist (fieldset legends) — every input is labelled.
+    expect((page.match(/<fieldset><legend>/g) ?? []).length).toBe(3);
+  });
+
+  it("submits the survey same-origin to /waitlist/survey and shows thanks", () => {
+    expect(page).toContain('fetch("/waitlist/survey",');
+    expect(page).toContain("感谢，开通时邮件通知你。");
+    // Survey error line also announced.
+    expect(page).toMatch(/<p[^>]*id="survey-err"[^>]*role="alert"/);
+  });
+
+  it("has no server-side template holes and injects dynamic text via textContent only", () => {
+    // The page is fully static server-side — any "${" would be an unevaluated
+    // template hole, any rendered "undefined" a leaked missing value.
+    expect(page).not.toContain("${");
+    expect(page).not.toContain(">undefined<");
+    // Client-side, dynamic values (position, error text) must go through
+    // textContent — innerHTML with response data would be an XSS hole. The
+    // page therefore does not use innerHTML at all.
+    expect(page).not.toContain("innerHTML");
+    expect(page).toContain('textContent=String(d.position)');
+  });
+});

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -3,16 +3,21 @@
 // optional survey (POST /waitlist/survey). Fully self-contained: inline
 // style/script only, no external requests.
 //
+// Visual language mirrors the official site (site/index.html + site/style.css):
+// dark base, radial green hero gradient, hairline borders, pill buttons, mono
+// eyebrows — so the page reads as the same product family as mediaryscout.app.
+//
 // Escaping discipline: unlike invite-page this page is FULLY STATIC — the
 // server interpolates zero values into it, so there is nothing to escape
 // here. Client-side, every dynamic value (position, server error text) is
 // inserted via textContent only; innerHTML is deliberately never used, and a
 // test pins both properties.
 
-// Aperture mark — same as apps/web/app/icon.svg, inlined so the page stays
-// fully self-contained (no external requests, strict CSP-friendly).
+// Aperture mark — same as apps/web/app/icon.svg and the nav logo on
+// mediaryscout.app, inlined so the page stays fully self-contained (no
+// external requests, strict CSP-friendly).
 const LOGO =
-  '<svg width="44" height="44" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Mediary Scout"><circle cx="16" cy="16" r="16" fill="#1ED760"/><g transform="translate(4,4)" fill="none" stroke="#0B3B1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m14.31 8 5.74 9.94"/><path d="M9.69 8h11.48"/><path d="m7.38 12 5.74-9.94"/><path d="M9.69 16 3.95 6.06"/><path d="M14.31 16H2.83"/><path d="m16.62 12-5.74 9.94"/></g></svg>';
+  '<svg width="28" height="28" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Mediary Scout"><circle cx="16" cy="16" r="16" fill="#1ED760"/><g transform="translate(4,4)" fill="none" stroke="#0B3B1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m14.31 8 5.74 9.94"/><path d="M9.69 8h11.48"/><path d="m7.38 12 5.74-9.94"/><path d="M9.69 16 3.95 6.06"/><path d="M14.31 16H2.83"/><path d="m16.62 12-5.74 9.94"/></g></svg>';
 
 export function betaPage(): string {
   return `<!doctype html>
@@ -22,50 +27,114 @@ export function betaPage(): string {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Scout Connect 远程访问 · 内测 · Mediary Scout Connect</title>
 <style>
-:root{--green:#1ED760;--green-dark:#0B3B1E;--ink:#1a2b22;--muted:#5b6b62;--line:#e3e9e5;--card:#fff;--bg:#f4f7f5}
+:root{--bg-base:#121212;--bg-surface:#181818;--bg-raised:#1f1f1f;--bg-card:#252525;--accent:#1ed760;--accent-press:#169c46;--text:#fff;--text-muted:#b3b3b3;--border:#4d4d4d;--border-outline:#7c7c7c;--err:#f3727f;--hairline:linear-gradient(90deg,transparent,#2c2c2c 25%,#2c2c2c 75%,transparent);--font:-apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif;--mono:ui-monospace,SFMono-Regular,monospace;color-scheme:dark}
 *{box-sizing:border-box}
-body{margin:0;font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--ink);line-height:1.7;min-height:100vh;display:flex;align-items:flex-start;justify-content:center;padding:2.5rem 1rem}
-.card{background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:0 4px 24px rgba(11,59,30,.06);max-width:600px;width:100%;padding:2.25rem 2rem 2rem}
-.brand{display:flex;align-items:center;gap:.7rem;margin-bottom:1.5rem}
-.brand .name{font-weight:700;font-size:1.05rem;letter-spacing:.01em}
-.brand .name span{color:var(--muted);font-weight:500}
-h1{font-size:1.45rem;line-height:1.3;margin:.2rem 0 1rem}
-h2{font-size:1.05rem;margin:1.75rem 0 .5rem}
-p{margin:.6rem 0}
-.muted{color:var(--muted);font-size:.92rem}
-input[type=email],textarea{width:100%;font:inherit;padding:.55rem .7rem;border:1px solid var(--line);border-radius:10px;background:#fff;color:var(--ink)}
-input[type=email]:focus,textarea:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
+body{margin:0;min-height:100vh;font-family:var(--font);color:var(--text);line-height:1.65;background:var(--bg-base)}
+/* Full-viewport hero gradient, anchored to the viewport like site's #hero. */
+body::before{content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;background:radial-gradient(120% 90% at 50% -20%,rgba(30,215,96,.28),rgba(30,215,96,.06) 42%,var(--bg-base) 75%)}
+:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+main{max-width:720px;margin:0 auto;padding:0 20px 56px;position:relative}
+
+/* Brand bar — nav-left from the site: aperture mark + wordmark. */
+.brand{display:flex;align-items:center;gap:10px;padding:24px 0 0}
+.brand svg{display:block;flex:none}
+.wordmark{font-weight:700;font-size:16px;letter-spacing:.01em}
+.connect-tag{font-family:var(--mono);font-size:10.5px;letter-spacing:1px;color:var(--accent);border:1px solid rgba(30,215,96,.35);border-radius:999px;padding:3px 9px}
+
+/* Hero — clamp-sized 900-weight title like the site, mono eyebrow, muted sub. */
+.hero{text-align:center;padding:56px 0 0}
+.eyebrow{font-family:var(--mono);font-size:11px;letter-spacing:2.2px;color:var(--accent);margin:0 0 16px}
+h1{font-size:clamp(2rem,7vw,2.8rem);font-weight:900;letter-spacing:-1px;line-height:1.12;margin:0 0 18px;text-wrap:balance}
+.sub{font-size:16px;color:var(--text-muted);max-width:600px;margin:0 auto;text-wrap:balance}
+.sub2{font-size:13.5px;color:#8f8f8f;max-width:560px;margin:14px auto 0;text-wrap:balance}
+.values{display:flex;justify-content:center;align-items:center;gap:10px 26px;flex-wrap:wrap;list-style:none;margin:28px 0 0;padding:0}
+.values li{display:flex;align-items:center;gap:8px;font-size:13.5px;color:var(--text-muted)}
+.values li svg{color:var(--accent);flex:none}
+
+/* Signup panel — dark glass card with the site's hairline-border treatment
+   (top-edge inset highlight + deep ambient shadow) and a faint green glow. */
+.panel{position:relative;margin:44px 0 0;background:rgba(24,24,24,.8);-webkit-backdrop-filter:blur(14px);backdrop-filter:blur(14px);border:1px solid #2b2b2b;border-radius:18px;box-shadow:inset 0 1px 0 rgba(255,255,255,.07),rgba(0,0,0,.55) 0 18px 40px -12px;padding:28px 28px 26px}
+.panel::before{content:"";position:absolute;inset:-48px -60px;z-index:-1;pointer-events:none;background:radial-gradient(ellipse at 50% 100%,rgba(30,215,96,.1),transparent 65%)}
+.peyebrow{font-family:var(--mono);font-size:10.5px;letter-spacing:1.5px;color:var(--accent);margin:0 0 8px}
+.price{font-size:.92rem;color:var(--text-muted);margin:0 0 20px;text-wrap:pretty}
+.field{display:block;margin:0 0 14px}
+.field label{display:block;font-size:.85rem;color:var(--text-muted);margin-bottom:6px}
+input[type=email],textarea{width:100%;font:inherit;padding:12px 14px;border:1px solid var(--border);border-radius:12px;background:var(--bg-raised);color:var(--text);transition:border-color .15s ease,box-shadow .15s ease}
+input[type=email]::placeholder,textarea::placeholder{color:#6b6b6b}
+input[type=email]:focus,textarea:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px rgba(30,215,96,.18)}
 textarea{resize:vertical}
-fieldset{border:1px solid var(--line);border-radius:10px;margin:.9rem 0;padding:.6rem .9rem .8rem}
-legend{font-weight:600;font-size:.95rem;padding:0 .3rem}
-fieldset label{display:inline-flex;align-items:center;gap:.35rem;margin:.25rem .9rem .25rem 0;font-size:.95rem}
-button{font:inherit;font-weight:600;padding:.6rem 1.15rem;cursor:pointer;border-radius:10px;border:1px solid transparent;transition:transform .05s ease}
-button:active{transform:translateY(1px)}
+button{font:inherit;font-weight:700;cursor:pointer;border-radius:500px;border:1px solid transparent;transition:transform .15s ease,background .15s ease,border-color .15s ease,opacity .15s ease}
 button:disabled{opacity:.55;cursor:default}
-.btn-primary{background:var(--green);color:var(--green-dark);border-color:var(--green)}
-.btn-primary:hover:not(:disabled){filter:brightness(1.05)}
-.btn-ghost{background:#fff;color:var(--green-dark);border-color:var(--line)}
-.btn-ghost:hover{border-color:var(--green)}
-.btnrow{display:flex;gap:.6rem;flex-wrap:wrap;margin-top:.9rem}
-.err{color:#b42318;font-size:.92rem}
-.footer{margin-top:2rem;padding-top:1rem;border-top:1px solid var(--line);font-size:.82rem;color:var(--muted);text-align:center}
-.footer a{color:var(--muted);font-weight:500;text-decoration:none}
-.footer a:hover{text-decoration:underline}
-@media(max-width:480px){.card{padding:1.75rem 1.25rem}}
+.btn-primary{background:var(--accent);color:#000;padding:13px 28px}
+.btn-primary:hover:not(:disabled){transform:scale(1.03)}
+.btn-primary:active:not(:disabled){background:var(--accent-press)}
+#signup .btn-primary{width:100%;font-size:.98rem}
+.btn-ghost{background:transparent;color:var(--text);border-color:var(--border-outline);padding:13px 24px}
+.btn-ghost:hover:not(:disabled){border-color:var(--text-muted);transform:scale(1.03)}
+.btnrow{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px}
+.btnrow .btn-primary{flex:1;min-width:150px}
+.err{color:var(--err);font-size:.9rem;margin:12px 0 0}
+
+/* Survey — flat editorial groups separated by center-fading hairlines
+   (no boxes), options as pill chips; the checked state highlight is a
+   :has() progressive enhancement over the always-visible accent inputs. */
+#welcome{font-size:1.05rem;margin:0 0 6px}
+#pos{color:var(--accent);font-weight:800}
+#step-survey h2{font-size:1rem;font-weight:700;margin:0 0 20px;color:var(--text)}
+#survey fieldset{border:0;min-width:0;margin:0 0 20px;padding:0 0 20px;position:relative}
+#survey fieldset:not(:last-of-type)::after{content:"";position:absolute;left:0;right:0;bottom:0;height:1px;background:var(--hairline)}
+#survey legend{padding:0;margin-bottom:2px;font-weight:700;font-size:15px;color:var(--text)}
+#survey fieldset label,#survey .optline label{display:inline-flex;align-items:center;gap:.4rem;margin:.45rem .55rem 0 0;padding:.42rem .85rem;border:1px solid #3a3a3a;border-radius:500px;font-size:.92rem;color:var(--text-muted);cursor:pointer;transition:border-color .15s ease,color .15s ease,background .15s ease}
+#survey label:has(input:checked){border-color:var(--accent);color:var(--text);background:rgba(30,215,96,.08)}
+input[type=radio],input[type=checkbox]{accent-color:var(--accent);margin:0}
+#survey .optline{margin:0 0 20px}
+#thanks:not([hidden]){display:flex;align-items:center;gap:10px;margin:20px 0 0;font-size:1.05rem}
+
+/* Footer — hairline-separated, quiet label voice like the site's trust row. */
+.footer{position:relative;margin-top:52px;padding-top:22px;text-align:center;font-size:.82rem;color:var(--text-muted)}
+.footer::before{content:"";position:absolute;top:0;left:12%;right:12%;height:1px;background:var(--hairline)}
+.footer a{color:var(--text-muted);font-weight:500;text-decoration:none;transition:color .15s ease}
+.footer a:hover{color:var(--text)}
+
+/* Load-in motion — same tkin discipline as the site's ticker lines. */
+.rise{opacity:0;transform:translateY(10px);animation:tkin .55s ease forwards}
+.d1{animation-delay:.05s}.d2{animation-delay:.14s}.d3{animation-delay:.23s}.d4{animation-delay:.32s}.d5{animation-delay:.41s}.d6{animation-delay:.5s}
+@keyframes tkin{to{opacity:1;transform:none}}
+@media (prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}.rise{opacity:1;transform:none}}
+
+@media(max-width:560px){
+.hero{padding-top:40px}
+.panel{margin-top:36px;padding:22px 18px 20px}
+.values{gap:8px 18px}
+.btnrow{flex-direction:column}
+.btnrow .btn-primary,.btnrow .btn-ghost{width:100%}
+}
 </style>
 </head>
 <body>
-<main class="card">
-<div class="brand">${LOGO}<div class="name">Mediary Scout <span>Connect</span></div></div>
+<main>
+<header class="brand">${LOGO}<span class="wordmark">Mediary Scout</span><span class="connect-tag">CONNECT</span></header>
 
+<section class="hero">
+<p class="eyebrow rise d1">SCOUT CONNECT · BETA</p>
+<h1 class="rise d2">Scout Connect 远程访问 · 内测</h1>
+<p class="sub rise d3">在外网也能打开家里实例的浏览器界面——出差时下发新任务、查转存进度、改配置。</p>
+<p class="sub2 rise d4">经 Cloudflare 加密隧道，不开端口、不要公网 IP、不需要域名。内容与凭据始终只在你自己的机器上。</p>
+<ul class="values rise d5">
+<li><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="11" width="16" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>加密隧道免端口</li>
+<li><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 12 7.5 12 10.5 5 14.5 19 17.5 12 21 12"/></svg>转存进度随时查</li>
+<li><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3l7 2.8v5.4c0 4.4-2.9 7.6-7 9.8-4.1-2.2-7-5.4-7-9.8V5.8z"/><path d="M9 12l2.2 2.2L15.5 9.8"/></svg>凭据不出你的机器</li>
+</ul>
+</section>
+
+<div class="panel rise d6">
 <section id="step-signup">
-<h1>Scout Connect 远程访问 · 内测</h1>
-<p>在外网也能打开家里实例的浏览器界面——出差时下发新任务、查转存进度、改配置。经 Cloudflare 加密隧道，不开端口、不要公网 IP、不需要域名。内容与凭据始终只在你自己的机器上。</p>
-<p class="muted">内测期免费，创始批 100 席；正式定价 ¥19/月 或 ¥199/年（创始价 ¥149/年）。先填邮箱，开通时邮件通知。</p>
+<p class="peyebrow">BETA WAITLIST</p>
+<p class="price">内测期免费，创始批 100 席；正式定价 ¥19/月 或 ¥199/年（创始价 ¥149/年）。先填邮箱，开通时邮件通知。</p>
 <form id="signup">
-<p><label for="email">邮箱</label><br>
+<p class="field"><label for="email">邮箱</label>
 <input id="email" name="email" type="email" required autocomplete="email" placeholder="you@example.com"></p>
-<div class="btnrow"><button id="join" type="submit" class="btn-primary" aria-label="申请内测席位" aria-busy="false">申请内测席位</button></div>
+<button id="join" type="submit" class="btn-primary" aria-label="申请内测席位" aria-busy="false">申请内测席位</button>
 <p id="err" class="err" role="alert" hidden></p>
 </form>
 </section>
@@ -92,8 +161,8 @@ button:disabled{opacity:.55;cursor:default}
 <label><input type="checkbox" name="use_cases" value="config"> 改配置</label>
 <label><input type="checkbox" name="use_cases" value="all"> 都有</label>
 </fieldset>
-<p><label><input id="donate" type="checkbox" name="donate" value="yes"> 如果喜欢这个项目，我愿意打赏作者</label></p>
-<p><label for="feedback">其他想说的</label><br>
+<p class="optline"><label><input id="donate" type="checkbox" name="donate" value="yes"> 如果喜欢这个项目，我愿意打赏作者</label></p>
+<p class="field"><label for="feedback">其他想说的</label>
 <textarea id="feedback" name="feedback" maxlength="500" rows="4"></textarea></p>
 <div class="btnrow">
 <button id="send" type="submit" class="btn-primary" aria-label="提交（可选）" aria-busy="false">提交（可选）</button>
@@ -101,10 +170,11 @@ button:disabled{opacity:.55;cursor:default}
 </div>
 <p id="survey-err" class="err" role="alert" hidden></p>
 </form>
-<p id="thanks" hidden>感谢，开通时邮件通知你。</p>
+<p id="thanks" hidden><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#1ed760" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M8.5 12.5l2.5 2.5 4.5-5"/></svg>感谢，开通时邮件通知你。</p>
 </section>
+</div>
 
-<div class="footer">内容全程留在你自己的设备上 · <a href="https://github.com/fancydirty/mediary-scout" target="_blank" rel="noopener">开源自部署</a></div>
+<div class="footer"><a href="https://github.com/fancydirty/mediary-scout" target="_blank" rel="noopener">开源</a> · 自部署 · <a href="https://mediaryscout.app" target="_blank" rel="noopener">mediaryscout.app</a></div>
 </main>
 <script type="module">
 const $=(id)=>document.getElementById(id);

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -1,0 +1,188 @@
+// Public beta signup page (GET /beta) — a single-page two-step flow:
+// step 1 collects the email (POST /waitlist, same origin), step 2 offers an
+// optional survey (POST /waitlist/survey). Fully self-contained: inline
+// style/script only, no external requests.
+//
+// Escaping discipline: unlike invite-page this page is FULLY STATIC — the
+// server interpolates zero values into it, so there is nothing to escape
+// here. Client-side, every dynamic value (position, server error text) is
+// inserted via textContent only; innerHTML is deliberately never used, and a
+// test pins both properties.
+
+// Aperture mark — same as apps/web/app/icon.svg, inlined so the page stays
+// fully self-contained (no external requests, strict CSP-friendly).
+const LOGO =
+  '<svg width="44" height="44" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Mediary Scout"><circle cx="16" cy="16" r="16" fill="#1ED760"/><g transform="translate(4,4)" fill="none" stroke="#0B3B1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m14.31 8 5.74 9.94"/><path d="M9.69 8h11.48"/><path d="m7.38 12 5.74-9.94"/><path d="M9.69 16 3.95 6.06"/><path d="M14.31 16H2.83"/><path d="m16.62 12-5.74 9.94"/></g></svg>';
+
+export function betaPage(): string {
+  return `<!doctype html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Scout Connect 远程访问 · 内测 · Mediary Scout Connect</title>
+<style>
+:root{--green:#1ED760;--green-dark:#0B3B1E;--ink:#1a2b22;--muted:#5b6b62;--line:#e3e9e5;--card:#fff;--bg:#f4f7f5}
+*{box-sizing:border-box}
+body{margin:0;font-family:system-ui,-apple-system,sans-serif;background:var(--bg);color:var(--ink);line-height:1.7;min-height:100vh;display:flex;align-items:flex-start;justify-content:center;padding:2.5rem 1rem}
+.card{background:var(--card);border:1px solid var(--line);border-radius:16px;box-shadow:0 4px 24px rgba(11,59,30,.06);max-width:600px;width:100%;padding:2.25rem 2rem 2rem}
+.brand{display:flex;align-items:center;gap:.7rem;margin-bottom:1.5rem}
+.brand .name{font-weight:700;font-size:1.05rem;letter-spacing:.01em}
+.brand .name span{color:var(--muted);font-weight:500}
+h1{font-size:1.45rem;line-height:1.3;margin:.2rem 0 1rem}
+h2{font-size:1.05rem;margin:1.75rem 0 .5rem}
+p{margin:.6rem 0}
+.muted{color:var(--muted);font-size:.92rem}
+input[type=email],textarea{width:100%;font:inherit;padding:.55rem .7rem;border:1px solid var(--line);border-radius:10px;background:#fff;color:var(--ink)}
+input[type=email]:focus,textarea:focus{outline:2px solid var(--green);outline-offset:1px;border-color:var(--green)}
+textarea{resize:vertical}
+fieldset{border:1px solid var(--line);border-radius:10px;margin:.9rem 0;padding:.6rem .9rem .8rem}
+legend{font-weight:600;font-size:.95rem;padding:0 .3rem}
+fieldset label{display:inline-flex;align-items:center;gap:.35rem;margin:.25rem .9rem .25rem 0;font-size:.95rem}
+button{font:inherit;font-weight:600;padding:.6rem 1.15rem;cursor:pointer;border-radius:10px;border:1px solid transparent;transition:transform .05s ease}
+button:active{transform:translateY(1px)}
+button:disabled{opacity:.55;cursor:default}
+.btn-primary{background:var(--green);color:var(--green-dark);border-color:var(--green)}
+.btn-primary:hover:not(:disabled){filter:brightness(1.05)}
+.btn-ghost{background:#fff;color:var(--green-dark);border-color:var(--line)}
+.btn-ghost:hover{border-color:var(--green)}
+.btnrow{display:flex;gap:.6rem;flex-wrap:wrap;margin-top:.9rem}
+.err{color:#b42318;font-size:.92rem}
+.footer{margin-top:2rem;padding-top:1rem;border-top:1px solid var(--line);font-size:.82rem;color:var(--muted);text-align:center}
+.footer a{color:var(--muted);font-weight:500;text-decoration:none}
+.footer a:hover{text-decoration:underline}
+@media(max-width:480px){.card{padding:1.75rem 1.25rem}}
+</style>
+</head>
+<body>
+<main class="card">
+<div class="brand">${LOGO}<div class="name">Mediary Scout <span>Connect</span></div></div>
+
+<section id="step-signup">
+<h1>Scout Connect 远程访问 · 内测</h1>
+<p>在外网也能打开家里实例的浏览器界面——出差时下发新任务、查转存进度、改配置。经 Cloudflare 加密隧道，不开端口、不要公网 IP、不需要域名。内容与凭据始终只在你自己的机器上。</p>
+<p class="muted">内测期免费，创始批 100 席；正式定价 ¥19/月 或 ¥199/年（创始价 ¥149/年）。先填邮箱，开通时邮件通知。</p>
+<form id="signup">
+<p><label for="email">邮箱</label><br>
+<input id="email" name="email" type="email" required autocomplete="email" placeholder="you@example.com"></p>
+<div class="btnrow"><button id="join" type="submit" class="btn-primary" aria-label="申请内测席位" aria-busy="false">申请内测席位</button></div>
+<p id="err" class="err" role="alert" hidden></p>
+</form>
+</section>
+
+<section id="step-survey" hidden>
+<p id="welcome"><span id="welcome-prefix">已登记，你是第 </span><b id="pos"></b> 位。</p>
+<h2>顺便帮个忙（可跳过）</h2>
+<form id="survey">
+<fieldset><legend>愿意付费吗</legend>
+<label><input type="radio" name="willing_to_pay" value="willing"> 愿意</label>
+<label><input type="radio" name="willing_to_pay" value="free"> 只想免费</label>
+<label><input type="radio" name="willing_to_pay" value="depends"> 看情况</label>
+</fieldset>
+<fieldset><legend>心理价位</legend>
+<label><input type="radio" name="price_point" value="9"> ¥9/月</label>
+<label><input type="radio" name="price_point" value="19"> ¥19/月</label>
+<label><input type="radio" name="price_point" value="29"> ¥29/月</label>
+<label><input type="radio" name="price_point" value="year149"> 年付 ¥149</label>
+<label><input type="radio" name="price_point" value="unsure"> 说不好</label>
+</fieldset>
+<fieldset><legend>你会在哪些场景用它</legend>
+<label><input type="checkbox" name="use_cases" value="progress"> 查进度</label>
+<label><input type="checkbox" name="use_cases" value="newtask"> 下新任务</label>
+<label><input type="checkbox" name="use_cases" value="config"> 改配置</label>
+<label><input type="checkbox" name="use_cases" value="all"> 都有</label>
+</fieldset>
+<p><label><input id="donate" type="checkbox" name="donate" value="yes"> 如果喜欢这个项目，我愿意打赏作者</label></p>
+<p><label for="feedback">其他想说的</label><br>
+<textarea id="feedback" name="feedback" maxlength="500" rows="4"></textarea></p>
+<div class="btnrow">
+<button id="send" type="submit" class="btn-primary" aria-label="提交（可选）" aria-busy="false">提交（可选）</button>
+<button id="skip" type="button" class="btn-ghost">跳过</button>
+</div>
+<p id="survey-err" class="err" role="alert" hidden></p>
+</form>
+<p id="thanks" hidden>感谢，开通时邮件通知你。</p>
+</section>
+
+<div class="footer">内容全程留在你自己的设备上 · <a href="https://github.com/fancydirty/mediary-scout" target="_blank" rel="noopener">开源自部署</a></div>
+</main>
+<script type="module">
+const $=(id)=>document.getElementById(id);
+let signupId=null;
+
+function showErr(el,msg){el.textContent=msg;el.hidden=false;}
+
+const joinBtn=$("join");
+const joinLabel=joinBtn.getAttribute("aria-label");
+function setJoinPending(pending){
+  joinBtn.disabled=pending;
+  joinBtn.setAttribute("aria-busy",pending?"true":"false");
+  joinBtn.setAttribute("aria-label",pending?"正在提交内测申请":joinLabel);
+  joinBtn.textContent=pending?"提交中…":joinLabel;
+}
+
+$("signup").onsubmit=async(ev)=>{
+  ev.preventDefault();
+  if(joinBtn.disabled)return;
+  const email=$("email").value.trim();
+  const err=$("err");
+  err.hidden=true;err.textContent="";
+  setJoinPending(true);
+  let r=null;
+  try{r=await fetch("/waitlist",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({email:email})});}
+  catch(_){setJoinPending(false);showErr(err,"网络异常，提交失败——请稍后再试。");return;}
+  let d=null;
+  try{d=await r.json();}catch(_){}
+  // 契约:两条成功路径(201/200)都必带 id:string 与 position:number。
+  if(r.ok&&d!==null&&typeof d.id==="string"&&typeof d.position==="number"){
+    signupId=d.id;
+    $("welcome-prefix").textContent=d.already_exists===true?"你已经在队列里，第 ":"已登记，你是第 ";
+    $("pos").textContent=String(d.position);
+    $("step-signup").hidden=true;
+    $("step-survey").hidden=false;
+    return;
+  }
+  setJoinPending(false);
+  showErr(err,(d!==null&&typeof d.error==="string")?d.error:"提交失败，请稍后再试。");
+};
+
+const sendBtn=$("send");
+const sendLabel=sendBtn.getAttribute("aria-label");
+function setSendPending(pending){
+  sendBtn.disabled=pending;
+  sendBtn.setAttribute("aria-busy",pending?"true":"false");
+  sendBtn.setAttribute("aria-label",pending?"正在提交":sendLabel);
+  sendBtn.textContent=pending?"提交中…":sendLabel;
+}
+function thanks(){$("survey").hidden=true;$("thanks").hidden=false;}
+$("skip").onclick=thanks;
+
+$("survey").onsubmit=async(ev)=>{
+  ev.preventDefault();
+  if(sendBtn.disabled||signupId===null)return;
+  const serr=$("survey-err");
+  serr.hidden=true;serr.textContent="";
+  const body={id:signupId};
+  const wp=document.querySelector('input[name="willing_to_pay"]:checked');
+  if(wp!==null)body.willing_to_pay=wp.value;
+  const pp=document.querySelector('input[name="price_point"]:checked');
+  if(pp!==null)body.price_point=pp.value;
+  const ucs=document.querySelectorAll('input[name="use_cases"]:checked');
+  if(ucs.length>0){body.use_cases=[];for(let i=0;i<ucs.length;i++)body.use_cases.push(ucs[i].value);}
+  if($("donate").checked)body.donate=true;
+  const fb=$("feedback").value.trim();
+  if(fb!=="")body.feedback=fb;
+  setSendPending(true);
+  let r=null;
+  try{r=await fetch("/waitlist/survey",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(body)});}
+  catch(_){setSendPending(false);showErr(serr,"网络异常，提交失败——请稍后再试。");return;}
+  if(r.status===204){thanks();return;}
+  let d=null;
+  try{d=await r.json();}catch(_){}
+  setSendPending(false);
+  showErr(serr,(d!==null&&typeof d.error==="string")?d.error:"提交失败，请稍后再试。");
+};
+</script>
+</body>
+</html>`;
+}

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -25,8 +25,13 @@ export function htmlPage(body: string, status = 200): Response {
       "content-type": "text/html; charset=utf-8",
       // Pages are fully self-contained (inline style/script only), so a strict
       // CSP is free defense-in-depth for a page that carries a one-time token.
+      // connect-src 'self' is load-bearing, not decorative: every page's
+      // inline script POSTs same-origin (invite reveal, admin console, beta
+      // signup), and connect-src falls back to default-src when absent —
+      // 'none' made the browser refuse those fetches outright (verified
+      // empirically: "Failed to fetch" without the directive, 200 with it).
       "content-security-policy":
-        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
       "x-content-type-options": "nosniff",
       // frame-ancestors only works as a CSP directive (above); x-frame-options
       // is the legacy header that actually blocks framing in older browsers.

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -716,6 +716,7 @@ describe("GET /api/admin/waitlist", () => {
       batch: 1,
       status: "pending",
       created_at: "2026-07-24T10:00:02.000Z",
+      survey_json: null,
     });
     await db.insertWaitlist({
       id: "wl_a",
@@ -723,6 +724,7 @@ describe("GET /api/admin/waitlist", () => {
       batch: 1,
       status: "pending",
       created_at: "2026-07-24T10:00:00.000Z",
+      survey_json: null,
     });
     await db.insertWaitlist({
       id: "wl_b",
@@ -730,6 +732,7 @@ describe("GET /api/admin/waitlist", () => {
       batch: 1,
       status: "pending",
       created_at: "2026-07-24T10:00:01.000Z",
+      survey_json: null,
     });
 
     const res = await handleRequest(adminGet("/api/admin/waitlist"), deps);
@@ -1115,6 +1118,7 @@ describe("POST /waitlist hardening", () => {
       batch: 1,
       status: "pending",
       created_at: "2026-07-24T09:00:00.000Z",
+      survey_json: null,
     });
     let precheckBlinded = false;
     const broken: ConnectDb = {
@@ -1175,6 +1179,7 @@ describe("POST /waitlist seat cap (founding batch = 100)", () => {
         batch: 1,
         status: "pending",
         created_at: `2026-07-24T09:${mm}:${ss}.000Z`,
+        survey_json: null,
       });
     }
   }

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -350,6 +350,24 @@ describe("handleRequest", () => {
     expect(await res.text()).toContain("链接无效");
   });
 
+  it("GET /beta → 200 signup page, CSP permits its same-origin fetch", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/beta`), deps);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+    const body = await res.text();
+    expect(body).toContain("Scout Connect 远程访问 · 内测");
+    expect(body).toContain('<form id="signup"');
+    // The page's inline script POSTs fetch("/waitlist") same-origin. Under the
+    // old CSP (default-src 'none', no connect-src) a real browser REFUSES that
+    // fetch (connect-src falls back to default-src) — verified empirically:
+    // "FETCH_BLOCKED Failed to fetch" without the directive, "FETCH_OK" with
+    // it. The invite page's reveal and the admin console needed it too.
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain("default-src 'none'");
+  });
+
   it("GET /i/:code with pending invite → 作者尚未开通, no reveal button", async () => {
     const { deps } = setup();
     const createRes = await createInviteViaApi(deps, { email: "alice@example.com" });

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1245,6 +1245,170 @@ describe("POST /waitlist seat cap (founding batch = 100)", () => {
   });
 });
 
+describe("POST /waitlist/survey", () => {
+  function surveyPost(body: unknown): Request {
+    return new Request(`${BASE}/waitlist/survey`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  /** Signs `email` up via the real route and returns the new waitlist id. */
+  async function signup(deps: RouteDeps, email: string): Promise<string> {
+    const res = await handleRequest(
+      new Request(`${BASE}/waitlist`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email }),
+      }),
+      deps,
+    );
+    expect(res.status).toBe(201);
+    return ((await res.json()) as { id: string }).id;
+  }
+
+  it("404 for an unknown id, nothing written", async () => {
+    const { db, deps } = setup();
+    const res = await handleRequest(
+      surveyPost({ id: "wl_nope", willing_to_pay: "willing" }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "waitlist entry not found" });
+    expect(await db.getWaitlistById("wl_nope")).toBeNull();
+  });
+
+  it("400 when id is missing or not a string", async () => {
+    const { deps } = setup();
+    for (const body of [{}, { id: 42 }, { id: "  " }]) {
+      const res = await handleRequest(surveyPost(body), deps);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "id required" });
+    }
+  });
+
+  it("204 and stores only the answered fields as JSON (round-trip)", async () => {
+    const { db, deps } = setup();
+    const id = await signup(deps, "survey@example.com");
+
+    const res = await handleRequest(
+      surveyPost({
+        id,
+        willing_to_pay: "willing",
+        price_point: "19",
+        use_cases: ["progress", "all"],
+        donate: true,
+        feedback: "加油",
+      }),
+      deps,
+    );
+
+    expect(res.status).toBe(204);
+    const row = await db.getWaitlistById(id);
+    expect(JSON.parse(row?.survey_json ?? "")).toEqual({
+      willing_to_pay: "willing",
+      price_point: "19",
+      use_cases: ["progress", "all"],
+      donate: true,
+      feedback: "加油",
+    });
+  });
+
+  it("ignores unknown fields — only known keys are persisted", async () => {
+    const { db, deps } = setup();
+    const id = await signup(deps, "unknown-fields@example.com");
+
+    const res = await handleRequest(
+      surveyPost({ id, willing_to_pay: "willing", hacker: "x", admin: true, email: "new@x.com" }),
+      deps,
+    );
+
+    expect(res.status).toBe(204);
+    expect(JSON.parse((await db.getWaitlistById(id))?.survey_json ?? "")).toEqual({
+      willing_to_pay: "willing",
+    });
+  });
+
+  it("truncates feedback at 500 chars server-side", async () => {
+    const { db, deps } = setup();
+    const id = await signup(deps, "long-feedback@example.com");
+
+    const res = await handleRequest(
+      surveyPost({ id, feedback: "a".repeat(600) }),
+      deps,
+    );
+
+    expect(res.status).toBe(204);
+    const stored = JSON.parse((await db.getWaitlistById(id))?.survey_json ?? "") as {
+      feedback: string;
+    };
+    expect(stored.feedback).toHaveLength(500);
+  });
+
+  it("id but no survey fields → 204, survey_json stays null (nothing clobbered)", async () => {
+    const { db, deps } = setup();
+    const id = await signup(deps, "empty-survey@example.com");
+
+    expect((await handleRequest(surveyPost({ id }), deps)).status).toBe(204);
+    expect((await db.getWaitlistById(id))?.survey_json).toBeNull();
+  });
+
+  it("an empty re-submit does not clobber answers already stored", async () => {
+    const { db, deps } = setup();
+    const id = await signup(deps, "resubmit@example.com");
+    await handleRequest(surveyPost({ id, donate: true }), deps);
+
+    // Second submit with no fields at all: answers from the first survive.
+    expect((await handleRequest(surveyPost({ id }), deps)).status).toBe(204);
+    expect(JSON.parse((await db.getWaitlistById(id))?.survey_json ?? "")).toEqual({
+      donate: true,
+    });
+  });
+
+  it("wrong-typed values are dropped, not stored and not a 500", async () => {
+    const { db, deps } = setup();
+    const id = await signup(deps, "types@example.com");
+
+    const res = await handleRequest(
+      surveyPost({ id, willing_to_pay: 5, use_cases: "all", donate: "yes", feedback: {} }),
+      deps,
+    );
+
+    expect(res.status).toBe(204);
+    expect((await db.getWaitlistById(id))?.survey_json).toBeNull();
+  });
+
+  it("non-string use_cases items are filtered out", async () => {
+    const { db, deps } = setup();
+    const id = await signup(deps, "uc@example.com");
+
+    const res = await handleRequest(
+      surveyPost({ id, use_cases: ["progress", 7, null, "all"] }),
+      deps,
+    );
+
+    expect(res.status).toBe(204);
+    expect(JSON.parse((await db.getWaitlistById(id))?.survey_json ?? "")).toEqual({
+      use_cases: ["progress", "all"],
+    });
+  });
+
+  it("oversized declared body → 413 (the shared capped reader)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(
+      new Request(`${BASE}/waitlist/survey`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "content-length": String(64 * 1024) },
+        body: JSON.stringify({ id: "wl_x" }),
+      }),
+      deps,
+    );
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: "body too large" });
+  });
+});
+
 // Copilot round 2, finding 1: readJsonBody() read and JSON.parse'd an
 // unbounded body. The email length cap runs AFTER that, so /waitlist — public
 // and unauthenticated — let a stranger make the Worker buffer and parse

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1279,6 +1279,46 @@ describe("POST /waitlist/survey", () => {
     expect(await db.getWaitlistById("wl_nope")).toBeNull();
   });
 
+  it("503 (not a bare 500) when the survey column does not exist yet (migration window)", async () => {
+    const { deps } = setup();
+    const id = await signup(deps, "win@example.com");
+    // Simulate the pre-0002 schema: updateWaitlistSurvey throws the missing-column error.
+    const windowDeps: RouteDeps = {
+      ...deps,
+      db: {
+        ...deps.db,
+        async updateWaitlistSurvey() {
+          throw new Error("no such column: survey_json");
+        },
+      },
+    };
+    const res = await handleRequest(
+      surveyPost({ id, willing_to_pay: "willing" }),
+      windowDeps,
+    );
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "survey temporarily unavailable" });
+  });
+
+  it("non-schema errors from updateWaitlistSurvey still propagate (not masked as 503)", async () => {
+    const { deps } = setup();
+    const id = await signup(deps, "realerr@example.com");
+    const errDeps: RouteDeps = {
+      ...deps,
+      db: {
+        ...deps.db,
+        async updateWaitlistSurvey() {
+          throw new Error("d1 connection reset");
+        },
+      },
+    };
+    // handleRequest 的兜底把未识别错误统一成 500 internal —— 关键是它绝不能
+    // 被误判成 503：只有「缺列」这种明确可恢复的情况才配 typed 状态码。
+    const res = await handleRequest(surveyPost({ id, willing_to_pay: "willing" }), errDeps);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "internal" });
+  });
+
   it("400 when id is missing or not a string", async () => {
     const { deps } = setup();
     for (const body of [{}, { id: 42 }, { id: "  " }]) {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -9,6 +9,7 @@ import { assertSlug } from "./slug.js";
 import { homePage } from "./html/home-page.js";
 import { adminPage } from "./html/admin-page.js";
 import { invitePage, type InvitePageState } from "./html/invite-page.js";
+import { betaPage } from "./html/beta-page.js";
 import { EMAIL_MAX_LENGTH, EMAIL_RE } from "./validation.js";
 import { newId } from "./ids.js";
 import { sha256Hex } from "./crypto-token.js";
@@ -186,6 +187,9 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   }
   if (method === "GET" && path === "/admin") {
     return htmlPage(adminPage());
+  }
+  if (method === "GET" && path === "/beta") {
+    return htmlPage(betaPage());
   }
 
   // ---- admin api (bearer required) ----

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -642,6 +642,9 @@ const SURVEY_FEEDBACK_MAX = 500;
  *        from the shared body reader)
  *   404 `{ error: "waitlist entry not found" }`
  *   413 `{ error: "body too large" }`
+ *   503 `{ error: "survey temporarily unavailable" }` — only in the migration
+ *        window (survey_json column missing); any other db error stays a
+ *        generic 500 and must never be masked as a 503
  *
  * Only keys actually answered are persisted, under their contract names —
  * unknown body keys are dropped, wrong-typed values are dropped, and

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -277,6 +277,9 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   if (path === "/waitlist" && method === "POST") {
     return await addToWaitlist(request, deps);
   }
+  if (path === "/waitlist/survey" && method === "POST") {
+    return await saveWaitlistSurvey(request, deps);
+  }
 
   // ---- instance status reporting (bearer token auth) ----
   if (path === "/api/instance/status" && method === "POST") {
@@ -620,6 +623,69 @@ async function waitlistPosition(
   row: { batch: number; created_at: string; id: string },
 ): Promise<number> {
   return deps.db.waitlistRankOf(row.batch, row.created_at, row.id);
+}
+
+/** Server-side twin of the /beta textarea's maxlength="500". */
+const SURVEY_FEEDBACK_MAX = 500;
+
+/**
+ * POST /waitlist/survey — the optional post-signup survey from GET /beta.
+ * Public and unauthenticated like POST /waitlist; the same 8 KB capped body
+ * reader applies.
+ *
+ * Request: `{ id: string, willing_to_pay?: string, price_point?: string,
+ *            use_cases?: string[], donate?: boolean, feedback?: string }`
+ *
+ * Responses:
+ *   204 — stored (or nothing to store); no body
+ *   400 `{ error: "id required" }` (plus "invalid json" / "invalid body"
+ *        from the shared body reader)
+ *   404 `{ error: "waitlist entry not found" }`
+ *   413 `{ error: "body too large" }`
+ *
+ * Only keys actually answered are persisted, under their contract names —
+ * unknown body keys are dropped, wrong-typed values are dropped, and
+ * `feedback` is capped at SURVEY_FEEDBACK_MAX chars. A submit with zero
+ * answered fields is a 204 WITHOUT touching survey_json, so a skipped/empty
+ * re-submit can never clobber answers already stored.
+ */
+async function saveWaitlistSurvey(request: Request, deps: RouteDeps): Promise<Response> {
+  const body = await readJsonBody(request);
+  const id = optString(body.id);
+  if (id === null) {
+    throw new HttpError(400, "id required");
+  }
+  if ((await deps.db.getWaitlistById(id)) === null) {
+    throw new HttpError(404, "waitlist entry not found");
+  }
+
+  const survey: Record<string, unknown> = {};
+  const willingToPay = optString(body.willing_to_pay);
+  if (willingToPay !== null) {
+    survey.willing_to_pay = willingToPay;
+  }
+  const pricePoint = optString(body.price_point);
+  if (pricePoint !== null) {
+    survey.price_point = pricePoint;
+  }
+  if (Array.isArray(body.use_cases)) {
+    const useCases = body.use_cases.filter((u): u is string => typeof u === "string");
+    if (useCases.length > 0) {
+      survey.use_cases = useCases;
+    }
+  }
+  if (typeof body.donate === "boolean") {
+    survey.donate = body.donate;
+  }
+  const feedback = optString(body.feedback);
+  if (feedback !== null) {
+    survey.feedback = feedback.slice(0, SURVEY_FEEDBACK_MAX);
+  }
+
+  if (Object.keys(survey).length > 0) {
+    await deps.db.updateWaitlistSurvey(id, JSON.stringify(survey));
+  }
+  return new Response(null, { status: 204 });
 }
 
 async function reportInstanceStatus(request: Request, deps: RouteDeps): Promise<Response> {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -568,6 +568,7 @@ async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Respons
     batch,
     status: WAITLIST_PENDING,
     created_at: deps.now(),
+    survey_json: null,
   };
   try {
     await deps.db.insertWaitlist(row);

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -683,7 +683,20 @@ async function saveWaitlistSurvey(request: Request, deps: RouteDeps): Promise<Re
   }
 
   if (Object.keys(survey).length > 0) {
-    await deps.db.updateWaitlistSurvey(id, JSON.stringify(survey));
+    try {
+      await deps.db.updateWaitlistSurvey(id, JSON.stringify(survey));
+    } catch (e) {
+      // Migration window: 0002 not yet applied → the column doesn't exist and
+      // the raw D1 error would surface as an unobservable 500 outside this
+      // route's declared contract. Answer in-contract instead: 503 tells the
+      // client "not you, us, try later" (the signup itself already succeeded).
+      const msg = e instanceof Error ? e.message : "";
+      const isMissingColumn =
+        msg.includes("survey_json") &&
+        (msg.includes("no such column") || msg.includes("no column named"));
+      if (!isMissingColumn) throw e;
+      throw new HttpError(503, "survey temporarily unavailable");
+    }
   }
   return new Response(null, { status: 204 });
 }

--- a/workers/scout-connect/src/schema.test.ts
+++ b/workers/scout-connect/src/schema.test.ts
@@ -16,6 +16,10 @@ const MIGRATION_SQL = readFileSync(
   new URL("../migrations/0001-drop-access-notnull-add-last-seen.sql", import.meta.url),
   "utf8",
 );
+const MIGRATION2_SQL = readFileSync(
+  new URL("../migrations/0002-waitlist-survey.sql", import.meta.url),
+  "utf8",
+);
 
 // The production shape BEFORE this Worker version: schema.sql as of 884f4c4.
 // `cf_access_app_id` is NOT NULL and `last_seen_at` does not exist — exactly
@@ -252,6 +256,49 @@ describe("schema.sql — fresh install against real SQLite", () => {
     expect(SCHEMA_SQL).not.toContain("部署时由运维脚本执行");
     expect(SCHEMA_SQL).not.toContain("endpoints_old");
   });
+
+  it("waitlist.survey_json exists as a nullable TEXT column", () => {
+    const { sqlite } = freshDb(SCHEMA_SQL);
+    const col = (
+      sqlite.prepare(`PRAGMA table_info(waitlist)`).all() as {
+        name: string;
+        type: string;
+        notnull: number;
+      }[]
+    ).find((c) => c.name === "survey_json");
+    // Nullable on purpose: most signups never answer the survey, and the
+    // column must default to NULL for them (and for pre-0002 rows).
+    expect(col).toMatchObject({ type: "TEXT", notnull: 0 });
+  });
+
+  it("D1 insertWaitlist persists survey_json and mapWaitlist returns it (round-trip)", async () => {
+    const { db } = freshDb(SCHEMA_SQL);
+    const survey = `{"willing_to_pay":"愿意","use_cases":["查进度"]}`;
+    await db.insertWaitlist({
+      id: "wl_s",
+      email: "s@x.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-26T00:00:00.000Z",
+      survey_json: survey,
+    });
+
+    expect((await db.getWaitlistByEmail("s@x.com", 1))?.survey_json).toBe(survey);
+  });
+
+  it("a waitlist row inserted without survey data reads back survey_json null", async () => {
+    const { db } = freshDb(SCHEMA_SQL);
+    await db.insertWaitlist({
+      id: "wl_n",
+      email: "n@x.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-26T00:00:00.000Z",
+      survey_json: null,
+    });
+
+    expect((await db.getWaitlistByEmail("n@x.com", 1))?.survey_json).toBeNull();
+  });
 });
 
 describe("waitlist rank against real SQLite — whole-second timestamp ties", () => {
@@ -269,9 +316,9 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
     // Inserted out of id order on purpose: rank must follow (created_at, id),
     // not physical insertion/rowid order.
     return Promise.all([
-      db.insertWaitlist({ id: "wl_b", email: "b@x.com", batch: 1, status: "pending", created_at: TS }),
-      db.insertWaitlist({ id: "wl_c", email: "c@x.com", batch: 1, status: "pending", created_at: TS }),
-      db.insertWaitlist({ id: "wl_a", email: "a@x.com", batch: 1, status: "pending", created_at: TS }),
+      db.insertWaitlist({ id: "wl_b", email: "b@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null }),
+      db.insertWaitlist({ id: "wl_c", email: "c@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null }),
+      db.insertWaitlist({ id: "wl_a", email: "a@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null }),
     ]);
   }
 
@@ -305,6 +352,7 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
       batch: 1,
       status: "pending",
       created_at: "2026-07-25T00:00:00.000Z",
+      survey_json: null,
     });
     await db.insertWaitlist({
       id: "wl_late",
@@ -312,6 +360,7 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
       batch: 1,
       status: "pending",
       created_at: "2026-07-27T00:00:00.000Z",
+      survey_json: null,
     });
     // A high id in another batch must not inflate batch 1 ranks.
     await db.insertWaitlist({
@@ -320,6 +369,7 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
       batch: 2,
       status: "pending",
       created_at: "2026-07-25T00:00:00.000Z",
+      survey_json: null,
     });
 
     expect(await db.waitlistRankOf(1, "2026-07-25T00:00:00.000Z", "wl_early")).toBe(1);
@@ -330,8 +380,8 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
   it("a same-second row with a lower id does not share the later row's rank", async () => {
     // The precise regression: under `created_at <= ?` both of these returned 2.
     const { db } = freshDb(SCHEMA_SQL);
-    await db.insertWaitlist({ id: "wl_1", email: "one@x.com", batch: 1, status: "pending", created_at: TS });
-    await db.insertWaitlist({ id: "wl_2", email: "two@x.com", batch: 1, status: "pending", created_at: TS });
+    await db.insertWaitlist({ id: "wl_1", email: "one@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null });
+    await db.insertWaitlist({ id: "wl_2", email: "two@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null });
 
     const a = await db.waitlistRankOf(1, TS, "wl_1");
     const b = await db.waitlistRankOf(1, TS, "wl_2");
@@ -368,6 +418,7 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
       batch: 1,
       status: "removed",
       created_at: "2026-07-25T00:00:00.000Z",
+      survey_json: null,
     });
     await db.insertWaitlist({
       id: "wl_here",
@@ -375,6 +426,7 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
       batch: 1,
       status: "pending",
       created_at: TS,
+      survey_json: null,
     });
 
     // Documented current behaviour: the 'removed' row IS counted, so the
@@ -399,9 +451,9 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
     // Insertion order deliberately != id order != nothing-in-particular, so a
     // rowid-ordered result is distinguishable from an (created_at, id) one.
     return Promise.all([
-      db.insertWaitlist({ id: "wl_c", email: "c@x.com", batch: 1, status: "pending", created_at: TS }),
-      db.insertWaitlist({ id: "wl_a", email: "a@x.com", batch: 1, status: "pending", created_at: TS }),
-      db.insertWaitlist({ id: "wl_b", email: "b@x.com", batch: 1, status: "pending", created_at: TS }),
+      db.insertWaitlist({ id: "wl_c", email: "c@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null }),
+      db.insertWaitlist({ id: "wl_a", email: "a@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null }),
+      db.insertWaitlist({ id: "wl_b", email: "b@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null }),
     ]);
   }
 
@@ -429,11 +481,11 @@ describe("waitlist rank against real SQLite — whole-second timestamp ties", ()
     // Two distinct seconds, ties inside each, inserted in scrambled order —
     // and a decoy in another batch that must not shift batch 1.
     await Promise.all([
-      db.insertWaitlist({ id: "wl_m", email: "m@x.com", batch: 1, status: "pending", created_at: "2026-07-27T00:00:00.000Z" }),
-      db.insertWaitlist({ id: "wl_c", email: "c@x.com", batch: 1, status: "pending", created_at: TS }),
-      db.insertWaitlist({ id: "wl_z", email: "z@x.com", batch: 1, status: "pending", created_at: "2026-07-27T00:00:00.000Z" }),
-      db.insertWaitlist({ id: "wl_a", email: "a@x.com", batch: 1, status: "pending", created_at: TS }),
-      db.insertWaitlist({ id: "wl_aaa_other", email: "o@x.com", batch: 2, status: "pending", created_at: TS }),
+      db.insertWaitlist({ id: "wl_m", email: "m@x.com", batch: 1, status: "pending", created_at: "2026-07-27T00:00:00.000Z", survey_json: null }),
+      db.insertWaitlist({ id: "wl_c", email: "c@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null }),
+      db.insertWaitlist({ id: "wl_z", email: "z@x.com", batch: 1, status: "pending", created_at: "2026-07-27T00:00:00.000Z", survey_json: null }),
+      db.insertWaitlist({ id: "wl_a", email: "a@x.com", batch: 1, status: "pending", created_at: TS, survey_json: null }),
+      db.insertWaitlist({ id: "wl_aaa_other", email: "o@x.com", batch: 2, status: "pending", created_at: TS, survey_json: null }),
     ]);
 
     const rows = await db.listWaitlist(1);
@@ -652,6 +704,9 @@ describe("migration 0001 — legacy install that predates the waitlist table", (
   it("ends with the correct waitlist shape and indexes", () => {
     const { sqlite } = freshDb(PRE_WAITLIST_SCHEMA_SQL);
     sqlite.exec(MIGRATION_SQL);
+    // The full pending chain — "the correct waitlist shape" is the shape this
+    // Worker version runs against, which includes 0002's survey_json.
+    sqlite.exec(MIGRATION2_SQL);
 
     const cols = sqlite.prepare(`PRAGMA table_info(waitlist)`).all() as {
       name: string;
@@ -659,9 +714,22 @@ describe("migration 0001 — legacy install that predates the waitlist table", (
       notnull: number;
       dflt_value: string | null;
     }[];
-    expect(cols.map((c) => c.name)).toEqual(["id", "email", "batch", "status", "created_at"]);
+    expect(cols.map((c) => c.name)).toEqual([
+      "id",
+      "email",
+      "batch",
+      "status",
+      "created_at",
+      "survey_json",
+    ]);
     // The whole point of step 8: the default must be the literal routes.ts uses.
     expect(cols.find((c) => c.name === "status")?.dflt_value).toBe("'pending'");
+    // 0002's column: nullable, no default — most rows never answer the survey.
+    expect(cols.find((c) => c.name === "survey_json")).toMatchObject({
+      type: "TEXT",
+      notnull: 0,
+      dflt_value: null,
+    });
 
     const idx = indexNames(sqlite);
     expect(idx).toContain("idx_waitlist_email_batch");
@@ -685,6 +753,7 @@ describe("migration 0001 — legacy install that predates the waitlist table", (
   it("converges on exactly the fresh schema.sql shape", () => {
     const migrated = freshDb(PRE_WAITLIST_SCHEMA_SQL);
     migrated.sqlite.exec(MIGRATION_SQL);
+    migrated.sqlite.exec(MIGRATION2_SQL);
     const fresh = freshDb(SCHEMA_SQL);
 
     const shapeOf = (sqlite: Sqlite, table: string): unknown =>
@@ -715,5 +784,78 @@ describe("migration 0001 — legacy install that predates the waitlist table", (
       // 'waiting' realigned to 'pending' by step 8's CASE.
       { id: "wl_legacy", email: "legacy@example.com", batch: 1, status: "pending" },
     ]);
+  });
+});
+
+// Migration 0002 adds the nullable waitlist.survey_json column that
+// POST /waitlist/survey writes. It is a single additive ALTER — no rebuild —
+// so already-queued signups keep their rows and simply read back NULL.
+describe("migration 0002 — waitlist.survey_json against real SQLite", () => {
+  it("is not wrapped in BEGIN/COMMIT (D1 rejects explicit transactions)", () => {
+    expect(MIGRATION2_SQL).not.toMatch(/^\s*BEGIN\b/im);
+    expect(MIGRATION2_SQL).not.toMatch(/^\s*COMMIT\b/im);
+  });
+
+  it("never contains the adjacent words wrangler's splitter string-matches on", () => {
+    // Same guard as migration 0001 above: the adjacent words anywhere in the
+    // file — INCLUDING inside a `--` comment — make `d1 execute --file` abort
+    // with "contains several transactions" before any SQL is parsed.
+    expect(MIGRATION2_SQL).not.toMatch(/BEGIN\s+TRANSACTION/i);
+    expect(MIGRATION2_SQL).not.toMatch(/^\s*SAVEPOINT\b/im);
+  });
+
+  it("documents how to run it and that it precedes the deploy", () => {
+    expect(MIGRATION2_SQL).toContain("wrangler d1 execute");
+    expect(MIGRATION2_SQL).toMatch(/BEFORE/i);
+  });
+
+  it("adds survey_json on top of 0001; the full chain converges with a fresh install", () => {
+    const migrated = freshDb(LEGACY_SCHEMA_SQL);
+    migrated.sqlite.exec(MIGRATION_SQL);
+    migrated.sqlite.exec(MIGRATION2_SQL);
+    const fresh = freshDb(SCHEMA_SQL);
+
+    const shapeOf = (sqlite: Sqlite, table: string): unknown =>
+      (sqlite.prepare(`PRAGMA table_info(${table})`).all() as {
+        name: string;
+        type: string;
+        notnull: number;
+        dflt_value: string | null;
+      }[]).map((c) => `${c.name} ${c.type} notnull=${c.notnull} default=${c.dflt_value}`);
+
+    // Fresh installs and fully-migrated installs must converge, or the next
+    // migration is written against a shape that only exists in one of them.
+    expect(shapeOf(migrated.sqlite, "waitlist")).toEqual(shapeOf(fresh.sqlite, "waitlist"));
+    expect(shapeOf(migrated.sqlite, "endpoints")).toEqual(shapeOf(fresh.sqlite, "endpoints"));
+    expect(indexNames(migrated.sqlite).sort()).toEqual(indexNames(fresh.sqlite).sort());
+  });
+
+  it("leaves already-queued rows untouched, survey_json NULL", () => {
+    const { sqlite } = freshDb(LEGACY_SCHEMA_SQL);
+    sqlite.exec(MIGRATION_SQL);
+    // A row queued under the post-0001 shape, before 0002 exists.
+    sqlite
+      .prepare(
+        `INSERT INTO waitlist (id, email, batch, status, created_at)
+         VALUES ('wl_pre', 'pre@x.com', 1, 'pending', '2026-07-01T00:00:00.000Z')`,
+      )
+      .run();
+
+    sqlite.exec(MIGRATION2_SQL);
+
+    const row = sqlite
+      .prepare(`SELECT id, email, batch, status, survey_json FROM waitlist WHERE id = 'wl_pre'`)
+      .get() as { survey_json: string | null };
+    expect(row).toMatchObject({ id: "wl_pre", email: "pre@x.com", batch: 1, status: "pending" });
+    expect(row.survey_json).toBeNull();
+  });
+
+  it("aborts rather than double-adding when applied twice", () => {
+    const { sqlite } = freshDb(LEGACY_SCHEMA_SQL);
+    sqlite.exec(MIGRATION_SQL);
+    sqlite.exec(MIGRATION2_SQL);
+    // SQLite has no `ADD COLUMN IF NOT EXISTS`; the guard is that the additive
+    // ALTER fails, and `wrangler d1 execute --file` rolls the file back.
+    expect(() => sqlite.exec(MIGRATION2_SQL)).toThrow(/duplicate column name/i);
   });
 });

--- a/workers/scout-connect/src/schema.test.ts
+++ b/workers/scout-connect/src/schema.test.ts
@@ -858,4 +858,29 @@ describe("migration 0002 — waitlist.survey_json against real SQLite", () => {
     // ALTER fails, and `wrangler d1 execute --file` rolls the file back.
     expect(() => sqlite.exec(MIGRATION2_SQL)).toThrow(/duplicate column name/i);
   });
+
+  it("updateWaitlistSurvey + getWaitlistById round-trip against real SQLite", async () => {
+    // The HTTP-layer survey tests run on the memory mock; this pins the real
+    // D1 SQL end to end on the migrated shape.
+    const { db, sqlite } = freshDb(LEGACY_SCHEMA_SQL);
+    sqlite.exec(MIGRATION_SQL);
+    sqlite.exec(MIGRATION2_SQL);
+    await db.insertWaitlist({
+      id: "wl_rt",
+      email: "rt@x.com",
+      batch: 1,
+      status: "pending",
+      created_at: "2026-07-26T00:00:00.000Z",
+      survey_json: null,
+    });
+
+    await db.updateWaitlistSurvey("wl_rt", `{"use_cases":["progress"],"feedback":"好"}`);
+
+    const row = await db.getWaitlistById("wl_rt");
+    expect(JSON.parse(row?.survey_json ?? "")).toEqual({
+      use_cases: ["progress"],
+      feedback: "好",
+    });
+    expect(await db.getWaitlistById("wl_missing")).toBeNull();
+  });
 });


### PR DESCRIPTION
Scout Connect 内测报名站，worker 承载（将挂 `beta.mediaryconnect.app` 为第二 custom domain，与 `/waitlist` API **同源**，零 CORS、零新基建）。

## 内容

**迁移 0002**：`waitlist.survey_json TEXT`（可空），schema.sql 同步，两个 backend 的 row 映射与 bind 列表都更新。

**`GET /beta`**：单页两步流程（服务端渲染的静态页，与 home/invite/admin 页同套 `esc()` 纪律）：
- 第一屏：营销文案 + 邮箱 + 申请按钮 → 同源 POST `/waitlist`（201/200/400/409/413 全部按真实契约处理）
- 第二屏：可选问卷（愿意付费吗 / 心理价位 / 使用场景 / 愿意打赏吗 / 开放反馈 500 字），提交到 `/waitlist/survey` 或直接跳过
- 问卷数据就是免费的定价调研

**`POST /waitlist/survey`**：按 id 更新 `survey_json`（白名单字段，未知键丢弃，feedback 服务端截断 500）。`{}` 无 id → 400；有 id 零字段 → 204 且不清空已存答案。

**设计**：深色 hero + 绿色径向渐变 + 玻璃卡片，视觉语言移植自 `site/style.css`（官网同一家人）。桌面/移动/问卷/感谢四态截图均验证过。滚动叙事、海报墙等官网 section 专属机制刻意不搬（单页用不上，违背官网自己的动效纪律）。

**顺带修了一个可能已影响生产的 bug**：共享 CSP `default-src 'none'` 没有 `connect-src`，而它会回落到 `default-src`——意味着**邀请页的 reveal 按钮和整个 admin 控制台在所有页面的 fetch 都被 CSP 拦着**。真浏览器实测确认，已加 `connect-src 'self'`（三个页面一起修好）。

## 验证

- 244 tests 全绿（+33），tsc 干净
- 真浏览器 e2e：填邮箱 → 第 2 位 → 填问卷 → admin API 确认 `survey_json` 完整落库；跳过路径 `survey_json` 保持 null
- 反向验证 ×3：删 mapWaitlist 字段 → 落库测试红；删 CSP 指令 → CSP 测试红；白名单改透传 → 未知字段测试红
- db-surface 防线绿（两个新 db 方法都有路由调用点）

## 部署步骤（合后执行，均不属本 PR）

1. **先跑迁移 0001 + 0002**（`wrangler d1 execute`，insertWaitlist 已 bind survey_json，先部署会让所有新报名 500）
2. wrangler.jsonc 加 `{ "pattern": "beta.mediaryconnect.app", "custom_domain": true }`
3. `wrangler deploy`
4. 验证 `beta.mediaryconnect.app/beta` 200