### PR TITLE
fix(site): 主站 CTA 指向 beta 报名页 + 文案纠正

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -265,9 +265,9 @@
       <div class="connect-banner">
         <div class="connect-text">
           <b>Mediary Connect</b>
-          <p>部署在内网 / NAS？一条加密隧道，就能在任何设备的浏览器打开你家的面板 —— 无需公网 IP、无需端口转发，Cloudflare Access 邮箱验证拦门。内容全程留在你自己的设备上。</p>
+          <p>部署在内网 / NAS？一条加密隧道，就能在任何设备的浏览器打开你家的面板 —— 无需公网 IP、无需端口转发，入口由应用自身的访问密码把守。内容全程留在你自己的设备上。</p>
         </div>
-        <a class="pill cta-outline" href="https://mediaryconnect.app">了解 / 申请邀请 →</a>
+        <a class="pill cta-outline" href="https://beta.mediaryconnect.app">了解 / 申请内测 →</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## 为什么

这是已关闭 PR #187 的核心修复,基于当前 main 重做(原分支落后 5 个 PR、rebase 会删掉 P1-P3 全部工作)。这两个 bug 现在仍在生产上:

1. 主站 connect-banner 的 CTA 指向 `https://mediaryconnect.app`(apex 说明页,**没有报名入口**)——真人点「申请邀请」进去是死胡同。改指 `https://beta.mediaryconnect.app`(报名页)。
2. 同一 banner 文案写「Cloudflare Access 邮箱验证拦门」,但 Access 已在 PR #175 废除,现为应用自身访问密码。一并纠正。

## 改了什么

`site/index.html` connect-banner 一处:
- `<p>` 文案:「Cloudflare Access 邮箱验证拦门」→「入口由应用自身的访问密码把守」
- `<a href>`:`mediaryconnect.app` → `beta.mediaryconnect.app`,文字「申请邀请」→「申请内测」

`<b>Mediary Connect</b>` 不动(main 上已是新名)。

## 为什么不需要测试

`site/` 是纯静态站(Vercel `mediary-site` 项目自动部署),无构建、无逻辑。全站 grep 确认无其它指向 apex 的 CTA、无残留 Access 文案,`git status` 确认只碰了 `site/index.html`。