### PR TITLE
refactor(connect): 产品名 Scout Connect → Mediary Connect

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       # queue (获取 stuck "排队", category dirs never provisioned). Must be vercel-ai.
       MEDIA_TRACK_AGENT_ADAPTER: vercel-ai
       MEDIA_TRACK_DEMO_SEED: "0"
-      # 隧道 token 也给 web:设置页「远程访问」用它作实例身份，向 Scout Connect
+      # 隧道 token 也给 web:设置页「远程访问」用它作实例身份，向 Mediary Connect
       # 报到查状态(仅发 Bearer 头做存活探针,不回传任何端点信息)。不传的话已开通
       # 的实例会把自己显示成「未开通」。cloudflared 那边同样需要它,两处读同一个
       # .env 变量。未设时为空 → tab 显示未开通,这正是自建/未开通实例的正确状态。

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -271,9 +271,9 @@ d. 登录身份默认走 One-time PIN(邮箱一次性验证码);若登录页提�
 完成后用简短中文汇报:隧道是否 Registered、Access 是否配置、面板是否(由用户确认)能进。
 ```
 
-### 方式三:Scout Connect（受邀）
+### 方式三:Mediary Connect（受邀）
 
-若你收到作者的 Scout Connect 邀请链接（`https://mediaryconnect.app/i/...`）:
+若你收到作者的 Mediary Connect 邀请链接（`https://mediaryconnect.app/i/...`）:
 
 1. 打开链接，按页显示一次连接信息（含 `TUNNEL_TOKEN`）。
 2. 写入实例 `.env` 的 `TUNNEL_TOKEN=...`（可复制页上的 Agent 提示词交给 coding agent 代配）。

--- a/site/index.html
+++ b/site/index.html
@@ -264,7 +264,7 @@
       </div>
       <div class="connect-banner">
         <div class="connect-text">
-          <b>Scout Connect</b>
+          <b>Mediary Connect</b>
           <p>部署在内网 / NAS？一条加密隧道，就能在任何设备的浏览器打开你家的面板 —— 无需公网 IP、无需端口转发，Cloudflare Access 邮箱验证拦门。内容全程留在你自己的设备上。</p>
         </div>
         <a class="pill cta-outline" href="https://mediaryconnect.app">了解 / 申请邀请 →</a>

