### PR TITLE
fix(settings): 远程访问按钮撑高变形

### DIFF
--- a/apps/web/components/settings/remote-access-section.tsx
+++ b/apps/web/components/settings/remote-access-section.tsx
@@ -58,7 +58,7 @@ export async function RemoteAccessSection({
           href={BETA_SITE_URL}
           target="_blank"
           rel="noopener noreferrer"
-          style={{ display: "inline-block", textDecoration: "none" }}
+          style={{ textDecoration: "none" }}
         >
           了解详情并申请内测 →
         </a>


### PR DESCRIPTION
## 问题

设置页远程访问的「了解详情并申请内测 →」按钮被撑成约两倍高,文字挤在上半部、下方一大块空白。

## 根因

按钮 `<a className="primary-button">` 上有内联 `style={{ display: "inline-block" }}`,覆盖了 `.primary-button` 定义的 `inline-flex`。`inline-block` 的 `<a>` 不认 flex 的垂直居中,`height: 44px` + `text-transform: uppercase` + `letter-spacing` 一起把文字顶到顶部。

**对照证据**:同文件的密码警告按钮(line 113)用同一个 `primary-button` 类、但没加 `inline-block` 覆盖 → 渲染正常。

## 修复

去掉 `display: "inline-block"`,保留 `text-decoration: none`(`<a>` 去下划线仍需要)。按钮回到 CSS 定义的 `inline-flex` 垂直居中。

apps/web 改动,已跑 `build:web`。纯 CSS 布局修复,合并后软路由 `git pull` + 重建可见。