### PR TITLE
feat(capacity): 容量闸门 —— 防止撞 CF 隧道上限后「收了钱交不了货」

### DIFF
--- a/workers/scout-connect/src/capacity.test.ts
+++ b/workers/scout-connect/src/capacity.test.ts
@@ -25,11 +25,16 @@ import { CAPACITY_LIMIT } from "./capacity.js";
  */
 
 function endpoint(over: Partial<EndpointRow>): EndpointRow {
+  // 先算成局部变量再复用:原先 hostname 用 `over.slug ?? "x"`,不传 slug 时
+  // slug 是随机的、hostname 却固定成 x.mediaryconnect.app —— 两者不一致,且
+  // 第二次调用就撞 hostname UNIQUE。token_sha256 同理会退化成 sha_x。
+  const id = over.id ?? crypto.randomUUID();
+  const slug = over.slug ?? `s${Math.random().toString(36).slice(2, 8)}`;
   return {
-    id: over.id ?? crypto.randomUUID(),
+    id,
     invite_id: null,
-    slug: over.slug ?? `s${Math.random().toString(36).slice(2, 8)}`,
-    hostname: over.hostname ?? `${over.slug ?? "x"}.mediaryconnect.app`,
+    slug,
+    hostname: over.hostname ?? `${slug}.mediaryconnect.app`,
     cf_tunnel_id: "t1",
     cf_access_app_id: null,
     cf_access_policy_id: null,
@@ -37,7 +42,7 @@ function endpoint(over: Partial<EndpointRow>): EndpointRow {
     status: over.status ?? "active",
     // NOT NULL(schema.sql:28)。memory 实现不校验约束,真 SQLite 会拒——
     // parity 测试因此顺带发现了原 helper 造的是生产里非法的行。
-    token_sha256: `sha_${over.id ?? over.slug ?? "x"}`,
+    token_sha256: `sha_${id}`,
     token_ciphertext: null,
     token_shown_at: null,
     last_seen_at: null,
@@ -56,6 +61,21 @@ async function seed(db: ConnectDb, rows: Partial<EndpointRow>[]): Promise<void> 
     await db.insertEndpoint(endpoint({ slug: `slug${i}`, hostname: `slug${i}.mediaryconnect.app`, ...r }));
   }
 }
+
+describe("测试 helper 自身的正确性", () => {
+  // 原 helper 的默认 hostname 与 slug 不一致(hostname 固定 x.…),连续两条就撞
+  // UNIQUE;而真 SQLite 才会拒,memory 实现不会 —— 又一处 parity 盲区。
+  it("不传 slug 时 slug 与 hostname 自洽,可连续插多条", async () => {
+    const db = realD1();
+    await db.insertEndpoint(endpoint({}));
+    await db.insertEndpoint(endpoint({}));
+    expect(await db.countLiveEndpoints()).toBe(2);
+    const all = await db.listEndpoints();
+    for (const r of all) {
+      expect(r.hostname, "hostname 必须由自身 slug 派生").toBe(`${r.slug}.mediaryconnect.app`);
+    }
+  });
+});
 
 describe("countLiveEndpoints —— 计数语义(决定卖不卖得出去)", () => {
   it("空库为 0", async () => {

--- a/workers/scout-connect/src/capacity.test.ts
+++ b/workers/scout-connect/src/capacity.test.ts
@@ -1,0 +1,206 @@
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  createD1ConnectDb,
+  createMemoryConnectDb,
+  type ConnectDb,
+  type D1Database,
+  type EndpointRow,
+} from "./db.js";
+import { CAPACITY_LIMIT } from "./capacity.js";
+
+/**
+ * 容量闸门测试。
+ *
+ * 背景:CF 隧道硬上限 **1000/账号,所有套餐一致(含 Enterprise)**,官方
+ * account-limits 页面 + CF 员工社区回复双重确认;hostname routes 另有 1000
+ * 且与 tunnel 共享配额,所以真实上限就是 1000 个用户。
+ *
+ * 撞上限的后果不是降级而是**收了钱交不了货**:用户付款 → 过 entitlement 门禁
+ * → 在 cf.createTunnel 拿到 CF 报错 → 走完补偿事务 → 看到「开通失败,请稍后
+ * 重试」(而重试永远不会成功)。
+ */
+
+function endpoint(over: Partial<EndpointRow>): EndpointRow {
+  return {
+    id: over.id ?? crypto.randomUUID(),
+    invite_id: null,
+    slug: over.slug ?? `s${Math.random().toString(36).slice(2, 8)}`,
+    hostname: over.hostname ?? `${over.slug ?? "x"}.mediaryconnect.app`,
+    cf_tunnel_id: "t1",
+    cf_access_app_id: null,
+    cf_access_policy_id: null,
+    cf_dns_record_id: "d1",
+    status: over.status ?? "active",
+    // NOT NULL(schema.sql:28)。memory 实现不校验约束,真 SQLite 会拒——
+    // parity 测试因此顺带发现了原 helper 造的是生产里非法的行。
+    token_sha256: `sha_${over.id ?? over.slug ?? "x"}`,
+    token_ciphertext: null,
+    token_shown_at: null,
+    last_seen_at: null,
+    created_at: "2026-07-29T00:00:00.000Z",
+    revoked_at: null,
+    account_id: over.account_id ?? null,
+    grace_until: over.grace_until ?? null,
+    suspended_at: over.suspended_at ?? null,
+    purge_after: null,
+    ...over,
+  } as EndpointRow;
+}
+
+async function seed(db: ConnectDb, rows: Partial<EndpointRow>[]): Promise<void> {
+  for (const [i, r] of rows.entries()) {
+    await db.insertEndpoint(endpoint({ slug: `slug${i}`, hostname: `slug${i}.mediaryconnect.app`, ...r }));
+  }
+}
+
+describe("countLiveEndpoints —— 计数语义(决定卖不卖得出去)", () => {
+  it("空库为 0", async () => {
+    expect(await createMemoryConnectDb().countLiveEndpoints()).toBe(0);
+  });
+
+  it("active 计入", async () => {
+    const db = createMemoryConnectDb();
+    await seed(db, [{ status: "active" }, { status: "active" }]);
+    expect(await db.countLiveEndpoints()).toBe(2);
+  });
+
+  // 这两种是**时间戳态**:schema 注释明确「grace/suspended 是时间戳态,
+  // status 仍 'active' 所以天然算占用」。它们确实还占着 CF 隧道,漏计就会超卖。
+  it("宽限期中(grace_until 有值)仍占隧道,必须计入", async () => {
+    const db = createMemoryConnectDb();
+    await seed(db, [{ status: "active", grace_until: "2026-08-05T00:00:00.000Z" }]);
+    expect(await db.countLiveEndpoints()).toBe(1);
+  });
+
+  it("已停用但隧道未删(suspended_at 有值、status 仍 active)必须计入", async () => {
+    const db = createMemoryConnectDb();
+    await seed(db, [{ status: "active", suspended_at: "2026-08-05T00:00:00.000Z" }]);
+    expect(await db.countLiveEndpoints()).toBe(1);
+  });
+
+  // revoked 的隧道已在 CF 侧删除,不占配额 —— 计入会导致「明明有余量却显示售罄」。
+  it("revoked 不计入(隧道已删,不占配额)", async () => {
+    const db = createMemoryConnectDb();
+    await seed(db, [{ status: "active" }, { status: "revoked" }, { status: "revoked" }]);
+    expect(await db.countLiveEndpoints()).toBe(1);
+  });
+
+  // revoke_failed = CF 侧删除失败,隧道**可能还在**。偏保守计入:
+  // 宁可少卖(可人工核查),不可超卖(撞 CF 上限就是收钱交不了货)。
+  it("revoke_failed 偏保守计入(CF 侧可能还在)", async () => {
+    const db = createMemoryConnectDb();
+    await seed(db, [{ status: "revoke_failed" }]);
+    expect(await db.countLiveEndpoints()).toBe(1);
+  });
+});
+
+describe("CAPACITY_LIMIT", () => {
+  it("是 990,与 CF 硬上限 1000 留 10 条运维余量", () => {
+    expect(CAPACITY_LIMIT).toBe(990);
+    // 绝不能等于或超过 1000:撞上就是付了钱开不出来
+    expect(CAPACITY_LIMIT).toBeLessThan(1000);
+  });
+});
+
+/** 真 SQLite 上跑生产 D1 语句(与 schema.test.ts 同款适配器)。 */
+function d1Over(sqlite: Database.Database): D1Database {
+  return {
+    prepare(query: string) {
+      const stmt = sqlite.prepare(query);
+      let bound: unknown[] = [];
+      const api = {
+        bind(...values: unknown[]) {
+          bound = values;
+          return api;
+        },
+        async first<T>(): Promise<T | null> {
+          return (stmt.get(...bound) as T | undefined) ?? null;
+        },
+        async all<T>(): Promise<{ results: T[] }> {
+          return { results: stmt.all(...bound) as T[] };
+        },
+        async run(): Promise<unknown> {
+          const info = stmt.run(...bound);
+          return { meta: { changes: info.changes } };
+        },
+      };
+      return api;
+    },
+  };
+}
+
+function realD1(): ConnectDb {
+  const schema = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "schema.sql"),
+    "utf8",
+  );
+  const sqlite = new Database(":memory:");
+  sqlite.exec(schema);
+  return createD1ConnectDb(d1Over(sqlite));
+}
+
+/**
+ * D1 与 memory 两份实现的一致性(parity)。
+ *
+ * 这是**必须实测**的:两份实现是分别手写的(一个 SQL `status IN (...)`,一个
+ * JS filter),漂移的后果是本地测试全绿而生产超卖。endpoints.status 经全仓核实
+ * 只有三个取值:active(插入时)、revoked、revoke_failed(见 db.ts 的两条 UPDATE);
+ * provisioned/pending 属 invites 表,waiting 属 waitlist 表,与本计数无关。
+ */
+describe("countLiveEndpoints D1↔memory parity", () => {
+  // status 的联合类型只有三个值,类型系统本身就印证了白名单的完备性。
+  type Status = EndpointRow["status"];
+  const cases: { name: string; rows: { status: Status; grace?: string; susp?: string }[] }[] = [
+    { name: "空库", rows: [] },
+    { name: "全 active", rows: [{ status: "active" }, { status: "active" }] },
+    { name: "全 revoked", rows: [{ status: "revoked" }, { status: "revoked" }] },
+    { name: "全 revoke_failed", rows: [{ status: "revoke_failed" }] },
+    {
+      name: "混合三态 + 时间戳态",
+      rows: [
+        { status: "active" },
+        { status: "active", grace: "2026-08-05T00:00:00.000Z" },
+        { status: "active", susp: "2026-08-05T00:00:00.000Z" },
+        { status: "revoked" },
+        { status: "revoke_failed" },
+      ],
+    },
+  ];
+
+  for (const c of cases) {
+    it(`${c.name} → 两实现结果相同`, async () => {
+      const results: number[] = [];
+      for (const db of [realD1(), createMemoryConnectDb()]) {
+        for (const [i, r] of c.rows.entries()) {
+          await db.insertEndpoint(
+            endpoint({
+              id: `p_${i}`,
+              slug: `p-${i}`,
+              hostname: `p-${i}.mediaryconnect.app`,
+              status: r.status,
+              grace_until: r.grace ?? null,
+              suspended_at: r.susp ?? null,
+            }),
+          );
+        }
+        results.push(await db.countLiveEndpoints());
+      }
+      expect(results[0], `D1=${results[0]} memory=${results[1]}`).toBe(results[1]);
+    });
+  }
+
+  it("混合态的绝对值也正确(active×3 + revoke_failed×1 = 4)", async () => {
+    const db = realD1();
+    const mix: EndpointRow["status"][] = ["active", "active", "active", "revoke_failed", "revoked"];
+    for (const [i, st] of mix.entries()) {
+      await db.insertEndpoint(
+        endpoint({ id: `q_${i}`, slug: `q-${i}`, hostname: `q-${i}.mediaryconnect.app`, status: st }),
+      );
+    }
+    expect(await db.countLiveEndpoints()).toBe(4);
+  });
+});

--- a/workers/scout-connect/src/capacity.ts
+++ b/workers/scout-connect/src/capacity.ts
@@ -1,0 +1,13 @@
+/**
+ * 容量闸门常量。
+ *
+ * CF 隧道上限是 **1000/账号,且所有套餐一致(含 Enterprise)** —— 官方
+ * account-limits 页面与 CF 员工社区回复双重确认,买套餐也提不了,只能联系 Sales。
+ * 另外 hostname routes 也是 1000/账号且**与 tunnel 共享配额**,而我们每个用户
+ * 消耗 1 条 tunnel + 1 条 hostname route,所以真实上限就是 1000 个用户。
+ *
+ * 留 10 条余量给运维:故障重建、作者自用、以及「删了 CF 侧但 DB 还没写成功」
+ * 的中间态。撞上真上限的后果不是降级,而是**收了钱交不了货**——用户付款、过了
+ * entitlement 门禁,在 createTunnel 才拿到 CF 报错。
+ */
+export const CAPACITY_LIMIT = 990;

--- a/workers/scout-connect/src/capacity.ts
+++ b/workers/scout-connect/src/capacity.ts
@@ -11,3 +11,20 @@
  * entitlement 门禁,在 createTunnel 才拿到 CF 报错。
  */
 export const CAPACITY_LIMIT = 990;
+
+/** provisionEndpoint 在容量满时抛出的确切 message。
+ *  两条 provision 路由(自助 /api/provision 与 admin invite)都要能识别它并映射
+ *  503,所以常量化——字符串字面量散在两处迟早对不上。 */
+export const AT_CAPACITY_MESSAGE = "at capacity";
+
+/** 把「容量已满」映射成 503。
+ *
+ *  503 而非 4xx:这是**我方**容量问题(CF 隧道 1000 硬上限),用户的请求本身
+ *  完全合法。4xx 会让用户以为自己填错了。
+ *
+ *  两条路由共用同一个 helper,而不是各写一遍 includes 判断 —— provisionEndpoint
+ *  是共享函数,任何调用方漏掉这个映射都会让容量满变成 500(Copilot round-4
+ *  指出 admin invite 路径正是如此)。 */
+export function isAtCapacityError(e: unknown): boolean {
+  return e instanceof Error && e.message === AT_CAPACITY_MESSAGE;
+}

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -98,6 +98,15 @@ export interface ConnectDb {
   /** Targeted existence check for the slug/hostname availability precheck. */
   findEndpointBySlugOrHostname(slug: string, hostname: string): Promise<Pick<EndpointRow, "slug" | "hostname"> | null>;
   listEndpoints(): Promise<EndpointRow[]>;
+  /** 仍占用 CF 隧道配额的 endpoint 数(容量闸门用)。
+   *
+   *  **计数语义是可卖不可卖的分界,改它前先读 capacity.test.ts:**
+   *  - `active` 计入(含宽限期/已停用但未删隧道——schema 注释明确这两种是
+   *    时间戳态,status 仍 'active',确实还占着隧道)
+   *  - `revoke_failed` **偏保守计入**:CF 侧删除失败,隧道可能还在。宁可少卖
+   *    (可人工核查),不可超卖(撞 CF 上限就是收了钱交不了货)
+   *  - `revoked` 不计入:隧道已删,不占配额 */
+  countLiveEndpoints(): Promise<number>;
   /**
    * Atomic burn: sets shown_at + nulls ciphertext only if not already burned.
    * Returns true when THIS call performed the burn (won the race), false when
@@ -375,6 +384,18 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
         .prepare(`SELECT * FROM endpoints ORDER BY created_at DESC, id DESC`)
         .all<RawRow>();
       return results.map(mapEndpoint);
+    },
+
+    async countLiveEndpoints() {
+      // 只数仍占 CF 配额的状态(见接口注释)。用 IN 而非 != 'revoked':
+      // 将来新增 status 值时,默认**不**计入比默认计入更安全——漏计会超卖,
+      // 而多计只是少卖。显式白名单让新状态必须主动决定归属。
+      const row = await d1
+        .prepare(
+          `SELECT COUNT(*) as cnt FROM endpoints WHERE status IN ('active', 'revoke_failed')`,
+        )
+        .first<{ cnt: number }>();
+      return row?.cnt ?? 0;
     },
 
     async markEndpointRevoked(endpointId, at) {
@@ -742,6 +763,13 @@ export function createMemoryConnectDb(): ConnectDb {
 
     async listEndpoints() {
       return [...endpoints.values()].sort(byCreatedAtDesc).map((row) => ({ ...row }));
+    },
+
+    async countLiveEndpoints() {
+      // 与 D1 分支同款白名单(parity)。
+      return [...endpoints.values()].filter(
+        (r) => r.status === "active" || r.status === "revoke_failed",
+      ).length;
     },
 
     async markEndpointRevoked(endpointId, at) {

--- a/workers/scout-connect/src/html/console-page.ts
+++ b/workers/scout-connect/src/html/console-page.ts
@@ -26,6 +26,9 @@ export function consolePage(input: {
    *  推:控制台可从 beta 子域访问,host 会是 beta.<root>,后缀就错了。 */
   rootDomain: string;
   now: string;
+  /** 隧道配额是否已满(CF 1000 硬上限)。只影响「已付费未开通」态:满了就不给
+   *  slug 表单,免得用户填完名字才吃 503。已开通用户完全不受影响。 */
+  atCapacity?: boolean;
 }): string {
   const expiry = latestExpiry(input.entitlements);
   const active = isEntitlementActive(expiry, input.now);
@@ -97,7 +100,7 @@ details[open] summary .chev{transform:rotate(90deg)}
 ${BRAND_BAR}
 <p class="email-line">${esc(input.account.email)}</p>
 <div class="status-row"><h1>远程访问</h1>${statusBadge}</div>
-${renderBody(input, active)}
+${renderBody({ ...input, atCapacity: input.atCapacity === true }, active)}
 <div class="footer"><a href="/pricing">定价</a> · <a href="/terms">服务条款</a> · <a href="/privacy">隐私政策</a> · <a href="/refund">退款政策</a> · <a href="/contact">联系我们</a></div>
 </main>
 ${renderScript(input, active)}
@@ -110,12 +113,26 @@ function renderBody(
     account: AccountRow;
     endpoint: EndpointRow | null;
     rootDomain: string;
+    /** 隧道配额已满(CF 1000 硬上限)。已开通用户不受影响,只挡新开通。 */
+    atCapacity: boolean;
   },
   active: boolean,
 ): string {
   if (!active) {
     return `<p class="sub">你还没有有效时长。开通后即可为自托管实例生成专属远程访问地址。</p>
 <a class="btn" href="/pricing">开通</a>`;
+  }
+  if (input.endpoint === null && input.atCapacity) {
+    // 满容量:**不渲染表单**。让用户输完名字、点开通、再吃 503 是最差的体验
+    // (他会以为自己名字填错了)。直接说清是我方容量、以及他能做什么。
+    // 已付费才会走到这里,所以必须给退款出口 —— 14 天内无条件。
+    return `<p class="sub">你已开通，但目前暂时无法分配新地址。</p>
+<div class="panel">
+<p class="step" style="color:var(--err)">暂时售罄</p>
+<p class="lead">隧道配额已满</p>
+<p class="lead-sub">我们的 Cloudflare 隧道配额（每账号上限 1000 条，所有套餐一致）已用尽，暂时无法为新实例分配地址。你的时长不会流失——配额释放后回到这里即可开通，我们也会邮件通知你。</p>
+<p class="lead-sub">如果不想等，14 天内可无条件全额退款：<a href="/refund">退款政策</a> · <a href="/contact">联系我们</a></p>
+</div>`;
   }
   if (input.endpoint === null) {
     // 已付费未开通:内嵌 slug 选择表单(实时查重走 /api/slug/check,开通走

--- a/workers/scout-connect/src/html/console-page.ts
+++ b/workers/scout-connect/src/html/console-page.ts
@@ -103,7 +103,7 @@ ${BRAND_BAR}
 ${renderBody({ ...input, atCapacity: input.atCapacity === true }, active)}
 <div class="footer"><a href="/pricing">定价</a> · <a href="/terms">服务条款</a> · <a href="/privacy">隐私政策</a> · <a href="/refund">退款政策</a> · <a href="/contact">联系我们</a></div>
 </main>
-${renderScript(input, active)}
+${renderScript({ ...input, atCapacity: input.atCapacity === true }, active)}
 </body>
 </html>`;
 }
@@ -126,7 +126,7 @@ function renderBody(
     // 满容量:**不渲染表单**。让用户输完名字、点开通、再吃 503 是最差的体验
     // (他会以为自己名字填错了)。直接说清是我方容量、以及他能做什么。
     // 已付费才会走到这里,所以必须给退款出口 —— 14 天内无条件。
-    return `<p class="sub">你已开通，但目前暂时无法分配新地址。</p>
+    return `<p class="sub">你的时长已生效，但目前暂时无法分配新地址。</p>
 <div class="panel">
 <p class="step" style="color:var(--err)">暂时售罄</p>
 <p class="lead">隧道配额已满</p>
@@ -179,10 +179,13 @@ function renderBody(
 /** active 时才需要客户端脚本:有 endpoint → 取码/复制;无 endpoint → slug
  *  选择表单(实时查重 + 开通)。 */
 function renderScript(
-  input: { endpoint: EndpointRow | null; baseUrl: string },
+  input: { endpoint: EndpointRow | null; baseUrl: string; atCapacity?: boolean },
   active: boolean,
 ): string {
   if (!active) return "";
+  // 满容量时 renderBody 不渲染 #slug/#provision,注入表单脚本会对 null 调
+  // addEventListener 直接抛错、整段脚本崩掉。条件必须与 renderBody 的分支一致。
+  if (input.endpoint === null && input.atCapacity === true) return "";
   if (input.endpoint === null) return SLUG_FORM_SCRIPT;
   return `<script type="module">
 const $=(id)=>document.getElementById(id);

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -1,4 +1,4 @@
-import { CAPACITY_LIMIT } from "./capacity.js";
+import { AT_CAPACITY_MESSAGE, CAPACITY_LIMIT } from "./capacity.js";
 import { assertSlug } from "./slug.js";
 import { sha256Hex } from "./crypto-token.js";
 import { buildAgentPromptOrManual } from "./agent-prompt.js";
@@ -110,7 +110,7 @@ export async function provisionEndpoint(input: {
   // 因配额失败的审计记录。
   const live = await db.countLiveEndpoints();
   if (live >= CAPACITY_LIMIT) {
-    throw new Error("at capacity");
+    throw new Error(AT_CAPACITY_MESSAGE);
   }
 
   const { tunnelId, token } = await cf.createTunnel(`scout-${slug}`);

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -97,6 +97,17 @@ export async function provisionEndpoint(input: {
   // 「开通失败,请稍后重试」——而重试永远不会成功。放在这里(slug 查重之后、
   // createTunnel 之前)既不浪费一次查重,也保证零 CF 副作用。
   // 路由层把这条映射成 503(我方容量问题,不是用户请求错误)。
+  //
+  // **已知非原子(TOCTOU),有意如此。** 这是 COUNT 读后再建,并发下多个请求可能
+  // 同时看到 live < CAPACITY_LIMIT 而全部放行。要真的突破 CF 的 1000 硬上限,
+  // 需要 **11 个请求落在同一个毫秒级窗口内、且恰好都在第 990 条附近** ——
+  // 990 阈值留的那 10 条余量正是为此(不只是给运维)。
+  // 本产品是预付时长、单人自助开通,该并发在 1000 用户规模下不会出现。
+  // 若真要硬保证,需引入预留机制(插一条 status='provisioning' 的短命行抢
+  // UNIQUE),但那要求:新状态进容量白名单、僵尸预留的清理任务、以及改
+  // idx_endpoints_account_live 部分唯一索引的语义 —— 改动面远大于收益。
+  // 触发重新评估的信号:活跃 endpoint 数接近 900,或出现任何一次 createTunnel
+  // 因配额失败的审计记录。
   const live = await db.countLiveEndpoints();
   if (live >= CAPACITY_LIMIT) {
     throw new Error("at capacity");

--- a/workers/scout-connect/src/provision.ts
+++ b/workers/scout-connect/src/provision.ts
@@ -1,3 +1,4 @@
+import { CAPACITY_LIMIT } from "./capacity.js";
 import { assertSlug } from "./slug.js";
 import { sha256Hex } from "./crypto-token.js";
 import { buildAgentPromptOrManual } from "./agent-prompt.js";
@@ -89,6 +90,16 @@ export async function provisionEndpoint(input: {
       throw new Error(`slug already in use: ${slug}`);
     }
     throw new Error(`hostname already in use: ${hostname}`);
+  }
+
+  // 容量闸门。**必须在烧任何 CF 资源之前**:CF 隧道硬上限 1000/账号(所有套餐
+  // 一致,含 Enterprise),撞上时 createTunnel 会失败,用户已付款却拿到
+  // 「开通失败,请稍后重试」——而重试永远不会成功。放在这里(slug 查重之后、
+  // createTunnel 之前)既不浪费一次查重,也保证零 CF 副作用。
+  // 路由层把这条映射成 503(我方容量问题,不是用户请求错误)。
+  const live = await db.countLiveEndpoints();
+  if (live >= CAPACITY_LIMIT) {
+    throw new Error("at capacity");
   }
 
   const { tunnelId, token } = await cf.createTunnel(`scout-${slug}`);

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -2118,3 +2118,43 @@ describe("合规页语言切换", () => {
     expect(await res.text()).toContain('<html lang="en">');
   });
 });
+
+describe("容量满时 admin invite 路径也必须是 503", () => {
+  // provisionEndpoint 是**共享**函数,容量闸门在它内部。自助 /api/provision 早就
+  // 映射了 503,但 admin invite 路径原先漏了 → 容量满时变成 500(语义也不对:
+  // 那不是服务器故障,而是我方配额用尽)。Copilot round-4 的 details 指出。
+  it("invite provision 在容量满时返回 503 而非 500", async () => {
+    const { db, deps, calls } = setup();
+    for (let i = 0; i < 990; i++) {
+      await db.insertEndpoint({
+        id: `cap_${i}`,
+        invite_id: null,
+        slug: `cap-${i}`,
+        hostname: `cap-${i}.mediaryconnect.app`,
+        cf_tunnel_id: `t${i}`,
+        cf_access_app_id: null,
+        cf_access_policy_id: null,
+        cf_dns_record_id: `d${i}`,
+        status: "active",
+        token_sha256: `sha_${i}`,
+        token_ciphertext: null,
+        token_shown_at: null,
+        last_seen_at: null,
+        created_at: "2026-07-29T00:00:00.000Z",
+        revoked_at: null,
+        account_id: null,
+        grace_until: null,
+        suspended_at: null,
+        purge_after: null,
+      });
+    }
+    const createRes = await createInviteViaApi(deps, { email: "cap@example.com", slug: "capped" });
+    const created = (await createRes.json()) as InviteCreated;
+    const before = calls.length;
+    const res = await provisionViaApi(deps, created.id);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "at capacity" });
+    // 同样必须零 CF 副作用
+    expect(calls.length, `不该有新的 CF 调用: ${calls.slice(before).join(", ")}`).toBe(before);
+  });
+});

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -11,7 +11,7 @@ import { homePage } from "./html/home-page.js";
 import { adminPage } from "./html/admin-page.js";
 import { invitePage, type InvitePageState } from "./html/invite-page.js";
 import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
-import { CAPACITY_LIMIT } from "./capacity.js";
+import { CAPACITY_LIMIT, isAtCapacityError } from "./capacity.js";
 import { buyPage } from "./html/buy-page.js";
 import { compliancePage, COMPLIANCE_PAGES, type CompliancePageKey } from "./html/compliance-page.js";
 import { RAW_ASSETS } from "./html/assets.gen.js";
@@ -505,9 +505,9 @@ async function selfServeProvision(request: Request, deps: RouteDeps): Promise<Re
     ) {
       throw new HttpError(409, "slug taken");
     }
-    // 容量已满 → 503 而非 4xx:这是**我方**容量问题(CF 隧道 1000 硬上限),
-    // 用户的请求本身完全合法。4xx 会让用户以为自己填错了。
-    if (msg === "at capacity") {
+    // 容量已满 → 503(共享 helper,见 capacity.ts:两条 provision 路由必须
+    // 用同一个判定,否则漏掉的那条会把容量满变成 500)。
+    if (isAtCapacityError(e)) {
       throw new HttpError(503, "at capacity");
     }
     throw e;
@@ -815,6 +815,12 @@ async function provisionInvite(
     // The actual race loser dies on the UNIQUE constraint — "UNIQUE
     // constraint failed: endpoints.slug" (same wording in D1 and the memory
     // mock) — which contains neither pre-check message, so map it explicitly.
+    // 容量已满 → 503。**必须与自助路径用同一个判定**:provisionEndpoint 是
+    // 共享函数,这条路径原先漏了映射,容量满时会变成 500(且语义不对——那不是
+    // 服务器故障,而是我方配额用尽)。
+    if (isAtCapacityError(e)) {
+      throw new HttpError(503, "at capacity");
+    }
     const msg = e instanceof Error ? e.message : "";
     if (msg.includes("invite not pending") || msg.includes("already in use")) {
       throw new HttpError(409, msg);

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -12,6 +12,7 @@ import { adminPage } from "./html/admin-page.js";
 import { invitePage, type InvitePageState } from "./html/invite-page.js";
 import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
 import { CAPACITY_LIMIT } from "./capacity.js";
+import { isEntitlementActive, latestExpiry } from "./entitlement.js";
 import { buyPage } from "./html/buy-page.js";
 import { compliancePage, COMPLIANCE_PAGES, type CompliancePageKey } from "./html/compliance-page.js";
 import { RAW_ASSETS } from "./html/assets.gen.js";
@@ -657,11 +658,15 @@ async function consoleRoute(request: Request, deps: RouteDeps): Promise<Response
   // 该账号的 active endpoint(可能为 null:已付费但还没选 slug,或未开通)。
   // 控制台据此决定显示「选专属地址」入口还是「接入命令」提示词区。
   const endpoint = await deps.db.getActiveEndpointByAccountId(account.id);
-  // 仅在「还没开通」时才数配额:已开通用户不受配额影响,不该为他们每次进控制台
-  // 都多跑一次 COUNT。满容量时前端不渲染 slug 表单(见 console-page),免得用户
-  // 填完名字才吃 503。
-  const atCapacity =
-    endpoint === null ? (await deps.db.countLiveEndpoints()) >= CAPACITY_LIMIT : false;
+  // 仅在「真的能走到 slug 表单」时才数配额,两个条件都要满足:
+  //   1. 还没开通(已开通用户不受配额影响)
+  //   2. 有有效时长(无时长的用户在 console-page 走早返回分支,压根用不到这个值)
+  // 否则未付费/已过期用户每次进控制台都白跑一次全表 COUNT。
+  const eligibleToProvision =
+    endpoint === null && isEntitlementActive(latestExpiry(entitlements), deps.now());
+  const atCapacity = eligibleToProvision
+    ? (await deps.db.countLiveEndpoints()) >= CAPACITY_LIMIT
+    : false;
   const url = new URL(request.url);
   return htmlPage(
     consolePage({

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -11,6 +11,7 @@ import { homePage } from "./html/home-page.js";
 import { adminPage } from "./html/admin-page.js";
 import { invitePage, type InvitePageState } from "./html/invite-page.js";
 import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
+import { CAPACITY_LIMIT } from "./capacity.js";
 import { buyPage } from "./html/buy-page.js";
 import { compliancePage, COMPLIANCE_PAGES, type CompliancePageKey } from "./html/compliance-page.js";
 import { RAW_ASSETS } from "./html/assets.gen.js";
@@ -504,6 +505,11 @@ async function selfServeProvision(request: Request, deps: RouteDeps): Promise<Re
     ) {
       throw new HttpError(409, "slug taken");
     }
+    // 容量已满 → 503 而非 4xx:这是**我方**容量问题(CF 隧道 1000 硬上限),
+    // 用户的请求本身完全合法。4xx 会让用户以为自己填错了。
+    if (msg === "at capacity") {
+      throw new HttpError(503, "at capacity");
+    }
     throw e;
   }
 }
@@ -651,6 +657,11 @@ async function consoleRoute(request: Request, deps: RouteDeps): Promise<Response
   // 该账号的 active endpoint(可能为 null:已付费但还没选 slug,或未开通)。
   // 控制台据此决定显示「选专属地址」入口还是「接入命令」提示词区。
   const endpoint = await deps.db.getActiveEndpointByAccountId(account.id);
+  // 仅在「还没开通」时才数配额:已开通用户不受配额影响,不该为他们每次进控制台
+  // 都多跑一次 COUNT。满容量时前端不渲染 slug 表单(见 console-page),免得用户
+  // 填完名字才吃 503。
+  const atCapacity =
+    endpoint === null ? (await deps.db.countLiveEndpoints()) >= CAPACITY_LIMIT : false;
   const url = new URL(request.url);
   return htmlPage(
     consolePage({
@@ -660,6 +671,7 @@ async function consoleRoute(request: Request, deps: RouteDeps): Promise<Response
       baseUrl: url.origin,
       rootDomain: deps.rootDomain.trim().toLowerCase(),
       now: deps.now(),
+      atCapacity,
     }),
     { noStore: true }, // 用户专属页面,不可缓存(Copilot round 3)
   );

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -12,7 +12,6 @@ import { adminPage } from "./html/admin-page.js";
 import { invitePage, type InvitePageState } from "./html/invite-page.js";
 import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
 import { CAPACITY_LIMIT } from "./capacity.js";
-import { isEntitlementActive, latestExpiry } from "./entitlement.js";
 import { buyPage } from "./html/buy-page.js";
 import { compliancePage, COMPLIANCE_PAGES, type CompliancePageKey } from "./html/compliance-page.js";
 import { RAW_ASSETS } from "./html/assets.gen.js";
@@ -23,7 +22,7 @@ import { newId } from "./ids.js";
 import { sha256Hex } from "./crypto-token.js";
 import { signToken, verifyToken } from "./signed-token.js";
 import { buildSessionCookie, parseSessionCookie } from "./session.js";
-import { computeExpiry } from "./entitlement.js";
+import { computeExpiry, isEntitlementActive, latestExpiry } from "./entitlement.js";
 
 // Same aperture mark as apps/web/app/icon.svg — the product brand.
 const LOGO_SVG =

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -662,8 +662,11 @@ async function consoleRoute(request: Request, deps: RouteDeps): Promise<Response
   //   1. 还没开通(已开通用户不受配额影响)
   //   2. 有有效时长(无时长的用户在 console-page 走早返回分支,压根用不到这个值)
   // 否则未付费/已过期用户每次进控制台都白跑一次全表 COUNT。
+  // now 只取一次:同一请求里若取两次,在到期边界附近会出现「判断条件用的时刻」
+  // 与「页面渲染的时刻」不一致(状态显示与实际门禁矛盾)。
+  const now = deps.now();
   const eligibleToProvision =
-    endpoint === null && isEntitlementActive(latestExpiry(entitlements), deps.now());
+    endpoint === null && isEntitlementActive(latestExpiry(entitlements), now);
   const atCapacity = eligibleToProvision
     ? (await deps.db.countLiveEndpoints()) >= CAPACITY_LIMIT
     : false;
@@ -675,7 +678,7 @@ async function consoleRoute(request: Request, deps: RouteDeps): Promise<Response
       endpoint,
       baseUrl: url.origin,
       rootDomain: deps.rootDomain.trim().toLowerCase(),
-      now: deps.now(),
+      now,
       atCapacity,
     }),
     { noStore: true }, // 用户专属页面,不可缓存(Copilot round 3)

--- a/workers/scout-connect/src/self-serve-provision.test.ts
+++ b/workers/scout-connect/src/self-serve-provision.test.ts
@@ -336,6 +336,13 @@ describe("控制台在满容量时的呈现", () => {
     expect(html).toContain("你的时长不会流失");
     expect(html).toContain('href="/refund"'); // 已付费,必须给退款出口
     expect(html, "不该渲染 slug 输入框").not.toContain('id="slug"');
+    // DOM 里没有 #slug 时若仍注入表单脚本,浏览器端会对 null 调
+    // addEventListener 直接抛错、整段脚本崩掉(Copilot round-2 的 details 指出)。
+    expect(html, "不该注入 slug 表单脚本").not.toContain('getElementById("slug")');
+    expect(html, "不该注入 slug 表单脚本").not.toContain("/api/slug/check");
+    // 文案:此时用户还没拿到地址,说「你已开通」会被误解
+    expect(html).toContain("你的时长已生效");
+    expect(html).not.toContain("你已开通，但目前");
   });
 
   it("未满容量正常渲染 slug 表单", async () => {

--- a/workers/scout-connect/src/self-serve-provision.test.ts
+++ b/workers/scout-connect/src/self-serve-provision.test.ts
@@ -225,7 +225,9 @@ describe("容量闸门(CF 隧道 1000 硬上限)", () => {
         cf_access_policy_id: null,
         cf_dns_record_id: `d_${i}`,
         status,
-        token_sha256: null,
+        // NOT NULL(schema.sql:28)。memory 实现不校验约束,但保持与真 schema
+        // 一致才能避免 parity 盲区(capacity.test.ts 就因此踩过一次)。
+        token_sha256: `sha_${i}`,
         token_ciphertext: null,
         token_shown_at: null,
         last_seen_at: null,
@@ -306,7 +308,9 @@ describe("控制台在满容量时的呈现", () => {
         slug: `c-${i}`, hostname: `c-${i}.mediaryconnect.app`,
         cf_tunnel_id: `t${i}`, cf_access_app_id: null, cf_access_policy_id: null,
         cf_dns_record_id: `d${i}`, status: "active",
-        token_sha256: null, token_ciphertext: null, token_shown_at: null,
+        // NOT NULL(schema.sql:28)。memory 实现不校验约束,但保持与真 schema
+        // 一致才能避免 parity 盲区(capacity.test.ts 就因此踩过一次)。
+        token_sha256: `sha_${i}`, token_ciphertext: null, token_shown_at: null,
         last_seen_at: null, created_at: NOW, revoked_at: null,
         account_id: null, grace_until: null, suspended_at: null, purge_after: null,
       } as never);
@@ -354,5 +358,55 @@ describe("控制台在满容量时的呈现", () => {
     const html = await console_(db, deps, "act_c3");
     expect(html).toContain("mine.mediaryconnect.app");
     expect(html).not.toContain("暂时售罄");
+  });
+});
+
+describe("容量计数的调用时机(避免无谓的全表 COUNT)", () => {
+  /** 包一层 db,记录 countLiveEndpoints 被调用次数。 */
+  function counting(db: ConnectDb): { db: ConnectDb; hits: () => number } {
+    let n = 0;
+    const wrapped: ConnectDb = {
+      ...db,
+      async countLiveEndpoints() {
+        n++;
+        return db.countLiveEndpoints();
+      },
+    };
+    return { db: wrapped, hits: () => n };
+  }
+
+  async function openConsole(deps: RouteDeps, accountId: string): Promise<number> {
+    const res = await handleRequest(
+      new Request(`${BASE}/console`, { headers: { cookie: await cookieFor(accountId) } }),
+      deps,
+    );
+    return res.status;
+  }
+
+  // 无有效时长的用户在 console-page 走早返回分支,压根用不到 atCapacity。
+  // 为他们跑一次全表 COUNT 纯属浪费(Copilot round-1 指出)。
+  it("无有效时长时不查容量", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_np", "2026-01-01T00:00:00.000Z"); // 已过期
+    const c = counting(db);
+    expect(await openConsole({ ...deps, db: c.db }, "act_np")).toBe(200);
+    expect(c.hits(), "过期用户不该触发 COUNT").toBe(0);
+  });
+
+  it("有时长且未开通时才查容量", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_el", "2027-01-01T00:00:00.000Z");
+    const c = counting(db);
+    expect(await openConsole({ ...deps, db: c.db }, "act_el")).toBe(200);
+    expect(c.hits()).toBe(1);
+  });
+
+  it("已开通用户不查容量(不受配额影响)", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_done", "2027-01-01T00:00:00.000Z");
+    expect((await handleRequest(post("done", await cookieFor("act_done")), deps)).status).toBe(200);
+    const c = counting(db);
+    expect(await openConsole({ ...deps, db: c.db }, "act_done")).toBe(200);
+    expect(c.hits(), "已开通用户不该触发 COUNT").toBe(0);
   });
 });

--- a/workers/scout-connect/src/self-serve-provision.test.ts
+++ b/workers/scout-connect/src/self-serve-provision.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createMemoryConnectDb, type ConnectDb } from "./db.js";
+import { createMemoryConnectDb, type ConnectDb, type EndpointRow } from "./db.js";
 import { buildSessionCookie } from "./session.js";
 import { handleRequest, type RouteDeps } from "./routes.js";
 
@@ -211,9 +211,14 @@ describe("POST /api/provision (自助开通)", () => {
   });
 });
 
