### PR TITLE
fix(settings): 远程访问心跳区分 401 与网络失败

### DIFF
--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -31,7 +31,7 @@ afterEach(() => {
 
 describe("resolveRemoteAccessState", () => {
   it("无 TUNNEL_TOKEN → not_provisioned，且**不发心跳**", async () => {
-    const sendHeartbeat = vi.fn(async () => true);
+    const sendHeartbeat = vi.fn(async () => "ok" as const);
     const state = await resolveRemoteAccessState({ token: undefined, sendHeartbeat });
     expect(state).toEqual({ kind: "not_provisioned" });
     // 没 token 就没身份可报——发了只会向 worker 暴露一台未开通实例的存在。
@@ -39,7 +39,7 @@ describe("resolveRemoteAccessState", () => {
   });
 
   it("空串 / 纯空白 token 视同未开通（.env 里 TUNNEL_TOKEN= 就是这形状）", async () => {
-    const sendHeartbeat = vi.fn(async () => true);
+    const sendHeartbeat = vi.fn(async () => "ok" as const);
     for (const token of ["", "   "]) {
       expect(await resolveRemoteAccessState({ token, sendHeartbeat })).toEqual({
         kind: "not_provisioned",
@@ -51,7 +51,7 @@ describe("resolveRemoteAccessState", () => {
   it("心跳 204 → active（hostname 无本地来源时为 null，绝不臆造）", async () => {
     const state = await resolveRemoteAccessState({
       token: "tok",
-      sendHeartbeat: async () => true,
+      sendHeartbeat: async () => "ok",
     });
     expect(state).toEqual({ kind: "active", hostname: null });
   });
@@ -60,15 +60,25 @@ describe("resolveRemoteAccessState", () => {
     const state = await resolveRemoteAccessState({
       token: "tok",
       hostname: "s1.mediaryconnect.app",
-      sendHeartbeat: async () => true,
+      sendHeartbeat: async () => "ok",
     });
     expect(state).toEqual({ kind: "active", hostname: "s1.mediaryconnect.app" });
   });
 
-  it("心跳失败（非 204）→ active_degraded", async () => {
+  it("心跳 401（token 不是我们发的，比如作者自带的旧隧道）→ not_provisioned，露出报名入口", async () => {
+    // 关键修复:有 TUNNEL_TOKEN 但 worker 不认(401)= 不是 Mediary Connect 开通的,
+    // 应显示未开通 + 报名入口,而不是「已开通但状态未知」。
+    const state = await resolveRemoteAccessState({
+      token: "someone-elses-tunnel-token",
+      sendHeartbeat: async () => "unauthorized",
+    });
+    expect(state).toEqual({ kind: "not_provisioned" });
+  });
+
+  it("心跳网络失败（超时/5xx，非 401）→ active_degraded,不劝退已开通用户重排队", async () => {
     const state = await resolveRemoteAccessState({
       token: "tok",
-      sendHeartbeat: async () => false,
+      sendHeartbeat: async () => "unreachable",
     });
     expect(state).toEqual({ kind: "active_degraded" });
   });
@@ -80,14 +90,15 @@ describe("resolveRemoteAccessState", () => {
         throw new Error("ECONNREFUSED");
       },
     });
+    // 抛错按不可达处理（degraded），不当成 401——网络炸了不该劝用户重排队。
     expect(state).toEqual({ kind: "active_degraded" });
   });
 
   it("token 绝不出现在返回的 state 里（这东西会被序列化进 RSC 载荷）", async () => {
     const token = "super-secret-connector-token";
     const states: RemoteAccessState[] = [
-      await resolveRemoteAccessState({ token, sendHeartbeat: async () => true }),
-      await resolveRemoteAccessState({ token, sendHeartbeat: async () => false }),
+      await resolveRemoteAccessState({ token, sendHeartbeat: async () => "ok" }),
+      await resolveRemoteAccessState({ token, sendHeartbeat: async () => "unreachable" }),
       await resolveRemoteAccessState({
         token,
         sendHeartbeat: async () => {
@@ -129,9 +140,9 @@ describe("resolveRemoteAccessState", () => {
     expect(url).toBe("https://mediaryconnect.app/api/instance/status");
   });
 
-  it("默认心跳：401（token 已吊销）→ active_degraded", async () => {
+  it("默认心跳：401（worker 不认这个 token）→ not_provisioned，露出报名入口", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 })));
-    expect(await resolveRemoteAccessState({ token: "revoked" })).toEqual({ kind: "active_degraded" });
+    expect(await resolveRemoteAccessState({ token: "not-ours" })).toEqual({ kind: "not_provisioned" });
   });
 
   it("默认心跳：200 也算失败——契约明确是 204 无 body", async () => {

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -37,8 +37,8 @@ export type RemoteAccessState =
   | { kind: "active_degraded" };
 
 /** 心跳三态。ok=worker 认这个 token(204);unauthorized=worker 明确不认(401,
- *  多半是自带的旧隧道 token,不是 Mediary Connect 发的);unreachable=网络
- *  抖动/超时/5xx——拿不准,按「已开通但暂时联系不上」处理。 */
+ *  多半是自带的旧隧道 token,不是 Mediary Connect 发的);unreachable=
+ *  其余状态码/网络错误(超时、4xx、5xx 等)——拿不准,按「已开通但暂时联系不上」处理。 */
 export type HeartbeatResult = "ok" | "unauthorized" | "unreachable";
 
 const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
@@ -92,7 +92,7 @@ async function defaultSendHeartbeat(token: string): Promise<HeartbeatResult> {
   if (res.status === 204) return "ok";
   // 401 是 worker 明确「不认这个 token」——多半是自带旧隧道的 token,不是
   // Mediary Connect 开通的。据此把状态显示为「未开通」(露出报名入口),而不是
-  // 「已开通但状态未知」。其余状态码当作暂时不可达。
+  // 「已开通但状态未知」。其余状态码(含其它 4xx/5xx)一律当作暂时不可达。
   if (res.status === 401) return "unauthorized";
   return "unreachable";
 }
@@ -125,6 +125,7 @@ export async function resolveRemoteAccessState(opts: {
       return { kind: "not_provisioned" };
     }
     if (result === "unreachable") {
+      // 其余状态码/网络错误:拿不准,保持「已开通但联系不上」。
       return { kind: "active_degraded" };
     }
   } catch {

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -36,6 +36,11 @@ export type RemoteAccessState =
   | { kind: "active"; hostname: string | null }
   | { kind: "active_degraded" };
 
+/** 心跳三态。ok=worker 认这个 token(204);unauthorized=worker 明确不认(401,
+ *  多半是自带的旧隧道 token,不是 Mediary Connect 发的);unreachable=网络
+ *  抖动/超时/5xx——拿不准,按「已开通但暂时联系不上」处理。 */
+export type HeartbeatResult = "ok" | "unauthorized" | "unreachable";
+
 const DEFAULT_WORKER_BASE = "https://mediaryconnect.app";
 
 /**
@@ -72,8 +77,9 @@ export function scoutConnectBaseUrl(): string {
  */
 const HEARTBEAT_TIMEOUT_MS = 5_000;
 
-/** 心跳一次。`true` = worker 明确回了 204（契约里唯一的成功）。 */
-async function defaultSendHeartbeat(token: string): Promise<boolean> {
+/** 心跳一次。契约里 204=ok,401=unauthorized(token 不是我们发的),
+ *  其余状态码/网络错误=unreachable。 */
+async function defaultSendHeartbeat(token: string): Promise<HeartbeatResult> {
   const res = await fetch(`${scoutConnectBaseUrl()}/api/instance/status`, {
     method: "POST",
     // 契约是 Bearer 头；worker 压根不读 body（大 body 都不会被读取）。
@@ -83,7 +89,12 @@ async function defaultSendHeartbeat(token: string): Promise<boolean> {
   });
   // 严格判 204：契约就是 204 无 body。放宽成 res.ok 会把任何反代/门禁塞回来的
   // 200 登录页当成「隧道健康」，那是最需要被显示为降级的场景。
-  return res.status === 204;
+  if (res.status === 204) return "ok";
+  // 401 是 worker 明确「不认这个 token」——多半是自带旧隧道的 token,不是
+  // Mediary Connect 开通的。据此把状态显示为「未开通」(露出报名入口),而不是
+  // 「已开通但状态未知」。其余状态码当作暂时不可达。
+  if (res.status === 401) return "unauthorized";
+  return "unreachable";
 }
 
 /**
@@ -96,7 +107,7 @@ export async function resolveRemoteAccessState(opts: {
   token: string | undefined;
   /** 本地已知的公网域名（当前无来源，见文件头注释）。 */
   hostname?: string | null;
-  sendHeartbeat?: (token: string) => Promise<boolean>;
+  sendHeartbeat?: (token: string) => Promise<HeartbeatResult>;
 }): Promise<RemoteAccessState> {
   const token = opts.token?.trim();
   if (!token) {
@@ -107,10 +118,17 @@ export async function resolveRemoteAccessState(opts: {
   try {
     // 捕获一切：这是在渲染路径上做的一次网络调用，worker 挂了不该炸掉设置页。
     // 也刻意不把 error 放进返回值——报错串里可能带着 token（见测试）。
-    if (!(await sendHeartbeat(token))) {
+    const result = await sendHeartbeat(token);
+    if (result === "unauthorized") {
+      // worker 不认这个 token = 不是 Mediary Connect 开通的(如自带旧隧道)。
+      // 显示未开通,露出报名入口,而不是把用户卡在「已开通但状态未知」。
+      return { kind: "not_provisioned" };
+    }
+    if (result === "unreachable") {
       return { kind: "active_degraded" };
     }
   } catch {
+    // 网络炸了按不可达处理:不劝退一个已付出配置成本的用户重新排队。
     return { kind: "active_degraded" };
   }
   return { kind: "active", hostname: opts.hostname ?? null };


### PR DESCRIPTION
## 问题

设置页「远程访问」的判定逻辑是「有 `TUNNEL_TOKEN` = 已开通」。作者软路由早年自建了 `media.dirtyfancy.sbs` 隧道,`.env` 里有那个 token,新代码把它误认成 Mediary Connect 已开通 → 显示「已开启但状态未知」,而且藏掉了报名入口。

将来「先自建 CF Tunnel、后来想用 Mediary Connect」的用户会遇到完全一样的困惑。

## 修复

心跳从 `boolean` 改为三态 `HeartbeatResult`(`ok` / `unauthorized` / `unreachable`)。**worker 侧本就已经区分**(`reportInstanceStatus`:204 认 token、401 不认),所以无需改 worker,只改 apps/web 的解读:

- **401**(worker 明确不认这个 token,多半是自带的旧隧道)→ `not_provisioned`,露出报名入口
- **超时 / 5xx / 网络错误** → `active_degraded`,保持「已开通」——不劝退一个已付出配置成本的用户重新排队
- **204** → `active`

## 验证

- 485 web 测试全绿;新增 401→not_provisioned、unreachable→degraded 两条,拆分了原来笼统的「非 204」
- 反向验证:让 401 不被识别后,对应测试精确变红
- apps/web 改动,已跑 `build:web`;三处 tsc 全过

合并后作者软路由 `git pull` + 重建即可看到:删掉旧 token 或让它 401 → 报名入口重新出现。