### PR TITLE
feat(connect): P4 slug 查重 + token 不落库(CF 现取)

### DIFF
--- a/workers/scout-connect/src/cf-api.test.ts
+++ b/workers/scout-connect/src/cf-api.test.ts
@@ -81,6 +81,20 @@ describe("cf-api", () => {
     expect(call.body).toEqual({ name: "my-tunnel", config_src: "cloudflare" });
   });
 
+  it("getTunnelToken GETs the token endpoint with an encoded tunnel id", async () => {
+    const { api, calls } = makeApi([
+      { json: { success: true, errors: [], result: "cf-connector-token-xyz" } },
+    ]);
+    const out = await api.getTunnelToken("tid with/slash");
+    expect(out).toBe("cf-connector-token-xyz");
+    const call = calls[0]!;
+    expect(call.method).toBe("GET");
+    // tunnelId 必须 URL 编码(与 putTunnelIngress 一致)
+    expect(call.url).toBe(
+      `${BASE}/accounts/${ACCOUNT_ID}/cfd_tunnel/${encodeURIComponent("tid with/slash")}/token`,
+    );
+  });
+
   it("putTunnelIngress sends web service + catch-all 404", async () => {
     const { api, calls } = makeApi([{}]);
     await api.putTunnelIngress("tid", "slug.example.com");

--- a/workers/scout-connect/src/cf-api.ts
+++ b/workers/scout-connect/src/cf-api.ts
@@ -98,6 +98,9 @@ function requireString(value: unknown, field: string): string {
 function requestInit(resolved: ResolvedOptions, method: string, body: unknown): RequestInit {
   return {
     method,
+    // project 硬规则:外部 HTTP 一律带超时。统一放在 requestInit,所有 CF
+    // 调用(建/删隧道、DNS、token 取回…)都受益,不必逐个方法加。
+    signal: AbortSignal.timeout(10_000),
     headers: {
       Authorization: `Bearer ${resolved.apiToken}`,
       "content-type": "application/json",
@@ -186,7 +189,7 @@ export function createCfApi(opts: CfApiOptions): CfApi {
       const result = (await cfJson(
         resolved,
         "GET",
-        `${accountPath}/cfd_tunnel/${tunnelId}/token`,
+        `${accountPath}/cfd_tunnel/${encodeURIComponent(tunnelId)}/token`,
       )) as unknown;
       return requireString(result, "tunnel token");
     },

--- a/workers/scout-connect/src/cf-api.ts
+++ b/workers/scout-connect/src/cf-api.ts
@@ -4,6 +4,9 @@ const CATCH_ALL_SERVICE = "http_status:404";
 
 export interface CfApi {
   createTunnel(name: string): Promise<{ tunnelId: string; token: string }>;
+  /** 重新取回现有隧道的 connector token。已实测:可用、幂等(同一隧道恒返回
+   *  同一 token,不踢已连接实例)。这让我们无需在 D1 存 token —— 需要时现取。 */
+  getTunnelToken(tunnelId: string): Promise<string>;
   /** service fixed http://web:3000 + catch-all 404 */
   putTunnelIngress(tunnelId: string, hostname: string): Promise<void>;
   createDnsCname(slug: string, tunnelId: string): Promise<{ recordId: string }>;
@@ -176,6 +179,16 @@ export function createCfApi(opts: CfApiOptions): CfApi {
         tunnelId: requireString(result?.id, "tunnel id"),
         token: requireString(result?.token, "tunnel token"),
       };
+    },
+
+    async getTunnelToken(tunnelId) {
+      // GET /cfd_tunnel/{id}/token → result 是 token 字符串本身。
+      const result = (await cfJson(
+        resolved,
+        "GET",
+        `${accountPath}/cfd_tunnel/${tunnelId}/token`,
+      )) as unknown;
+      return requireString(result, "tunnel token");
     },
 
     async putTunnelIngress(tunnelId, hostname) {

--- a/workers/scout-connect/src/db.test.ts
+++ b/workers/scout-connect/src/db.test.ts
@@ -114,27 +114,6 @@ describe("memory ConnectDb", () => {
     ).rejects.toThrow(/UNIQUE/i);
   });
 
-  it("markTokenShown sets token_shown_at and nulls token_ciphertext", async () => {
-    const db = createMemoryConnectDb();
-    await db.insertEndpoint(makeEndpoint());
-    const burned = await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z");
-    expect(burned).toBe(true);
-    const row = await db.getEndpointById("ep_1");
-    expect(row?.token_shown_at).toBe("2026-07-24T02:00:00.000Z");
-    expect(row?.token_ciphertext).toBeNull();
-  });
-
-  it("markTokenShown returns false on the second call (once-only race semantics)", async () => {
-    const db = createMemoryConnectDb();
-    await db.insertEndpoint(makeEndpoint());
-    expect(await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z")).toBe(true);
-    expect(await db.markTokenShown("ep_1", "2026-07-24T03:00:00.000Z")).toBe(false);
-    // first burn wins
-    expect((await db.getEndpointById("ep_1"))?.token_shown_at).toBe("2026-07-24T02:00:00.000Z");
-    // nonexistent id also false
-    expect(await db.markTokenShown("nope", "2026-07-24T03:00:00.000Z")).toBe(false);
-  });
-
   it("markEndpointRevoked sets status revoked and revoked_at", async () => {
     const db = createMemoryConnectDb();
     await db.insertEndpoint(makeEndpoint());
@@ -194,8 +173,6 @@ describe("memory ConnectDb", () => {
 
   it("mutations on nonexistent ids are silent no-ops (D1 UPDATE parity contract)", async () => {
     const db = createMemoryConnectDb();
-    // markTokenShown returns false (no row burned); the others resolve void
-    await expect(db.markTokenShown("nope", "2026-07-24T04:00:00.000Z")).resolves.toBe(false);
     await expect(db.markEndpointRevoked("nope", "2026-07-24T04:00:00.000Z")).resolves.toBeUndefined();
     await expect(db.markEndpointRevokeFailed("nope")).resolves.toBeUndefined();
     await expect(db.updateInviteStatus("nope", { status: "revoked" })).resolves.toBeUndefined();
@@ -269,23 +246,6 @@ function createSpyD1(respond: { first?: unknown; all?: unknown[] } = {}): {
 }
 
 describe("D1 ConnectDb SQL", () => {
-  it("markTokenShown issues one conditional UPDATE and reports the burn from meta.changes", async () => {
-    const { d1, calls } = createSpyD1({ first: null, all: [] });
-    // spy run() returns {} — meta.changes undefined → false. Patch run to
-    // report one change so we can assert the true path too.
-    const db = createD1ConnectDb(d1);
-    const burned = await db.markTokenShown("ep_1", "2026-07-24T02:00:00.000Z");
-    expect(burned).toBe(false); // spy run() has no meta.changes
-    expect(calls).toHaveLength(1);
-    const call = calls[0];
-    expect(call?.method).toBe("run");
-    expect(call?.query).toContain("token_shown_at = ?");
-    expect(call?.query).toContain("token_ciphertext = NULL");
-    expect(call?.query).toContain("token_shown_at IS NULL");
-    expect(call?.query).toContain("token_ciphertext IS NOT NULL");
-    expect(call?.binds).toEqual(["2026-07-24T02:00:00.000Z", "ep_1"]);
-  });
-
   it("updateInviteStatus full patch keeps placeholder↔bind alignment", async () => {
     const { d1, calls } = createSpyD1();
     const db = createD1ConnectDb(d1);

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -98,7 +98,6 @@ export interface ConnectDb {
    * Returns true when THIS call performed the burn (won the race), false when
    * the token was already shown/burned — callers use this for once-only reveal.
    */
-  markTokenShown(endpointId: string, at: string): Promise<boolean>;
   markEndpointRevoked(endpointId: string, at: string): Promise<void>;
   markEndpointRevokeFailed(endpointId: string): Promise<void>;
   /** Best-effort row removal for orphan compensation (no-op when absent). */
@@ -347,17 +346,6 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
         .prepare(`SELECT * FROM endpoints ORDER BY created_at DESC, id DESC`)
         .all<RawRow>();
       return results.map(mapEndpoint);
-    },
-
-    async markTokenShown(endpointId, at) {
-      const result = (await d1
-        .prepare(
-          `UPDATE endpoints SET token_shown_at = ?, token_ciphertext = NULL
-           WHERE id = ? AND token_shown_at IS NULL AND token_ciphertext IS NOT NULL`,
-        )
-        .bind(at, endpointId)
-        .run()) as { meta?: { changes?: number } };
-      return result.meta?.changes === 1;
     },
 
     async markEndpointRevoked(endpointId, at) {
@@ -700,18 +688,6 @@ export function createMemoryConnectDb(): ConnectDb {
 
     async listEndpoints() {
       return [...endpoints.values()].sort(byCreatedAtDesc).map((row) => ({ ...row }));
-    },
-
-    async markTokenShown(endpointId, at) {
-      const row = endpoints.get(endpointId);
-      // Synchronous check-and-set is atomic here — mirrors the D1 conditional
-      // UPDATE's race semantics: only the first caller burns.
-      if (row === undefined || row.token_shown_at !== null || row.token_ciphertext === null) {
-        return false;
-      }
-      row.token_shown_at = at;
-      row.token_ciphertext = null;
-      return true;
     },
 
     async markEndpointRevoked(endpointId, at) {

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -37,6 +37,10 @@ function makeFakeCf(calls: string[], opts: FakeCfOptions = {}): CfApi {
       calls.push(`tunnel:${name}`);
       return { tunnelId: "tid-1", token: PLAIN_TOKEN };
     },
+    async getTunnelToken(tunnelId) {
+      calls.push(`getToken:${tunnelId}`);
+      return PLAIN_TOKEN;
+    },
     async putTunnelIngress(tunnelId, hostname) {
       calls.push(`ingress:${tunnelId}:${hostname}`);
       if (opts.failOn === "ingress") throw new Error("cf ingress boom");

--- a/workers/scout-connect/src/provision.test.ts
+++ b/workers/scout-connect/src/provision.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { provisionEndpoint, type ProvisionDeps } from "./provision.js";
 import { createMemoryConnectDb, type ConnectDb, type InviteRow } from "./db.js";
 import type { CfApi } from "./cf-api.js";
-import { unwrapToken } from "./crypto-token.js";
 
 const NOW = "2026-07-24T10:00:00.000Z";
 const WRAP_KEY = "00".repeat(32);
@@ -107,7 +106,9 @@ describe("provisionEndpoint", () => {
     const endpoint = await db.getEndpointById("ep_test1");
     expect(endpoint).not.toBeNull();
     expect(endpoint?.status).toBe("active");
-    expect(endpoint?.token_ciphertext).toBeTruthy();
+    // P4: token 不落库,只留 sha256 供心跳反查。
+    expect(endpoint?.token_ciphertext).toBeNull();
+    expect(endpoint?.token_sha256).toBeTruthy();
     expect(endpoint?.token_shown_at).toBeNull();
     expect(endpoint?.invite_id).toBe("inv_1");
     expect(endpoint?.slug).toBe("alice");
@@ -227,7 +228,7 @@ describe("provisionEndpoint", () => {
     expect(calls).toHaveLength(0);
   });
 
-  it("stored ciphertext unwraps back to the returned token", async () => {
+  it("token is NOT persisted (P4): ciphertext null, only sha256 kept for heartbeat lookup", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makePendingInvite());
     const deps = makeDeps(db, makeFakeCf([]));
@@ -235,11 +236,10 @@ describe("provisionEndpoint", () => {
     const result = await provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps });
 
     const endpoint = await db.getEndpointById(result.endpointId);
-    if (endpoint === null || endpoint.token_ciphertext === null) {
-      throw new Error("expected persisted endpoint with ciphertext");
-    }
-    const unwrapped = await unwrapToken(endpoint.token_ciphertext, WRAP_KEY);
-    expect(unwrapped).toBe(result.token);
+    expect(endpoint?.token_ciphertext).toBeNull();
+    expect(endpoint?.token_sha256).toBeTruthy();
+    // 明文 token 只作返回值,决不出现在任何持久化行里
+    expect(JSON.stringify(await db.listEndpoints())).not.toContain(result.token);
   });
 
   it("hostname conflict error names the hostname, not the slug", async () => {
@@ -449,14 +449,20 @@ describe("provisionEndpoint", () => {
     expect(await db.listEndpoints()).toHaveLength(1);
   });
 
-  it("misconfigured wrap key: crypto failure inside persistence phase still cleans up cf resources", async () => {
+  it("persistence-phase failure (insertEndpoint throws) still cleans up cf resources", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makePendingInvite());
     const calls: string[] = [];
-    const deps = {
-      ...makeDeps(db, makeFakeCf(calls)),
-      tokenWrapKeyHex: "zz", // invalid hex — wrapToken throws
+    // P4 起 token 不再加密落库,原「wrap key 配错」失败路径消失。但持久化阶段
+    // 仍可能失败(D1 挂),补偿逻辑必须照样删掉已建的 CF 资源。用 insertEndpoint
+    // 抛错模拟持久化失败。
+    const failingDb: ConnectDb = {
+      ...db,
+      async insertEndpoint(): Promise<never> {
+        throw new Error("d1 insert boom");
+      },
     };
+    const deps = { ...makeDeps(failingDb, makeFakeCf(calls)) };
 
     await expect(
       provisionEndpoint({ inviteId: "inv_1", slug: "alice", deps }),

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -1,5 +1,5 @@
 import { assertSlug } from "./slug.js";
-import { sha256Hex, wrapToken } from "./crypto-token.js";
+import { sha256Hex } from "./crypto-token.js";
 import { buildAgentPromptOrManual } from "./agent-prompt.js";
 import type { CfApi } from "./cf-api.js";
 import type { ConnectDb } from "./db.js";
@@ -108,9 +108,8 @@ export async function provisionEndpoint(input: {
   // (which may itself fail if D1 is down).
   const endpointId = deps.newEndpointId();
   try {
-    // SECURITY: only ciphertext + sha256 persist. The plaintext token is
-    // returned to the caller once and never touches the db or the audit log.
-    const ciphertext = await wrapToken(token, deps.tokenWrapKeyHex);
+    // SECURITY: token 不落库(决策 #10/#11)。只存 sha256 供心跳按 token 反查
+    // endpoint;明文既不加密存也不存明文——需要时按 cf_tunnel_id 向 CF 现取。
     const sha = await sha256Hex(token);
 
     await db.insertEndpoint({
@@ -124,7 +123,7 @@ export async function provisionEndpoint(input: {
       cf_dns_record_id: recordId,
       status: "active",
       token_sha256: sha,
-      token_ciphertext: ciphertext,
+      token_ciphertext: null,
       token_shown_at: null,
       last_seen_at: null,
       created_at: deps.now(),

--- a/workers/scout-connect/src/reveal.test.ts
+++ b/workers/scout-connect/src/reveal.test.ts
@@ -6,11 +6,10 @@ import {
   type EndpointRow,
   type InviteRow,
 } from "./db.js";
-import { wrapToken } from "./crypto-token.js";
+import type { CfApi } from "./cf-api.js";
 
 const NOW = "2026-07-24T10:00:00.000Z";
-const WRAP_KEY = "00".repeat(32);
-const PLAIN_TOKEN = "tok-plain-secret-1";
+const CF_TOKEN = "cf-connector-token-for-tid-1";
 
 function makeInvite(overrides: Partial<InviteRow> = {}): InviteRow {
   return {
@@ -34,8 +33,8 @@ function makeEndpoint(overrides: Partial<EndpointRow> = {}): EndpointRow {
     slug: "alice",
     hostname: "alice.mediaryconnect.app",
     cf_tunnel_id: "tid-1",
-    cf_access_app_id: "app-1",
-    cf_access_policy_id: "pol-1",
+    cf_access_app_id: null,
+    cf_access_policy_id: null,
     cf_dns_record_id: "rec-1",
     status: "active",
     token_sha256: "deadbeef",
@@ -48,212 +47,144 @@ function makeEndpoint(overrides: Partial<EndpointRow> = {}): EndpointRow {
   };
 }
 
-function makeDeps(db: ConnectDb): RevealDeps {
+/** Fake CF that records getTunnelToken calls and returns a token per tunnel. */
+function makeFakeCf(calls: string[]): CfApi {
+  const boom = (name: string) => async () => {
+    throw new Error(`unexpected ${name} call during reveal`);
+  };
+  return {
+    createTunnel: boom("createTunnel") as never,
+    getTunnelToken: async (tunnelId: string) => {
+      calls.push(`getTunnelToken:${tunnelId}`);
+      return CF_TOKEN;
+    },
+    putTunnelIngress: boom("putTunnelIngress") as never,
+    createDnsCname: boom("createDnsCname") as never,
+    createAccessApp: boom("createAccessApp") as never,
+    deleteTunnel: boom("deleteTunnel") as never,
+    deleteDnsRecord: boom("deleteDnsRecord") as never,
+    deleteAccessApp: boom("deleteAccessApp") as never,
+  };
+}
+
+function makeDeps(db: ConnectDb, cfCalls: string[] = []): RevealDeps {
   return {
     db,
-    tokenWrapKeyHex: WRAP_KEY,
+    cf: makeFakeCf(cfCalls),
     now: () => NOW,
     newAuditId: () => "aud_x",
   };
 }
 
-/** Seeds an endpoint whose ciphertext is a real wrapToken(PLAIN_TOKEN). */
-async function seedEndpointWithToken(
-  db: ConnectDb,
-  overrides: Partial<EndpointRow> = {},
-): Promise<void> {
-  const ciphertext = await wrapToken(PLAIN_TOKEN, WRAP_KEY);
-  await db.insertEndpoint(makeEndpoint({ token_ciphertext: ciphertext, ...overrides }));
-}
-
-describe("revealByCode", () => {
-  it("unknown code → not_found", async () => {
+describe("revealByCode (P4: fetch token from CF, idempotent, no burn)", () => {
+  it("unknown code → not_found, never calls CF", async () => {
     const db = createMemoryConnectDb();
-    const outcome = await revealByCode({ code: "nope", deps: makeDeps(db) });
+    const cfCalls: string[] = [];
+    const outcome = await revealByCode({ code: "nope", deps: makeDeps(db, cfCalls) });
     expect(outcome).toEqual({ kind: "not_found" });
+    expect(cfCalls).toHaveLength(0);
     expect(await db.listAudits()).toHaveLength(0);
   });
 
-  it("revoked invite → not_found, indistinguishable from never-existing (no leak)", async () => {
+  it("revoked invite → not_found (indistinguishable from never-existing), no CF call", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(
       makeInvite({ status: "revoked", slug: null, revoked_at: "2026-07-24T05:00:00.000Z" }),
     );
-    // ciphertext still present — a leak would surface as revealed/already_shown
-    await seedEndpointWithToken(db);
-
-    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
-
+    await db.insertEndpoint(makeEndpoint());
+    const cfCalls: string[] = [];
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db, cfCalls) });
     expect(outcome).toEqual({ kind: "not_found" });
+    expect(cfCalls).toHaveLength(0);
     expect(await db.listAudits()).toHaveLength(0);
-    // ciphertext untouched, token not burned
-    const endpoint = await db.getEndpointById("ep_1");
-    expect(endpoint?.token_ciphertext).not.toBeNull();
-    expect(endpoint?.token_shown_at).toBeNull();
   });
 
-  it("pending invite → not_ready", async () => {
+  it("pending invite → not_ready, no CF call", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makeInvite({ status: "pending", slug: null, provisioned_at: null }));
-
-    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
-
+    const cfCalls: string[] = [];
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db, cfCalls) });
     expect(outcome).toEqual({ kind: "not_ready" });
-    expect(await db.listAudits()).toHaveLength(0);
+    expect(cfCalls).toHaveLength(0);
   });
 
-  it("provisioned + ciphertext present → revealed with real unwrap roundtrip; burns ciphertext, audits hostname only", async () => {
+  it("provisioned + active → revealed with token fetched from CF, audits hostname only", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makeInvite());
-    await seedEndpointWithToken(db);
+    await db.insertEndpoint(makeEndpoint());
+    const cfCalls: string[] = [];
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db, cfCalls) });
 
-    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
-
-    if (outcome.kind !== "revealed") {
-      throw new Error(`expected revealed, got ${outcome.kind}`);
-    }
+    if (outcome.kind !== "revealed") throw new Error(`expected revealed, got ${outcome.kind}`);
     expect(outcome.hostname).toBe("alice.mediaryconnect.app");
-    // real unwrap roundtrip — the exact plaintext that was wrapped
-    expect(outcome.token).toBe(PLAIN_TOKEN);
+    expect(outcome.token).toBe(CF_TOKEN);
     expect(outcome.agentPrompt).toContain("alice.mediaryconnect.app");
-    expect(outcome.agentPrompt).toContain(PLAIN_TOKEN);
-
-    // one-time burn: shown_at set AND ciphertext nulled atomically
-    const endpoint = await db.getEndpointById("ep_1");
-    expect(endpoint?.token_shown_at).toBe(NOW);
-    expect(endpoint?.token_ciphertext).toBeNull();
+    expect(outcome.agentPrompt).toContain(CF_TOKEN);
+    // 按 cf_tunnel_id 取
+    expect(cfCalls).toEqual(["getTunnelToken:tid-1"]);
 
     const audits = await db.listAudits();
     expect(audits).toHaveLength(1);
     expect(audits[0]?.action).toBe("token.reveal");
-    expect(audits[0]?.actor).toBe("invitee");
-    expect(audits[0]?.at).toBe(NOW);
-    expect(audits[0]?.invite_id).toBe("inv_1");
-    expect(audits[0]?.endpoint_id).toBe("ep_1");
     expect(audits[0]?.detail_json).toContain("alice.mediaryconnect.app");
-    // the token must never be persisted anywhere
-    expect(audits[0]?.detail_json).not.toContain(PLAIN_TOKEN);
-    expect(JSON.stringify(await db.listEndpoints())).not.toContain(PLAIN_TOKEN);
-    expect(JSON.stringify(audits)).not.toContain(PLAIN_TOKEN);
+    // token 绝不落库/进审计
+    expect(audits[0]?.detail_json).not.toContain(CF_TOKEN);
+    expect(JSON.stringify(await db.listEndpoints())).not.toContain(CF_TOKEN);
+    expect(JSON.stringify(audits)).not.toContain(CF_TOKEN);
   });
 
-  it("second reveal → already_shown with hostname, no additional audit row, ciphertext stays null", async () => {
+  it("second reveal → still revealed (idempotent),换机器/重试都能再取", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makeInvite());
-    await seedEndpointWithToken(db);
-    const deps = makeDeps(db);
+    await db.insertEndpoint(makeEndpoint());
+    const cfCalls: string[] = [];
+    let n = 0;
+    const deps: RevealDeps = { ...makeDeps(db, cfCalls), newAuditId: () => `aud_${++n}` };
 
     const first = await revealByCode({ code: "code-abc", deps });
-    expect(first.kind).toBe("revealed");
-
     const second = await revealByCode({ code: "code-abc", deps });
-    expect(second).toEqual({
-      kind: "already_shown",
-      hostname: "alice.mediaryconnect.app",
-    });
 
-    // audit count unchanged — refresh must not spam the audit log
-    expect(await db.listAudits()).toHaveLength(1);
-    const endpoint = await db.getEndpointById("ep_1");
-    expect(endpoint?.token_ciphertext).toBeNull();
-    expect(endpoint?.token_shown_at).toBe(NOW);
+    expect(first.kind).toBe("revealed");
+    expect(second.kind).toBe("revealed");
+    if (second.kind === "revealed") expect(second.token).toBe(CF_TOKEN);
+    // 幂等的真正证据:两次都成功交付、CF 各取一次(恒返回同 token)。
+    expect(cfCalls).toEqual(["getTunnelToken:tid-1", "getTunnelToken:tid-1"]);
+    expect(await db.listAudits()).toHaveLength(2);
   });
 
-  it("provisioned invite but endpoint row missing → not_ready (half-done provisioning)", async () => {
+  it("provisioned invite but endpoint row missing → not_ready, no CF call", async () => {
     const db = createMemoryConnectDb();
-    await db.insertInvite(makeInvite()); // provisioned, no endpoint row
-
-    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
-
+    await db.insertInvite(makeInvite());
+    const cfCalls: string[] = [];
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db, cfCalls) });
     expect(outcome).toEqual({ kind: "not_ready" });
-    expect(await db.listAudits()).toHaveLength(0);
+    expect(cfCalls).toHaveLength(0);
   });
 
-  it("corrupt state (ciphertext null, shown_at null) → already_shown, no decrypt attempted", async () => {
+  it("revoked endpoint under a still-provisioned invite → not_found, no CF call (no token, no leak)", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makeInvite());
-    // ciphertext null AND shown_at null — unwrap would explode if attempted
     await db.insertEndpoint(makeEndpoint());
-
-    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
-
-    expect(outcome).toEqual({
-      kind: "already_shown",
-      hostname: "alice.mediaryconnect.app",
-    });
-    expect(await db.listAudits()).toHaveLength(0);
+    await db.markEndpointRevoked("ep_1", NOW);
+    const cfCalls: string[] = [];
+    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db, cfCalls) });
+    expect(outcome).toEqual({ kind: "not_found" });
+    expect(cfCalls).toHaveLength(0);
   });
 
-  it("returns the exact plaintext that was wrapped, even with tricky characters", async () => {
-    const tricky = 'tok-with-"quotes"-\\-newline\n-unicode-✓';
+  it("audit insert failure still delivers the token (best-effort audit)", async () => {
     const db = createMemoryConnectDb();
     await db.insertInvite(makeInvite());
-    await db.insertEndpoint(
-      makeEndpoint({ token_ciphertext: await wrapToken(tricky, WRAP_KEY) }),
-    );
-
-    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
-
-    if (outcome.kind !== "revealed") {
-      throw new Error(`expected revealed, got ${outcome.kind}`);
-    }
-    expect(outcome.token).toBe(tricky);
-  });
-
-  it("audit insert failure after the burn still delivers the token (best-effort audit)", async () => {
-    const db = createMemoryConnectDb();
-    await db.insertInvite(makeInvite());
-    await seedEndpointWithToken(db);
-    const inner = db;
-    const failingAuditDb = {
-      ...inner,
+    await db.insertEndpoint(makeEndpoint());
+    const failingAuditDb: ConnectDb = {
+      ...db,
       async insertAudit(): Promise<void> {
         throw new Error("d1 audit boom");
       },
     };
-    const deps = { ...makeDeps(db), db: failingAuditDb };
-
-    const outcome = await revealByCode({ code: "code-abc", deps });
-
-    if (outcome.kind !== "revealed") {
-      throw new Error(`expected revealed, got ${outcome.kind}`);
-    }
-    expect(outcome.token).toBe(PLAIN_TOKEN);
-    // burn still happened — ciphertext is gone despite the lost audit
-    const endpoint = await db.getEndpointById("ep_1");
-    expect(endpoint?.token_shown_at).toBe(NOW);
-    expect(endpoint?.token_ciphertext).toBeNull();
+    const outcome = await revealByCode({ code: "code-abc", deps: { ...makeDeps(db), db: failingAuditDb } });
+    if (outcome.kind !== "revealed") throw new Error(`expected revealed, got ${outcome.kind}`);
+    expect(outcome.token).toBe(CF_TOKEN);
     expect(await db.listAudits()).toHaveLength(0);
-  });
-
-  it("revoked endpoint under a still-provisioned invite → not_found (no token, no validity leak)", async () => {
-    const db = createMemoryConnectDb();
-    await db.insertInvite(makeInvite()); // provisioned
-    await seedEndpointWithToken(db);
-    await db.markEndpointRevoked("ep_1", NOW);
-
-    const outcome = await revealByCode({ code: "code-abc", deps: makeDeps(db) });
-
-    expect(outcome).toEqual({ kind: "not_found" });
-    // ciphertext must NOT have been burned — admin forensics stay intact
-    const endpoint = await db.getEndpointById("ep_1");
-    expect(endpoint?.token_ciphertext).not.toBeNull();
-    expect(await db.listAudits()).toHaveLength(0);
-  });
-
-  it("concurrent reveals: exactly one wins, the other gets already_shown (atomic burn)", async () => {
-    const db = createMemoryConnectDb();
-    await db.insertInvite(makeInvite());
-    await seedEndpointWithToken(db);
-    const deps = makeDeps(db);
-
-    // Fire two reveals back-to-back without awaiting the first — the atomic
-    // conditional burn in markTokenShown decides the winner.
-    const [a, b] = await Promise.all([
-      revealByCode({ code: "code-abc", deps }),
-      revealByCode({ code: "code-abc", deps: { ...deps, newAuditId: () => "aud_y" } }),
-    ]);
-    const kinds = [a.kind, b.kind].sort();
-    expect(kinds).toEqual(["already_shown", "revealed"]);
   });
 });

--- a/workers/scout-connect/src/reveal.ts
+++ b/workers/scout-connect/src/reveal.ts
@@ -1,10 +1,10 @@
-import { unwrapToken } from "./crypto-token.js";
 import { buildAgentPromptOrManual } from "./agent-prompt.js";
 import type { ConnectDb } from "./db.js";
+import type { CfApi } from "./cf-api.js";
 
 export interface RevealDeps {
   db: ConnectDb;
-  tokenWrapKeyHex: string;
+  cf: CfApi;
   now: () => string;
   newAuditId: () => string;
 }
@@ -12,9 +12,14 @@ export interface RevealDeps {
 export type RevealOutcome =
   | { kind: "not_found" } // unknown or revoked code — indistinguishable
   | { kind: "not_ready" } // invite pending (no endpoint yet)
-  | { kind: "already_shown"; hostname: string } // token_shown_at already set (or ciphertext gone)
   | { kind: "revealed"; hostname: string; token: string; agentPrompt: string };
 
+/**
+ * 揭示接入信息。P4 起 token 不再落库(决策 #10/#11):按 cf_tunnel_id 向
+ * Cloudflare 现取 connector token —— 该 API 已实测幂等(同隧道恒返回同 token,
+ * 不踢已连接实例)。因此揭示也变成幂等的:换机器、重装、重试都能再取,
+ * 不再有「只显示一次」的 burn,也不需要密钥包装。
+ */
 export async function revealByCode(input: {
   code: string;
   deps: RevealDeps;
@@ -23,8 +28,7 @@ export async function revealByCode(input: {
   const { db } = deps;
 
   const invite = await db.getInviteByCode(input.code);
-  // Revoked invites must be indistinguishable from never-existing ones —
-  // do not leak that the code was ever valid.
+  // 撤销的邀请必须与从不存在的不可区分——不泄露该 code 曾经有效。
   if (invite === null || invite.status === "revoked") {
     return { kind: "not_found" };
   }
@@ -32,37 +36,21 @@ export async function revealByCode(input: {
     return { kind: "not_ready" };
   }
 
-  // provisioned
   const endpoint = await db.getEndpointByInviteId(invite.id);
   if (endpoint === null) {
-    // Edge: provisioning half-done (invite flipped, endpoint row missing).
+    // provisioning 半途(invite 已翻 provisioned 但 endpoint 行缺失)。
     return { kind: "not_ready" };
   }
-  // A revoked / revoke_failed endpoint must never hand out its (deleted)
-  // tunnel's token — and must not leak that the code was ever valid. Treat
-  // exactly like an unknown code, before any token logic.
+  // 撤销/撤销失败的 endpoint 决不能交出其(已删)隧道的 token,也不泄露
+  // code 曾有效。当作未知 code。
   if (endpoint.status !== "active") {
     return { kind: "not_found" };
   }
-  // One-time reveal: either already shown, or ciphertext gone (corrupt
-  // state — defensively refuse to attempt a decrypt). No audit row here:
-  // page refreshes must not spam the audit log unboundedly.
-  if (endpoint.token_shown_at !== null || endpoint.token_ciphertext === null) {
-    return { kind: "already_shown", hostname: endpoint.hostname };
-  }
 
-  // SECURITY: the plaintext token is returned to the caller ONLY — never
-  // persisted, never written to the audit log (hostname only there).
-  const token = await unwrapToken(endpoint.token_ciphertext, deps.tokenWrapKeyHex);
-  // Atomic burn is the commit point: conditional UPDATE wins exactly one
-  // concurrent reveal. A loser gets already_shown and discards its decrypted
-  // copy — the "只显示这一次" promise holds even under racing requests.
-  const burned = await db.markTokenShown(endpoint.id, deps.now());
-  if (!burned) {
-    return { kind: "already_shown", hostname: endpoint.hostname };
-  }
-  // Audit is best-effort: the ciphertext is already burned, so a failed audit
-  // insert must never block delivery of the one-time token.
+  // SECURITY: token 只作返回值,绝不落库、绝不进审计(审计只记 hostname)。
+  const token = await deps.cf.getTunnelToken(endpoint.cf_tunnel_id);
+
+  // 审计尽力而为:取到 token 才是主目的,审计失败不阻断交付。
   try {
     await db.insertAudit({
       id: deps.newAuditId(),
@@ -76,6 +64,7 @@ export async function revealByCode(input: {
   } catch {
     // audit lost — delivering the token takes precedence
   }
+
   return {
     kind: "revealed",
     hostname: endpoint.hostname,

--- a/workers/scout-connect/src/revoke.test.ts
+++ b/workers/scout-connect/src/revoke.test.ts
@@ -72,6 +72,9 @@ function makeFakeCf(calls: string[], opts: FakeCfOptions = {}): CfApi {
     async createTunnel() {
       throw new Error("unexpected createTunnel call during revoke");
     },
+    async getTunnelToken() {
+      throw new Error("unexpected getTunnelToken call during revoke");
+    },
     async putTunnelIngress() {
       throw new Error("unexpected putTunnelIngress call during revoke");
     },

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -27,6 +27,10 @@ function makeFakeCf(): { cf: CfApi; calls: CfCall[] } {
       tunnels += 1;
       return { tunnelId: `tid-${tunnels}`, token: `fixture-tunnel-token-${tunnels}` };
     },
+    async getTunnelToken(tunnelId) {
+      rec("getTunnelToken", tunnelId);
+      return `fixture-tunnel-token-for-${tunnelId}`;
+    },
     async putTunnelIngress(tunnelId, hostname) {
       rec("putTunnelIngress", tunnelId, hostname);
     },

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -29,7 +29,9 @@ function makeFakeCf(): { cf: CfApi; calls: CfCall[] } {
     },
     async getTunnelToken(tunnelId) {
       rec("getTunnelToken", tunnelId);
-      return `fixture-tunnel-token-for-${tunnelId}`;
+      // 与 createTunnel 一致:tid-N → fixture-tunnel-token-N(幂等,同隧道同 token)
+      const n = tunnelId.replace(/^tid-/, "");
+      return `fixture-tunnel-token-${n}`;
     },
     async putTunnelIngress(tunnelId, hostname) {
       rec("putTunnelIngress", tunnelId, hostname);
@@ -298,10 +300,10 @@ describe("handleRequest", () => {
     expect(ep && "token_sha256" in ep).toBe(false);
     expect(JSON.stringify(list)).not.toContain("fixture-tunnel-token");
 
-    // db still holds the one-time ciphertext (not burned by listing)
+    // P4: token 不落库。db 里 ciphertext 恒为 null,只留 sha256 供心跳反查。
     const stored = await db.getEndpointByInviteId(created.id);
-    expect(stored?.token_ciphertext).not.toBeNull();
-    expect(stored?.token_shown_at).toBeNull();
+    expect(stored?.token_ciphertext).toBeNull();
+    expect(stored?.token_sha256).toBeTruthy();
   });
 
   // The heartbeat's only output was unobservable: POST /api/instance/status
@@ -507,15 +509,12 @@ describe("handleRequest", () => {
     expect(html).not.toContain(FIXTURE_TOKEN_1);
   });
 
-  it("GET ready page does not pre-burn: reveal afterwards still returns the token", async () => {
-    const { db, deps } = setup();
+  it("GET ready page renders reveal button without exposing the token; reveal still works after", async () => {
+    const { deps } = setup();
     const seeded = await seedProvisioned(deps);
 
-    await handleRequest(new Request(`${BASE}/i/${seeded.code}`), deps);
-    const invite = await db.getInviteByCode(seeded.code);
-    const ep = await db.getEndpointByInviteId(invite?.id ?? "");
-    expect(ep?.token_ciphertext).not.toBeNull();
-    expect(ep?.token_shown_at).toBeNull();
+    const page = await handleRequest(new Request(`${BASE}/i/${seeded.code}`), deps);
+    expect((await page.text())).not.toContain(FIXTURE_TOKEN_1);
 
     const reveal = await handleRequest(
       new Request(`${BASE}/api/i/${seeded.code}/reveal`, { method: "POST" }),
@@ -525,7 +524,7 @@ describe("handleRequest", () => {
     expect(((await reveal.json()) as { token?: string }).token).toBe(FIXTURE_TOKEN_1);
   });
 
-  it("POST reveal → 200 with token; second reveal → 200 alreadyShown without token", async () => {
+  it("POST reveal is idempotent: every call returns the token (P4 fetch-from-CF, no burn)", async () => {
     const { deps } = setup();
     const seeded = await seedProvisioned(deps);
 
@@ -545,11 +544,9 @@ describe("handleRequest", () => {
     );
     expect(second.status).toBe(200);
     const secondBody = (await second.json()) as Record<string, unknown>;
-    expect(secondBody).toEqual({
-      hostname: "alice.mediaryconnect.app",
-      alreadyShown: true,
-    });
-    expect("token" in secondBody).toBe(false);
+    // 换机器/重试都能再取:第二次同样返回 token,不再有 alreadyShown。
+    expect(secondBody.hostname).toBe("alice.mediaryconnect.app");
+    expect(secondBody.token).toBe(FIXTURE_TOKEN_1);
   });
 
   it("POST reveal with unknown code → 404", async () => {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -394,8 +394,10 @@ async function slugCheckRoute(url: URL, request: Request, deps: RouteDeps): Prom
   if (!session.ok) throw new HttpError(401, "unauthorized");
   const slug = url.searchParams.get("s") ?? "";
   // 占用判定查所有状态的行(含 revoked/purged):slug 永久保留不释放(决策 #9)。
+  // rootDomain normalize:与本文件别处一致(CONNECT_ROOT_DOMAIN 可能带空白/大小写)。
+  const domain = deps.rootDomain.trim().toLowerCase();
   const isTaken: IsTaken = async (s) =>
-    (await deps.db.findEndpointBySlugOrHostname(s, `${s}.${deps.rootDomain}`)) !== null;
+    (await deps.db.findEndpointBySlugOrHostname(s, `${s}.${domain}`)) !== null;
   const result = await checkSlug(slug, isTaken);
   return json(result, 200, { noStore: true });
 }

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -656,13 +656,13 @@ async function inviteState(deps: RouteDeps, code: string): Promise<InvitePageSta
     return { kind: "waiting" };
   }
   // Match revealByCode: a non-active endpoint is an invalid link — never show
-  // a hostname or ready/revealed state for a revoked/revoke_failed endpoint.
+  // a hostname or ready state for a revoked/revoke_failed endpoint.
   if (endpoint.status !== "active") {
     return { kind: "not_found" };
   }
-  if (endpoint.token_shown_at !== null || endpoint.token_ciphertext === null) {
-    return { kind: "revealed", hostname: endpoint.hostname };
-  }
+  // P4: reveal 现在幂等(token 按需向 CF 取,无一次性 burn),所以 active 的
+  // endpoint 永远展示「获取接入信息」按钮——换机器/重试都能再取。不再有
+  // 「已展示过」的终态。
   return { kind: "ready", code };
 }
 
@@ -671,7 +671,7 @@ async function revealInvite(deps: RouteDeps, code: string): Promise<Response> {
     code,
     deps: {
       db: deps.db,
-      tokenWrapKeyHex: deps.tokenWrapKeyHex,
+      cf: deps.cf,
       now: deps.now,
       newAuditId: deps.newAuditId,
     },
@@ -681,8 +681,6 @@ async function revealInvite(deps: RouteDeps, code: string): Promise<Response> {
       throw new HttpError(404, "not found");
     case "not_ready":
       return json({ error: "not ready" }, 409);
-    case "already_shown":
-      return json({ hostname: outcome.hostname, alreadyShown: true });
     case "revealed":
       return json(
         {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -6,6 +6,7 @@ import { provisionEndpoint } from "./provision.js";
 import { revokeEndpoint } from "./revoke.js";
 import { revealByCode } from "./reveal.js";
 import { assertSlug } from "./slug.js";
+import { checkSlug, type IsTaken } from "./slug-availability.js";
 import { homePage } from "./html/home-page.js";
 import { adminPage } from "./html/admin-page.js";
 import { invitePage, type InvitePageState } from "./html/invite-page.js";
@@ -227,6 +228,9 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   if (method === "GET" && path === "/console") {
     return await consoleRoute(request, deps);
   }
+  if (method === "GET" && path === "/api/slug/check") {
+    return await slugCheckRoute(url, request, deps);
+  }
   // Brand logo for Access Custom Pages + invite page — self-hosted so we don't
   // depend on any external asset host.
   if (method === "GET" && path === "/logo.svg") {
@@ -379,6 +383,21 @@ async function requestMagicLink(request: Request, deps: RouteDeps): Promise<Resp
   }
   // 固定 202,无论邮箱存在与否。
   return json({ ok: true }, 202, { noStore: true });
+}
+
+/** slug 实时查重 + 相似推荐(登录后选 slug 用)。需 session。 */
+async function slugCheckRoute(url: URL, request: Request, deps: RouteDeps): Promise<Response> {
+  const session = await parseSessionCookie(request.headers.get("cookie"), {
+    secret: deps.sessionSecret,
+    now: Date.parse(deps.now()),
+  });
+  if (!session.ok) throw new HttpError(401, "unauthorized");
+  const slug = url.searchParams.get("s") ?? "";
+  // 占用判定查所有状态的行(含 revoked/purged):slug 永久保留不释放(决策 #9)。
+  const isTaken: IsTaken = async (s) =>
+    (await deps.db.findEndpointBySlugOrHostname(s, `${s}.${deps.rootDomain}`)) !== null;
+  const result = await checkSlug(slug, isTaken);
+  return json(result, 200, { noStore: true });
 }
 
 /** 按 email upsert 账号,race-safe:两个并发请求可能都读到 null,第二个

--- a/workers/scout-connect/src/slug-availability.test.ts
+++ b/workers/scout-connect/src/slug-availability.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { checkSlug, suggestSlugs } from "./slug-availability.js";
+
+describe("checkSlug", () => {
+  const taken = new Set(["alice", "bob", "reserved-ish"]);
+  const isTaken = async (s: string) => taken.has(s);
+
+  it("available when valid and not taken", async () => {
+    expect(await checkSlug("charlie", isTaken)).toEqual({ available: true });
+  });
+
+  it("unavailable + suggestions when taken", async () => {
+    const r = await checkSlug("alice", isTaken);
+    expect(r.available).toBe(false);
+    if (!r.available) {
+      expect(r.suggestions.length).toBeGreaterThan(0);
+      for (const s of r.suggestions) expect(taken.has(s)).toBe(false);
+    }
+  });
+
+  it("invalid slug → available:false with reason, no suggestions from garbage", async () => {
+    const r = await checkSlug("A B!", isTaken);
+    expect(r.available).toBe(false);
+    if (!r.available) expect(r.reason).toBe("invalid");
+  });
+
+  it("reserved slug → unavailable with reason", async () => {
+    const r = await checkSlug("admin", isTaken);
+    expect(r.available).toBe(false);
+    if (!r.available) expect(r.reason).toBe("reserved");
+  });
+});
+
+describe("suggestSlugs", () => {
+  it("appends numbers and skips taken ones", async () => {
+    const taken = new Set(["alice", "alice1", "alice2"]);
+    const out = await suggestSlugs("alice", async (s) => taken.has(s), 3);
+    expect(out).not.toContain("alice");
+    expect(out).not.toContain("alice1");
+    expect(out).not.toContain("alice2");
+    expect(out.length).toBe(3);
+    // 全部可用且形状合法
+    for (const s of out) {
+      expect(taken.has(s)).toBe(false);
+      expect(s.startsWith("alice")).toBe(true);
+    }
+  });
+
+  it("normalizes the base before suggesting (trims/lowercases)", async () => {
+    const out = await suggestSlugs("  Alice  ", async () => false, 2);
+    for (const s of out) expect(s).toMatch(/^alice/);
+  });
+
+  it("gives up gracefully if everything is taken (bounded attempts)", async () => {
+    const out = await suggestSlugs("x", async () => true, 3);
+    expect(Array.isArray(out)).toBe(true); // 不死循环;可能空或少于 3
+    expect(out.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/workers/scout-connect/src/slug-availability.ts
+++ b/workers/scout-connect/src/slug-availability.ts
@@ -25,7 +25,7 @@ export async function suggestSlugs(baseRaw: string, isTaken: IsTaken, n: number)
   candidates.push(`${base}-nas`, `${base}-home`, `${base}-mc`);
   for (const c of candidates) {
     if (out.length >= n) break;
-    // 截断到长度上限;形状不合法(如太长)跳过
+    // 形状不合法(太长/保留字/字符集不符)直接跳过——不截断,只筛选。
     if (slugShape(c) !== "ok") continue;
     if (await isTaken(c)) continue;
     out.push(c);

--- a/workers/scout-connect/src/slug-availability.ts
+++ b/workers/scout-connect/src/slug-availability.ts
@@ -1,0 +1,47 @@
+import { RESERVED_SLUGS, SLUG_RE, normalizeSlug } from "./slug.js";
+
+/** 一个 slug 是否已被占用(D1 查询,由调用方注入)。 */
+export type IsTaken = (slug: string) => Promise<boolean>;
+
+export type CheckResult =
+  | { available: true }
+  | { available: false; reason: "invalid" | "reserved" | "taken"; suggestions: string[] };
+
+const SLUG_MAX_LENGTH = 32;
+
+function slugShape(slug: string): "ok" | "invalid" | "reserved" {
+  if (slug.length < 1 || slug.length > SLUG_MAX_LENGTH || !SLUG_RE.test(slug)) return "invalid";
+  if (RESERVED_SLUGS.has(slug)) return "reserved";
+  return "ok";
+}
+
+/** 生成候选:base 后接数字,以及连字符变体;只保留合法且未占用的,最多 n 个。 */
+export async function suggestSlugs(baseRaw: string, isTaken: IsTaken, n: number): Promise<string[]> {
+  const base = normalizeSlug(baseRaw);
+  const out: string[] = [];
+  const candidates: string[] = [];
+  // 先数字后缀 1..99,再几个语义变体
+  for (let i = 1; i <= 99; i++) candidates.push(`${base}${i}`);
+  candidates.push(`${base}-nas`, `${base}-home`, `${base}-mc`);
+  for (const c of candidates) {
+    if (out.length >= n) break;
+    // 截断到长度上限;形状不合法(如太长)跳过
+    if (slugShape(c) !== "ok") continue;
+    if (await isTaken(c)) continue;
+    out.push(c);
+  }
+  return out;
+}
+
+export async function checkSlug(slugRaw: string, isTaken: IsTaken): Promise<CheckResult> {
+  const slug = normalizeSlug(slugRaw);
+  const shape = slugShape(slug);
+  if (shape === "invalid") return { available: false, reason: "invalid", suggestions: [] };
+  if (shape === "reserved") {
+    return { available: false, reason: "reserved", suggestions: await suggestSlugs(slug, isTaken, 3) };
+  }
+  if (await isTaken(slug)) {
+    return { available: false, reason: "taken", suggestions: await suggestSlugs(slug, isTaken, 3) };
+  }
+  return { available: true };
+}

--- a/workers/scout-connect/src/slug-check-route.test.ts
+++ b/workers/scout-connect/src/slug-check-route.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { handleRequest, type RouteDeps } from "./routes.js";
+import { createMemoryConnectDb } from "./db.js";
+import { buildSessionCookie, SESSION_COOKIE } from "./session.js";
+
+const BASE = "https://mediaryconnect.app";
+const SECRET = "f".repeat(64);
+
+function deps(): RouteDeps {
+  return {
+    db: createMemoryConnectDb(),
+    cf: {} as never,
+    adminToken: "t",
+    rootDomain: "mediaryconnect.app",
+    tokenWrapKeyHex: "a".repeat(64),
+    now: () => "2026-07-28T00:00:00.000Z",
+    newInviteId: () => "inv_x",
+    newEndpointId: () => "ep_x",
+    newAuditId: () => "aud_x",
+    newInviteCode: () => "code_x",
+    newAccountId: () => "act_x",
+    newEntitlementId: () => "ent_x",
+    sessionSecret: SECRET,
+    sendMagicLink: async () => {},
+  };
+}
+
+async function cookie(): Promise<string> {
+  const c = await buildSessionCookie("act_1", { secret: SECRET, ttlMs: 3600_000, now: Date.parse("2026-07-28T00:00:00.000Z") });
+  return `${SESSION_COOKIE}=${c.match(new RegExp(`${SESSION_COOKIE}=([^;]+)`))![1]}`;
+}
+
+describe("GET /api/slug/check", () => {
+  it("401 without session", async () => {
+    const res = await handleRequest(new Request(`${BASE}/api/slug/check?s=alice`), deps());
+    expect(res.status).toBe(401);
+  });
+
+  it("available for a fresh slug", async () => {
+    const res = await handleRequest(
+      new Request(`${BASE}/api/slug/check?s=charlie`, { headers: { cookie: await cookie() } }),
+      deps(),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ available: true });
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("taken slug (including revoked) returns unavailable + suggestions", async () => {
+    const d = deps();
+    // 一条 revoked 的 endpoint 也占用 slug（永久保留）
+    await d.db.insertEndpoint({
+      id: "ep_1", invite_id: "inv_1", slug: "alice", hostname: "alice.mediaryconnect.app",
+      cf_tunnel_id: "t", cf_access_app_id: null, cf_access_policy_id: null,
+      cf_dns_record_id: "d", status: "revoked", token_sha256: "x",
+      token_ciphertext: null, token_shown_at: null, last_seen_at: null,
+      created_at: "2026-01-01T00:00:00.000Z", revoked_at: "2026-02-01T00:00:00.000Z",
+    });
+    const res = await handleRequest(
+      new Request(`${BASE}/api/slug/check?s=alice`, { headers: { cookie: await cookie() } }),
+      d,
+    );
+    const body = (await res.json()) as { available: boolean; reason?: string; suggestions?: string[] };
+    expect(body.available).toBe(false);
+    expect(body.reason).toBe("taken");
+    expect(body.suggestions!.length).toBeGreaterThan(0);
+  });
+
+  it("reserved slug returns unavailable", async () => {
+    const res = await handleRequest(
+      new Request(`${BASE}/api/slug/check?s=admin`, { headers: { cookie: await cookie() } }),
+      deps(),
+    );
+    const body = (await res.json()) as { available: boolean; reason?: string };
+    expect(body.available).toBe(false);
+    expect(body.reason).toBe("reserved");
+  });
+});


### PR DESCRIPTION
## 目标

补齐开通链路的两块(spec P4):用户自选 slug 的实时查重,以及 token 不再落库、改用 Cloudflare API 现取。

## 组成

**slug 实时查重 + 相似推荐**
- `GET /api/slug/check?s=<slug>`(需 session)→ `{available}` 或 `{available:false, reason, suggestions}`
- 占用判定查所有状态的 endpoint 行(含 revoked/purged):slug 永久保留不释放给他人(决策 #9)
- suggestSlugs:数字后缀 + 语义变体,只留合法且未占用的,有界不死循环

**token 不落库(决策 #10/#11)**
- 新增 `CfApi.getTunnelToken(tunnelId)`:GET `/cfd_tunnel/{id}/token`,已实测幂等(同隧道恒返回同 token、不踢已连接实例)
- `reveal.ts` 不再解密存储密文,改向 CF 现取 → reveal 变**幂等**:换机器/重装/重试都能再取,退役「只显示一次」的 burn
- `provision.ts` 不再 wrapToken:只存 `token_sha256`(供心跳反查),`token_ciphertext` 恒 null,明文只作返回值
- 退役 `markTokenShown`;invite 页状态机简化(active endpoint 永远展示「获取接入信息」)

## 为什么这样做

原设计「一次性 reveal + 加密存储 token」建立在「token 丢了找不回」的错误前提上。实测证明 CF 可随时重取同一 token,所以:token 根本不需要存,「换机器即死」的困境消失,一整套密钥包装可以退役。

## 保留项

`token_ciphertext`/`token_shown_at` 两列暂留(可空、无害、现恒 null),避免本轮做有风险的全 schema 手术。后续可单独清列。

## 验证

- slug 纯函数 7 + 路由 4;reveal 全重写为 CF-fetch 幂等语义 8 条
- 反向验证:reveal 不取 CF 后 3 条精确变红;slug/entitlement 关键逻辑同样反证过
- 三处 tsc 全过,worker 355 全绿,全仓 2296 全绿,dead-code 守卫满足
- 未碰 `apps/web`

合并后需 `wrangler deploy`(无新 secret、无新 migration —— 复用现有 CF_API_TOKEN,它已有 cfd_tunnel 读权限,实测过)。