### PR TITLE
feat(connect): Turnstile gate on /waitlist

### DIFF
--- a/workers/scout-connect/src/env.ts
+++ b/workers/scout-connect/src/env.ts
@@ -8,4 +8,10 @@ export interface Env {
   CF_ZONE_ID: string;
   TOKEN_WRAP_KEY: string;
   CONNECT_ROOT_DOMAIN: string;
+  // Cloudflare Turnstile (bot protection on the public beta waitlist). Both
+  // optional: the gate is active ONLY when both are configured — the sitekey
+  // is a public var (wrangler.jsonc), the secret comes from `wrangler secret
+  // put TURNSTILE_SECRET`. Either missing → no widget, no verification.
+  TURNSTILE_SITEKEY?: string;
+  TURNSTILE_SECRET?: string;
 }

--- a/workers/scout-connect/src/html/beta-page.test.ts
+++ b/workers/scout-connect/src/html/beta-page.test.ts
@@ -110,9 +110,10 @@ describe("betaPage", () => {
 });
 
 describe("betaPage Turnstile (sitekey configured)", () => {
-  // Public value by design (it ships in the page and in wrangler.jsonc vars) —
-  // this is the real production sitekey, used here as the fixture.
-  const SITEKEY = "0x4AAAAAAD-wkGraJigl3YK0";
+  // Sitekey 是公开值（随页面和 wrangler.jsonc vars 一起发布），但这里刻意
+  // 用「形状合法的假 key」而不是生产实际值：测试断言的是插值行为，不该在
+  // widget 轮换时被迫改测试。
+  const SITEKEY = "0xAAAAAAAAfixture-key01";
   const withKey = betaPage(SITEKEY);
 
   it("loads the Turnstile api.js (deferred) and renders the widget inside the signup form", () => {

--- a/workers/scout-connect/src/html/beta-page.test.ts
+++ b/workers/scout-connect/src/html/beta-page.test.ts
@@ -108,3 +108,68 @@ describe("betaPage", () => {
     expect(page).toContain('textContent=String(d.position)');
   });
 });
+
+describe("betaPage Turnstile (sitekey configured)", () => {
+  // Public value by design (it ships in the page and in wrangler.jsonc vars) —
+  // this is the real production sitekey, used here as the fixture.
+  const SITEKEY = "0x4AAAAAAD-wkGraJigl3YK0";
+  const withKey = betaPage(SITEKEY);
+
+  it("loads the Turnstile api.js (deferred) and renders the widget inside the signup form", () => {
+    expect(withKey).toContain(
+      '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>',
+    );
+    expect(withKey).toContain(
+      `<div class="cf-turnstile" data-sitekey="${SITEKEY}" data-theme="dark"></div>`,
+    );
+    // The widget must sit INSIDE <form id="signup"> so the token hidden input
+    // is scoped to the signup submit.
+    const formStart = withKey.indexOf('<form id="signup"');
+    const formEnd = withKey.indexOf("</form>", formStart);
+    const widgetAt = withKey.indexOf('class="cf-turnstile"');
+    expect(formStart).toBeGreaterThanOrEqual(0);
+    expect(widgetAt).toBeGreaterThan(formStart);
+    expect(widgetAt).toBeLessThan(formEnd);
+  });
+
+  it("submit JS reads the token and posts it as turnstile_token", () => {
+    expect(withKey).toContain('document.querySelector("[name=cf-turnstile-response]")');
+    expect(withKey).toContain("turnstile_token");
+  });
+
+  it("blocks the submit client-side with 人机验证未完成，请稍候 while the token is empty", () => {
+    expect(withKey).toContain("人机验证未完成，请稍候");
+  });
+
+  it("still renders no template holes with the sitekey interpolated", () => {
+    expect(withKey).not.toContain("${");
+    expect(withKey).not.toContain(">undefined<");
+    expect(withKey).not.toContain("innerHTML");
+  });
+});
+
+describe("betaPage Turnstile (sitekey absent)", () => {
+  it("renders NO turnstile markup at all without a sitekey", () => {
+    for (const p of [betaPage(), betaPage(undefined)]) {
+      expect(p).not.toContain("cf-turnstile");
+      expect(p).not.toContain("challenges.cloudflare.com");
+      expect(p).not.toContain("turnstile_token");
+      expect(p).not.toContain("人机验证");
+    }
+  });
+
+  it("empty/whitespace sitekey behaves as absent", () => {
+    for (const p of [betaPage(""), betaPage("   ")]) {
+      expect(p).not.toContain("cf-turnstile");
+      expect(p).not.toContain("challenges.cloudflare.com");
+    }
+  });
+
+  it("a sitekey outside the real charset is refused (no markup injection via env)", () => {
+    // The sitekey is interpolated into an HTML attribute; a malformed env
+    // value must degrade to "no widget", never break out of the attribute.
+    const p = betaPage('x"><script>alert(1)</script>');
+    expect(p).not.toContain("cf-turnstile");
+    expect(p).not.toContain("alert(1)");
+  });
+});

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -11,11 +11,17 @@
 // dark base, radial green hero gradient, hairline borders, pill buttons, mono
 // eyebrows — so the page reads as the same product family as mediaryscout.app.
 //
-// Escaping discipline: unlike invite-page this page is FULLY STATIC — the
-// server interpolates zero values into it, so there is nothing to escape
-// here. Client-side, every dynamic value (position, server error text) is
-// inserted via textContent only; innerHTML is deliberately never used, and a
-// test pins both properties.
+// Escaping discipline: the ONLY server-interpolated value is the Turnstile
+// sitekey (a public, Cloudflare-issued identifier — escaped via esc() below).
+// The secret NEVER reaches this page. Client-side, every dynamic value
+// (position, server error text) is inserted via textContent only; innerHTML
+// is deliberately never used, and a test pins both properties.
+
+function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c,
+  );
+}
 
 // Aperture mark — same as apps/web/app/icon.svg and the nav logo on
 // mediaryscout.app, inlined so the page stays fully self-contained (no
@@ -23,13 +29,35 @@
 const LOGO =
   '<svg width="28" height="28" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Mediary Scout"><circle cx="16" cy="16" r="16" fill="#1ED760"/><g transform="translate(4,4)" fill="none" stroke="#0B3B1E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m14.31 8 5.74 9.94"/><path d="M9.69 8h11.48"/><path d="m7.38 12 5.74-9.94"/><path d="M9.69 16 3.95 6.06"/><path d="M14.31 16H2.83"/><path d="m16.62 12-5.74 9.94"/></g></svg>';
 
