### PR TITLE
fix(workflow): 「重试中」通知带上真实报因，不再一律「网络波动」(#196)

### DIFF
--- a/packages/workflow/src/agent-error.test.ts
+++ b/packages/workflow/src/agent-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { LLM_AUTH_GUIDANCE, describeAgentRunError } from "./agent-error.js";
+import { LLM_AUTH_GUIDANCE, describeAgentRunError, summarizeErrorForNotification } from "./agent-error.js";
 
 describe("describeAgentRunError", () => {
   it("maps a bare 'Unauthorized' error to the actionable LLM-auth guidance", () => {
@@ -121,5 +121,47 @@ describe("describeAgentRunError — does NOT misclassify netdisk (brand) auth er
   it("does NOT map a bare numeric 401 in an unrelated message to the guidance", () => {
     const msg = "HTTP 401 while fetching subtitle index";
     expect(describeAgentRunError(new Error(msg))).toBe(msg);
+  });
+});
+
+describe("summarizeErrorForNotification", () => {
+  it("keeps a short human provider message intact (the whole point: show the real cause)", () => {
+    expect(summarizeErrorForNotification("QUARK_TRANSFER_FAILED: 分享已取消")).toBe(
+      "QUARK_TRANSFER_FAILED: 分享已取消",
+    );
+    expect(summarizeErrorForNotification("夸克登录超时,请重新登录")).toBe("夸克登录超时,请重新登录");
+  });
+
+  it("collapses newlines/whitespace into a single line", () => {
+    expect(summarizeErrorForNotification("line one\n\n  line   two\t")).toBe("line one line two");
+  });
+
+  it("redacts URL userinfo credentials", () => {
+    const out = summarizeErrorForNotification("fetch failed https://alice:s3cretPass@drive.quark.cn/x");
+    expect(out).toContain("https://***@drive.quark.cn/x");
+    expect(out).not.toContain("s3cretPass");
+  });
+
+  it("redacts cookie/token/key style assignments but keeps the field name", () => {
+    const out = summarizeErrorForNotification("QuarkAuthError access_token=abcdef123456ghijkl");
+    expect(out).not.toContain("abcdef123456ghijkl");
+    expect(out).toContain("access_token=***");
+  });
+
+  it("redacts a bare long opaque secret (>=32 chars)", () => {
+    const secret = "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8";
+    const out = summarizeErrorForNotification(`transfer rejected token ${secret} invalid`);
+    expect(out).not.toContain(secret);
+    expect(out).toContain("***");
+    // surrounding human words survive
+    expect(out).toContain("transfer rejected token");
+    expect(out).toContain("invalid");
+  });
+
+  it("truncates an over-long message with an ellipsis (after redaction, never mid-secret)", () => {
+    const long = `网络中断 ${"很".repeat(200)}`;
+    const out = summarizeErrorForNotification(long);
+    expect(out.length).toBeLessThanOrEqual(140);
+    expect(out.endsWith("…")).toBe(true);
   });
 });

--- a/packages/workflow/src/agent-error.ts
+++ b/packages/workflow/src/agent-error.ts
@@ -122,3 +122,39 @@ export function describeAgentRunError(error: unknown): string {
   }
   return "Workflow failed";
 }
+
+/** Max length of the error summary appended to a retry notification. Long enough
+ *  to carry a provider message ("夸克登录超时"/"分享已取消"/"访问频繁"…), short
+ *  enough for a push/card line. */
+const NOTIFY_SUMMARY_MAX = 140;
+
+/**
+ * A SHORT, SECRET-SAFE one-line summary of an error message, for surfacing the
+ * real cause in a *retry* notification (previously hidden behind "网络波动").
+ *
+ * Notifications are user-visible (in-app card + Bark/Server酱/企微 push), and a
+ * raw drive error can carry a cookie/token/query-credential. This collapses
+ * whitespace, redacts obvious secret material, then truncates — so the user sees
+ * WHY it is retrying without us leaking their credentials into a push channel.
+ *
+ * Order matters: redact BEFORE truncating (never truncate a secret in half and
+ * leak the prefix). The raw error is untouched — logs + auditEvents keep full
+ * detail for our own diagnosis.
+ */
+export function summarizeErrorForNotification(raw: string): string {
+  let s = raw.replace(/\s+/g, " ").trim();
+  // URL userinfo credentials: scheme://user:pass@host → scheme://***@host
+  s = s.replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, "$1***@");
+  // key/token/cookie/password style assignments: name=<value> → name=***
+  // (covers cookie=, token=, api_key=, access_token=, pwd=, stoken=, __puus=, sid=…)
+  s = s.replace(
+    /([A-Za-z_][A-Za-z0-9_-]*(?:key|token|cookie|secret|pass(?:word|wd)?|sign|stoken|puus|sid))\s*[=:]\s*[^\s,;&"']{6,}/gi,
+    "$1=***",
+  );
+  // Bare long opaque secrets (>=32 chars of base64url/hex-ish, no spaces) → ***
+  s = s.replace(/[A-Za-z0-9_-]{32,}/g, "***");
+  if (s.length > NOTIFY_SUMMARY_MAX) {
+    s = `${s.slice(0, NOTIFY_SUMMARY_MAX - 1)}…`;
+  }
+  return s;
+}

--- a/packages/workflow/src/worker.ts
+++ b/packages/workflow/src/worker.ts
@@ -18,7 +18,7 @@ import {
   requeueWorkflowRunForRetry,
 } from "./repository.js";
 import { isTransientAcquisitionError } from "./acquisition-v2/transient-error.js";
-import { describeAgentRunError } from "./agent-error.js";
+import { describeAgentRunError, summarizeErrorForNotification } from "./agent-error.js";
 import { formatReportPushText } from "./notification-report.js";
 import { isMovieUnreleased } from "./domain.js";
 import { isGuangYaAuthError } from "./guangya-client.js";
@@ -231,8 +231,12 @@ export async function handleWorkflowRunFailure(input: {
   if (willRetry) {
     workflowRun = requeueWorkflowRunForRetry(claimed.workflowRun, errorMessage, nowIso);
     const minutes = Math.round((AUTO_REQUEUE_BACKOFF_MS[priorCount] ?? 0) / 60_000);
+    // 把真实报因摘要带进「重试中」通知——以前一律「网络波动」把根因藏了,
+    // 用户和我们都得翻日志才知道发生了什么(issue #196)。摘要已脱敏+截断,
+    // 不会把 cookie/token 泄进推送渠道;原始错误仍在日志/auditEvents 里。
     report = failureReport(claimed, "retrying", [
       `网络波动 · 第 ${priorCount + 1} 次自动重试,约 ${minutes} 分钟后`,
+      `原因:${summarizeErrorForNotification(errorMessage)}`,
     ]);
   } else {
     workflowRun = failWorkflowRun(claimed.workflowRun, errorMessage, nowIso);

--- a/packages/workflow/tests/handle-workflow-failure.test.ts
+++ b/packages/workflow/tests/handle-workflow-failure.test.ts
@@ -72,6 +72,34 @@ describe("handleWorkflowRunFailure", () => {
     expect(saved.notifications[0]?.report?.status).toBe("retrying");
   });
 
+  it("surfaces the real cause in the retry notification (no longer hidden behind 网络波动, issue #196)", async () => {
+    const save = vi.fn(async (_input: PersistWorkflowRunSnapshotInput) => {});
+    await handleWorkflowRunFailure({
+      claimed: snapshot(),
+      error: new Error("fetch failed: 夸克访问频繁,请稍后再试"),
+      repository: { saveWorkflowRunSnapshot: save },
+      now,
+    });
+    const report = save.mock.calls[0]![0].notifications[0]?.report;
+    expect(report?.status).toBe("retrying");
+    // 既保留「网络波动·重试」那句,又多一句「原因:…」把真错亮出来。
+    expect(report?.lines.some((l) => l.includes("网络波动"))).toBe(true);
+    expect(report?.lines.some((l) => l.includes("原因:") && l.includes("夸克访问频繁"))).toBe(true);
+  });
+
+  it("redacts secrets from the retry-cause line (never leak a cookie/token into a push)", async () => {
+    const save = vi.fn(async (_input: PersistWorkflowRunSnapshotInput) => {});
+    await handleWorkflowRunFailure({
+      claimed: snapshot(),
+      error: new Error("fetch failed https://u:sup3rSecretPw@drive.quark.cn/x timeout"),
+      repository: { saveWorkflowRunSnapshot: save },
+      now,
+    });
+    const body = save.mock.calls[0]![0].notifications[0]?.body ?? "";
+    expect(body).not.toContain("sup3rSecretPw");
+    expect(body).toContain("原因:");
+  });
+
   it("terminally fails a transient error AT the cap (failed + failed notification)", async () => {
     const save = vi.fn(async (_input: PersistWorkflowRunSnapshotInput) => {});
     const out = await handleWorkflowRunFailure({


### PR DESCRIPTION
## 起因
issue #196:用户转存夸克卡在「正在转存到网盘」,通知反复「网络波动·第 N 次自动重试」。我这边复现不出来,而**截图里看不到任何根因**——因为重试通知把真错藏了。

## 问题
`worker.ts` 的重试分支只写死一行「网络波动 · 第 N 次自动重试」,真实 `errorMessage` **只在终态失败时**才进通知(`worker.ts` 旧 240-241)。而 `isTransientAcquisitionError` 的匹配词很宽(`timeout`/`fetch failed`/`network error`/`ECONNRESET`…),所以各种转存报错都会被折叠成「网络波动」。

后果:用户卡在重试时看不到原因,我们诊断只能让用户去翻 `docker compose logs` 或查 `workflow_runs.payload->auditEvents`。

## 改动
- **新增 `summarizeErrorForNotification`**(`agent-error.ts`):单行化 → **先脱敏 → 再截断**(≤140 字)。
  脱敏覆盖:URL userinfo(`https://u:pw@host`)、`*key/token/cookie/secret/pass/sign/sid=` 赋值、≥32 字符裸密串。
  **顺序很关键**:先截断会把密串截半、泄露前缀。
  理由:通知会推到 Bark / Server酱 / 企微,原始网盘报错可能带 cookie/token。
- **`worker.ts` 重试分支**在原行后追加 `原因:<摘要>`。原始 error 不动,日志/auditEvents 仍留全文。
- 前端无需改:`apps/web/app/notifications/page.tsx:229-262` 本来就渲染 `report.lines` 全部条目。

## 验证
- agent-error +6 例:人类可读原文保留、压行、三类脱敏、截断带省略号。
- worker +2 例:重试通知含「原因」且带真错;密串不出现在 body。
- **反向验证**:删掉「原因」行 → worker 2 例红;旁路脱敏 → 5 例红。
- 全仓 **2348** 测试通过(+8),三处 tsc + `build:web` 全绿。

## 效果
以后这类故障用户在通知卡片上直接看到「原因:夸克访问频繁…」这类真因,不必再翻日志——#196 若再现即可自证。