### PR TITLE
feat(connect): beta subdomain root serves the signup page

### DIFF
--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -223,10 +223,10 @@ describe("accountPasswordHref（保留 ?w 工作区上下文）", () => {
 });
 
 describe("BETA_SITE_URL（设置页跳转链接的唯一来源）", () => {
-  it("是 https 绝对地址且以 /beta 结尾——根路径是说明页，不是报名表单", () => {
-    // Copilot PR #182：只校验域名会把「指到域名根」当成通过，
-    // 而 GET / 返回的是 Scout Connect 说明页，报名页在 GET /beta。
-    expect(BETA_SITE_URL).toMatch(/^https:\/\/[a-z0-9.-]+\/beta$/);
+  it("是 https 绝对地址、无尾斜杠、无路径——根即表单（worker Host 分流）", () => {
+    // 规范地址就是裸子域名：worker 对 beta.* 的根路径直接 serving 报名页，
+    // "beta.…/beta" 是结巴。若有人把路径改回 /beta 或别处，这条测试先红。
+    expect(BETA_SITE_URL).toMatch(/^https:\/\/beta\.[a-z0-9.-]+$/);
     expect(BETA_SITE_URL.endsWith("/")).toBe(false);
   });
 });

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -120,8 +120,9 @@ export async function resolveRemoteAccessState(opts: {
  * 内测报名站的对外地址（唯一来源）。
  *
  * 指向 worker 承载的报名页——与 /waitlist API 同部署，只换了更好记的域名。
- * 根路径即是表单（worker 对 beta 子域名按 Host 分流到 /beta 处理器），
- * 不要再加 /beta 后缀——"beta.…/beta" 是结巴。
+ * 根路径即是表单（worker 对 beta 子域名的 GET / 按 Host 直接 serving 同一
+ * 页面函数——不是内部转发到 /beta 路由）。不要再加 /beta 后缀——
+ * "beta.…/beta" 是结巴。
  * 设置页「远程访问」tab 的跳转链接从这里取，不要在组件里另写一份。
  * 注意：没有「链接可用性」的自动探测。如果 beta 站未来下线或迁移，
  * 需要的动作是改代码——把 tab 的 not_provisioned 分支改回 return null

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -119,15 +119,15 @@ export async function resolveRemoteAccessState(opts: {
 /**
  * 内测报名站的对外地址（唯一来源）。
  *
- * 指向 worker 承载的 /beta 页——与 /waitlist API 同部署，只换了更好记的域名。
- * 必须带 /beta 路径：该子域名的根路径 `GET /` 是 Scout Connect 说明页，
- * 报名表单只在 `GET /beta`。
+ * 指向 worker 承载的报名页——与 /waitlist API 同部署，只换了更好记的域名。
+ * 根路径即是表单（worker 对 beta 子域名按 Host 分流到 /beta 处理器），
+ * 不要再加 /beta 后缀——"beta.…/beta" 是结巴。
  * 设置页「远程访问」tab 的跳转链接从这里取，不要在组件里另写一份。
  * 注意：没有「链接可用性」的自动探测。如果 beta 站未来下线或迁移，
  * 需要的动作是改代码——把 tab 的 not_provisioned 分支改回 return null
  * （触发 settings-tabs 的自动隐藏），而不是指望某个开关。
  */
-export const BETA_SITE_URL = "https://beta.mediaryconnect.app/beta";
+export const BETA_SITE_URL = "https://beta.mediaryconnect.app";
 
 /** 服务端读实例隧道 token（docker-compose 需把 `TUNNEL_TOKEN` 也传给 web 服务）。 */
 export function instanceTunnelToken(): string | undefined {

--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -60,7 +60,7 @@ Ranking counts every row in the batch regardless of `waitlist.status`. Only
 TRIPWIRE tests in `src/schema.test.ts` and `src/db.test.ts`.
 
 `POST /waitlist/survey` — the optional post-signup survey offered by
-`GET /beta` after a successful signup. Body
+`GET /beta` (also served at the beta subdomain's root; the canonical URL is bare `beta.mediaryconnect.app`) after a successful signup. Body
 `{ id, willing_to_pay?, price_point?, use_cases?, donate?, feedback? }`.
 
 | Status | Body |

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -1,4 +1,8 @@
-// Public beta signup page (GET /beta) — a single-page two-step flow:
+// Public beta signup page — a single-page two-step flow.
+//
+// Entry points: GET /beta on any host, and GET / on the beta subdomain
+// (host-routed in routes.ts). The canonical public URL is the bare
+// beta.mediaryconnect.app — print that one everywhere, never …/beta.
 // step 1 collects the email (POST /waitlist, same origin), step 2 offers an
 // optional survey (POST /waitlist/survey). Fully self-contained: inline
 // style/script only, no external requests.

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -147,6 +147,16 @@ describe("handleRequest", () => {
     expect(html).not.toContain("Scout Connect 说明");
   });
 
+  it("beta root routing survives an un-normalized rootDomain env value", async () => {
+    // CONNECT_ROOT_DOMAIN 从 env 原样进来，不 trim 不小写。带大小写/空格的
+    // 配置不该让 beta 根路径静默退回说明页（Copilot PR #183）。
+    const { deps } = setup();
+    const messyDeps = { ...deps, rootDomain: "  MediaryConnect.APP  " };
+    const res = await handleRequest(new Request("https://beta.mediaryconnect.app/"), messyDeps);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("申请内测席位");
+  });
+
   it("GET / on apex still serves the home page (host routing must not leak)", async () => {
     const { deps } = setup();
     const res = await handleRequest(new Request(`${BASE}/`), deps);

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -136,6 +136,34 @@ describe("handleRequest", () => {
     expect(await res.text()).toContain("Scout Connect");
   });
 
+  it("GET / on the beta subdomain serves the signup page (canonical URL is the bare host)", async () => {
+    const { deps } = setup();
+    // beta.mediaryconnect.app 就是规范地址——"beta.…/beta" 是结巴。
+    // 该子域名的根路径必须直接给报名表单，而不是 Scout Connect 说明页。
+    const res = await handleRequest(new Request("https://beta.mediaryconnect.app/"), deps);
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("申请内测席位");
+    expect(html).not.toContain("Scout Connect 说明");
+  });
+
+  it("GET / on apex still serves the home page (host routing must not leak)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/`), deps);
+    const html = await res.text();
+    expect(html).toContain("Scout Connect");
+    expect(html).not.toContain("申请内测席位");
+  });
+
+  it("GET /beta keeps working on both hosts (no regression)", async () => {
+    const { deps } = setup();
+    for (const host of [BASE, "https://beta.mediaryconnect.app"]) {
+      const res = await handleRequest(new Request(`${host}/beta`), deps);
+      expect(res.status).toBe(200);
+      expect(await res.text()).toContain("申请内测席位");
+    }
+  });
+
   it("GET /healthz → ok", async () => {
     const { deps } = setup();
     const res = await handleRequest(new Request(`${BASE}/healthz`), deps);

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -640,7 +640,8 @@ async function waitlistPosition(
 const SURVEY_FEEDBACK_MAX = 500;
 
 /**
- * POST /waitlist/survey — the optional post-signup survey from GET /beta.
+ * POST /waitlist/survey — the optional post-signup survey from the beta page
+ * (served at GET /beta, and at GET / on the beta subdomain).
  * Public and unauthenticated like POST /waitlist; the same 8 KB capped body
  * reader applies.
  *

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -168,6 +168,13 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   }
 
   if (method === "GET" && path === "/") {
+    // The beta subdomain's root IS the signup page: "beta.mediaryconnect.app"
+    // is the canonical marketing URL, so "beta.…/beta" would stutter. Apex
+    // keeps the Scout Connect home page; the check is host-exact so no other
+    // subdomain (or the apex) accidentally gets the signup page.
+    if (url.hostname.toLowerCase() === `beta.${deps.rootDomain}`) {
+      return htmlPage(betaPage());
+    }
     return htmlPage(homePage());
   }
   if (method === "GET" && path === "/healthz") {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -172,7 +172,11 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
     // is the canonical marketing URL, so "beta.…/beta" would stutter. Apex
     // keeps the Scout Connect home page; the check is host-exact so no other
     // subdomain (or the apex) accidentally gets the signup page.
-    if (url.hostname.toLowerCase() === `beta.${deps.rootDomain}`) {
+    // Normalize BOTH sides: url.hostname is already lowercase, but
+    // deps.rootDomain comes from env (CONNECT_ROOT_DOMAIN) untrimmed — a
+    // mixed-case or space-padded value would silently break this routing.
+    const betaHost = `beta.${deps.rootDomain.trim().toLowerCase()}`;
+    if (url.hostname.toLowerCase() === betaHost) {
       return htmlPage(betaPage());
     }
     return htmlPage(homePage());


### PR DESCRIPTION
`beta.mediaryconnect.app/beta` 重复了。修worker 而不是绕：

- **Host 分流**：`beta.<rootDomain>` 的根路径直接 serving 报名表单；apex 保持 Scout Connect 说明页。检查是 host 精确匹配，不会漏到 apex 或其它子域名。`/beta` 在两个域名上都继续可用。
- **`BETA_SITE_URL` 去掉路径**，回到干净的 `https://beta.mediaryconnect.app`——设置页按钮跳转的终态地址。常量注释与测试同步（测试现在钉死「裸子域名」形态，谁加回路径谁先红）。

反向验证：去掉 Host 分流，beta 根路径测试变红。

合并后需要 `wrangler deploy` 一次（worker 改动），我会执行并生产验证。