-export function betaPage(): string {
+export function betaPage(turnstileSitekey?: string): string {
+  // Turnstile 仅在配置了公开 sitekey 时启用（与 worker 的 secret 成对出现；
+  // 缺任意一个，页面与 /waitlist 都不设防，供本地开发用）。三个片段——
+  // api.js script、widget div、提交 JS 的 token 逻辑——必须同源注入或同源缺席，
+  // 否则 absent 形态会泄漏 cf-turnstile / 人机验证 字样（有测试钉着）。
+  const rawKey = (turnstileSitekey ?? "").trim();
+  // env 进来的值会被插进 HTML 属性：只接受 Turnstile key 的真实字符集
+  // （0x4AAAAAAD-… 这类 [0-9A-Za-z_-]）。恶意/畸形值整体降级为无 widget，
+  // 绝不靠转义硬插（esc 挡得住引号，挡不住"为什么把怪东西放进页面"）。
+  const sitekey = /^[0-9A-Za-z_-]+$/.test(rawKey) ? rawKey : "";
+  const tsScript = sitekey
+    ? `\n<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>`
+    : "";
+  const tsWidget = sitekey
+    ? `<div class="cf-turnstile" data-sitekey="${esc(sitekey)}" data-theme="dark"></div>`
+    : "";
+  const tsTokenRead = sitekey
+    ? `const tsToken=(document.querySelector("[name=cf-turnstile-response]")||{value:""}).value.trim();
+  if(!tsToken){setJoinPending(false);showErr(err,"人机验证未完成，请稍候");return;}`
+    : "";
+  const tsBody = sitekey
+    ? `JSON.stringify({email:email,turnstile_token:tsToken})`
+    : `JSON.stringify({email:email})`;
   return `<!doctype html>
 <html lang="zh">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Scout Connect 远程访问 · 内测 · Mediary Scout Connect</title>
+<title>Scout Connect 远程访问 · 内测 · Mediary Scout Connect</title>${tsScript}
 <style>
 :root{--bg-base:#121212;--bg-surface:#181818;--bg-raised:#1f1f1f;--bg-card:#252525;--accent:#1ed760;--accent-press:#169c46;--text:#fff;--text-muted:#b3b3b3;--border:#4d4d4d;--border-outline:#7c7c7c;--err:#f3727f;--hairline:linear-gradient(90deg,transparent,#2c2c2c 25%,#2c2c2c 75%,transparent);--font:-apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif;--mono:ui-monospace,SFMono-Regular,monospace;color-scheme:dark}
 *{box-sizing:border-box}
@@ -138,6 +166,7 @@ input[type=radio],input[type=checkbox]{accent-color:var(--accent);margin:0}
 <form id="signup">
 <p class="field"><label for="email">邮箱</label>
 <input id="email" name="email" type="email" required autocomplete="email" placeholder="you@example.com"></p>
+${tsWidget}
 <button id="join" type="submit" class="btn-primary" aria-label="申请内测席位" aria-busy="false">申请内测席位</button>
 <p id="err" class="err" role="alert" hidden></p>
 </form>
@@ -202,8 +231,9 @@ $("signup").onsubmit=async(ev)=>{
   const err=$("err");
   err.hidden=true;err.textContent="";
   setJoinPending(true);
+  ${tsTokenRead}
   let r=null;
-  try{r=await fetch("/waitlist",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({email:email})});}
+  try{r=await fetch("/waitlist",{method:"POST",headers:{"content-type":"application/json"},body:${tsBody}});}
   catch(_){setJoinPending(false);showErr(err,"网络异常，提交失败——请稍后再试。");return;}
   let d=null;
   try{d=await r.json();}catch(_){}

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -17,6 +17,19 @@
 // (position, server error text) is inserted via textContent only; innerHTML
 // is deliberately never used, and a test pins both properties.
 
+/**
+ * env 进来的 sitekey 会被插进 HTML 属性：只接受 Turnstile key 的真实字符集
+ * （0x4AAAAAAD-… 这类 [0-9A-Za-z_-]）。恶意/畸形值归一为空串（=无 widget），
+ * 绝不靠转义硬插（esc 挡得住引号，挡不住"为什么把怪东西放进页面"）。
+ *
+ * routes.ts 的门**必须**用同一个归一化：否则 env 配了畸形 sitekey 时，
+ * 页面不渲染 widget 而门却开着，所有报名 400 且用户拿不到 token。
+ */
+export function normalizeTurnstileSitekey(raw?: string): string {
+  const key = (raw ?? "").trim();
+  return /^[0-9A-Za-z_-]+$/.test(key) ? key : "";
+}
+
 function esc(s: string): string {
   return s.replace(/[&<>"']/g, (c) =>
     ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c,
@@ -34,11 +47,7 @@ export function betaPage(turnstileSitekey?: string): string {
   // 缺任意一个，页面与 /waitlist 都不设防，供本地开发用）。三个片段——
   // api.js script、widget div、提交 JS 的 token 逻辑——必须同源注入或同源缺席，
   // 否则 absent 形态会泄漏 cf-turnstile / 人机验证 字样（有测试钉着）。
-  const rawKey = (turnstileSitekey ?? "").trim();
-  // env 进来的值会被插进 HTML 属性：只接受 Turnstile key 的真实字符集
-  // （0x4AAAAAAD-… 这类 [0-9A-Za-z_-]）。恶意/畸形值整体降级为无 widget，
-  // 绝不靠转义硬插（esc 挡得住引号，挡不住"为什么把怪东西放进页面"）。
-  const sitekey = /^[0-9A-Za-z_-]+$/.test(rawKey) ? rawKey : "";
+  const sitekey = normalizeTurnstileSitekey(turnstileSitekey);
   const tsScript = sitekey
     ? `\n<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>`
     : "";

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -4,8 +4,11 @@
 // (host-routed in routes.ts). The canonical public URL is the bare
 // beta.mediaryconnect.app — print that one everywhere, never …/beta.
 // step 1 collects the email (POST /waitlist, same origin), step 2 offers an
-// optional survey (POST /waitlist/survey). Fully self-contained: inline
-// style/script only, no external requests.
+// optional survey (POST /waitlist/survey). Style/script are inline only —
+// the page ships no first-party asset requests. The ONE external dependency
+// is conditional: when the Turnstile gate is configured it loads
+// challenges.cloudflare.com (api.js + challenge iframe); ungated, the page
+// makes no external requests at all.
 //
 // Visual language mirrors the official site (site/index.html + site/style.css):
 // dark base, radial green hero gradient, hairline borders, pill buttons, mono

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -33,8 +33,11 @@ export function htmlPage(body: string, status = 200): Response {
       // challenges.cloudflare.com (script/frame/connect) is the beta page's
       // Turnstile widget. On the shared policy for all pages — htmlPage() is
       // shared, per-page CSP would only invite drift.
+      // script-src 刻意不含 'self'：本 worker 的每个 <script> 要么内联、要么
+      // 是上面那个 Turnstile CDN 地址，没有任何同源脚本资源。加了不解决问题，
+      // 只是白白放宽（connect-src 'self' 是另一回事，那条是 fetch 用的）。
       "content-security-policy":
-        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline' 'self' https://challenges.cloudflare.com; connect-src 'self' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline' https://challenges.cloudflare.com; connect-src 'self' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
       "x-content-type-options": "nosniff",
       // frame-ancestors only works as a CSP directive (above); x-frame-options
       // is the legacy header that actually blocks framing in older browsers.

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -30,8 +30,11 @@ export function htmlPage(body: string, status = 200): Response {
       // signup), and connect-src falls back to default-src when absent —
       // 'none' made the browser refuse those fetches outright (verified
       // empirically: "Failed to fetch" without the directive, 200 with it).
+      // challenges.cloudflare.com (script/frame/connect) is the beta page's
+      // Turnstile widget. On the shared policy for all pages — htmlPage() is
+      // shared, per-page CSP would only invite drift.
       "content-security-policy":
-        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+        "default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline' 'self' https://challenges.cloudflare.com; connect-src 'self' https://challenges.cloudflare.com; frame-src https://challenges.cloudflare.com; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
       "x-content-type-options": "nosniff",
       // frame-ancestors only works as a CSP directive (above); x-frame-options
       // is the legacy header that actually blocks framing in older browsers.

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -23,8 +23,10 @@ export function htmlPage(body: string, status = 200): Response {
     status,
     headers: {
       "content-type": "text/html; charset=utf-8",
-      // Pages are fully self-contained (inline style/script only), so a strict
-      // CSP is free defense-in-depth for a page that carries a one-time token.
+      // Pages carry inline style/script only — no first-party asset requests —
+      // so a strict CSP is free defense-in-depth for a page that carries a
+      // one-time token. The ONE third-party source is conditional: the beta
+      // page's Turnstile widget (allowlisted below).
       // connect-src 'self' is load-bearing, not decorative: every page's
       // inline script POSTs same-origin (invite reveal, admin console, beta
       // signup), and connect-src falls back to default-src when absent —

--- a/workers/scout-connect/src/index.ts
+++ b/workers/scout-connect/src/index.ts
@@ -21,6 +21,8 @@ export default {
       newEndpointId: () => newId("ep"),
       newAuditId: () => newId("aud"),
       newInviteCode,
+      turnstileSitekey: env.TURNSTILE_SITEKEY,
+      turnstileSecret: env.TURNSTILE_SECRET,
     });
   },
 };

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1849,6 +1849,21 @@ describe("POST /waitlist Turnstile gate", () => {
     expect(await db.countWaitlist(1)).toBe(2);
   });
 
+  it("malformed sitekey (even with secret) → gate OFF consistently: no widget AND signup passes", async () => {
+    // 页面侧 trim + 字符集校验会拒绝畸形 sitekey（不渲染 widget）；
+    // 门侧若只看 truthy 就会开着——用户没有任何途径拿 token，报名全 400。
+    // 两侧必须归一到同一个判定（Copilot PR #184 round 2）。
+    const { db, deps } = setup();
+    const fetchSpy = forbidFetch();
+    const messy = { ...deps, turnstileSitekey: ' x"><script>', turnstileSecret: TS_SECRET };
+    const page = await handleRequest(new Request(`${BASE}/beta`), messy);
+    expect(await page.text()).not.toContain("cf-turnstile");
+    const res = await handleRequest(waitlistPost({ email: "no-widget@example.com" }), messy);
+    expect(res.status).toBe(201);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await db.countWaitlist(1)).toBe(1);
+  });
+
   it("GET /beta renders the widget only when BOTH halves are configured", async () => {
     const { deps } = setup();
     const both = await handleRequest(new Request(`${BASE}/beta`), tsDeps(deps));

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1754,7 +1754,7 @@ describe("POST /waitlist Turnstile gate", () => {
 
   it("configured + siteverify success:true → 201; request is form-encoded with secret+token+remoteip and a timeout signal", async () => {
     const { deps } = setup();
-    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const calls: Array<{ url: string; init?: RequestInit | undefined }> = [];
     vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
       calls.push({
         url:

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1773,7 +1773,7 @@ describe("POST /waitlist Turnstile gate", () => {
     expect(res.status).toBe(201);
     expect(calls).toHaveLength(1);
     const call = calls[0]!;
-    expect(call.url).toBe("https://challenges.cloudflare.com/siteverify");
+    expect(call.url).toBe("https://challenges.cloudflare.com/turnstile/v0/siteverify");
     expect(call.init?.method).toBe("POST");
     expect(call.init?.headers).toMatchObject({
       "content-type": "application/x-www-form-urlencoded",

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -415,9 +415,10 @@ describe("handleRequest", () => {
     const csp = res.headers.get("content-security-policy") ?? "";
     // New Turnstile sources (exact directive bodies — a dropped source here
     // silently breaks the widget in production while tests stay green):
-    expect(csp).toContain(
-      "script-src 'unsafe-inline' 'self' https://challenges.cloudflare.com",
-    );
+    expect(csp).toContain("script-src 'unsafe-inline' https://challenges.cloudflare.com");
+    // 最小权限：没有任何同源脚本资源（每个 <script> 要么内联、要么是上面的
+    // Turnstile CDN），所以 script-src 不该出现 'self'。
+    expect(csp).not.toContain("script-src 'unsafe-inline' 'self'");
     expect(csp).toContain("frame-src https://challenges.cloudflare.com");
     expect(csp).toContain("connect-src 'self' https://challenges.cloudflare.com");
     // Pre-existing directives unchanged:

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -417,8 +417,14 @@ describe("handleRequest", () => {
     // silently breaks the widget in production while tests stay green):
     expect(csp).toContain("script-src 'unsafe-inline' https://challenges.cloudflare.com");
     // 最小权限：没有任何同源脚本资源（每个 <script> 要么内联、要么是上面的
-    // Turnstile CDN），所以 script-src 不该出现 'self'。
-    expect(csp).not.toContain("script-src 'unsafe-inline' 'self'");
+    // Turnstile CDN），所以 script-src 指令里不该出现 'self' —— 按指令解析，
+    // 不靠子串匹配（子串写法漏掉 "…https://… 'self'" 这种换序）。
+    const scriptSrc = (csp.split(";").find((d) => d.trim().startsWith("script-src ")) ?? "")
+      .trim()
+      .split(/\s+/)
+      .slice(1);
+    expect(scriptSrc).not.toContain("'self'");
+    expect(scriptSrc).toEqual(["'unsafe-inline'", "https://challenges.cloudflare.com"]);
     expect(csp).toContain("frame-src https://challenges.cloudflare.com");
     expect(csp).toContain("connect-src 'self' https://challenges.cloudflare.com");
     // Pre-existing directives unchanged:
@@ -1905,6 +1911,47 @@ describe("POST /waitlist Turnstile gate", () => {
     const logged = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
     expect(logged).toMatch(/TimeoutError/);
     expect(logged).not.toMatch(/unknown error/);
+  });
+
+  // wrangler secret put 从文件/echo 灌进来时极易带上尾换行。带空白的 secret
+  // 会让门「开着但永远验不过」——报名漏斗 100% 静默死，且用户侧只看到 403。
+  it("secret with surrounding whitespace: gate stays on and siteverify receives the TRIMMED secret", async () => {
+    const { db, deps } = setup();
+    let sentSecret: string | null = null;
+    vi.stubGlobal("fetch", async (_input: unknown, init?: RequestInit) => {
+      sentSecret = new URLSearchParams(String(init?.body ?? "")).get("secret");
+      return siteverifyJson({ success: true });
+    });
+    const res = await handleRequest(
+      waitlistPost({ email: "human@example.com", turnstile_token: "tok-ws" }),
+      { ...deps, turnstileSitekey: TS_SITEKEY, turnstileSecret: `  ${TS_SECRET}\n` },
+    );
+    expect(res.status).toBe(201);
+    expect(sentSecret).toBe(TS_SECRET);
+    expect(await db.countWaitlist(1)).toBe(1);
+  });
+
+  it("whitespace-only secret counts as UNCONFIGURED (gate off), never as a usable secret", async () => {
+    const { db, deps } = setup();
+    const fetchSpy = forbidFetch();
+    const res = await handleRequest(waitlistPost({ email: "free@example.com" }), {
+      ...deps,
+      turnstileSitekey: TS_SITEKEY,
+      turnstileSecret: "   \n",
+    });
+    expect(res.status).toBe(201); // 门关着=按未配置处理，报名照常
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await db.countWaitlist(1)).toBe(1);
+  });
+
+  it("whitespace-only secret also keeps the widget OFF the page (page and gate stay in lockstep)", async () => {
+    const { deps } = setup();
+    const page = await handleRequest(new Request(`${BASE}/beta`), {
+      ...deps,
+      turnstileSitekey: TS_SITEKEY,
+      turnstileSecret: "   ",
+    });
+    expect(await page.text()).not.toContain("cf-turnstile");
   });
 
   it("unconfigured (no turnstile deps) → unchanged behavior, fetch NEVER called", async () => {

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1820,6 +1820,92 @@ describe("POST /waitlist Turnstile gate", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  // 运维可观测性：CF 挂掉 / secret 配错 与「来的全是机器人」在 fail-closed
+  // 之下产生完全相同的用户可见结果（403）。若日志也一样，报名漏斗静默归零
+  // 且无人知情。基础设施异常必须留下 console.error，且绝不带 secret/token。
+  it("siteverify non-2xx → still 403 (fail closed) but logs an error carrying the status, never the secret/token", async () => {
+    const { db, deps } = setup();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", async () => new Response("upstream boom", { status: 502 }));
+    const res = await handleRequest(
+      waitlistPost({ email: "human@example.com", turnstile_token: "tok-502" }),
+      tsDeps(deps),
+    );
+    expect(res.status).toBe(403);
+    expect(await db.countWaitlist(1)).toBe(0);
+    const logged = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toMatch(/502/);
+    expect(logged).not.toContain(TS_SECRET);
+    expect(logged).not.toContain("tok-502");
+  });
+
+  it("siteverify 200 with a non-JSON body → 403 and an error log (not silently indistinguishable from a bot)", async () => {
+    const { deps } = setup();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      async () => new Response("<html>nope</html>", { status: 200, headers: { "content-type": "text/html" } }),
+    );
+    const res = await handleRequest(
+      waitlistPost({ email: "human@example.com", turnstile_token: "tok-html" }),
+      tsDeps(deps),
+    );
+    expect(res.status).toBe(403);
+    expect(errSpy).toHaveBeenCalled();
+    const logged = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).not.toContain(TS_SECRET);
+    expect(logged).not.toContain("tok-html");
+  });
+
+  it("success:false carrying a CONFIG error-code (invalid-input-secret) is logged — a misconfigured secret must not look like bot traffic", async () => {
+    const { deps } = setup();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", async () =>
+      siteverifyJson({ success: false, "error-codes": ["invalid-input-secret"] }),
+    );
+    const res = await handleRequest(
+      waitlistPost({ email: "human@example.com", turnstile_token: "tok-cfg" }),
+      tsDeps(deps),
+    );
+    expect(res.status).toBe(403);
+    const logged = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toMatch(/invalid-input-secret/);
+    expect(logged).not.toContain(TS_SECRET);
+    expect(logged).not.toContain("tok-cfg");
+  });
+
+  it("a plain bot rejection (invalid-input-response) stays quiet — no error spam on the normal path", async () => {
+    const { deps } = setup();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", async () =>
+      siteverifyJson({ success: false, "error-codes": ["invalid-input-response"] }),
+    );
+    const res = await handleRequest(
+      waitlistPost({ email: "bot@example.com", turnstile_token: "tok-bot" }),
+      tsDeps(deps),
+    );
+    expect(res.status).toBe(403);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("a DOMException-like timeout is logged by NAME, not as \"unknown error\"", async () => {
+    const { deps } = setup();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Some runtimes' DOMException is not `instanceof Error`; the logger must
+    // still surface TimeoutError instead of a useless "unknown error".
+    vi.stubGlobal("fetch", async () => {
+      throw { name: "TimeoutError", message: "The operation was aborted due to timeout" };
+    });
+    const res = await handleRequest(
+      waitlistPost({ email: "human@example.com", turnstile_token: "tok-timeout" }),
+      tsDeps(deps),
+    );
+    expect(res.status).toBe(403);
+    const logged = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toMatch(/TimeoutError/);
+    expect(logged).not.toMatch(/unknown error/);
+  });
+
   it("unconfigured (no turnstile deps) → unchanged behavior, fetch NEVER called", async () => {
     const { db, deps } = setup();
     const fetchSpy = forbidFetch();

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { handleRequest, MAX_JSON_BODY_BYTES, type RouteDeps } from "./routes.js";
 import { createMemoryConnectDb, type ConnectDb } from "./db.js";
 import type { CfApi } from "./cf-api.js";
@@ -404,6 +404,28 @@ describe("handleRequest", () => {
     const csp = res.headers.get("content-security-policy") ?? "";
     expect(csp).toContain("connect-src 'self'");
     expect(csp).toContain("default-src 'none'");
+  });
+
+  it("GET pages carry a CSP that allows the Cloudflare Turnstile assets", async () => {
+    // The beta signup page's bot gate (Turnstile) loads api.js, renders an
+    // iframe, and beacons to challenges.cloudflare.com. htmlPage()'s CSP is
+    // shared by home/invite/admin/beta, so the allowlist lives there for all.
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/beta`), deps);
+    const csp = res.headers.get("content-security-policy") ?? "";
+    // New Turnstile sources (exact directive bodies — a dropped source here
+    // silently breaks the widget in production while tests stay green):
+    expect(csp).toContain(
+      "script-src 'unsafe-inline' 'self' https://challenges.cloudflare.com",
+    );
+    expect(csp).toContain("frame-src https://challenges.cloudflare.com");
+    expect(csp).toContain("connect-src 'self' https://challenges.cloudflare.com");
+    // Pre-existing directives unchanged:
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain("style-src 'unsafe-inline'");
+    expect(csp).toContain("base-uri 'none'");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("frame-ancestors 'none'");
   });
 
   it("GET /i/:code with pending invite → 作者尚未开通, no reveal button", async () => {
@@ -1655,5 +1677,196 @@ describe("request body size cap", () => {
     expect((await handleRequest(chunkedRequest(`${BASE}/waitlist`, overCap), deps)).status).toBe(
       413,
     );
+  });
+});
+
+// Cloudflare Turnstile gate on the public signup funnel (bot protection).
+// Active ONLY when BOTH turnstileSitekey (public var) and turnstileSecret
+// (wrangler secret) are configured in deps — either missing → the route
+// behaves exactly as before and siteverify is never called.
+describe("POST /waitlist Turnstile gate", () => {
+  const TS_SITEKEY = "0x4AAAAAAD-wkGraJigl3YK0-gate-fixture";
+  const TS_SECRET = "turnstile-secret-gate-fixture"; // fixture only — must never leak into responses/logs
+
+  function tsDeps(deps: RouteDeps): RouteDeps {
+    return { ...deps, turnstileSitekey: TS_SITEKEY, turnstileSecret: TS_SECRET };
+  }
+
+  function waitlistPost(body: unknown, headers: Record<string, string> = {}): Request {
+    return new Request(`${BASE}/waitlist`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: JSON.stringify(body),
+    });
+  }
+
+  /** Stubs global fetch to explode — the gate must never reach siteverify. */
+  function forbidFetch() {
+    const spy = vi.fn(() => {
+      throw new Error("fetch must not be called in this scenario");
+    });
+    vi.stubGlobal("fetch", spy);
+    return spy;
+  }
+
+  function siteverifyJson(payload: unknown): Response {
+    return new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("configured + missing/empty/non-string token → 400 turnstile required, siteverify never called, nothing stored", async () => {
+    const { db, deps } = setup();
+    const fetchSpy = forbidFetch();
+    for (const body of [
+      { email: "a@example.com" },
+      { email: "a@example.com", turnstile_token: "" },
+      { email: "a@example.com", turnstile_token: "   " },
+      { email: "a@example.com", turnstile_token: 42 },
+    ]) {
+      const res = await handleRequest(waitlistPost(body), tsDeps(deps));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "turnstile required" });
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await db.countWaitlist(1)).toBe(0);
+  });
+
+  it("configured + siteverify success:false → 403 turnstile failed, nothing stored", async () => {
+    const { db, deps } = setup();
+    vi.stubGlobal("fetch", async () =>
+      siteverifyJson({ success: false, "error-codes": ["invalid-input-response"] }),
+    );
+    const res = await handleRequest(
+      waitlistPost({ email: "bot@example.com", turnstile_token: "tok-bad" }),
+      tsDeps(deps),
+    );
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "turnstile failed" });
+    expect(await db.countWaitlist(1)).toBe(0);
+  });
+
+  it("configured + siteverify success:true → 201; request is form-encoded with secret+token+remoteip and a timeout signal", async () => {
+    const { deps } = setup();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+      calls.push({
+        url:
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+        init,
+      });
+      return siteverifyJson({ success: true });
+    });
+    const res = await handleRequest(
+      waitlistPost(
+        { email: "human@example.com", turnstile_token: "tok-ok" },
+        { "cf-connecting-ip": "203.0.113.9" },
+      ),
+      tsDeps(deps),
+    );
+    expect(res.status).toBe(201);
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.url).toBe("https://challenges.cloudflare.com/siteverify");
+    expect(call.init?.method).toBe("POST");
+    expect(call.init?.headers).toMatchObject({
+      "content-type": "application/x-www-form-urlencoded",
+    });
+    const form = new URLSearchParams(call.init?.body as string);
+    expect(form.get("secret")).toBe(TS_SECRET);
+    expect(form.get("response")).toBe("tok-ok");
+    expect(form.get("remoteip")).toBe("203.0.113.9");
+    // Project rule: every external HTTP call is bounded by a timeout signal.
+    expect(call.init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("configured + siteverify network/timeout error → 403 fail closed, and the secret/token leak into neither response nor logs", async () => {
+    const { db, deps } = setup();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("fetch", async () => {
+      throw new DOMException("The operation timed out", "TimeoutError");
+    });
+    const res = await handleRequest(
+      waitlistPost({ email: "human@example.com", turnstile_token: "tok-leakcheck" }),
+      tsDeps(deps),
+    );
+    expect(res.status).toBe(403);
+    const bodyText = JSON.stringify(await res.json());
+    expect(bodyText).not.toContain(TS_SECRET);
+    expect(bodyText).not.toContain("tok-leakcheck");
+    expect(await db.countWaitlist(1)).toBe(0);
+    // Fail-closed was logged — but the log carries neither the secret nor the token.
+    expect(errSpy).toHaveBeenCalled();
+    const logged = errSpy.mock.calls.map((args) => args.map(String).join(" ")).join("\n");
+    expect(logged).not.toContain(TS_SECRET);
+    expect(logged).not.toContain("tok-leakcheck");
+  });
+
+  it("an invalid email gets its plain 400 WITHOUT consuming the single-use token (shape validated before the gate)", async () => {
+    // siteverify tokens are single-use: burning one on a request that was
+    // doomed on email shape would 403 the user's corrected retry. The gate
+    // therefore runs after the cheap shape checks, before any db work.
+    const { deps } = setup();
+    const fetchSpy = forbidFetch();
+    const res = await handleRequest(waitlistPost({ email: "not-an-email" }), tsDeps(deps));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "invalid email" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("unconfigured (no turnstile deps) → unchanged behavior, fetch NEVER called", async () => {
+    const { db, deps } = setup();
+    const fetchSpy = forbidFetch();
+    const res = await handleRequest(waitlistPost({ email: "free@example.com" }), deps);
+    expect(res.status).toBe(201);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await db.countWaitlist(1)).toBe(1);
+  });
+
+  it("only one half configured → gate stays OFF (both sitekey and secret are required)", async () => {
+    const { db, deps } = setup();
+    const fetchSpy = forbidFetch();
+    // Sitekey without secret: the page mints tokens nobody can verify; secret
+    // without sitekey: no widget exists to mint tokens. Enforcing in either
+    // misconfiguration would 400 every signup — the gate must stay off.
+    const sitekeyOnly = await handleRequest(waitlistPost({ email: "k@example.com" }), {
+      ...deps,
+      turnstileSitekey: TS_SITEKEY,
+    });
+    expect(sitekeyOnly.status).toBe(201);
+    const secretOnly = await handleRequest(waitlistPost({ email: "s@example.com" }), {
+      ...deps,
+      turnstileSecret: TS_SECRET,
+    });
+    expect(secretOnly.status).toBe(201);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await db.countWaitlist(1)).toBe(2);
+  });
+
+  it("GET /beta renders the widget only when BOTH halves are configured", async () => {
+    const { deps } = setup();
+    const both = await handleRequest(new Request(`${BASE}/beta`), tsDeps(deps));
+    expect(await both.text()).toContain(`data-sitekey="${TS_SITEKEY}"`);
+
+    const sitekeyOnly = await handleRequest(new Request(`${BASE}/beta`), {
+      ...deps,
+      turnstileSitekey: TS_SITEKEY,
+    });
+    expect(await sitekeyOnly.text()).not.toContain("cf-turnstile");
+
+    const secretOnly = await handleRequest(new Request(`${BASE}/beta`), {
+      ...deps,
+      turnstileSecret: TS_SECRET,
+    });
+    expect(await secretOnly.text()).not.toContain("cf-turnstile");
+
+    const neither = await handleRequest(new Request(`${BASE}/beta`), deps);
+    expect(await neither.text()).not.toContain("cf-turnstile");
   });
 });

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -30,7 +30,8 @@ export interface RouteDeps {
   newAuditId: () => string;
   newInviteCode: () => string;
   // Cloudflare Turnstile config for the public waitlist gate. Both optional —
-  // the gate is active ONLY when both are set (see turnstileConfig below);
+  // the gate is active ONLY when both are set — the paired rule lives in
+  // turnstileSitekeyIfConfigured() / turnstileGateEnabled() below;
   // either absent → no widget rendered, POST /waitlist skips verification.
   turnstileSitekey?: string | undefined;
   turnstileSecret?: string | undefined;
@@ -562,15 +563,59 @@ async function verifyTurnstile(secret: string, token: string, remoteIp: string |
       body: form.toString(),
       signal: AbortSignal.timeout(5_000),
     });