--- a/site/style.css
+++ b/site/style.css
@@ -893,7 +893,7 @@ section {
   background: linear-gradient(180deg, transparent, #242424 25%, #242424 75%, transparent);
 }
 
-/* Scout Connect banner */
+/* Mediary Connect banner */
 .connect-banner {
   margin-top: 56px;
   padding: 28px 32px;

--- a/workers/scout-connect/README.md
+++ b/workers/scout-connect/README.md
@@ -1,4 +1,4 @@
-# Scout Connect — remote access control plane
+# Mediary Connect — remote access control plane
 
 Invite-only remote access for self-hosted Mediary Scout instances. The control
 plane provisions, per invitee, a Cloudflare Tunnel + public hostname

--- a/workers/scout-connect/docs/atomic-env-operations.md
+++ b/workers/scout-connect/docs/atomic-env-operations.md
@@ -1,4 +1,4 @@
-# Scout Connect 原子化 .env 操作设计
+# Mediary Connect 原子化 .env 操作设计
 
 ## 问题
 当前 agent 直接修改 .env，风险：

--- a/workers/scout-connect/schema.sql
+++ b/workers/scout-connect/schema.sql
@@ -47,7 +47,7 @@ CREATE INDEX idx_endpoints_status ON endpoints(status);
 -- endpoint by token hash; without this it is a full table scan.
 CREATE INDEX idx_endpoints_token_sha256 ON endpoints(token_sha256);
 
--- Waitlist for Scout Connect beta (阶段 1).
+-- Waitlist for Mediary Connect beta (阶段 1).
 CREATE TABLE waitlist (
   id TEXT PRIMARY KEY,
   email TEXT NOT NULL,

--- a/workers/scout-connect/src/agent-prompt.test.ts
+++ b/workers/scout-connect/src/agent-prompt.test.ts
@@ -28,7 +28,7 @@ describe("buildAgentPrompt", () => {
 
   it("contains key fixed phrases", () => {
     const out = buildAgentPrompt(INPUT);
-    expect(out).toContain("Scout Connect");
+    expect(out).toContain("Mediary Connect");
     expect(out).toContain("docker compose --profile tunnel up -d");
     expect(out).toContain("TUNNEL_TRANSPORT_PROTOCOL=http2");
     expect(out).toContain("Registered tunnel connection");

--- a/workers/scout-connect/src/agent-prompt.ts
+++ b/workers/scout-connect/src/agent-prompt.ts
@@ -33,7 +33,7 @@ export function buildAgentPrompt(input: {
   if (!/^[a-zA-Z0-9.-]+$/.test(input.hostname)) {
     throw new Error("hostname contains characters that cannot be embedded");
   }
-  return `你是在帮用户配置 Mediary Scout 的「Scout Connect」远程访问。
+  return `你是在帮用户配置 Mediary Scout 的「Mediary Connect」远程访问。
 
 目标:让用户的自托管实例经 Cloudflare Tunnel 发布到:
   https://${input.hostname}
@@ -285,7 +285,7 @@ export function buildAgentPromptOrManual(input: {
   if (canEmbedTunnelToken(input.tunnelToken)) {
     return buildAgentPrompt(input);
   }
-  return `你是在帮用户配置 Mediary Scout 的「Scout Connect」远程访问。
+  return `你是在帮用户配置 Mediary Scout 的「Mediary Connect」远程访问。
 
 ⚠️ 这个 tunnel token 的格式不常见(含换行或保留标记),自动脚本无法安全生成。
 请让用户联系支持重新签发 token,不要尝试手工拼 shell 命令写入。

--- a/workers/scout-connect/src/cf-api.test.ts
+++ b/workers/scout-connect/src/cf-api.test.ts
@@ -125,7 +125,7 @@ describe("cf-api", () => {
       },
     ]);
     const out = await api.createAccessApp({
-      name: "Scout Connect slug",
+      name: "Mediary Connect slug",
       domain: "slug.example.com",
       email: "user@example.com",
     });
@@ -145,7 +145,7 @@ describe("cf-api", () => {
         include: Array<{ email: { email: string } }>;
       }>;
     };
-    expect(body.name).toBe("Scout Connect slug");
+    expect(body.name).toBe("Mediary Connect slug");
     expect(body.domain).toBe("slug.example.com");
     expect(body.type).toBe("self_hosted");
     expect(body.session_duration).toBe("24h");

--- a/workers/scout-connect/src/html/admin-page.ts
+++ b/workers/scout-connect/src/html/admin-page.ts
@@ -7,7 +7,7 @@ export function adminPage(): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Scout Connect Admin</title>
+<title>Mediary Connect Admin</title>
 <style>
 body{font-family:system-ui,sans-serif;max-width:1000px;margin:2rem auto;padding:0 1rem;color:#222;font-size:14px}
 input,button{font:inherit;padding:.35rem .5rem}
@@ -21,7 +21,7 @@ h1{font-size:1.3rem}h2{font-size:1.05rem;margin-top:2rem}
 </style>
 </head>
 <body>
-<h1>Scout Connect Admin</h1>
+<h1>Mediary Connect Admin</h1>
 <p>
 <label>Admin Token <input id="token" type="password" size="42" autocomplete="off"></label>
 <button id="save-token">保存 Token</button>

--- a/workers/scout-connect/src/html/beta-page.test.ts
+++ b/workers/scout-connect/src/html/beta-page.test.ts
@@ -8,11 +8,11 @@ describe("betaPage", () => {
     expect(page.startsWith("<!doctype html>")).toBe(true);
     expect(page).toContain('<html lang="zh">');
     expect(page).toContain('<meta charset="utf-8">');
-    expect(page).toContain("<title>Scout Connect 远程访问 · 内测 · Mediary Scout Connect</title>");
+    expect(page).toContain("<title>Mediary Connect 远程访问 · 内测</title>");
   });
 
   it("renders the honest marketing copy (what it is, pricing, 100 seats)", () => {
-    expect(page).toContain("Scout Connect 远程访问 · 内测");
+    expect(page).toContain("Mediary Connect 远程访问 · 内测");
     expect(page).toContain("在外网也能打开家里实例的浏览器界面");
     expect(page).toContain("经 Cloudflare 加密隧道，不开端口、不要公网 IP、不需要域名");
     expect(page).toContain("内容与凭据始终只在你自己的机器上");

--- a/workers/scout-connect/src/html/beta-page.test.ts
+++ b/workers/scout-connect/src/html/beta-page.test.ts
@@ -13,6 +13,9 @@ describe("betaPage", () => {
 
   it("renders the honest marketing copy (what it is, pricing, 100 seats)", () => {
     expect(page).toContain("Mediary Connect 远程访问 · 内测");
+    // eyebrow 是大写形态，单独钉住——round 1 评审抓到它漏改。
+    expect(page).toContain("MEDIARY CONNECT · BETA");
+    expect(page).not.toMatch(/SCOUT CONNECT/);
     expect(page).toContain("在外网也能打开家里实例的浏览器界面");
     expect(page).toContain("经 Cloudflare 加密隧道，不开端口、不要公网 IP、不需要域名");
     expect(page).toContain("内容与凭据始终只在你自己的机器上");

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -160,7 +160,7 @@ input[type=radio],input[type=checkbox]{accent-color:var(--accent);margin:0}
 <header class="brand">${LOGO}<span class="wordmark">Mediary Scout</span><span class="connect-tag">CONNECT</span></header>
 
 <section class="hero">
-<p class="eyebrow rise d1">SCOUT CONNECT · BETA</p>
+<p class="eyebrow rise d1">MEDIARY CONNECT · BETA</p>
 <h1 class="rise d2">Mediary Connect 远程访问 · 内测</h1>
 <p class="sub rise d3">在外网也能打开家里实例的浏览器界面——出差时下发新任务、查转存进度、改配置。</p>
 <p class="sub2 rise d4">经 Cloudflare 加密隧道，不开端口、不要公网 IP、不需要域名。内容与凭据始终只在你自己的机器上。</p>

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -69,7 +69,7 @@ export function betaPage(turnstileSitekey?: string): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Scout Connect 远程访问 · 内测 · Mediary Scout Connect</title>${tsScript}
+<title>Mediary Connect 远程访问 · 内测</title>${tsScript}
 <style>
 :root{--bg-base:#121212;--bg-surface:#181818;--bg-raised:#1f1f1f;--bg-card:#252525;--accent:#1ed760;--accent-press:#169c46;--text:#fff;--text-muted:#b3b3b3;--border:#4d4d4d;--border-outline:#7c7c7c;--err:#f3727f;--hairline:linear-gradient(90deg,transparent,#2c2c2c 25%,#2c2c2c 75%,transparent);--font:-apple-system,BlinkMacSystemFont,"PingFang SC","Microsoft YaHei",sans-serif;--mono:ui-monospace,SFMono-Regular,monospace;color-scheme:dark}
 *{box-sizing:border-box}
@@ -161,7 +161,7 @@ input[type=radio],input[type=checkbox]{accent-color:var(--accent);margin:0}
 
 <section class="hero">
 <p class="eyebrow rise d1">SCOUT CONNECT · BETA</p>
-<h1 class="rise d2">Scout Connect 远程访问 · 内测</h1>
+<h1 class="rise d2">Mediary Connect 远程访问 · 内测</h1>
 <p class="sub rise d3">在外网也能打开家里实例的浏览器界面——出差时下发新任务、查转存进度、改配置。</p>
 <p class="sub2 rise d4">经 Cloudflare 加密隧道，不开端口、不要公网 IP、不需要域名。内容与凭据始终只在你自己的机器上。</p>
 <ul class="values rise d5">

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -4,7 +4,7 @@ export function homePage(): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Scout Connect</title>
+<title>Mediary Connect</title>
 <style>
 body{font-family:system-ui,sans-serif;max-width:640px;margin:4rem auto;padding:0 1rem;color:#222;line-height:1.7}
 h1{font-size:1.6rem}
@@ -13,9 +13,9 @@ a{color:#06c}
 </head>
 <body>
 <main>
-<h1>Scout Connect</h1>
-<p lang="zh">Scout Connect 是自托管 Mediary Scout 的远程访问之门:通过 Cloudflare Tunnel 把你自己的实例安全地发布到一个专属域名,入口由应用自身的访问密码把守(首次打开时设置)。你的媒体内容与各类凭据始终留在你自己的机器上,这里只负责开门。</p>
-<p lang="en">Scout Connect is the remote access door for self-hosted Mediary Scout: it publishes your own instance to a dedicated hostname over a Cloudflare Tunnel, gated by the app's own access password (set on first open). Your content and credentials always stay on your own machines — this service only opens the door.</p>
+<h1>Mediary Connect</h1>
+<p lang="zh">Mediary Connect 是自托管 Mediary Scout 的远程访问之门:通过 Cloudflare Tunnel 把你自己的实例安全地发布到一个专属域名,入口由应用自身的访问密码把守(首次打开时设置)。你的媒体内容与各类凭据始终留在你自己的机器上,这里只负责开门。</p>
+<p lang="en">Mediary Connect is the remote access door for self-hosted Mediary Scout: it publishes your own instance to a dedicated hostname over a Cloudflare Tunnel, gated by the app's own access password (set on first open). Your content and credentials always stay on your own machines — this service only opens the door.</p>
 <p><a href="https://github.com/fancydirty/mediary-scout">github.com/fancydirty/mediary-scout</a></p>
 </main>
 </body>

--- a/workers/scout-connect/src/html/invite-page.ts
+++ b/workers/scout-connect/src/html/invite-page.ts
@@ -32,7 +32,7 @@ function shell(title: string, body: string): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>${escapeHtml(title)} · Mediary Scout Connect</title>
+<title>${escapeHtml(title)} · Mediary Connect</title>
 <style>
 :root{--green:#1ED760;--green-dark:#0B3B1E;--ink:#1a2b22;--muted:#5b6b62;--line:#e3e9e5;--card:#fff;--bg:#f4f7f5}
 *{box-sizing:border-box}

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -128,23 +128,23 @@ async function seedProvisioned(deps: RouteDeps): Promise<InviteCreated & Provisi
 }
 
 describe("handleRequest", () => {
-  it("GET / → 200 HTML containing Scout Connect", async () => {
+  it("GET / → 200 HTML containing Mediary Connect", async () => {
     const { deps } = setup();
     const res = await handleRequest(new Request(`${BASE}/`), deps);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
-    expect(await res.text()).toContain("Scout Connect");
+    expect(await res.text()).toContain("Mediary Connect");
   });
 
   it("GET / on the beta subdomain serves the signup page (canonical URL is the bare host)", async () => {
     const { deps } = setup();
     // beta.mediaryconnect.app 就是规范地址——"beta.…/beta" 是结巴。
-    // 该子域名的根路径必须直接给报名表单，而不是 Scout Connect 说明页。
+    // 该子域名的根路径必须直接给报名表单，而不是 Mediary Connect 说明页。
     const res = await handleRequest(new Request("https://beta.mediaryconnect.app/"), deps);
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html).toContain("申请内测席位");
-    expect(html).not.toContain("Scout Connect 说明");
+    expect(html).not.toContain("Mediary Connect 说明");
   });
 
   it("beta root routing survives an un-normalized rootDomain env value", async () => {
@@ -161,7 +161,7 @@ describe("handleRequest", () => {
     const { deps } = setup();
     const res = await handleRequest(new Request(`${BASE}/`), deps);
     const html = await res.text();
-    expect(html).toContain("Scout Connect");
+    expect(html).toContain("Mediary Connect");
     expect(html).not.toContain("申请内测席位");
   });
 
@@ -394,7 +394,7 @@ describe("handleRequest", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
     const body = await res.text();
-    expect(body).toContain("Scout Connect 远程访问 · 内测");
+    expect(body).toContain("Mediary Connect 远程访问 · 内测");
     expect(body).toContain('<form id="signup"');
     // The page's inline script POSTs fetch("/waitlist") same-origin. Under the
     // old CSP (default-src 'none', no connect-src) a real browser REFUSES that

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -176,7 +176,7 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   if (method === "GET" && path === "/") {
     // The beta subdomain's root IS the signup page: "beta.mediaryconnect.app"
     // is the canonical marketing URL, so "beta.…/beta" would stutter. Apex
-    // keeps the Scout Connect home page; the check is host-exact so no other
+    // keeps the Mediary Connect home page; the check is host-exact so no other
     // subdomain (or the apex) accidentally gets the signup page.
     // Normalize BOTH sides: url.hostname is already lowercase, but
     // deps.rootDomain comes from env (CONNECT_ROOT_DOMAIN) untrimmed — a


### PR DESCRIPTION
## 为什么

产品名与域名对不上：域名是 `mediaryconnect.app`，产品名却叫 "Scout Connect"（取的是主产品名 Mediary Scout 的后半截 + Connect）。用户看到域名和页面标题会以为是两个东西。

## 改了什么

17 个文件，**纯展示层**：

- worker 页面（home/beta/admin/invite）的 title 与 h1
- agent 提示词开头那句（两个函数各一处）
- 主站 banner 标题、deploy.md 方式三小节
- style.css / docker-compose.yml / schema.sql / routes.ts 四处注释
- README 与 atomic-env-operations.md 标题
- 相应测试断言

beta 页 title 顺带去掉冗余后缀「· Mediary Scout Connect」——新名字已含 Mediary。

## 刻意不改

| 项 | 原因 |
|----|------|
| `Mediary Scout`（主产品名） | 只改 "Scout Connect" 这个组合 |
| 目录名 `workers/scout-connect/` | 基础设施标识 |
| wrangler 项目名 `scout-connect` | 改了等于新建 worker，部署断裂 |
| D1 数据库名 `scout-connect` | 改了等于新库 |
| CF 隧道命名前缀 `scout-<slug>` | 改了要重建所有存量隧道 |
| `docs/superpowers/` 历史 spec/plan/handoff | 那是当时的记录 |

## 零风险依据

`schema.sql` 与 `docker-compose.yml` 里的出现**全是注释**（已逐条 `git diff` 确认未动任何表/列/环境变量），所以本次改动：

- 零数据迁移
- 零 API 契约变更
- 零环境变量变更

## 验证

- 先改测试断言钉新名字，确认 **6 条精确变红**，再改实现
- worker 279 tests 全绿；用 `git stash` 对照确认改动前后测试数量一致，无用例丢失
- 全仓 2220 tests 全绿
- `npm run typecheck` 干净
- 全仓 grep 残留为零（排除刻意保留的历史文档）
- 未碰 `apps/web`（`git diff --stat main -- apps/web` 为空），故不需要 `build:web`

合并后需一次 `wrangler deploy` 才在生产生效。