### PR TITLE
fix(funnel): 主站 CTA 直达 beta 报名站；apex 补上报名入口

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -265,9 +265,9 @@
       <div class="connect-banner">
         <div class="connect-text">
           <b>Scout Connect</b>
-          <p>部署在内网 / NAS？一条加密隧道，就能在任何设备的浏览器打开你家的面板 —— 无需公网 IP、无需端口转发，Cloudflare Access 邮箱验证拦门。内容全程留在你自己的设备上。</p>
+          <p>部署在内网 / NAS？一条加密隧道，就能在任何设备的浏览器打开你家的面板 —— 无需公网 IP、无需端口转发，入口由应用自身的访问密码把守。内容全程留在你自己的设备上。</p>
         </div>
-        <a class="pill cta-outline" href="https://mediaryconnect.app">了解 / 申请邀请 →</a>
+        <a class="pill cta-outline" href="https://beta.mediaryconnect.app">了解 / 申请内测 →</a>
       </div>
     </div>
   </section>

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -9,6 +9,8 @@ export function homePage(): string {
 body{font-family:system-ui,sans-serif;max-width:640px;margin:4rem auto;padding:0 1rem;color:#222;line-height:1.7}
 h1{font-size:1.6rem}
 a{color:#06c}
+.cta{display:inline-block;margin:1.5rem 0 .5rem;padding:.7rem 1.4rem;border-radius:999px;background:#1ed760;color:#06210f;font-weight:700;text-decoration:none}
+.cta-note{margin:0;font-size:.9rem;color:#666}
 </style>
 </head>
 <body>
@@ -16,6 +18,8 @@ a{color:#06c}
 <h1>Scout Connect</h1>
 <p lang="zh">Scout Connect 是自托管 Mediary Scout 的远程访问之门:通过 Cloudflare Tunnel 把你自己的实例安全地发布到一个专属域名,入口由应用自身的访问密码把守(首次打开时设置)。你的媒体内容与各类凭据始终留在你自己的机器上,这里只负责开门。</p>
 <p lang="en">Scout Connect is the remote access door for self-hosted Mediary Scout: it publishes your own instance to a dedicated hostname over a Cloudflare Tunnel, gated by the app's own access password (set on first open). Your content and credentials always stay on your own machines — this service only opens the door.</p>
+<p><a class="cta" href="https://beta.mediaryconnect.app">申请内测席位 →</a></p>
+<p class="cta-note">内测期免费，创始批 100 席。</p>
 <p><a href="https://github.com/fancydirty/mediary-scout">github.com/fancydirty/mediary-scout</a></p>
 </main>
 </body>

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -162,7 +162,20 @@ describe("handleRequest", () => {
     const res = await handleRequest(new Request(`${BASE}/`), deps);
     const html = await res.text();
     expect(html).toContain("Scout Connect");
-    expect(html).not.toContain("申请内测席位");
+    // 断言的是「apex 不发报名表单本体」，而不是某句文案——apex 现在有一个
+    // 指向 beta 站的 CTA，文案里出现"申请内测席位"是对的。
+    expect(html).not.toContain('type="email"');
+    expect(html).not.toContain("cf-turnstile");
+  });
+
+  it("apex home page links to the beta signup site (it must not be a dead end)", async () => {
+    // apex 曾经只有介绍文字 + 一个 GitHub 链接：真人落在这里无从报名，
+    // 而主站的 CTA 一度就指向这里 —— 白漏掉的注册流量。说明页可以留，
+    // 但必须给出口。
+    const { deps } = setup();
+    const html = await handleRequest(new Request(`${BASE}/`), deps).then((r) => r.text());
+    expect(html).toContain("https://beta.mediaryconnect.app");
+    expect(html).toMatch(/申请内测|内测席位|报名/);
   });
 
   it("GET /beta keeps working on both hosts (no regression)", async () => {

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -164,8 +164,10 @@ describe("handleRequest", () => {
     expect(html).toContain("Scout Connect");
     // 断言的是「apex 不发报名表单本体」，而不是某句文案——apex 现在有一个
     // 指向 beta 站的 CTA，文案里出现"申请内测席位"是对的。
-    expect(html).not.toContain('type="email"');
-    expect(html).not.toContain("cf-turnstile");
+    // 用正则而非子串：单/双引号与 = 两侧空格都不该让这条断言失效。
+    expect(html).not.toMatch(/type\s*=\s*["']email["']/i);
+    expect(html).not.toMatch(/class\s*=\s*["'][^"']*cf-turnstile/i);
+    expect(html).not.toMatch(/<form\b/i);
   });
 
   it("apex home page links to the beta signup site (it must not be a dead end)", async () => {


### PR DESCRIPTION
## 问题

真实浏览器 UA 访问 apex 根路径 24 小时约 35-40 次（CF analytics 实测，已排除 curl / Go-http-client / DomainArrivalsBot 等扫描器流量），同期报名数 **1**。

漏斗断在最前面一环：

- 主站 `site/index.html` 的「了解 / 申请邀请 →」CTA 指向 `mediaryconnect.app`（apex）
- 而 apex 页面全文 **978 字节**，只有一段中英文介绍 + 一个 GitHub 链接，**零报名入口**，全文也不提 `beta.` 子域名
- 报名表单实际在 `beta.mediaryconnect.app`

点「申请邀请」的人落在一个没有出口的页面上。

## 改动

1. 主站 CTA 改指 `https://beta.mediaryconnect.app`（表单所在地），文字改为「了解 / 申请内测 →」。
2. 同一段 banner 文案还在说「Cloudflare Access 邮箱验证拦门」—— Access 已在 PR #175 废除，现在是应用自身访问密码 → 文案同步纠正。
3. apex 说明页保留介绍职能，但补一个指向 beta 站的绿色 CTA + 「内测期免费，创始批 100 席」说明，从其他途径落到 apex 的人也不再卡死。

## 测试

- 新增：apex 必须给出 beta 站出口（链接 + 报名字样）。
- 调整：原有「apex 不发报名页」断言从匹配文案 `不含"申请内测席位"` 改为匹配**表单本体**（`type="email"` / `cf-turnstile`）—— apex 现在合法地包含这句 CTA 文案，用文案做反向断言已不成立。

280 worker 测试全绿，typecheck 干净。

## 部署

`site/` 是静态站，按主站既有发布方式生效；apex 页面改动需一次 `wrangler deploy`。