-    const data = (await res.json().catch(() => null)) as { success?: boolean } | null;
-    return data?.success === true;
+    // 基础设施异常必须与「正常拦截」在日志里可区分：两者对用户都是 403，
+    // 若日志也一样，CF 挂掉/secret 配错会让报名漏斗静默归零且无人知情。
+    if (!res.ok) {
+      console.error("turnstile siteverify HTTP error, status:", res.status);
+      return false;
+    }
+    const data = (await res.json().catch(() => null)) as TurnstileVerifyResponse | null;
+    if (data === null) {
+      console.error("turnstile siteverify returned a non-JSON body, status:", res.status);
+      return false;
+    }
+    if (data.success === true) return true;
+    const actionable = turnstileActionableCodes(data);
+    if (actionable.length > 0) {
+      // error-codes 是 CF 的固定枚举，既不含 secret 也不含用户 token。
+      console.error("turnstile siteverify config/infra error:", actionable.join(","));
+    }
+    return false;
   } catch (e) {
-    console.error(
-      "turnstile siteverify failed:",
-      e instanceof Error ? e.name : "unknown error",
-    );
+    console.error("turnstile siteverify failed:", errorName(e));
     return false;
   }
+}
+
+type TurnstileVerifyResponse = { success?: boolean; "error-codes"?: unknown };
+
+/** 需要运维介入的 siteverify error-codes（其余属于正常拦截，不该刷日志）。
+ *  见 developers.cloudflare.com/turnstile/get-started/server-side-validation。
+ *  刻意排除 missing/invalid-input-response 与 timeout-or-duplicate——过期、
+ *  重放、机器人是这条公开漏斗的日常，报警值为零。 */
+const TURNSTILE_ACTIONABLE_CODES = new Set([
+  "missing-input-secret",
+  "invalid-input-secret",
+  "invalid-widget-id",
+  "invalid-parsed-secret",
+  "bad-request",
+  "internal-error",
+]);
+
+function turnstileActionableCodes(data: TurnstileVerifyResponse): string[] {
+  const raw = data["error-codes"];
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((c): c is string => typeof c === "string" && TURNSTILE_ACTIONABLE_CODES.has(c));
+}
+
+/** 某些运行时的 DOMException 不是 `instanceof Error`（AbortSignal.timeout 抛的
+ *  就是它）——只按 instanceof 取名字会把 TimeoutError 记成 "unknown error"。 */
+function errorName(e: unknown): string {
+  if (typeof e === "object" && e !== null && "name" in e) {
+    const n = (e as { name?: unknown }).name;
+    if (typeof n === "string" && n.length > 0) return n;
+  }
+  return "unknown error";
 }
 
 async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Response> {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -538,7 +538,14 @@ function turnstileSitekeyIfConfigured(deps: RouteDeps): string | undefined {
   // 与页面同一个归一化（trim + 字符集校验）：畸形 sitekey 会让页面不渲染
   // widget，此时门也必须关——否则用户没有任何途径拿到 token，报名全 400。
   const key = normalizeTurnstileSitekey(deps.turnstileSitekey);
-  return key && deps.turnstileSecret ? key : undefined;
+  return key && turnstileSecretIfConfigured(deps) ? key : undefined;
+}
+
+/** 归一化后的 secret：`wrangler secret put` 从文件/echo 灌进来常带尾换行，
+ *  原样用会让门「开着但永远验不过」（报名 100% 静默死）。纯空白 = 未配置。 */
+function turnstileSecretIfConfigured(deps: RouteDeps): string | undefined {
+  const secret = deps.turnstileSecret?.trim();
+  return secret ? secret : undefined;
 }
 
 /** Turnstile 门是否启用——与 turnstileSitekeyIfConfigured 同一条「成对」规则。 */
@@ -653,7 +660,8 @@ async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Respons
     }
     const remoteIp = request.headers.get("cf-connecting-ip")?.trim() || null;
     // turnstileGateEnabled 只表达规则，不给 TS 收窄——secret 在此单独取值收窄。