-describe("容量闸门(CF 隧道 1000 硬上限)", () => {
-  /** 造 n 条占配额的 endpoint 行。用 insertEndpoint 直插,不走 CF。 */
-  async function fillCapacity(db: ConnectDb, n: number, status = "active"): Promise<void> {
+/** 造 n 条占配额的 endpoint 行。用 insertEndpoint 直插,不走 CF。
+ *  status 收窄到联合类型:宽泛的 string 会逼着用 as never 断言,
+ *  那样测试数据就绕过了类型检查(而这些数据的形状正是本 PR 的核心)。 */
+async function fillEndpoints(
+  db: ConnectDb,
+  n: number,
+  status: EndpointRow["status"] = "active",
+): Promise<void> {
     for (let i = 0; i < n; i++) {
       await db.insertEndpoint({
         id: `fill_${status}_${i}`,
@@ -237,15 +242,16 @@ describe("容量闸门(CF 隧道 1000 硬上限)", () => {
         grace_until: null,
         suspended_at: null,
         purge_after: null,
-      } as never);
-    }
+      });
   }
+}
 
+describe("容量闸门(CF 隧道 1000 硬上限)", () => {
   it("未达上限正常开通", async () => {
     const calls: string[] = [];
     const { deps, db } = setup(calls);
     await seedAccount(db, "act_ok", "2027-01-01T00:00:00.000Z");
-    await fillCapacity(db, 989);
+    await fillEndpoints(db, 989);
     const res = await handleRequest(post("undercap", await cookieFor("act_ok")), deps);
     expect(res.status).toBe(200);
     expect(calls.some((c) => c.startsWith("createTunnel"))).toBe(true);
@@ -254,7 +260,7 @@ describe("容量闸门(CF 隧道 1000 硬上限)", () => {
   it("达到 990 时返回 503 at capacity", async () => {
     const { deps, db } = setup();
     await seedAccount(db, "act_full", "2027-01-01T00:00:00.000Z");
-    await fillCapacity(db, 990);
+    await fillEndpoints(db, 990);
     const res = await handleRequest(post("overcap", await cookieFor("act_full")), deps);
     expect(res.status).toBe(503);
     expect(await res.json()).toEqual({ error: "at capacity" });
@@ -266,7 +272,7 @@ describe("容量闸门(CF 隧道 1000 硬上限)", () => {
     const calls: string[] = [];
     const { deps, db } = setup(calls);
     await seedAccount(db, "act_zero", "2027-01-01T00:00:00.000Z");
-    await fillCapacity(db, 990);
+    await fillEndpoints(db, 990);
     const res = await handleRequest(post("nocf", await cookieFor("act_zero")), deps);
     expect(res.status).toBe(503);
     expect(calls, `不该有任何 CF 调用,实际: ${calls.join(", ")}`).toEqual([]);
@@ -277,7 +283,7 @@ describe("容量闸门(CF 隧道 1000 硬上限)", () => {
   it("无有效时长时先返回 402,而不是 503", async () => {
     const { deps, db } = setup();
     await seedAccount(db, "act_exp", "2026-01-01T00:00:00.000Z"); // 已过期
-    await fillCapacity(db, 990);
+    await fillEndpoints(db, 990);
     const res = await handleRequest(post("expired", await cookieFor("act_exp")), deps);
     expect(res.status).toBe(402);
   });
@@ -285,7 +291,7 @@ describe("容量闸门(CF 隧道 1000 硬上限)", () => {
   it("revoked 行不占配额:990 条 revoked 仍可开通", async () => {
     const { deps, db } = setup();
     await seedAccount(db, "act_rev", "2027-01-01T00:00:00.000Z");
-    await fillCapacity(db, 990, "revoked");
+    await fillEndpoints(db, 990, "revoked");
     const res = await handleRequest(post("afterrevoke", await cookieFor("act_rev")), deps);
     expect(res.status).toBe(200);
   });
@@ -294,28 +300,14 @@ describe("容量闸门(CF 隧道 1000 硬上限)", () => {
   it("revoke_failed 偏保守计入,占满即拒", async () => {
     const { deps, db } = setup();
     await seedAccount(db, "act_rf", "2027-01-01T00:00:00.000Z");
-    await fillCapacity(db, 990, "revoke_failed");
+    await fillEndpoints(db, 990, "revoke_failed");
     const res = await handleRequest(post("rf", await cookieFor("act_rf")), deps);
     expect(res.status).toBe(503);
   });
 });
 
 describe("控制台在满容量时的呈现", () => {
-  async function fill(db: ConnectDb, n: number): Promise<void> {
-    for (let i = 0; i < n; i++) {
-      await db.insertEndpoint({
-        id: `c_${i}`, invite_id: null,
-        slug: `c-${i}`, hostname: `c-${i}.mediaryconnect.app`,
-        cf_tunnel_id: `t${i}`, cf_access_app_id: null, cf_access_policy_id: null,
-        cf_dns_record_id: `d${i}`, status: "active",
-        // NOT NULL(schema.sql:28)。memory 实现不校验约束,但保持与真 schema
-        // 一致才能避免 parity 盲区(capacity.test.ts 就因此踩过一次)。
-        token_sha256: `sha_${i}`, token_ciphertext: null, token_shown_at: null,
-        last_seen_at: null, created_at: NOW, revoked_at: null,
-        account_id: null, grace_until: null, suspended_at: null, purge_after: null,
-      } as never);
-    }
-  }
+  // 复用上面的 fillEndpoints:两份构造同样的行,分开维护迟早漂移。
 
   async function console_(db: ConnectDb, deps: RouteDeps, accountId: string): Promise<string> {
     const res = await handleRequest(
@@ -330,7 +322,7 @@ describe("控制台在满容量时的呈现", () => {
   it("满容量时不渲染 slug 表单,而是说明售罄并给退款出口", async () => {
     const { deps, db } = setup();
     await seedAccount(db, "act_c1", "2027-01-01T00:00:00.000Z");
-    await fill(db, 990);
+    await fillEndpoints(db, 990);
     const html = await console_(db, deps, "act_c1");
     expect(html).toContain("暂时售罄");
     expect(html).toContain("你的时长不会流失");
@@ -348,7 +340,7 @@ describe("控制台在满容量时的呈现", () => {
   it("未满容量正常渲染 slug 表单", async () => {
     const { deps, db } = setup();
     await seedAccount(db, "act_c2", "2027-01-01T00:00:00.000Z");
-    await fill(db, 989);
+    await fillEndpoints(db, 989);
     const html = await console_(db, deps, "act_c2");
     expect(html).toContain('id="slug"');
     expect(html).not.toContain("暂时售罄");
@@ -361,7 +353,7 @@ describe("控制台在满容量时的呈现", () => {
     await seedAccount(db, "act_c3", "2027-01-01T00:00:00.000Z");
     const ok = await handleRequest(post("mine", await cookieFor("act_c3")), deps);
     expect(ok.status).toBe(200);
-    await fill(db, 990); // 事后占满
+    await fillEndpoints(db, 990); // 事后占满
     const html = await console_(db, deps, "act_c3");
     expect(html).toContain("mine.mediaryconnect.app");
     expect(html).not.toContain("暂时售罄");

--- a/workers/scout-connect/src/self-serve-provision.test.ts
+++ b/workers/scout-connect/src/self-serve-provision.test.ts
@@ -210,3 +210,149 @@ describe("POST /api/provision (自助开通)", () => {
     expect(ep?.account_id).toBeNull();
   });
 });
+
+describe("容量闸门(CF 隧道 1000 硬上限)", () => {
+  /** 造 n 条占配额的 endpoint 行。用 insertEndpoint 直插,不走 CF。 */
+  async function fillCapacity(db: ConnectDb, n: number, status = "active"): Promise<void> {
+    for (let i = 0; i < n; i++) {
+      await db.insertEndpoint({
+        id: `fill_${status}_${i}`,
+        invite_id: null,
+        slug: `fill-${status}-${i}`,
+        hostname: `fill-${status}-${i}.mediaryconnect.app`,
+        cf_tunnel_id: `t_${i}`,
+        cf_access_app_id: null,
+        cf_access_policy_id: null,
+        cf_dns_record_id: `d_${i}`,
+        status,
+        token_sha256: null,
+        token_ciphertext: null,
+        token_shown_at: null,
+        last_seen_at: null,
+        created_at: NOW,
+        revoked_at: null,
+        account_id: null,
+        grace_until: null,
+        suspended_at: null,
+        purge_after: null,
+      } as never);
+    }
+  }
+
+  it("未达上限正常开通", async () => {
+    const calls: string[] = [];
+    const { deps, db } = setup(calls);
+    await seedAccount(db, "act_ok", "2027-01-01T00:00:00.000Z");
+    await fillCapacity(db, 989);
+    const res = await handleRequest(post("undercap", await cookieFor("act_ok")), deps);
+    expect(res.status).toBe(200);
+    expect(calls.some((c) => c.startsWith("createTunnel"))).toBe(true);
+  });
+
+  it("达到 990 时返回 503 at capacity", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_full", "2027-01-01T00:00:00.000Z");
+    await fillCapacity(db, 990);
+    const res = await handleRequest(post("overcap", await cookieFor("act_full")), deps);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "at capacity" });
+  });
+
+  // 这是本测试的核心:超限时若已经建了隧道,就会真的吃掉 CF 配额,
+  // 而且补偿失败还会留下孤儿资源。必须**零 CF 调用**。
+  it("超限时不得调用任何 CF API(零副作用)", async () => {
+    const calls: string[] = [];
+    const { deps, db } = setup(calls);
+    await seedAccount(db, "act_zero", "2027-01-01T00:00:00.000Z");
+    await fillCapacity(db, 990);
+    const res = await handleRequest(post("nocf", await cookieFor("act_zero")), deps);
+    expect(res.status).toBe(503);
+    expect(calls, `不该有任何 CF 调用,实际: ${calls.join(", ")}`).toEqual([]);
+  });
+
+  // 402(无时长)必须比 503(容量满)更早判:否则一个过期用户在满容量时
+  // 会看到「售罄」,误以为是我们的问题、而不是他该续期。
+  it("无有效时长时先返回 402,而不是 503", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_exp", "2026-01-01T00:00:00.000Z"); // 已过期
+    await fillCapacity(db, 990);
+    const res = await handleRequest(post("expired", await cookieFor("act_exp")), deps);
+    expect(res.status).toBe(402);
+  });
+
+  it("revoked 行不占配额:990 条 revoked 仍可开通", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_rev", "2027-01-01T00:00:00.000Z");
+    await fillCapacity(db, 990, "revoked");
+    const res = await handleRequest(post("afterrevoke", await cookieFor("act_rev")), deps);
+    expect(res.status).toBe(200);
+  });
+
+  // CF 侧删除失败 → 隧道可能还在 → 偏保守计入,宁可少卖不可超卖。
+  it("revoke_failed 偏保守计入,占满即拒", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_rf", "2027-01-01T00:00:00.000Z");
+    await fillCapacity(db, 990, "revoke_failed");
+    const res = await handleRequest(post("rf", await cookieFor("act_rf")), deps);
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("控制台在满容量时的呈现", () => {
+  async function fill(db: ConnectDb, n: number): Promise<void> {
+    for (let i = 0; i < n; i++) {
+      await db.insertEndpoint({
+        id: `c_${i}`, invite_id: null,
+        slug: `c-${i}`, hostname: `c-${i}.mediaryconnect.app`,
+        cf_tunnel_id: `t${i}`, cf_access_app_id: null, cf_access_policy_id: null,
+        cf_dns_record_id: `d${i}`, status: "active",
+        token_sha256: null, token_ciphertext: null, token_shown_at: null,
+        last_seen_at: null, created_at: NOW, revoked_at: null,
+        account_id: null, grace_until: null, suspended_at: null, purge_after: null,
+      } as never);
+    }
+  }
+
+  async function console_(db: ConnectDb, deps: RouteDeps, accountId: string): Promise<string> {
+    const res = await handleRequest(
+      new Request(`${BASE}/console`, { headers: { cookie: await cookieFor(accountId) } }),
+      deps,
+    );
+    expect(res.status).toBe(200);
+    return res.text();
+  }
+
+  // 让用户输完名字、点开通、才吃 503 是最差的体验(他会以为名字填错了)。
+  it("满容量时不渲染 slug 表单,而是说明售罄并给退款出口", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_c1", "2027-01-01T00:00:00.000Z");
+    await fill(db, 990);
+    const html = await console_(db, deps, "act_c1");
+    expect(html).toContain("暂时售罄");
+    expect(html).toContain("你的时长不会流失");
+    expect(html).toContain('href="/refund"'); // 已付费,必须给退款出口
+    expect(html, "不该渲染 slug 输入框").not.toContain('id="slug"');
+  });
+
+  it("未满容量正常渲染 slug 表单", async () => {
+    const { deps, db } = setup();
+    await seedAccount(db, "act_c2", "2027-01-01T00:00:00.000Z");
+    await fill(db, 989);
+    const html = await console_(db, deps, "act_c2");
+    expect(html).toContain('id="slug"');
+    expect(html).not.toContain("暂时售罄");
+  });
+
+  // 已开通用户不受配额影响 —— 满容量也不该干扰他的接入区。
+  it("已开通用户在满容量时仍看到自己的接入区", async () => {
+    const calls: string[] = [];
+    const { deps, db } = setup(calls);
+    await seedAccount(db, "act_c3", "2027-01-01T00:00:00.000Z");
+    const ok = await handleRequest(post("mine", await cookieFor("act_c3")), deps);
+    expect(ok.status).toBe(200);
+    await fill(db, 990); // 事后占满
+    const html = await console_(db, deps, "act_c3");
+    expect(html).toContain("mine.mediaryconnect.app");
+    expect(html).not.toContain("暂时售罄");
+  });
+});


### PR DESCRIPTION
PR-C1（四个 PR 的第一个）。spec 在 `docs/superpowers/specs/2026-07-29-capacity-billing-expiry-slug-design.md`（gitignored）。

## 为什么这个先做

在此之前 provision **完全没有容量检查**。第 1001 个用户会付款、过 entitlement 门禁，直到 `cf.createTunnel` 才拿到 CF 报错，走完补偿事务后看到「开通失败，请稍后重试」——**而重试永远不会成功**。

讽刺的是：waitlist 那条**不烧配额**的路径早就有上限（`WAITLIST_SEAT_CAP`），真正烧 CF 配额的 provision 反而没有。

## 外部事实（一手核实，不是记忆）

- CF 隧道上限 **1000/账号，且所有套餐一致（含 Enterprise）**。来源：官方 `account-limits` 页面 + CF 员工社区回复「1,000 tunnel limit is the same for all plans, including Enterprise」。买套餐提不了额，只能联系 Sales。
- **hostname routes 也是 1000/账号，且与 tunnel 共享配额**。我们每用户消耗 1 tunnel + 1 route → 真实上限就是 1000 个用户。

## 实现

**计数语义**（这是可卖不可卖的分界）：白名单 `status IN ('active','revoke_failed')`。

用白名单而非 `!= 'revoked'` 是有意的：将来新增 status 时，「默认不计入」会**超卖**，而「默认计入」只是**少卖**。显式白名单强制新状态主动决定归属。

| status | 计入 | 理由 |
|---|---|---|
| `active` | ✅ | 占着隧道 |
| `active` + `grace_until`/`suspended_at` | ✅ | 时间戳态，status 仍 active，**确实还占隧道**（schema 注释已明确） |
| `revoke_failed` | ✅ 偏保守 | CF 侧删除失败，隧道可能还在。宁可少卖，不可超卖 |
| `revoked` | ❌ | 隧道已删，不占配额（计入会导致「有余量却显示售罄」） |

**阈值** `CAPACITY_LIMIT = 990`，留 10 条给运维：故障重建、作者自用、以及「CF 已删但 DB 未写成功」的中间态。

**闸门位置**在 slug 查重之后、`createTunnel` 之前 —— 既不浪费一次查重，又保证超限时**零 CF 副作用**。映射 **503**（我方容量问题，不是用户请求错误；4xx 会让用户以为自己填错了）。402 无时长仍优先于 503（过期用户该看到「续期」而不是「售罄」）。

**前端**：满容量时**不渲染 slug 表单**。让用户输完名字、点开通、再吃 503 是最差的体验。直接说明是我方配额、时长不会流失、并给退款出口（走到这里的都已付费）。已开通用户完全不受影响，且只在「还没开通」时才跑 COUNT。

## 验证

**D1↔memory parity 实测**（用 `schema.test.ts` 同款 better-sqlite3 适配器跑真 SQL 语句）：5 组数据两实现结果一致。两份实现是分别手写的（一个 SQL `IN`、一个 JS filter），漂移会导致本地全绿而**生产超卖**。

这轮 parity 顺带发现一个问题：**原测试 helper 造的行在生产 schema 下是非法的**（`token_sha256` NOT NULL，而 memory 实现不校验约束，所以一直没暴露）。已修。

`endpoints.status` 经全仓核实**只有三个取值**（`active`/`revoked`/`revoke_failed`）；`provisioned`/`pending` 属 invites 表、`waiting` 属 waitlist 表，与本计数无关。且 `EndpointRow["status"]` 是联合类型，类型系统本身印证了白名单完备。

**反向验证三处，各自精确转红**：
- 闸门挪到 `createTunnel` 之后 → 「零 CF 调用」测试红
- memory 实现漏掉 `revoke_failed` → parity 测试红
- `atCapacity` 恒为 false → 前端测试红

**2431 测试全绿，三处 tsc + `build:web` 全过。**

## 不做（YAGNI）

多 CF 账号分片扩容、自动提额 —— 1000 用户前不会遇到。

## 后续 PR

C2 付费链路（Paddle webhook）· C3 到期状态机（cron，唯一会真删生产资源的，会先做 dry-run）· C4 slug 页打磨