-    const secret = deps.turnstileSecret;
+    // 必须走同一个归一化，否则送去 siteverify 的还是带空白的原值。
+    const secret = turnstileSecretIfConfigured(deps);
     if (!secret) throw new HttpError(500, "internal");
     const ok = await verifyTurnstile(secret, token, remoteIp);
     if (!ok) {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -9,7 +9,7 @@ import { assertSlug } from "./slug.js";
 import { homePage } from "./html/home-page.js";
 import { adminPage } from "./html/admin-page.js";
 import { invitePage, type InvitePageState } from "./html/invite-page.js";
-import { betaPage } from "./html/beta-page.js";
+import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
 import { EMAIL_MAX_LENGTH, EMAIL_RE } from "./validation.js";
 import { newId } from "./ids.js";
 import { sha256Hex } from "./crypto-token.js";
@@ -534,12 +534,15 @@ function isUniqueViolation(e: unknown): boolean {
  * secret 无 sitekey → 没有 widget 可铸）。与 /waitlist 的门同一条规则。
  */
 function turnstileSitekeyIfConfigured(deps: RouteDeps): string | undefined {
-  return deps.turnstileSitekey && deps.turnstileSecret ? deps.turnstileSitekey : undefined;
+  // 与页面同一个归一化（trim + 字符集校验）：畸形 sitekey 会让页面不渲染
+  // widget，此时门也必须关——否则用户没有任何途径拿到 token，报名全 400。
+  const key = normalizeTurnstileSitekey(deps.turnstileSitekey);
+  return key && deps.turnstileSecret ? key : undefined;
 }
 
 /** Turnstile 门是否启用——与 turnstileSitekeyIfConfigured 同一条「成对」规则。 */
 function turnstileGateEnabled(deps: RouteDeps): boolean {
-  return Boolean(deps.turnstileSitekey && deps.turnstileSecret);
+  return turnstileSitekeyIfConfigured(deps) !== undefined;
 }
 
 /**

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -182,7 +182,7 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
     // mixed-case or space-padded value would silently break this routing.
     const betaHost = `beta.${deps.rootDomain.trim().toLowerCase()}`;
     if (url.hostname.toLowerCase() === betaHost) {
-      return htmlPage(betaPage());
+      return htmlPage(betaPage(turnstileSitekeyIfConfigured(deps)));
     }
     return htmlPage(homePage());
   }
@@ -205,7 +205,7 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
     return htmlPage(adminPage());
   }
   if (method === "GET" && path === "/beta") {
-    return htmlPage(betaPage());
+    return htmlPage(betaPage(turnstileSitekeyIfConfigured(deps)));
   }
 
   // ---- admin api (bearer required) ----
@@ -529,6 +529,47 @@ function isUniqueViolation(e: unknown): boolean {
  * omits `position` there is stale — see the comment on the branch itself for
  * why it is deliberate. `position` is 1-based within the batch.
  */
+/**
+ * sitekey 只在两半齐备时下发页面（sitekey 无 secret → 铸出验不了的 token；
+ * secret 无 sitekey → 没有 widget 可铸）。与 /waitlist 的门同一条规则。
+ */
+function turnstileSitekeyIfConfigured(deps: RouteDeps): string | undefined {
+  return deps.turnstileSitekey && deps.turnstileSecret ? deps.turnstileSitekey : undefined;
+}
+
+/** Turnstile 门是否启用——与 turnstileSitekeyIfConfigured 同一条「成对」规则。 */
+function turnstileGateEnabled(deps: RouteDeps): boolean {
+  return Boolean(deps.turnstileSitekey && deps.turnstileSecret);
+}
+
+/**
+ * Cloudflare Turnstile 服务端校验（siteverify）。project 硬规则：外部 HTTP
+ * 一律带超时。失败一律 fail CLOSED（这是公开报名漏斗，宁误杀不放过）——
+ * 但日志里绝不带 secret 与用户 token。
+ */
+async function verifyTurnstile(secret: string, token: string, remoteIp: string | null): Promise<boolean> {
+  const form = new URLSearchParams();
+  form.set("secret", secret);
+  form.set("response", token);
+  if (remoteIp) form.set("remoteip", remoteIp);
+  try {
+    const res = await fetch("https://challenges.cloudflare.com/siteverify", {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: form.toString(),
+      signal: AbortSignal.timeout(5_000),
+    });
+    const data = (await res.json().catch(() => null)) as { success?: boolean } | null;
+    return data?.success === true;
+  } catch (e) {
+    console.error(
+      "turnstile siteverify failed:",
+      e instanceof Error ? e.name : "unknown error",
+    );
+    return false;
+  }
+}
+
 async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Response> {
   const body = await readJsonBody(request);
   const emailRaw = body.email;
@@ -551,6 +592,28 @@ async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Respons
   const email = emailRaw.trim().toLowerCase();
   if (email.length > EMAIL_MAX_LENGTH || !EMAIL_RE.test(email)) {
     throw new HttpError(400, "invalid email");
+  }
+
+  // Turnstile 门：仅在配置了 secret 时启用（与页面 widget 成对；未配置=本地
+  // 开发，全链路不设防）。位置刻意在邮箱形状校验**之后**——siteverify 的
+  // token 是一次性的，不能浪费在一个注定 400 的请求上。
+  // Turnstile 门：仅在 sitekey+secret 成对配置时启用（未配置=本地开发，
+  // 全链路不设防）。位置刻意在邮箱形状校验**之后**——siteverify 的
+  // token 是一次性的，不能浪费在一个注定 400 的请求上。
+  if (turnstileGateEnabled(deps)) {
+    const rawToken = body.turnstile_token;
+    const token = typeof rawToken === "string" ? rawToken.trim() : "";
+    if (token === "") {
+      throw new HttpError(400, "turnstile required");
+    }
+    const remoteIp = request.headers.get("cf-connecting-ip")?.trim() || null;
+    // turnstileGateEnabled 只表达规则，不给 TS 收窄——secret 在此单独取值收窄。
+    const secret = deps.turnstileSecret;
+    if (!secret) throw new HttpError(500, "internal");
+    const ok = await verifyTurnstile(secret, token, remoteIp);
+    if (!ok) {
+      throw new HttpError(403, "turnstile failed");
+    }
   }
 
   const batch = WAITLIST_BATCH;

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -514,14 +514,20 @@ function isUniqueViolation(e: unknown): boolean {
 /**
  * POST /waitlist — public, unauthenticated signup.
  *
- * Request: `{ email: string }` (≤ EMAIL_MAX_LENGTH bytes; trimmed+lowercased).
+ * Request: `{ email: string, turnstile_token?: string }`
+ * (email ≤ EMAIL_MAX_LENGTH bytes; trimmed+lowercased. turnstile_token is
+ * REQUIRED when the Turnstile gate is configured — see turnstileGateEnabled —
+ * and ignored entirely when it is not.)
  *
  * Responses — `position` is present on EVERY success path, new or repeat:
  *   201 `{ id: string, position: number }`
  *   200 `{ already_exists: true, id: string, position: number }`
- *   400 `{ error: "email required" | "invalid email" }`
- *       (plus "invalid json" / "invalid body" from the
- *        shared body reader)
+ *   400 `{ error: "email required" | "invalid email" | "turnstile required" }`
+ *       ("turnstile required" only when the gate is on and the token is
+ *        missing/blank/non-string; plus "invalid json" / "invalid body"
+ *        from the shared body reader)
+ *   403 `{ error: "turnstile failed" }` — gate on and siteverify did not
+ *       return success (fail CLOSED: network/timeout/non-2xx count as failure)
  *   409 `{ error: "本批内测席位已满" }` — founding batch at WAITLIST_SEAT_CAP;
  *       NEW emails only, repeats still get their 200 below
  *   413 `{ error: "body too large" }`

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -29,6 +29,11 @@ export interface RouteDeps {
   newEndpointId: () => string;
   newAuditId: () => string;
   newInviteCode: () => string;
+  // Cloudflare Turnstile config for the public waitlist gate. Both optional —
+  // the gate is active ONLY when both are set (see turnstileConfig below);
+  // either absent → no widget rendered, POST /waitlist skips verification.
+  turnstileSitekey?: string | undefined;
+  turnstileSecret?: string | undefined;
 }
 
 export async function handleRequest(request: Request, deps: RouteDeps): Promise<Response> {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -553,7 +553,7 @@ async function verifyTurnstile(secret: string, token: string, remoteIp: string |
   form.set("response", token);
   if (remoteIp) form.set("remoteip", remoteIp);
   try {
-    const res = await fetch("https://challenges.cloudflare.com/siteverify", {
+    const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: form.toString(),
@@ -594,9 +594,6 @@ async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Respons
     throw new HttpError(400, "invalid email");
   }
 
-  // Turnstile 门：仅在配置了 secret 时启用（与页面 widget 成对；未配置=本地
-  // 开发，全链路不设防）。位置刻意在邮箱形状校验**之后**——siteverify 的
-  // token 是一次性的，不能浪费在一个注定 400 的请求上。
   // Turnstile 门：仅在 sitekey+secret 成对配置时启用（未配置=本地开发，
   // 全链路不设防）。位置刻意在邮箱形状校验**之后**——siteverify 的
   // token 是一次性的，不能浪费在一个注定 400 的请求上。

--- a/workers/scout-connect/wrangler.jsonc
+++ b/workers/scout-connect/wrangler.jsonc
@@ -16,6 +16,11 @@
     }
   ],
   "vars": {
-    "CONNECT_ROOT_DOMAIN": "mediaryconnect.app"
+    "CONNECT_ROOT_DOMAIN": "mediaryconnect.app",
+    // Public Turnstile sitekey for the beta signup widget (safe to commit —
+    // sitekeys ship in page HTML by design). The paired TURNSTILE_SECRET stays
+    // a `wrangler secret`. The gate activates only when BOTH are configured;
+    // either missing → no widget, no verification (src/routes.ts).
+    "TURNSTILE_SITEKEY": "0x4AAAAAAD-wkGraJigl3YK0"
   }
 }


### PR DESCRIPTION
公开报名漏斗加 Cloudflare Turnstile（managed 无感模式），防机器人灌满创始批 100 席——zone 限流只是减速带，这才是墙。

## 结构

- **成对开关**：sitekey（vars，公开）+ secret（wrangler secret）**两半齐备才启用**。sitekey 无 secret → 铸出验不了的 token；secret 无 sitekey → 没有 widget 铸 token；任一误配下开门都会 400 所有报名。未配置（本地开发/测试）全链路不设防，既有测试零改动通过。
- **页面**（beta-page.ts）：widget 在表单内渲染（dark theme），提交 JS 读 `cf-turnstile-response`、空值客户端拦截（人机验证未完成，请稍候）、token 随 body 提交。无 sitekey 时页面**零** turnstile 标记（测试钉死）。env 传入的 key 过 `^[0-9A-Za-z_-]+$` 字符集校验——畸形值整体降级为无 widget，不玩转义硬插。
- **CSP**（http.ts 共享策略）：`challenges.cloudflare.com` 进 script/frame/connect 三个源。共享页（home/invite/admin/beta）统一放行，不搞 per-page CSP。
- **服务端**（routes.ts）：`verifyTurnstile()` form-encoded 打 siteverify，5s AbortSignal（项目硬规则），任何错误 **fail closed**（宁误杀不放过），日志不带 secret/token。门在邮箱形状校验**之后**——siteverify token 一次性，不能烧在注定 400 的请求上。

## 验证

- 270 tests 全绿（含子代理先写的 9 个 RED 测试 + 我补的成对开关/字符集/泄露测试）
- tsc 干净
- 反向验证：关掉门 → 4 个门测试红；删 CSP 源 → CSP 测试红

## 部署后真机验证项（我做）

`beta.mediaryconnect.app` 上：widget 渲染 → 无 token 提交被客户端拦 → 正常提交通过 → curl 无 token 直打 API 吃 400 turnstile required。