### PR TITLE
feat(paddle): 付款自动入账 —— grantEntitlement 抽取 + webhook 验签 + 月数白名单

### DIFF
--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -163,6 +163,9 @@ export interface ConnectDb {
    *  (两笔都基于同一快照,用户付 24 个月只拿到 12)。写入后从整本账重算,
    *  与快照不符就用这个方法修正。见 grant.ts 与 entitlement.ts:recomputeExpiry。 */
   updateEntitlementExpiry(entitlementId: string, expiresAt: string): Promise<void>;
+  /** 按 paddle_transaction_id 查那笔时长。幂等重投时用来定位「上次收敛失败
+   *  留下的错值行」并自愈,见 grant.ts。 */
+  getEntitlementByTransactionId(txnId: string): Promise<EntitlementRow | null>;
   listEntitlements(accountId: string): Promise<EntitlementRow[]>;
 }
 
@@ -625,6 +628,15 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
         .run();
     },
 
+    async getEntitlementByTransactionId(txnId) {
+      // 与 listEntitlements 同款:entitlements 的列与 EntitlementRow 一一对应,
+      // 不需要 mapper(其它表有 nullable 归一才需要)。
+      return await d1
+        .prepare(`SELECT * FROM entitlements WHERE paddle_transaction_id = ? LIMIT 1`)
+        .bind(txnId)
+        .first<EntitlementRow>();
+    },
+
     async listEntitlements(accountId) {
       const rows = await d1
         .prepare(`SELECT * FROM entitlements WHERE account_id = ? ORDER BY created_at ASC`)
@@ -966,6 +978,13 @@ export function createMemoryConnectDb(): ConnectDb {
       const row = entitlements.get(entitlementId);
       if (row === undefined) return;
       entitlements.set(entitlementId, { ...row, expires_at: expiresAt });
+    },
+
+    async getEntitlementByTransactionId(txnId) {
+      for (const row of entitlements.values()) {
+        if (row.paddle_transaction_id === txnId) return { ...row };
+      }
+      return null;
     },
   };
 }

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -649,7 +649,7 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
 
     async listEntitlements(accountId) {
       const rows = await d1
-        .prepare(`SELECT * FROM entitlements WHERE account_id = ? ORDER BY created_at ASC`)
+        .prepare(`SELECT * FROM entitlements WHERE account_id = ? ORDER BY created_at ASC, id ASC`)
         .bind(accountId)
         .all<EntitlementRow>();
       return rows.results;
@@ -979,7 +979,9 @@ export function createMemoryConnectDb(): ConnectDb {
     async listEntitlements(accountId) {
       return [...entitlements.values()]
         .filter((e) => e.account_id === accountId)
-        .sort((a, b) => a.created_at.localeCompare(b.created_at))
+        // 与 D1 分支同款 ORDER BY created_at ASC, id ASC:相等 created_at 时
+        // SQLite 不保证稳定,不带 id 两个实现会给出不同顺序(parity 缺口)。
+        .sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id))
         .map((e) => ({ ...e }));
     },
 

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -622,10 +622,19 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
     },
 
     async updateEntitlementExpiry(entitlementId, expiresAt) {
-      await d1
+      // **必须检查 meta.changes。** 0 行受影响与"成功"在 D1 里无法从返回值区分,
+      // 而这个 UPDATE 是并发收敛的最后一步:静默失败会让基于陈旧快照的错值
+      // 永久留下(用户永久少拿一个周期),且没有任何后台任务会重算账本。
+      // 抛错则冒泡到 webhook → 503 → Paddle 重投 → 幂等分支自愈。
+      // 同款先例见 markTokenShown(它也依赖 meta.changes)。
+      const res = (await d1
         .prepare(`UPDATE entitlements SET expires_at = ? WHERE id = ?`)
         .bind(expiresAt, entitlementId)
-        .run();
+        .run()) as { meta?: { changes?: number } };
+      const changes = res?.meta?.changes;
+      if (typeof changes === "number" && changes === 0) {
+        throw new Error(`updateEntitlementExpiry affected 0 rows: ${entitlementId}`);
+      }
     },
 
     async getEntitlementByTransactionId(txnId) {
@@ -974,9 +983,12 @@ export function createMemoryConnectDb(): ConnectDb {
     },
 
     async updateEntitlementExpiry(entitlementId, expiresAt) {
-      // 与 D1 分支同款语义(parity):不存在的 id 静默无操作,与 SQL UPDATE 一致。
+      // parity:D1 分支在 0 行受影响时抛错(那是并发收敛静默失败的信号),
+      // 这里也必须抛,否则 memory 测试会绿而生产会留下错值。
       const row = entitlements.get(entitlementId);
-      if (row === undefined) return;
+      if (row === undefined) {
+        throw new Error(`updateEntitlementExpiry affected 0 rows: ${entitlementId}`);
+      }
       entitlements.set(entitlementId, { ...row, expires_at: expiresAt });
     },
 

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -157,6 +157,12 @@ export interface ConnectDb {
   updateAccountLastLogin(id: string, at: string): Promise<void>;
   /** 幂等插入时长记录。paddle_transaction_id 已存在时返回 false(不重复加时长)。 */
   insertEntitlement(row: EntitlementRow): Promise<boolean>;
+  /** 修正某笔时长的 expires_at。
+   *
+   *  用于并发下的账本收敛:「读最新到期→加N月→写」在并发时会 lost update
+   *  (两笔都基于同一快照,用户付 24 个月只拿到 12)。写入后从整本账重算,
+   *  与快照不符就用这个方法修正。见 grant.ts 与 entitlement.ts:recomputeExpiry。 */
+  updateEntitlementExpiry(entitlementId: string, expiresAt: string): Promise<void>;
   listEntitlements(accountId: string): Promise<EntitlementRow[]>;
 }
 
@@ -612,6 +618,13 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
       }
     },
 
+    async updateEntitlementExpiry(entitlementId, expiresAt) {
+      await d1
+        .prepare(`UPDATE entitlements SET expires_at = ? WHERE id = ?`)
+        .bind(expiresAt, entitlementId)
+        .run();
+    },
+
     async listEntitlements(accountId) {
       const rows = await d1
         .prepare(`SELECT * FROM entitlements WHERE account_id = ? ORDER BY created_at ASC`)
@@ -946,6 +959,13 @@ export function createMemoryConnectDb(): ConnectDb {
         .filter((e) => e.account_id === accountId)
         .sort((a, b) => a.created_at.localeCompare(b.created_at))
         .map((e) => ({ ...e }));
+    },
+
+    async updateEntitlementExpiry(entitlementId, expiresAt) {
+      // 与 D1 分支同款语义(parity):不存在的 id 静默无操作,与 SQL UPDATE 一致。
+      const row = entitlements.get(entitlementId);
+      if (row === undefined) return;
+      entitlements.set(entitlementId, { ...row, expires_at: expiresAt });
     },
   };
 }

--- a/workers/scout-connect/src/db.ts
+++ b/workers/scout-connect/src/db.ts
@@ -626,7 +626,8 @@ export function createD1ConnectDb(d1: D1Database): ConnectDb {
       // 而这个 UPDATE 是并发收敛的最后一步:静默失败会让基于陈旧快照的错值
       // 永久留下(用户永久少拿一个周期),且没有任何后台任务会重算账本。
       // 抛错则冒泡到 webhook → 503 → Paddle 重投 → 幂等分支自愈。
-      // 同款先例见 markTokenShown(它也依赖 meta.changes)。
+      // (注:D1 把受影响行数放在 run() 返回值的 meta.changes 里;
+      //  这里刻意只在**确定为 0** 时抛,拿不到该字段的运行时不误报。)
       const res = (await d1
         .prepare(`UPDATE entitlements SET expires_at = ? WHERE id = ?`)
         .bind(expiresAt, entitlementId)

--- a/workers/scout-connect/src/entitlement.test.ts
+++ b/workers/scout-connect/src/entitlement.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { addMonths, computeExpiry, isEntitlementActive } from "./entitlement.js";
+import { addMonths, computeExpiry, isEntitlementActive, recomputeExpiry } from "./entitlement.js";
 
 describe("entitlement 时长计算", () => {
   describe("addMonths", () => {
@@ -55,5 +55,68 @@ describe("entitlement 时长计算", () => {
     it("unparseable expiry is inactive (fail closed, never grant on garbage)", () => {
       expect(isEntitlementActive("not-a-date", "2026-07-28T00:00:00.000Z")).toBe(false);
     });
+  });
+});
+
+describe("recomputeExpiry 的排序稳健性", () => {
+  const row = (id: string, created: string, months: number, expires = "2027-01-01T00:00:00.000Z") => ({
+    id,
+    created_at: created,
+    months,
+    expires_at: expires,
+  });
+
+  // 坏值让 Date.parse 得 NaN,比较器返回 NaN 等同返回 0 → 排序保证静默失效。
+  // 实测一个坏值就能把 2026-03 排到 2026-01 前面。localeCompare 对坏值仍给
+  // 确定顺序,结果可复现。
+  it("created_at 含坏值时仍给确定结果(不因 NaN 乱序)", () => {
+    const rows = [row("a", "2026-03-01T00:00:00.000Z", 1), row("b", "BAD", 12), row("c", "2026-01-01T00:00:00.000Z", 3)];
+    const first = recomputeExpiry(rows);
+    // 多次调用、不同输入顺序,结果必须一致(确定性才是这里的核心保证)
+    for (const shuffled of [
+      [rows[2]!, rows[0]!, rows[1]!],
+      [rows[1]!, rows[2]!, rows[0]!],
+    ]) {
+      expect(recomputeExpiry(shuffled)).toBe(first);
+    }
+  });
+
+  // 同毫秒时前两个键都可能相等 —— 尤其自愈会把同账号多行的 expires_at 写成
+  // 同一个值。此时若无 id 兜底,顺序交给 DB,而月加法不满足结合律
+  // (月末钳位有损),不同顺序真会差一天。
+  it("同 created_at 同 expires_at 时靠 id 定序(结果与输入顺序无关)", () => {
+    const same = "2026-01-31T00:00:00.000Z";
+    const exp = "2027-01-31T00:00:00.000Z";
+    const a = row("id_a", same, 1, exp);
+    const b = row("id_b", same, 2, exp);
+    expect(recomputeExpiry([a, b])).toBe(recomputeExpiry([b, a]));
+  });
+
+  it("月加法不满足结合律 —— 所以顺序保证是必需的", () => {
+    // 这条是上面那个测试存在的理由:月末钳位有损,顺序真的影响结果
+    expect(addMonths(addMonths("2026-01-31T00:00:00.000Z", 1), 1)).not.toBe(
+      addMonths("2026-01-31T00:00:00.000Z", 2),
+    );
+  });
+
+  // 坏 created_at 会让 addMonths 里的 new Date("BAD") 成为 Invalid Date,
+  // toISOString() 抛 RangeError → 冒到 webhook 就是 500 → 无限重投。
+  // 重算的职责是「用能用的数据算出真值」,不是整笔崩掉 ——
+  // 崩掉会连带让好的那些行也拿不到时长。
+  it("坏行被跳过而不抛错,好行仍正确计入", () => {
+    const good = row("g", "2026-01-01T00:00:00.000Z", 12);
+    const badDate = row("b", "NOT-A-DATE", 12);
+    const badMonths = { ...row("m", "2026-02-01T00:00:00.000Z", 0), months: 0 };
+    expect(() => recomputeExpiry([good, badDate, badMonths])).not.toThrow();
+    // 只有 good 计入 → 2026-01-01 + 12 个月
+    expect(recomputeExpiry([good, badDate, badMonths])).toBe("2027-01-01T00:00:00.000Z");
+  });
+
+  it("全是坏行时返回 null 而不抛错", () => {
+    expect(recomputeExpiry([row("a", "BAD", 12), row("b", "", 12)])).toBeNull();
+  });
+
+  it("空账本返回 null", () => {
+    expect(recomputeExpiry([])).toBeNull();
   });
 });

--- a/workers/scout-connect/src/entitlement.test.ts
+++ b/workers/scout-connect/src/entitlement.test.ts
@@ -116,6 +116,30 @@ describe("recomputeExpiry 的排序稳健性", () => {
     expect(recomputeExpiry([row("a", "BAD", 12), row("b", "", 12)])).toBeNull();
   });
 
+  // expires_at 是本函数自己会改写的派生缓存(grant.ts 的收敛会写它)。
+  // 若把它当排序键,「重算结果」就依赖「上次重算写下的缓存」—— 本该幂等的
+  // 重算变成有状态的。这条钉住:同 created_at 时,expires_at 取任何值都不影响结果。
+  it("结果不受 expires_at 缓存影响(它是派生字段)", () => {
+    const same = "2026-01-31T00:00:00.000Z";
+    // months=[1,2] 在 01-31 基准上,两种叠加顺序差 2 天(月末钳位有损):
+    //   先+1再+2 → 2026-04-28;先+2再+1 → 2026-04-30
+    // 让 expires_at 的大小顺序与 id 顺序**相反**:若 expires_at 参与排序,
+    // 叠加顺序就会翻转,结果随之变化。
+    const a = { id: "id_a", created_at: same, months: 1 };
+    const b = { id: "id_b", created_at: same, months: 2 };
+    // 按 id 定序(a→b):先 +1 再 +2
+    const byId = recomputeExpiry([a, b]);
+    expect(byId).toBe("2026-04-28T00:00:00.000Z");
+    // 塞入会诱导反向排序的 expires_at 缓存;结果必须不变
+    const withCache = recomputeExpiry([
+      { ...a, expires_at: "2099-12-31T00:00:00.000Z" },
+      { ...b, expires_at: "2000-01-01T00:00:00.000Z" },
+    ] as never);
+    expect(withCache, "expires_at 不该影响叠加顺序").toBe(byId);
+    // 输入顺序也不该影响(id 决定一切)
+    expect(recomputeExpiry([b, a])).toBe(byId);
+  });
+
   it("空账本返回 null", () => {
     expect(recomputeExpiry([])).toBeNull();
   });

--- a/workers/scout-connect/src/entitlement.ts
+++ b/workers/scout-connect/src/entitlement.ts
@@ -57,3 +57,36 @@ export function latestExpiry(entitlements: { expires_at: string }[]): string | n
   }
   return latest;
 }
+
+/**
+ * 从**整本账**重算最新到期时刻(并发安全的核心)。
+ *
+ * 为什么需要它:`grantEntitlement` 的「读最新到期 → 加 N 个月 → 写入」在并发下
+ * 有 lost update —— 两个 webhook 同时进来,都读到同一个 currentExpiry,各自算出
+ * 同一个 expires_at,结果**用户付了 24 个月只拿到 12 个月**(已用确定性交错实测
+ * 复现)。D1 没有跨请求事务,加不了锁。
+ *
+ * 解法是让账本自身可重算:`expires_at` 列只是缓存,真值由「所有 months 之和」
+ * 决定。按 created_at 顺序把每笔的月数依次叠加,得到的结果与写入顺序无关 ——
+ * 无论两个请求谁先谁后,重算出来都一样。
+ *
+ * 续费语义保持不变:每一步都用 computeExpiry(未到期从旧到期叠加,已过期从
+ * 当笔的时刻重启)。
+ */
+export function recomputeExpiry(
+  entitlements: { expires_at: string; months: number; created_at: string }[],
+): string | null {
+  if (entitlements.length === 0) return null;
+  // 按创建时间排序(同一时刻则按 expires_at 稳定化,避免顺序不确定)。
+  const sorted = [...entitlements].sort((a, b) => {
+    const d = Date.parse(a.created_at) - Date.parse(b.created_at);
+    if (d !== 0) return d;
+    return Date.parse(a.expires_at) - Date.parse(b.expires_at);
+  });
+  let acc: string | null = null;
+  for (const e of sorted) {
+    // 以「这笔充值发生的时刻」为 now:已过期就从那一刻重启,未过期则叠加。
+    acc = computeExpiry({ currentExpiry: acc, months: e.months, now: e.created_at });
+  }
+  return acc;
+}

--- a/workers/scout-connect/src/entitlement.ts
+++ b/workers/scout-connect/src/entitlement.ts
@@ -74,7 +74,8 @@ export function latestExpiry(entitlements: { expires_at: string }[]): string | n
  * 当笔的时刻重启)。
  */
 export function recomputeExpiry(
-  entitlements: { id: string; expires_at: string; months: number; created_at: string }[],
+  // 刻意不要 expires_at:它是本函数改写的派生缓存,不该参与计算或排序。
+  entitlements: { id: string; months: number; created_at: string }[],
 ): string | null {
   if (entitlements.length === 0) return null;
   // 按创建时间排序。
@@ -85,17 +86,20 @@ export function recomputeExpiry(
   // created_at/expires_at 都是固定宽度的 ISO-8601 UTC,字典序即时间序
   // (本仓 byCreatedAtAsc/Desc 也是这么做的)。
   //
-  // **tie-break 必须带上 id**:同毫秒时前两个键都可能相等 —— 尤其自愈逻辑会把
-  // 同账号多行的 expires_at 写成同一个值,那时第二个键退化成 no-op,顺序就交给
-  // 了 DB。而 SQLite 的 ORDER BY 对相等键不保证稳定(EXPLAIN 显示走 TEMP
-  // B-TREE),memory 实现的顺序又与 D1 不同。而月加法不满足结合律
-  // (addMonths(addMonths(x,1),1) ≠ addMonths(x,2),月末钳位是有损的),
-  // 所以顺序不同真会算出差一天的结果。id 是主键,保证全序。
+  // **只用内在键排序:created_at 然后 id。刻意不含 expires_at。**
+  // expires_at 是本函数自己会改写的**派生缓存**(grant.ts 的收敛会把它写成
+  // truth)。把它当排序键意味着「重算结果依赖上一次重算写下的缓存」——
+  // 那让本该幂等的重算变成有状态的,同 created_at 时甚至可能因为缓存被改而
+  // 在两次重算间得到不同答案。
+  // id 是主键,天然全序,足以打破 created_at 相等的平局。
+  //
+  // 为什么必须有确定的全序:月加法**不满足结合律**
+  // (addMonths(addMonths(x,1),1) ≠ addMonths(x,2),月末钳位有损),
+  // 所以顺序不同真会算出差一天的到期。而 SQLite 的 ORDER BY 对相等键不保证
+  // 稳定(EXPLAIN 显示走 TEMP B-TREE),memory 实现的顺序又与 D1 不同 ——
+  // 排序不能指望 DB。
   const sorted = [...entitlements].sort(
-    (a, b) =>
-      a.created_at.localeCompare(b.created_at) ||
-      a.expires_at.localeCompare(b.expires_at) ||
-      a.id.localeCompare(b.id),
+    (a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id),
   );
   let acc: string | null = null;
   for (const e of sorted) {

--- a/workers/scout-connect/src/entitlement.ts
+++ b/workers/scout-connect/src/entitlement.ts
@@ -74,17 +74,38 @@ export function latestExpiry(entitlements: { expires_at: string }[]): string | n
  * 当笔的时刻重启)。
  */
 export function recomputeExpiry(
-  entitlements: { expires_at: string; months: number; created_at: string }[],
+  entitlements: { id: string; expires_at: string; months: number; created_at: string }[],
 ): string | null {
   if (entitlements.length === 0) return null;
-  // 按创建时间排序(同一时刻则按 expires_at 稳定化,避免顺序不确定)。
-  const sorted = [...entitlements].sort((a, b) => {
-    const d = Date.parse(a.created_at) - Date.parse(b.created_at);
-    if (d !== 0) return d;
-    return Date.parse(a.expires_at) - Date.parse(b.expires_at);
-  });
+  // 按创建时间排序。
+  //
+  // **用 localeCompare 而非 Date.parse 相减**:坏值会让 Date.parse 得 NaN,
+  // 比较器返回 NaN 等同于返回 0 → 排序保证静默失效。实测一个坏值就能把
+  // 2026-03 排到 2026-01 前面;而 localeCompare 对坏值仍给确定顺序,结果可复现。
+  // created_at/expires_at 都是固定宽度的 ISO-8601 UTC,字典序即时间序
+  // (本仓 byCreatedAtAsc/Desc 也是这么做的)。
+  //
+  // **tie-break 必须带上 id**:同毫秒时前两个键都可能相等 —— 尤其自愈逻辑会把
+  // 同账号多行的 expires_at 写成同一个值,那时第二个键退化成 no-op,顺序就交给
+  // 了 DB。而 SQLite 的 ORDER BY 对相等键不保证稳定(EXPLAIN 显示走 TEMP
+  // B-TREE),memory 实现的顺序又与 D1 不同。而月加法不满足结合律
+  // (addMonths(addMonths(x,1),1) ≠ addMonths(x,2),月末钳位是有损的),
+  // 所以顺序不同真会算出差一天的结果。id 是主键,保证全序。
+  const sorted = [...entitlements].sort(
+    (a, b) =>
+      a.created_at.localeCompare(b.created_at) ||
+      a.expires_at.localeCompare(b.expires_at) ||
+      a.id.localeCompare(b.id),
+  );
   let acc: string | null = null;
   for (const e of sorted) {
+    // **跳过 created_at 坏值的行。** 不只是排序问题:坏值会让 addMonths 里的
+    // `new Date("BAD")` 变成 Invalid Date,`toISOString()` 抛 RangeError,
+    // 冒到 webhook 就是 500 → Paddle 无限重投(测试抓到过)。
+    // 账本里出现坏时刻本身是数据事故,但重算的职责是「用能用的数据算出真值」,
+    // 而不是整笔崩掉 —— 崩掉会连带让好的那些行也拿不到时长。
+    if (!Number.isFinite(Date.parse(e.created_at))) continue;
+    if (!Number.isInteger(e.months) || e.months < 1) continue;
     // 以「这笔充值发生的时刻」为 now:已过期就从那一刻重启,未过期则叠加。
     acc = computeExpiry({ currentExpiry: acc, months: e.months, now: e.created_at });
   }

--- a/workers/scout-connect/src/env.ts
+++ b/workers/scout-connect/src/env.ts
@@ -23,4 +23,8 @@ export interface Env {
   // PADDLE_ENVIRONMENT: "sandbox" | "production"(缺省视为 production)。
   PADDLE_CLIENT_TOKEN?: string;
   PADDLE_ENVIRONMENT?: string;
+  // notification destination 的 endpoint secret(pdl_ntfset_ 前缀)。
+  // **wrangler secret,不是 vars** —— 它是验签密钥,泄露等于任何人都能凭空
+  // 发时长。未配置时 /api/paddle/webhook 一律 503(fail closed)。
+  PADDLE_WEBHOOK_SECRET?: string;
 }

--- a/workers/scout-connect/src/env.ts
+++ b/workers/scout-connect/src/env.ts
@@ -27,4 +27,7 @@ export interface Env {
   // **wrangler secret,不是 vars** —— 它是验签密钥,泄露等于任何人都能凭空
   // 发时长。未配置时 /api/paddle/webhook 一律 503(fail closed)。
   PADDLE_WEBHOOK_SECRET?: string;
+  // Paddle 服务端 API key(创建交易用)。**wrangler secret**,不是 vars。
+  // 未配置时 /api/checkout 返回 503(结账未开放),不影响其它路径。
+  PADDLE_API_KEY?: string;
 }

--- a/workers/scout-connect/src/grant.test.ts
+++ b/workers/scout-connect/src/grant.test.ts
@@ -225,3 +225,78 @@ describe("并发安全:lost update", () => {
     expect(second.expiresAt).toBe("2027-01-29T12:00:00.000Z");
   });
 });
+
+describe("重投自愈:上次并发收敛失败留下的错值要能修正", () => {
+  // 并发收敛发生在 insert 之后、update 之前。若 update 因 D1 抖动失败 →
+  // webhook 返回 503 → Paddle 重投 → 走幂等分支。若幂等分支只回读不重算,
+  // 那个基于陈旧快照的错值会**永久留下**,用户永久少拿一个周期(实测复现)。
+  it("幂等重投会把错的 expires_at 修正为账本真值", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    await grantEntitlement(
+      { email: "heal@example.com", months: 12, source: "paddle", paddleTransactionId: "t1" },
+      d,
+    );
+    const acct = await db.getAccountByEmail("heal@example.com");
+    // 种一个「上次收敛失败留下的错值行」:基于陈旧快照算的 2027 而非应有的 2028
+    await db.insertEntitlement({
+      id: "ent_stale",
+      account_id: acct!.id,
+      expires_at: "2027-07-29T12:00:00.000Z",
+      source: "paddle",
+      paddle_transaction_id: "t2",
+      months: 12,
+      created_at: NOW,
+    });
+    const before = (await db.listEntitlements(acct!.id)).map((e) => e.expires_at).sort().pop();
+    expect(before, "前置条件:错值存在").toBe("2027-07-29T12:00:00.000Z");
+
+    const replay = await grantEntitlement(
+      { email: "heal@example.com", months: 12, source: "paddle", paddleTransactionId: "t2" },
+      d,
+    );
+    expect(replay.applied, "仍是幂等命中").toBe(false);
+    expect(replay.expiresAt, "返回账本真值").toBe("2028-07-29T12:00:00.000Z");
+    const after = (await db.listEntitlements(acct!.id)).map((e) => e.expires_at).sort().pop();
+    expect(after, "DB 里的错值必须被改正").toBe("2028-07-29T12:00:00.000Z");
+  });
+
+  it("值已正确时重投不做多余写入", async () => {
+    const db = createMemoryConnectDb();
+    let updates = 0;
+    const counted: ConnectDb = {
+      ...db,
+      async updateEntitlementExpiry(id: string, exp: string) {
+        updates++;
+        return db.updateEntitlementExpiry(id, exp);
+      },
+    };
+    const d = deps(counted);
+    await grantEntitlement(
+      { email: "noop@example.com", months: 12, source: "paddle", paddleTransactionId: "n1" },
+      d,
+    );
+    const baseline = updates;
+    await grantEntitlement(
+      { email: "noop@example.com", months: 12, source: "paddle", paddleTransactionId: "n1" },
+      d,
+    );
+    expect(updates, "无需修正时不该写").toBe(baseline);
+  });
+
+  // 手工授予没有 txn id,幂等分支的自愈靠 txn id 定位,这条路径不该炸。
+  it("手工授予(null txn id)的重投路径安全", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    const r1 = await grantEntitlement(
+      { email: "man@example.com", months: 1, source: "manual", paddleTransactionId: null },
+      d,
+    );
+    expect(r1.applied).toBe(true);
+    const r2 = await grantEntitlement(
+      { email: "man@example.com", months: 1, source: "manual", paddleTransactionId: null },
+      d,
+    );
+    expect(r2.applied, "null txn id 不参与幂等,应真入账").toBe(true);
+  });
+});

--- a/workers/scout-connect/src/grant.test.ts
+++ b/workers/scout-connect/src/grant.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryConnectDb, type ConnectDb } from "./db.js";
+import { grantEntitlement, type GrantDeps } from "./grant.js";
+
+const NOW = "2026-07-29T12:00:00.000Z";
+
+function deps(db: ConnectDb, over: Partial<GrantDeps> = {}): GrantDeps {
+  // 两个序列必须独立:原先 ent 复用 account 的计数器,同一账号第二次授予会
+  // 生成重复 id 撞主键(真实 worker 用 crypto.randomUUID,不会有这个问题)。
+  let acct = 0;
+  let ent = 0;
+  return {
+    db,
+    now: () => NOW,
+    newAccountId: () => `act_${++acct}`,
+    newEntitlementId: () => `ent_${++ent}`,
+    ...over,
+  };
+}
+
+describe("grantEntitlement", () => {
+  it("首次充值:建账号 + 从当下起算", async () => {
+    const db = createMemoryConnectDb();
+    const r = await grantEntitlement(
+      { email: "a@example.com", months: 12, source: "paddle", paddleTransactionId: "txn_1" },
+      deps(db),
+    );
+    expect(r.applied).toBe(true);
+    expect(r.expiresAt).toBe("2027-07-29T12:00:00.000Z");
+    const acct = await db.getAccountByEmail("a@example.com");
+    expect(acct).not.toBeNull();
+  });
+
+  // 续费语义:未到期从旧到期叠加(不浪费剩余时长)。
+  it("未到期续费从旧到期叠加", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    await grantEntitlement(
+      { email: "b@example.com", months: 3, source: "paddle", paddleTransactionId: "t1" },
+      d,
+    );
+    const second = await grantEntitlement(
+      { email: "b@example.com", months: 3, source: "paddle", paddleTransactionId: "t2" },
+      d,
+    );
+    // 2026-10-29 再加 3 个月 → 2027-01-29,而不是从当下起算的 2026-10-29
+    expect(second.expiresAt).toBe("2027-01-29T12:00:00.000Z");
+  });
+
+  it("已过期则从当下重启(不把断掉的时间补回来)", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    const acct = await db.insertAccount({
+      id: "act_old",
+      email: "c@example.com",
+      created_at: "2025-01-01T00:00:00.000Z",
+      login_password_hash: null,
+    } as never);
+    await db.insertEntitlement({
+      id: "ent_old",
+      account_id: acct.id,
+      expires_at: "2026-01-01T00:00:00.000Z", // 已过期
+      source: "manual",
+      paddle_transaction_id: null,
+      months: 12,
+      created_at: "2025-01-01T00:00:00.000Z",
+    });
+    const r = await grantEntitlement(
+      { email: "c@example.com", months: 3, source: "paddle", paddleTransactionId: "t3" },
+      d,
+    );
+    expect(r.expiresAt).toBe("2026-10-29T12:00:00.000Z"); // 从 NOW 起算
+  });
+
+  // 幂等是收钱系统的命门:Paddle 会重投 webhook,重复入账等于白送时长。
+  it("同一 paddle_transaction_id 重投不重复入账", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    const first = await grantEntitlement(
+      { email: "d@example.com", months: 12, source: "paddle", paddleTransactionId: "txn_dup" },
+      d,
+    );
+    expect(first.applied).toBe(true);
+    const replay = await grantEntitlement(
+      { email: "d@example.com", months: 12, source: "paddle", paddleTransactionId: "txn_dup" },
+      d,
+    );
+    expect(replay.applied, "重投必须被识别为幂等").toBe(false);
+    const ents = await db.listEntitlements((await db.getAccountByEmail("d@example.com"))!.id);
+    expect(ents.length, "只应有一条时长记录").toBe(1);
+  });
+
+  it("重投返回的 expiresAt 是已存在的到期时刻,不是又叠加一次的", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    const first = await grantEntitlement(
+      { email: "e@example.com", months: 12, source: "paddle", paddleTransactionId: "txn_e" },
+      d,
+    );
+    const replay = await grantEntitlement(
+      { email: "e@example.com", months: 12, source: "paddle", paddleTransactionId: "txn_e" },
+      d,
+    );
+    expect(replay.expiresAt).toBe(first.expiresAt);
+  });
+
+  it("邮箱大小写与空白归一(同一人不该建两个账号)", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    await grantEntitlement(
+      { email: "  MiXeD@Example.COM  ", months: 3, source: "paddle", paddleTransactionId: "t5" },
+      d,
+    );
+    await grantEntitlement(
+      { email: "mixed@example.com", months: 3, source: "paddle", paddleTransactionId: "t6" },
+      d,
+    );
+    const acct = await db.getAccountByEmail("mixed@example.com");
+    expect(acct).not.toBeNull();
+    const ents = await db.listEntitlements(acct!.id);
+    expect(ents.length, "应挂在同一个账号下").toBe(2);
+  });
+
+  it("手工授予(admin)不带 paddle_transaction_id 也能工作", async () => {
+    const db = createMemoryConnectDb();
+    const r = await grantEntitlement(
+      { email: "f@example.com", months: 6, source: "manual", paddleTransactionId: null },
+      deps(db),
+    );
+    expect(r.applied).toBe(true);
+    const ents = await db.listEntitlements(r.accountId);
+    expect(ents[0]?.paddle_transaction_id).toBeNull();
+  });
+
+  // 没有 txn id 的多次手工授予不该被幂等误吞(偏唯一索引只覆盖非 null)。
+  it("多次手工授予都入账(null txn id 不参与幂等)", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    await grantEntitlement(
+      { email: "g@example.com", months: 1, source: "manual", paddleTransactionId: null },
+      d,
+    );
+    const second = await grantEntitlement(
+      { email: "g@example.com", months: 1, source: "manual", paddleTransactionId: null },
+      d,
+    );
+    expect(second.applied).toBe(true);
+    const ents = await db.listEntitlements(second.accountId);
+    expect(ents.length).toBe(2);
+  });
+});

--- a/workers/scout-connect/src/grant.test.ts
+++ b/workers/scout-connect/src/grant.test.ts
@@ -149,3 +149,79 @@ describe("grantEntitlement", () => {
     expect(ents.length).toBe(2);
   });
 });
+
+describe("并发安全:lost update", () => {
+  /** 让第一次 listEntitlements 延迟返回,制造「两个请求都在对方写入前读到账本」
+   *  的真交错 —— 这正是多实例 worker 同时收到两个 webhook 时会发生的。 */
+  function racingDb(base: ConnectDb): ConnectDb {
+    let first = true;
+    return {
+      ...base,
+      async listEntitlements(id: string) {
+        const rows = await base.listEntitlements(id);
+        if (first) {
+          first = false;
+          await new Promise((r) => setTimeout(r, 20));
+        }
+        return rows;
+      },
+    };
+  }
+
+  // 修复前:两笔都基于同一个空快照算出 2027-07-29,用户付了 24 个月只拿到 12
+  // (已用确定性交错实测复现)。D1 没有跨请求事务,所以靠「写入后从整本账重算
+  // 并修正本行」收敛 —— 重算结果与写入顺序无关。
+  it("并发两笔不同交易,时长不丢(24 个月全给到)", async () => {
+    const db = racingDb(createMemoryConnectDb());
+    const d = deps(db);
+    await Promise.all([
+      grantEntitlement(
+        { email: "race@example.com", months: 12, source: "paddle", paddleTransactionId: "t1" },
+        d,
+      ),
+      grantEntitlement(
+        { email: "race@example.com", months: 12, source: "paddle", paddleTransactionId: "t2" },
+        d,
+      ),
+    ]);
+    const acct = await db.getAccountByEmail("race@example.com");
+    const ents = await db.listEntitlements(acct!.id);
+    expect(ents.length, "两笔都要入账").toBe(2);
+    const max = ents.map((e) => e.expires_at).sort().pop();
+    expect(max, "24 个月应到 2028-07-29,而非 2027(少给 12 个月)").toBe(
+      "2028-07-29T12:00:00.000Z",
+    );
+  });
+
+  it("并发三笔:36 个月全给到", async () => {
+    const db = racingDb(createMemoryConnectDb());
+    const d = deps(db);
+    await Promise.all(
+      ["a", "b", "c"].map((t) =>
+        grantEntitlement(
+          { email: "race3@example.com", months: 12, source: "paddle", paddleTransactionId: t },
+          d,
+        ),
+      ),
+    );
+    const acct = await db.getAccountByEmail("race3@example.com");
+    const ents = await db.listEntitlements(acct!.id);
+    expect(ents.length).toBe(3);
+    expect(ents.map((e) => e.expires_at).sort().pop()).toBe("2029-07-29T12:00:00.000Z");
+  });
+
+  // 非并发路径不该被重算改坏。
+  it("串行两笔仍是正常叠加(重算不引入回归)", async () => {
+    const db = createMemoryConnectDb();
+    const d = deps(db);
+    await grantEntitlement(
+      { email: "seq@example.com", months: 3, source: "paddle", paddleTransactionId: "s1" },
+      d,
+    );
+    const second = await grantEntitlement(
+      { email: "seq@example.com", months: 3, source: "paddle", paddleTransactionId: "s2" },
+      d,
+    );
+    expect(second.expiresAt).toBe("2027-01-29T12:00:00.000Z");
+  });
+});

--- a/workers/scout-connect/src/grant.ts
+++ b/workers/scout-connect/src/grant.ts
@@ -1,4 +1,4 @@
-import { computeExpiry, latestExpiry } from "./entitlement.js";
+import { computeExpiry, latestExpiry, recomputeExpiry } from "./entitlement.js";
 import type { AccountRow, ConnectDb, EntitlementRow } from "./db.js";
 
 /**
@@ -75,8 +75,9 @@ export async function grantEntitlement(
     now,
   });
 
+  const entitlementId = deps.newEntitlementId();
   const applied = await deps.db.insertEntitlement({
-    id: deps.newEntitlementId(),
+    id: entitlementId,
     account_id: account.id,
     expires_at: expiresAt,
     source: input.source,
@@ -91,6 +92,19 @@ export async function grantEntitlement(
     // 一个周期。Paddle 重投很常见,回错值会让控制台显示比实际更长的有效期。
     const after = await deps.db.listEntitlements(account.id);
     return { accountId: account.id, expiresAt: latestExpiry(after) ?? expiresAt, applied: false };
+  }
+
+  // **并发安全:写入后从整本账重算,并在需要时修正本行。**
+  // 「读最新到期 → 加 N 个月 → 写」在并发下有 lost update:两个 webhook 同时
+  // 进来会读到同一个 currentExpiry,各自算出同一个 expires_at,结果用户付了
+  // 24 个月只拿到 12 个月(已用确定性交错实测复现)。D1 没有跨请求事务,加不了锁。
+  // 重算的结果与写入顺序无关,所以两个并发请求最终都会收敛到正确值。
+  const all = await deps.db.listEntitlements(account.id);
+  const truth = recomputeExpiry(all);
+  if (truth !== null && truth !== expiresAt) {
+    // 本行的 expires_at 是基于陈旧快照算的,按账本真值修正。
+    await deps.db.updateEntitlementExpiry(entitlementId, truth);
+    return { accountId: account.id, expiresAt: truth, applied: true };
   }
   return { accountId: account.id, expiresAt, applied: true };
 }

--- a/workers/scout-connect/src/grant.ts
+++ b/workers/scout-connect/src/grant.ts
@@ -1,0 +1,96 @@
+import { computeExpiry, latestExpiry } from "./entitlement.js";
+import type { AccountRow, ConnectDb, EntitlementRow } from "./db.js";
+
+/**
+ * 发放预付时长(账本式)。
+ *
+ * 由两条路径共用:admin 手工授予(`POST /api/admin/grant`)与 Paddle webhook
+ * 付款入账。抽出来的理由不只是去重 —— 它们的续费语义、幂等语义、账号 upsert
+ * 的竞态处理必须**完全一致**。此前 adminGrant 里还手写了一遍「找最新到期」的
+ * for 循环,而 entitlement.ts 早就有 latestExpiry();两份实现迟早漂移。
+ */
+
+export interface GrantDeps {
+  db: ConnectDb;
+  now: () => string;
+  newAccountId: () => string;
+  newEntitlementId: () => string;
+}
+
+export interface GrantInput {
+  /** 未归一的邮箱(本函数负责 trim + lowercase)。 */
+  email: string;
+  months: number;
+  /** 复用 EntitlementRow 的联合类型,而不是宽泛 string:发放来源是有限集合,
+   *  写错值会让账本对不上(也无法按来源统计)。 */
+  source: EntitlementRow["source"];
+  /** Paddle 交易 ID。幂等键 —— 同一交易重投不会重复入账。
+   *  手工授予传 null(schema 的偏唯一索引只覆盖非 null,故多次手工授予都入账)。 */
+  paddleTransactionId: string | null;
+}
+
+export interface GrantResult {
+  accountId: string;
+  /** 授予后的最新到期时刻。幂等命中时是**已存在**的到期时刻,不会再叠加一次。 */
+  expiresAt: string;
+  /** true = 真的入账了;false = 幂等命中(同一 paddle_transaction_id 已入过)。 */
+  applied: boolean;
+}
+
+/** 账号 upsert,并发安全:UNIQUE 冲突时重读对手插入的行。 */
+async function upsertAccount(email: string, deps: GrantDeps): Promise<AccountRow> {
+  const existing = await deps.db.getAccountByEmail(email);
+  if (existing !== null) return existing;
+  try {
+    return await deps.db.insertAccount({
+      id: deps.newAccountId(),
+      email,
+      paddle_customer_id: null,
+      created_at: deps.now(),
+      last_login_at: null,
+    });
+  } catch (e) {
+    // 并发对手赢了这一插:重读它插入的行。读不到说明 UNIQUE 失败另有其因,
+    // 那是真异常,不能吞。
+    const raced = await deps.db.getAccountByEmail(email);
+    if (raced === null) throw e;
+    return raced;
+  }
+}
+
+export async function grantEntitlement(
+  input: GrantInput,
+  deps: GrantDeps,
+): Promise<GrantResult> {
+  // 邮箱归一:Paddle 回传的大小写不一定与注册时一致,不归一会给同一个人建两个
+  // 账号(付了钱却在另一个账号下)。
+  const email = input.email.trim().toLowerCase();
+  const now = deps.now();
+  const account = await upsertAccount(email, deps);
+
+  const ents = await deps.db.listEntitlements(account.id);
+  const expiresAt = computeExpiry({
+    currentExpiry: latestExpiry(ents),
+    months: input.months,
+    now,
+  });
+
+  const applied = await deps.db.insertEntitlement({
+    id: deps.newEntitlementId(),
+    account_id: account.id,
+    expires_at: expiresAt,
+    source: input.source,
+    paddle_transaction_id: input.paddleTransactionId,
+    months: input.months,
+    created_at: now,
+  });
+
+  if (!applied) {
+    // 幂等命中(同一 paddle_transaction_id 已入过账)。**必须回读**而不是返回
+    // 上面算出的 expiresAt —— 那个值是「假设本次入账」算出来的,比真实到期多
+    // 一个周期。Paddle 重投很常见,回错值会让控制台显示比实际更长的有效期。
+    const after = await deps.db.listEntitlements(account.id);
+    return { accountId: account.id, expiresAt: latestExpiry(after) ?? expiresAt, applied: false };
+  }
+  return { accountId: account.id, expiresAt, applied: true };
+}

--- a/workers/scout-connect/src/grant.ts
+++ b/workers/scout-connect/src/grant.ts
@@ -91,7 +91,23 @@ export async function grantEntitlement(
     // 上面算出的 expiresAt —— 那个值是「假设本次入账」算出来的,比真实到期多
     // 一个周期。Paddle 重投很常见,回错值会让控制台显示比实际更长的有效期。
     const after = await deps.db.listEntitlements(account.id);
-    return { accountId: account.id, expiresAt: latestExpiry(after) ?? expiresAt, applied: false };
+    // **重投要有自愈能力。** 上一次的并发收敛(下面那段)可能在 insert 之后、
+    // update 之前失败(D1 抖动 → webhook 503 → Paddle 重投)。若幂等分支只回读,
+    // 那个基于陈旧快照的错值会**永久留下** —— 用户永久少拿一个周期(实测复现)。
+    // 所以这里也重算,并在必要时修正本笔交易对应的那行。
+    const truth = recomputeExpiry(after);
+    if (truth !== null && input.paddleTransactionId !== null) {
+      const existing = await deps.db.getEntitlementByTransactionId(input.paddleTransactionId);
+      if (existing !== null && existing.expires_at !== truth) {
+        await deps.db.updateEntitlementExpiry(existing.id, truth);
+        return { accountId: account.id, expiresAt: truth, applied: false };
+      }
+    }
+    return {
+      accountId: account.id,
+      expiresAt: truth ?? latestExpiry(after) ?? expiresAt,
+      applied: false,
+    };
   }
 
   // **并发安全:写入后从整本账重算,并在需要时修正本行。**

--- a/workers/scout-connect/src/index.ts
+++ b/workers/scout-connect/src/index.ts
@@ -25,6 +25,7 @@ export default {
       turnstileSitekey: env.TURNSTILE_SITEKEY,
       paddleClientToken: env.PADDLE_CLIENT_TOKEN,
       paddleEnvironment: env.PADDLE_ENVIRONMENT,
+      paddleWebhookSecret: env.PADDLE_WEBHOOK_SECRET,
       turnstileSecret: env.TURNSTILE_SECRET,
       newAccountId: () => newId("act"),
       newEntitlementId: () => newId("ent"),

--- a/workers/scout-connect/src/index.ts
+++ b/workers/scout-connect/src/index.ts
@@ -4,6 +4,7 @@ import { newId, newInviteCode } from "./ids.js";
 import { handleRequest } from "./routes.js";
 import { createMagicLinkSender } from "./magic-link-sender.js";
 import type { Env } from "./env.js";
+import { createPaddleApi } from "./paddle-api.js";
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -26,6 +27,13 @@ export default {
       paddleClientToken: env.PADDLE_CLIENT_TOKEN,
       paddleEnvironment: env.PADDLE_ENVIRONMENT,
       paddleWebhookSecret: env.PADDLE_WEBHOOK_SECRET,
+      paddleApi:
+        env.PADDLE_API_KEY === undefined || env.PADDLE_API_KEY.trim() === ""
+          ? undefined
+          : createPaddleApi({
+              apiKey: env.PADDLE_API_KEY,
+              environment: env.PADDLE_ENVIRONMENT ?? "production",
+            }),
       turnstileSecret: env.TURNSTILE_SECRET,
       newAccountId: () => newId("act"),
       newEntitlementId: () => newId("ent"),

--- a/workers/scout-connect/src/index.ts
+++ b/workers/scout-connect/src/index.ts
@@ -5,6 +5,7 @@ import { handleRequest } from "./routes.js";
 import { createMagicLinkSender } from "./magic-link-sender.js";
 import type { Env } from "./env.js";
 import { createPaddleApi } from "./paddle-api.js";
+import { priceMonthsFor } from "./paddle-event.js";
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -27,6 +28,9 @@ export default {
       paddleClientToken: env.PADDLE_CLIENT_TOKEN,
       paddleEnvironment: env.PADDLE_ENVIRONMENT,
       paddleWebhookSecret: env.PADDLE_WEBHOOK_SECRET,
+      // 按环境选白名单。**未配置时是 undefined 而非回落 sandbox** ——
+      // 路由层据此 fail-closed(503),见 routes.ts 的注释。
+      paddlePriceMonths: priceMonthsFor(env.PADDLE_ENVIRONMENT) ?? undefined,
       paddleApi:
         env.PADDLE_API_KEY === undefined || env.PADDLE_API_KEY.trim() === ""
           ? undefined

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -38,6 +38,11 @@ export function createPaddleApi(input: {
     async createTransaction({ priceId, accountEmail, checkoutUrl }) {
       const res = await fetch(`${base}/transactions`, {
         method: "POST",
+        // 超时是必需的,不是保险:没有它,上游抖动会让请求长时间挂起、占用
+        // worker 并发额度并放大故障面。同仓其它外部调用(cf-api 10s、
+        // magic-link 5s、turnstile 5s)都设了。创建交易走的是用户点「购买」
+        // 的同步路径,10s 已经比人能忍的等待更长。
+        signal: AbortSignal.timeout(10_000),
         headers: {
           authorization: `Bearer ${input.apiKey}`,
           "content-type": "application/json",

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -1,0 +1,79 @@
+/**
+ * 创建 Paddle 交易(结账的起点)。
+ *
+ * **为什么必须由我方创建交易,而不是让 Paddle 自己生成:**
+ * webhook 要知道「这笔付款属于哪个登录账号」。唯一可靠的载体是交易的
+ * `custom_data.account_email` —— 而它只能在创建交易时写入。
+ *
+ * 实测确认(sandbox 真实事件):`transaction.completed` 的 data 里**没有嵌套的
+ * customer 对象**,只有 `customer_id`。所以「从 payload 直接拿邮箱」这条路不存在;
+ * 而 `custom_data` 确实会原样透传到 webhook。
+ *
+ * 另一件实测确认的事:**显式传 `checkout.url` 会覆盖账号级的 default payment
+ * link**。这让同一个 Paddle 账号能承载多个产品 —— 各自传自己的域名,default
+ * 填谁都不生效。
+ */
+
+import type { PriceMonthsMap } from "./paddle-event.js";
+
+export interface PaddleApi {
+  createTransaction(input: {
+    priceId: string;
+    accountEmail: string;
+    checkoutUrl: string;
+  }): Promise<{ transactionId: string; checkoutUrl: string }>;
+}
+
+/** 真实 Paddle API 客户端。sandbox 与 live 的 base URL 不同。 */
+export function createPaddleApi(input: {
+  apiKey: string;
+  /** "sandbox" | "production"。 */
+  environment: string;
+}): PaddleApi {
+  const base =
+    input.environment.trim().toLowerCase() === "sandbox"
+      ? "https://sandbox-api.paddle.com"
+      : "https://api.paddle.com";
+  return {
+    async createTransaction({ priceId, accountEmail, checkoutUrl }) {
+      const res = await fetch(`${base}/transactions`, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${input.apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          items: [{ price_id: priceId, quantity: 1 }],
+          collection_mode: "automatic",
+          // webhook 靠这个把付款关联到登录账号 —— 见本文件头部注释。
+          custom_data: { account_email: accountEmail },
+          // 显式指定,不依赖账号级 default(那个可能指向别的产品)。
+          checkout: { url: checkoutUrl },
+        }),
+      });
+      if (!res.ok) {
+        // 不把 Paddle 的响应体透给客户端(可能含内部细节);只留状态码给日志。
+        throw new Error(`paddle createTransaction failed: ${res.status}`);
+      }
+      const body = (await res.json()) as {
+        data?: { id?: unknown; checkout?: { url?: unknown } | null };
+      };
+      const transactionId = typeof body.data?.id === "string" ? body.data.id : "";
+      const url = typeof body.data?.checkout?.url === "string" ? body.data.checkout.url : "";
+      if (transactionId === "" || url === "") {
+        throw new Error("paddle createTransaction returned no id/checkout url");
+      }
+      return { transactionId, checkoutUrl: url };
+    },
+  };
+}
+
+/** 校验 price_id 是否属于我方白名单。
+ *
+ *  **不能让客户端随便传 price_id**:那等于允许任何人拿一个自己知道的、更便宜的
+ *  price 去结账。只放行白名单里的档位 —— 与 webhook 用的是同一份表,天然一致。 */
+export function isKnownPriceId(priceId: string, priceMonths: PriceMonthsMap): boolean {
+  // Object.hasOwn 而非 `in`/下标:普通对象字面量的原型链上有 toString 等,
+  // 下标访问会返回 function 而非 undefined(webhook 侧踩过这个坑)。
+  return priceId !== "" && Object.hasOwn(priceMonths, priceId);
+}

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -284,3 +284,44 @@ describe("外部调用必须有超时", () => {
     expect(seen[1]).toBe("https://api.paddle.com/transactions");
   });
 });
+
+describe("服务器时钟畸形时 fail-closed(不伪装成未登录)", () => {
+  // 裸 Date.parse(deps.now()) 在 now 坏值时得 NaN → session 总被判无效 → 401,
+  // 误导排障(以为用户没登录,真正的问题是服务器时钟)。本仓已有两处
+  // `server time unavailable` 的先例,这条契约要统一。
+  it.each(["NOT-A-DATE", "", "2026-13-45T99:99:99Z"])(
+    "now()=%s 时返回 500 server time unavailable,而非 401",
+    async (badNow) => {
+      const { db, deps } = setup({ now: () => badNow });
+      await seedAccount(db, "act_clock", "clock@example.com");
+      const res = await handleRequest(
+        new Request(`${BASE}/api/checkout`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            // cookie 用正常时刻签发,确保"无效"只可能来自坏 now
+            cookie: await cookieFor("act_clock"),
+          },
+          body: JSON.stringify({ price_id: YEAR_PRICE }),
+        }),
+        deps,
+      );
+      expect(res.status, `now=${badNow} 不该是 401`).toBe(500);
+      expect(await res.text()).toContain("server time unavailable");
+    },
+  );
+
+  // 同一守卫覆盖所有走 session 的路由,不只是新加的 checkout。
+  it("其它 session 路由同样 fail-closed(不是只修了 checkout)", async () => {
+    const { db, deps } = setup({ now: () => "BAD" });
+    await seedAccount(db, "act_c2", "c2@example.com");
+    const cookie = await cookieFor("act_c2");
+    for (const path of ["/console", "/api/slug/check?s=abc"]) {
+      const res = await handleRequest(
+        new Request(`${BASE}${path}`, { headers: { cookie } }),
+        deps,
+      );
+      expect(res.status, `${path} 应 fail-closed`).toBe(500);
+    }
+  });
+});

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -46,6 +46,7 @@ function setup(over: Partial<RouteDeps> = {}): {
     sessionSecret: SECRET,
     sendMagicLink: async () => {},
     paddleApi: fakeApi(calls),
+    paddlePriceMonths: SANDBOX_PRICE_MONTHS,
     ...over,
   };
   return { db, deps, calls };
@@ -211,5 +212,72 @@ describe("isKnownPriceId", () => {
   it("空串与未知 id 拒绝", () => {
     expect(isKnownPriceId("", SANDBOX_PRICE_MONTHS)).toBe(false);
     expect(isKnownPriceId("pri_nope", SANDBOX_PRICE_MONTHS)).toBe(false);
+  });
+});
+
+describe("白名单未配置时 checkout 也 fail-closed", () => {
+  // 回落 sandbox 的后果:用户拿 live price_id 结账被判 400「未知档位」,
+  // 而真正的问题是我方配置没同步 —— 503 才是诚实的状态码。
+  it("白名单缺失 → 503(而非把合法 price 判成 400)", async () => {
+    const { db, deps, calls } = setup({ paddlePriceMonths: undefined });
+    await seedAccount(db, "act_np", "np@example.com");
+    const res = await post(deps, { price_id: YEAR_PRICE }, await cookieFor("act_np"));
+    expect(res.status).toBe(503);
+    expect(calls, "不该碰 Paddle").toEqual([]);
+  });
+});
+
+describe("外部调用必须有超时", () => {
+  // 没有超时,上游抖动会让请求挂住并占用 worker 并发额度、放大故障面。
+  // 同仓其它外部调用(cf-api 10s、magic-link 5s、turnstile 5s)都设了,
+  // 这里原先是唯一的例外。
+  it("createTransaction 带 AbortSignal 超时", async () => {
+    const { createPaddleApi } = await import("./paddle-api.js");
+    let seenSignal: unknown = undefined;
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: unknown, init?: { signal?: unknown }) => {
+      seenSignal = init?.signal;
+      return new Response(
+        JSON.stringify({ data: { id: "txn_t", checkout: { url: "https://x/buy?_ptxn=txn_t" } } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof globalThis.fetch;
+    try {
+      const api = createPaddleApi({ apiKey: "k", environment: "sandbox" });
+      await api.createTransaction({
+        priceId: YEAR_PRICE,
+        accountEmail: "a@b.c",
+        checkoutUrl: "https://x/buy",
+      });
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+    expect(seenSignal, "必须传 signal").toBeInstanceOf(AbortSignal);
+  });
+
+  it("sandbox 与 production 打不同的 base URL", async () => {
+    const { createPaddleApi } = await import("./paddle-api.js");
+    const seen: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: unknown) => {
+      seen.push(String(url));
+      return new Response(
+        JSON.stringify({ data: { id: "t", checkout: { url: "https://x/buy?_ptxn=t" } } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof globalThis.fetch;
+    try {
+      for (const env of ["sandbox", "production"]) {
+        await createPaddleApi({ apiKey: "k", environment: env }).createTransaction({
+          priceId: YEAR_PRICE,
+          accountEmail: "a@b.c",
+          checkoutUrl: "https://x/buy",
+        });
+      }
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+    expect(seen[0]).toContain("sandbox-api.paddle.com");
+    expect(seen[1]).toBe("https://api.paddle.com/transactions");
   });
 });

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryConnectDb, type ConnectDb } from "./db.js";
+import { buildSessionCookie } from "./session.js";
+import { handleRequest, type RouteDeps } from "./routes.js";
+import { isKnownPriceId, type PaddleApi } from "./paddle-api.js";
+import { SANDBOX_PRICE_MONTHS } from "./paddle-event.js";
+
+const BASE = "https://mediaryconnect.app";
+const NOW = "2026-07-29T12:00:00.000Z";
+const SECRET = "f".repeat(64);
+const YEAR_PRICE = "pri_01kypfzvbkhp0a7npjg87ptxpb";
+
+function fakeApi(calls: unknown[]): PaddleApi {
+  return {
+    async createTransaction(input) {
+      calls.push(input);
+      return {
+        transactionId: "txn_new",
+        checkoutUrl: "https://mediaryconnect.app/buy?_ptxn=txn_new",
+      };
+    },
+  };
+}
+
+function setup(over: Partial<RouteDeps> = {}): {
+  db: ConnectDb;
+  deps: RouteDeps;
+  calls: unknown[];
+} {
+  const db = createMemoryConnectDb();
+  const calls: unknown[] = [];
+  let n = 0;
+  const deps: RouteDeps = {
+    db,
+    cf: {} as never,
+    adminToken: "admin",
+    rootDomain: "mediaryconnect.app",
+    tokenWrapKeyHex: "a".repeat(64),
+    now: () => NOW,
+    newInviteId: () => `inv_${++n}`,
+    newEndpointId: () => `ep_${n}`,
+    newAuditId: () => `aud_${++n}`,
+    newInviteCode: () => `code_${n}`,
+    newAccountId: () => `act_${++n}`,
+    newEntitlementId: () => `ent_${++n}`,
+    sessionSecret: SECRET,
+    sendMagicLink: async () => {},
+    paddleApi: fakeApi(calls),
+    ...over,
+  };
+  return { db, deps, calls };
+}
+
+async function seedAccount(db: ConnectDb, id: string, email: string): Promise<void> {
+  await db.insertAccount({
+    id,
+    email,
+    paddle_customer_id: null,
+    created_at: NOW,
+    last_login_at: null,
+  });
+}
+
+async function cookieFor(accountId: string): Promise<string> {
+  return buildSessionCookie(accountId, { secret: SECRET, ttlMs: 3600_000, now: Date.parse(NOW) });
+}
+
+async function post(
+  deps: RouteDeps,
+  body: unknown,
+  cookie?: string,
+): Promise<Response> {
+  return handleRequest(
+    new Request(`${BASE}/api/checkout`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(cookie === undefined ? {} : { cookie }),
+      },
+      body: JSON.stringify(body),
+    }),
+    deps,
+  );
+}
+
+describe("POST /api/checkout", () => {
+  // 这个端点存在的**唯一理由**:webhook 需要 custom_data.account_email 才知道
+  // 这笔钱属于谁。实测确认 transaction.completed 的 payload 里没有嵌套 customer
+  // 对象(只有 customer_id),所以「从 payload 直接拿邮箱」这条路不存在。
+  // 没有这个端点,真实付款的结果是 no_email + 零入账 + 200(Paddle 不再重投)。
+  it("创建交易时把登录账号邮箱写进 custom_data", async () => {
+    const { db, deps, calls } = setup();
+    await seedAccount(db, "act_1", "buyer@example.com");
+    const res = await post(deps, { price_id: YEAR_PRICE }, await cookieFor("act_1"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      checkout_url: "https://mediaryconnect.app/buy?_ptxn=txn_new",
+      transaction_id: "txn_new",
+    });
+    expect(calls).toEqual([
+      {
+        priceId: YEAR_PRICE,
+        accountEmail: "buyer@example.com",
+        checkoutUrl: "https://mediaryconnect.app/buy",
+      },
+    ]);
+  });
+
+  // 邮箱取自**登录账号**而非请求体:用户可能用公司卡/家人的卡付款,
+  // 但时长必须落在他登录的账号上。
+  it("邮箱来自 session 对应的账号,不接受请求体里的邮箱", async () => {
+    const { db, deps, calls } = setup();
+    await seedAccount(db, "act_2", "real@example.com");
+    await post(
+      deps,
+      { price_id: YEAR_PRICE, account_email: "attacker@example.com" },
+      await cookieFor("act_2"),
+    );
+    expect((calls[0] as { accountEmail: string }).accountEmail).toBe("real@example.com");
+  });
+
+  it("未登录 → 401", async () => {
+    const { deps, calls } = setup();
+    const res = await post(deps, { price_id: YEAR_PRICE });
+    expect(res.status).toBe(401);
+    expect(calls, "不该碰 Paddle").toEqual([]);
+  });
+
+  it("session 有效但账号已删 → 401", async () => {
+    const { deps } = setup();
+    const res = await post(deps, { price_id: YEAR_PRICE }, await cookieFor("act_ghost"));
+    expect(res.status).toBe(401);
+  });
+
+  // 让客户端随便传 price_id 等于允许任何人拿更便宜的 price 结账。
+  it("未知 price_id → 400,不碰 Paddle", async () => {
+    const { db, deps, calls } = setup();
+    await seedAccount(db, "act_3", "b@example.com");
+    for (const pid of ["pri_fake", "", "toString", "__proto__", "constructor"]) {
+      const res = await post(deps, { price_id: pid }, await cookieFor("act_3"));
+      expect(res.status, `price_id=${pid}`).toBe(400);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  it("缺 price_id → 400", async () => {
+    const { db, deps } = setup();
+    await seedAccount(db, "act_4", "c@example.com");
+    expect((await post(deps, {}, await cookieFor("act_4"))).status).toBe(400);
+  });
+
+  it("未配置 Paddle API → 503(配置缺失,不是代码故障)", async () => {
+    const { db, deps } = setup({ paddleApi: undefined });
+    await seedAccount(db, "act_5", "d@example.com");
+    const res = await post(deps, { price_id: YEAR_PRICE }, await cookieFor("act_5"));
+    expect(res.status).toBe(503);
+  });
+
+  it("Paddle 失败 → 502,不回显上游内容", async () => {
+    const { db, deps } = setup({
+      paddleApi: {
+        async createTransaction() {
+          throw new Error("paddle createTransaction failed: 403 forbidden secret=abc");
+        },
+      },
+    });
+    await seedAccount(db, "act_6", "e@example.com");
+    const res = await post(deps, { price_id: YEAR_PRICE }, await cookieFor("act_6"));
+    expect(res.status).toBe(502);
+    const text = await res.text();
+    expect(text).not.toContain("forbidden");
+    expect(text).not.toContain("secret=abc");
+  });
+
+  it("checkoutUrl 用请求的 origin(不硬编码域名)", async () => {
+    const { db, deps, calls } = setup();
+    await seedAccount(db, "act_7", "f@example.com");
+    await handleRequest(
+      new Request("https://beta.mediaryconnect.app/api/checkout", {
+        method: "POST",
+        headers: { "content-type": "application/json", cookie: await cookieFor("act_7") },
+        body: JSON.stringify({ price_id: YEAR_PRICE }),
+      }),
+      deps,
+    );
+    expect((calls[0] as { checkoutUrl: string }).checkoutUrl).toBe(
+      "https://beta.mediaryconnect.app/buy",
+    );
+  });
+
+  it("GET 不被路由", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/api/checkout`), deps);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("isKnownPriceId", () => {
+  it("白名单内放行", () => {
+    expect(isKnownPriceId(YEAR_PRICE, SANDBOX_PRICE_MONTHS)).toBe(true);
+  });
+
+  // 与 webhook 侧同一个坑:下标访问会命中 Object.prototype。
+  it.each(["toString", "valueOf", "constructor", "__proto__", "hasOwnProperty"])(
+    "原型链属性不算白名单:%s",
+    (evil) => {
+      expect(isKnownPriceId(evil, SANDBOX_PRICE_MONTHS)).toBe(false);
+    },
+  );
+
+  it("空串与未知 id 拒绝", () => {
+    expect(isKnownPriceId("", SANDBOX_PRICE_MONTHS)).toBe(false);
+    expect(isKnownPriceId("pri_nope", SANDBOX_PRICE_MONTHS)).toBe(false);
+  });
+});

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -218,8 +218,11 @@ describe("isKnownPriceId", () => {
 describe("白名单未配置时 checkout 也 fail-closed", () => {
   // 回落 sandbox 的后果:用户拿 live price_id 结账被判 400「未知档位」,
   // 而真正的问题是我方配置没同步 —— 503 才是诚实的状态码。
-  it("白名单缺失 → 503(而非把合法 price 判成 400)", async () => {
-    const { db, deps, calls } = setup({ paddlePriceMonths: undefined });
+  it.each([
+    ["undefined", undefined],
+    ["空对象(误注入)", {}],
+  ])("白名单%s → 503(而非把合法 price 判成 400)", async (_name, map) => {
+    const { db, deps, calls } = setup({ paddlePriceMonths: map });
     await seedAccount(db, "act_np", "np@example.com");
     const res = await post(deps, { price_id: YEAR_PRICE }, await cookieFor("act_np"));
     expect(res.status).toBe(503);

--- a/workers/scout-connect/src/paddle-event.test.ts
+++ b/workers/scout-connect/src/paddle-event.test.ts
@@ -117,7 +117,9 @@ describe("parseTransactionCompleted", () => {
     expect(r.reason).toBe("months_mismatch");
   });
 
-  it("多条目累加(将来若允许一次买两段时长)", () => {
+  // 多 items(哪怕同一 price 重复)会累加月数,是一条放大路径。
+  // 产品上不存在「一次买两段时长」,故直接拒绝。
+  it("多条目一律拒绝(累加是放大路径)", () => {
     const r = parseTransactionCompleted(
       txnData({
         items: [
@@ -127,15 +129,36 @@ describe("parseTransactionCompleted", () => {
       }),
       SANDBOX_PRICE_MONTHS,
     );
-    expect(r.ok && r.grant.months).toBe(15);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("too_many_items");
   });
 
-  it("quantity 参与计算", () => {
+  it("同一 price 重复两次也拒绝", () => {
     const r = parseTransactionCompleted(
-      txnData({ items: [{ price: { id: QUARTER_PRICE }, quantity: 2 }] }),
+      txnData({
+        items: [
+          { price: { id: YEAR_PRICE }, quantity: 1 },
+          { price: { id: YEAR_PRICE }, quantity: 1 },
+        ],
+      }),
       SANDBOX_PRICE_MONTHS,
     );
-    expect(r.ok && r.grant.months).toBe(6);
+    expect(r.ok).toBe(false);
+  });
+
+  // quantity=10 曾能把 12 个月放大到 120(买 1 年拿 10 年),而 120 恰好等于旧上限。
+  // 唯一防线是 Paddle 后台的 quantity.maximum=1 —— 那在 Paddle 侧,不在我们代码里。
+  it("quantity 必须恰好是 1(>1 是放大路径)", () => {
+    for (const q of [2, 10, 11, 100]) {
+      const r = parseTransactionCompleted(
+        txnData({ items: [{ price: { id: QUARTER_PRICE }, quantity: q }] }),
+        SANDBOX_PRICE_MONTHS,
+      );
+      expect(r.ok, `quantity=${q} 应被拒`).toBe(false);
+      if (r.ok) continue;
+      expect(r.reason).toBe("bad_quantity");
+    }
   });
 
   // 收钱路径不做「默认放行」:早先畸形 quantity 被当成 1 继续发时长,那是在
@@ -152,16 +175,23 @@ describe("parseTransactionCompleted", () => {
     }
   });
 
-  it("累加结果超出 [1,120] 时拒绝,reason 与 unknown_price 区分", () => {
+  // 上限收到实际最长档位(24)而非 adminGrant 的 120:webhook 来源不可信。
+  it("超出 MAX_WEBHOOK_MONTHS 的白名单值被拒(reason 独立)", () => {
     const r = parseTransactionCompleted(
-      txnData({ items: [{ price: { id: YEAR_PRICE }, quantity: 11 }] }), // 132 个月
-      SANDBOX_PRICE_MONTHS,
+      txnData({ items: [{ price: { id: "pri_absurd" }, quantity: 1 }] }),
+      { pri_absurd: 36 }, // 白名单里配了个超过 24 的值
     );
     expect(r.ok).toBe(false);
     if (r.ok) return;
-    // 这类失败意味着 quantity 异常或白名单配错,不是"没见过这个 price"。
-    // reason 会被拼成审计 action,混淆会让告警失准。
     expect(r.reason).toBe("months_out_of_range");
+  });
+
+  it("恰好 24 个月(两年档)通过", () => {
+    const r = parseTransactionCompleted(
+      txnData({ items: [{ price: { id: "pri_01kypfzvpf02z5731sbnva3n82" }, quantity: 1 }] }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok && r.grant.months).toBe(24);
   });
 
   // account_email 是权威:用户可能用公司卡/家人的卡付款,但时长必须落在他
@@ -228,4 +258,50 @@ describe("SANDBOX_PRICE_MONTHS", () => {
   it("四个档位与定价页一致(季3/年12/两年24/创始12)", () => {
     expect(Object.values(SANDBOX_PRICE_MONTHS).sort((a, b) => a - b)).toEqual([3, 12, 12, 24]);
   });
+});
+
+describe("原型链污染:未知 price_id 不得命中 Object.prototype", () => {
+  // priceMonths 是普通对象字面量,原型链上有 toString/valueOf/constructor/__proto__。
+  // `priceMonths["toString"]` 返回 function 而非 undefined → 逃过 unknown_price;
+  // 随后 `function * 1 = NaN`,而 `NaN < 1` 与 `NaN > 24` **两边都是 false**
+  // → 连范围检查也逃过,最终产出 months=NaN。实测复现过。
+  it.each(["toString", "valueOf", "constructor", "__proto__", "hasOwnProperty", "isPrototypeOf"])(
+    "price_id=%s 被判为 unknown_price(而非 NaN 月数)",
+    (evil) => {
+      const r = parseTransactionCompleted(
+        txnData({ items: [{ price: { id: evil }, quantity: 1 }] }),
+        SANDBOX_PRICE_MONTHS,
+      );
+      expect(r.ok, `${evil} 必须被拒`).toBe(false);
+      if (r.ok) return;
+      expect(r.reason).toBe("unknown_price");
+    },
+  );
+
+  it("白名单值本身畸形时也拒(非整数/负数/NaN)", () => {
+    for (const bad of [0, -1, 1.5, NaN, Infinity]) {
+      const r = parseTransactionCompleted(
+        txnData({ items: [{ price: { id: "pri_bad" }, quantity: 1 }] }),
+        { pri_bad: bad },
+      );
+      expect(r.ok, `白名单值=${bad}`).toBe(false);
+    }
+  });
+});
+
+describe("items 元素为 null 不得抛错(500 → 无限重投)", () => {
+  it("items:[null] 安全归到 unknown_price", () => {
+    const r = parseTransactionCompleted(txnData({ items: [null] }), SANDBOX_PRICE_MONTHS);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("unknown_price");
+  });
+
+  it.each([[[{}]], [[{ price: null }]], [[{ price: {} }]]])(
+    "畸形 item 结构安全拒绝:%j",
+    (items) => {
+      const r = parseTransactionCompleted(txnData({ items }), SANDBOX_PRICE_MONTHS);
+      expect(r.ok).toBe(false);
+    },
+  );
 });

--- a/workers/scout-connect/src/paddle-event.test.ts
+++ b/workers/scout-connect/src/paddle-event.test.ts
@@ -130,22 +130,25 @@ describe("parseTransactionCompleted", () => {
     expect(r.ok && r.grant.months).toBe(15);
   });
 
-  it("quantity 参与计算,畸形值按 1", () => {
-    expect(
-      (() => {
-        const r = parseTransactionCompleted(
-          txnData({ items: [{ price: { id: QUARTER_PRICE }, quantity: 2 }] }),
-          SANDBOX_PRICE_MONTHS,
-        );
-        return r.ok && r.grant.months;
-      })(),
-    ).toBe(6);
-    for (const q of [0, -1, 1.5, "2", null, undefined]) {
+  it("quantity 参与计算", () => {
+    const r = parseTransactionCompleted(
+      txnData({ items: [{ price: { id: QUARTER_PRICE }, quantity: 2 }] }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok && r.grant.months).toBe(6);
+  });
+
+  // 收钱路径不做「默认放行」:早先畸形 quantity 被当成 1 继续发时长,那是在
+  // 上游或集成异常时替它猜,可能过发。宁可拒绝 + 留审计等人工核对。
+  it("畸形 quantity 一律拒绝,不当成 1", () => {
+    for (const q of [0, -1, 1.5, "2", null, undefined, NaN]) {
       const r = parseTransactionCompleted(
         txnData({ items: [{ price: { id: QUARTER_PRICE }, quantity: q }] }),
         SANDBOX_PRICE_MONTHS,
       );
-      expect(r.ok && r.grant.months, `quantity=${String(q)}`).toBe(3);
+      expect(r.ok, `quantity=${String(q)} 应被拒`).toBe(false);
+      if (r.ok) continue;
+      expect(r.reason).toBe("bad_quantity");
     }
   });
 

--- a/workers/scout-connect/src/paddle-event.test.ts
+++ b/workers/scout-connect/src/paddle-event.test.ts
@@ -149,12 +149,16 @@ describe("parseTransactionCompleted", () => {
     }
   });
 
-  it("累加结果超出 [1,120] 时拒绝", () => {
+  it("累加结果超出 [1,120] 时拒绝,reason 与 unknown_price 区分", () => {
     const r = parseTransactionCompleted(
       txnData({ items: [{ price: { id: YEAR_PRICE }, quantity: 11 }] }), // 132 个月
       SANDBOX_PRICE_MONTHS,
     );
     expect(r.ok).toBe(false);
+    if (r.ok) return;
+    // 这类失败意味着 quantity 异常或白名单配错,不是"没见过这个 price"。
+    // reason 会被拼成审计 action,混淆会让告警失准。
+    expect(r.reason).toBe("months_out_of_range");
   });
 
   // account_email 是权威:用户可能用公司卡/家人的卡付款,但时长必须落在他

--- a/workers/scout-connect/src/paddle-event.test.ts
+++ b/workers/scout-connect/src/paddle-event.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseTransactionCompleted,
+  SANDBOX_PRICE_MONTHS,
+  type PriceMonthsMap,
+} from "./paddle-event.js";
+
+const YEAR_PRICE = "pri_01kypfzvbkhp0a7npjg87ptxpb"; // 年度 ¥108 / 12 个月
+const QUARTER_PRICE = "pri_01kypfzv2jqg2qv0g25bn05v28"; // 季度 ¥45 / 3 个月
+
+/** 真实 payload 的 data 部分(形状取自 sandbox 通知,非文档臆测)。 */
+function txnData(over: Record<string, unknown> = {}): unknown {
+  return {
+    id: "txn_01kypg4pmc3ks3251rhdvgv8dx",
+    status: "completed",
+    customer_id: "ctm_x",
+    currency_code: "CNY",
+    custom_data: { account_email: "buyer@example.com" },
+    details: { totals: { total: "10800", grand_total: "10800" } },
+    items: [
+      { price: { id: YEAR_PRICE, custom_data: { months: 12, plan: "year" } }, quantity: 1 },
+    ],
+    ...over,
+  };
+}
+
+describe("parseTransactionCompleted", () => {
+  it("正常年付交易 → 12 个月,邮箱取 custom_data.account_email", () => {
+    const r = parseTransactionCompleted(txnData(), SANDBOX_PRICE_MONTHS);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.grant).toEqual({
+      months: 12,
+      email: "buyer@example.com",
+      transactionId: "txn_01kypg4pmc3ks3251rhdvgv8dx",
+      source: "paddle",
+    });
+  });
+
+  it("季付 → 3 个月", () => {
+    const r = parseTransactionCompleted(
+      txnData({
+        items: [{ price: { id: QUARTER_PRICE, custom_data: { months: 3 } }, quantity: 1 }],
+      }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok && r.grant.months).toBe(3);
+  });
+
+  // 只处理真收到钱的交易。
+  it.each(["draft", "ready", "billed", "canceled", "past_due"])(
+    "status=%s 不发时长",
+    (status) => {
+      const r = parseTransactionCompleted(txnData({ status }), SANDBOX_PRICE_MONTHS);
+      expect(r.ok).toBe(false);
+      if (r.ok) return;
+      expect(r.reason).toBe("not_completed");
+    },
+  );
+
+  // 白名单是权威:未知 price 宁可不发,也不凭猜。
+  it("未知 price_id 拒绝(可能是新档位没同步,也可能是伪造)", () => {
+    const r = parseTransactionCompleted(
+      txnData({ items: [{ price: { id: "pri_unknown" }, quantity: 1 }] }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("unknown_price");
+  });
+
+  // 这是白名单 + 交叉校验的核心价值:抓「后台改了价而代码没同步」。
+  it("custom_data.months 与白名单不一致时拒绝", () => {
+    const r = parseTransactionCompleted(
+      txnData({
+        items: [{ price: { id: YEAR_PRICE, custom_data: { months: 999 } }, quantity: 1 }],
+      }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("months_mismatch");
+    expect(r.detail).toContain("whitelist=12");
+    expect(r.detail).toContain("custom_data=999");
+  });
+
+  // 伪造 custom_data 抬高月数必须无效 —— 白名单说了算。
+  it("伪造的 custom_data 无法抬高月数", () => {
+    const r = parseTransactionCompleted(
+      txnData({
+        items: [{ price: { id: YEAR_PRICE, custom_data: { months: 120 } }, quantity: 1 }],
+      }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok, "不一致就该拒绝,而不是取较大值").toBe(false);
+  });
+
+  it("custom_data 没声明数字时以白名单为准(不阻断)", () => {
+    for (const custom of [null, undefined, {}, { months: "12" }, { months: 1.5 }]) {
+      const r = parseTransactionCompleted(
+        txnData({ items: [{ price: { id: YEAR_PRICE, custom_data: custom }, quantity: 1 }] }),
+        SANDBOX_PRICE_MONTHS,
+      );
+      expect(r.ok, `custom=${JSON.stringify(custom)}`).toBe(true);
+      expect(r.ok && r.grant.months).toBe(12);
+    }
+  });
+
+  // 0 与 999 同类:都是「声明了数字但与白名单不符」,该报警而非静默忽略。
+  it("custom_data.months 为 0 也算不一致(不是畸形忽略)", () => {
+    const r = parseTransactionCompleted(
+      txnData({ items: [{ price: { id: YEAR_PRICE, custom_data: { months: 0 } }, quantity: 1 }] }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("months_mismatch");
+  });
+
+  it("多条目累加(将来若允许一次买两段时长)", () => {
+    const r = parseTransactionCompleted(
+      txnData({
+        items: [
+          { price: { id: YEAR_PRICE }, quantity: 1 },
+          { price: { id: QUARTER_PRICE }, quantity: 1 },
+        ],
+      }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok && r.grant.months).toBe(15);
+  });
+
+  it("quantity 参与计算,畸形值按 1", () => {
+    expect(
+      (() => {
+        const r = parseTransactionCompleted(
+          txnData({ items: [{ price: { id: QUARTER_PRICE }, quantity: 2 }] }),
+          SANDBOX_PRICE_MONTHS,
+        );
+        return r.ok && r.grant.months;
+      })(),
+    ).toBe(6);
+    for (const q of [0, -1, 1.5, "2", null, undefined]) {
+      const r = parseTransactionCompleted(
+        txnData({ items: [{ price: { id: QUARTER_PRICE }, quantity: q }] }),
+        SANDBOX_PRICE_MONTHS,
+      );
+      expect(r.ok && r.grant.months, `quantity=${String(q)}`).toBe(3);
+    }
+  });
+
+  it("累加结果超出 [1,120] 时拒绝", () => {
+    const r = parseTransactionCompleted(
+      txnData({ items: [{ price: { id: YEAR_PRICE }, quantity: 11 }] }), // 132 个月
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  // account_email 是权威:用户可能用公司卡/家人的卡付款,但时长必须落在他
+  // 登录的那个账号上。
+  it("account_email 优先于 customer.email", () => {
+    const r = parseTransactionCompleted(
+      txnData({
+        custom_data: { account_email: "login@example.com" },
+        customer: { email: "payer@example.com" },
+      }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok && r.grant.email).toBe("login@example.com");
+  });
+
+  it("没有 account_email 时回落 customer.email", () => {
+    const r = parseTransactionCompleted(
+      txnData({ custom_data: null, customer: { email: "payer@example.com" } }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok && r.grant.email).toBe("payer@example.com");
+  });
+
+  // 真实历史通知里 custom_data 就是 null。付了钱却不知道给谁 → 必须留审计,
+  // 绝不能静默丢弃。
+  it("两个邮箱来源都没有 → no_email(调用方须留审计,不可静默丢弃)", () => {
+    const r = parseTransactionCompleted(
+      txnData({ custom_data: null, customer: null }),
+      SANDBOX_PRICE_MONTHS,
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("no_email");
+    expect(r.detail).toContain("txn_");
+  });
+
+  it("非对象 data 安全拒绝(null/undefined/字符串/数字)", () => {
+    for (const data of [null, undefined, "string", 42] as unknown[]) {
+      const r = parseTransactionCompleted(data, SANDBOX_PRICE_MONTHS);
+      expect(r.ok, `data=${String(data)}`).toBe(false);
+    }
+  });
+
+  it("空 items 拒绝", () => {
+    const r = parseTransactionCompleted(txnData({ items: [] }), SANDBOX_PRICE_MONTHS);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("no_items");
+  });
+
+  it("白名单可注入(sandbox 与 live 的 price_id 不同)", () => {
+    const live: PriceMonthsMap = { pri_live_year: 12 };
+    const r = parseTransactionCompleted(
+      txnData({ items: [{ price: { id: "pri_live_year" }, quantity: 1 }] }),
+      live,
+    );
+    expect(r.ok && r.grant.months).toBe(12);
+    // sandbox 的 id 在 live 白名单里就该被拒
+    expect(parseTransactionCompleted(txnData(), live).ok).toBe(false);
+  });
+});
+
+describe("SANDBOX_PRICE_MONTHS", () => {
+  it("四个档位与定价页一致(季3/年12/两年24/创始12)", () => {
+    expect(Object.values(SANDBOX_PRICE_MONTHS).sort((a, b) => a - b)).toEqual([3, 12, 12, 24]);
+  });
+});

--- a/workers/scout-connect/src/paddle-event.ts
+++ b/workers/scout-connect/src/paddle-event.ts
@@ -1,0 +1,163 @@
+/**
+ * Paddle webhook 事件解析:从 `transaction.completed` 算出该发多少个月。
+ *
+ * payload 形状取自 sandbox 真实通知(不是照文档猜):
+ *   { event_id, event_type, occurred_at, notification_id,
+ *     data: { id, status, customer_id, custom_data, currency_code,
+ *             details: { totals: {...} },
+ *             items: [{ price: { id, custom_data, product_id }, quantity }] } }
+ */
+
+import type { EntitlementRow } from "./db.js";
+
+/**
+ * price_id → 月数白名单。**这是权威**,`custom_data.months` 只做交叉校验。
+ *
+ * 为什么不直接信 payload 里的 custom_data:那是可以在 Paddle 后台改的值,
+ * 而后台权限与代码权限是两套。白名单保证「后台被改/被入侵也不会凭空多发时长」。
+ * 反过来 custom_data 也不能不看 —— 它能抓到「后台改了价而代码忘了同步」:
+ * 两者不一致时拒绝并要求人工核对,比静默按其中一个执行安全。
+ *
+ * sandbox 与 live 的 price_id 完全不同(两套独立环境),故按环境分别列出。
+ */
+export interface PriceMonthsMap {
+  readonly [priceId: string]: number;
+}
+
+/** sandbox 的四个 one-time price(2026-07-29 建)。 */
+export const SANDBOX_PRICE_MONTHS: PriceMonthsMap = {
+  pri_01kypfzv2jqg2qv0g25bn05v28: 3, // 季度 ¥45
+  pri_01kypfzvbkhp0a7npjg87ptxpb: 12, // 年度 ¥108
+  pri_01kypfzvpf02z5731sbnva3n82: 24, // 两年 ¥188
+  pri_01kypfzvyvgmytaefznh4npsz7: 12, // 创始价 ¥88
+};
+
+export type ParseFailure =
+  | "not_completed"
+  | "no_items"
+  | "unknown_price"
+  | "months_mismatch"
+  | "no_email";
+
+export interface ParsedGrant {
+  months: number;
+  email: string;
+  transactionId: string;
+  source: EntitlementRow["source"];
+}
+
+export type ParseResult =
+  | { ok: true; grant: ParsedGrant }
+  | { ok: false; reason: ParseFailure; detail: string };
+
+interface TxnItem {
+  price?: { id?: unknown; custom_data?: unknown } | null;
+  quantity?: unknown;
+}
+
+/**
+ * 取 custom_data.months 用于交叉校验。
+ *
+ * 关键区分:**「没声明」与「声明了但对不上」是两件事**。
+ * - 返回 null = 压根没有可比的声明(缺字段、非整数、非数字)→ 跳过交叉校验,
+ *   以白名单为准
+ * - 返回数字 = 有声明(**即便超出合理范围**)→ 必须与白名单比对
+ *
+ * 早先这里把 `m > 120` 也归成 null,于是 `months: 999` 被静默忽略、交叉校验
+ * 直接跳过 —— 而 999 恰恰是最该报警的情形(后台被改或被伪造)。范围检查放在
+ * 累加之后统一做,这里只负责"有没有声明一个数字"。
+ */
+function readMonthsFromCustomData(custom: unknown): number | null {
+  if (typeof custom !== "object" || custom === null) return null;
+  const m = (custom as { months?: unknown }).months;
+  if (typeof m !== "number" || !Number.isFinite(m) || !Number.isInteger(m)) return null;
+  return m;
+}
+
+/**
+ * 从 `transaction.completed` 的 data 解析出要发放的时长。
+ *
+ * 邮箱来源优先级:
+ *   1. `data.custom_data.account_email` —— 我方创建交易时写入的登录账号邮箱。
+ *      **这是权威**:用户可能用另一个邮箱付款(公司卡、家人代付),而时长必须
+ *      落在他登录的那个账号上。
+ *   2. `data.customer.email` —— 兜底。仅当交易不是我方创建时才可能走到
+ *      (比如后台手工建的交易)。
+ *
+ * 两个都没有 → `no_email`。调用方**不得静默丢弃**:那意味着用户付了钱而
+ * 系统不知道该给谁,必须留审计供人工处理。
+ */
+export function parseTransactionCompleted(
+  data: unknown,
+  priceMonths: PriceMonthsMap,
+): ParseResult {
+  if (typeof data !== "object" || data === null) {
+    return { ok: false, reason: "not_completed", detail: "data is not an object" };
+  }
+  const d = data as {
+    id?: unknown;
+    status?: unknown;
+    custom_data?: unknown;
+    customer?: { email?: unknown } | null;
+    items?: unknown;
+  };
+
+  // 只处理真正完成的交易。draft/ready/billed 都还没收到钱。
+  if (d.status !== "completed") {
+    return { ok: false, reason: "not_completed", detail: `status=${String(d.status)}` };
+  }
+  const transactionId = typeof d.id === "string" ? d.id : "";
+  if (transactionId === "") {
+    return { ok: false, reason: "not_completed", detail: "missing transaction id" };
+  }
+
+  const items = Array.isArray(d.items) ? (d.items as TxnItem[]) : [];
+  if (items.length === 0) {
+    return { ok: false, reason: "no_items", detail: "items is empty" };
+  }
+
+  // 累加所有条目的月数 × 数量。正常只会有一条(price 的 quantity 上限设为 1),
+  // 但按累加处理更稳:将来若允许一次买两段时长,语义天然正确。
+  let months = 0;
+  for (const item of items) {
+    const priceId = typeof item.price?.id === "string" ? item.price.id : "";
+    const mapped = priceId === "" ? undefined : priceMonths[priceId];
+    if (mapped === undefined) {
+      // 未知 price_id:可能是新建了档位但没更新白名单,也可能是伪造。
+      // 一律拒绝 —— 凭猜发时长比不发更糟。
+      return { ok: false, reason: "unknown_price", detail: `price_id=${priceId}` };
+    }
+    const declared = readMonthsFromCustomData(item.price?.custom_data);
+    if (declared !== null && declared !== mapped) {
+      // 后台 custom_data 与代码白名单不一致 → 有人改了价而代码没同步(或反之)。
+      // 拒绝并要求人工核对:静默按其中一个执行,会导致账本与实际售卖不符。
+      return {
+        ok: false,
+        reason: "months_mismatch",
+        detail: `price_id=${priceId} whitelist=${mapped} custom_data=${declared}`,
+      };
+    }
+    const qty = typeof item.quantity === "number" && Number.isInteger(item.quantity) && item.quantity > 0
+      ? item.quantity
+      : 1;
+    months += mapped * qty;
+  }
+  if (months < 1 || months > 120) {
+    return { ok: false, reason: "unknown_price", detail: `computed months out of range: ${months}` };
+  }
+
+  const custom = typeof d.custom_data === "object" && d.custom_data !== null ? d.custom_data : {};
+  const fromCustom = (custom as { account_email?: unknown }).account_email;
+  const fromCustomer = d.customer?.email;
+  const email =
+    typeof fromCustom === "string" && fromCustom.trim() !== ""
+      ? fromCustom
+      : typeof fromCustomer === "string" && fromCustomer.trim() !== ""
+        ? fromCustomer
+        : "";
+  if (email === "") {
+    return { ok: false, reason: "no_email", detail: `txn=${transactionId}` };
+  }
+
+  return { ok: true, grant: { months, email, transactionId, source: "paddle" } };
+}

--- a/workers/scout-connect/src/paddle-event.ts
+++ b/workers/scout-connect/src/paddle-event.ts
@@ -36,6 +36,7 @@ export type ParseFailure =
   | "not_completed"
   | "no_items"
   | "unknown_price"
+  | "months_out_of_range"
   | "months_mismatch"
   | "no_email";
 
@@ -143,7 +144,14 @@ export function parseTransactionCompleted(
     months += mapped * qty;
   }
   if (months < 1 || months > 120) {
-    return { ok: false, reason: "unknown_price", detail: `computed months out of range: ${months}` };
+    // 与 unknown_price 分开:routes.ts 会用 reason 拼审计 action
+    // (paddle.unprocessable.<reason>),混在一起会让告警指向错误的原因。
+    // 这类失败通常意味着 quantity 异常或白名单配错,不是"没见过这个 price"。
+    return {
+      ok: false,
+      reason: "months_out_of_range",
+      detail: `computed months out of range: ${months}`,
+    };
   }
 
   const custom = typeof d.custom_data === "object" && d.custom_data !== null ? d.custom_data : {};

--- a/workers/scout-connect/src/paddle-event.ts
+++ b/workers/scout-connect/src/paddle-event.ts
@@ -20,6 +20,10 @@ import type { EntitlementRow } from "./db.js";
  *
  * sandbox 与 live 的 price_id 完全不同(两套独立环境),故按环境分别列出。
  */
+/** webhook 单笔可发放的月数上限。取实际最长档位(两年=24)。
+ *  adminGrant 用 120 是因为 admin 可信;webhook 来源不可信,上限必须贴着真实售卖。 */
+export const MAX_WEBHOOK_MONTHS = 24;
+
 export interface PriceMonthsMap {
   readonly [priceId: string]: number;
 }
@@ -38,6 +42,7 @@ export type ParseFailure =
   | "unknown_price"
   | "months_out_of_range"
   | "bad_quantity"
+  | "too_many_items"
   | "months_mismatch"
   | "no_email";
 
@@ -117,14 +122,27 @@ export function parseTransactionCompleted(
   if (items.length === 0) {
     return { ok: false, reason: "no_items", detail: "items is empty" };
   }
+  // 一笔交易只该有一个档位。多 items(哪怕是同一个 price_id 重复)会累加月数,
+  // 是又一条放大路径。产品上不存在"一次买两段时长"的场景,故直接拒绝。
+  if (items.length > 1) {
+    return { ok: false, reason: "too_many_items", detail: `items=${items.length}` };
+  }
 
   // 累加所有条目的月数 × 数量。正常只会有一条(price 的 quantity 上限设为 1),
   // 但按累加处理更稳:将来若允许一次买两段时长,语义天然正确。
   let months = 0;
   for (const item of items) {
-    const priceId = typeof item.price?.id === "string" ? item.price.id : "";
-    const mapped = priceId === "" ? undefined : priceMonths[priceId];
-    if (mapped === undefined) {
+    // M5: item 本身可能是 null(items 通过了 Array.isArray 但元素为 null),
+    // `item.price?.id` 的 ?. 保护的是 price 而不是 item。
+    const priceId = typeof item?.price?.id === "string" ? item.price.id : "";
+    // **必须用 Object.hasOwn**:普通对象字面量的原型链上有 toString/valueOf/
+    // constructor/__proto__,`priceMonths["toString"]` 会返回一个 function 而非
+    // undefined,于是逃过下面的 unknown_price 检查,随后 `function * 1 = NaN`,
+    // 而 `NaN < 1` 与 `NaN > 120` **两边都是 false** —— 连范围检查也逃过。
+    // 实测确认这条路径能产出 months=NaN。
+    const mapped =
+      priceId !== "" && Object.hasOwn(priceMonths, priceId) ? priceMonths[priceId] : undefined;
+    if (typeof mapped !== "number" || !Number.isInteger(mapped) || mapped < 1) {
       // 未知 price_id:可能是新建了档位但没更新白名单,也可能是伪造。
       // 一律拒绝 —— 凭猜发时长比不发更糟。
       return { ok: false, reason: "unknown_price", detail: `price_id=${priceId}` };
@@ -142,20 +160,23 @@ export function parseTransactionCompleted(
     // **收钱路径不做"默认放行"。** 早先畸形 quantity(0/负数/小数/字符串)会被
     // 当成 1 继续发时长 —— 那是在上游或集成异常时替它猜,可能过发。
     // 一律拒绝并留审计,让人工核对比静默发时长安全。
-    if (
-      typeof item.quantity !== "number" ||
-      !Number.isInteger(item.quantity) ||
-      item.quantity < 1
-    ) {
+    // **quantity 必须恰好是 1。** 早先只查「整数且 >=1」,于是 quantity=10 能把
+    // 12 个月放大到 120(买 1 年拿 10 年)—— 而 120 恰好等于旧上限,顺利通过。
+    // 目前唯一的防线是 Paddle 后台给每个 price 设了 quantity.maximum=1,那道防线
+    // **在 Paddle 侧而不在我们的代码里**:后台一次误改就白送 9 年。
+    // 一人一实例是产品决策(见 idx_endpoints_account_live),这里 assert 它。
+    if (item?.quantity !== 1) {
       return {
         ok: false,
         reason: "bad_quantity",
-        detail: `price_id=${priceId} quantity=${JSON.stringify(item.quantity)}`,
+        detail: `price_id=${priceId} quantity=${JSON.stringify(item?.quantity)}`,
       };
     }
-    months += mapped * item.quantity;
+    months += mapped;
   }
-  if (months < 1 || months > 120) {
+  // 上限收到**实际最长档位**(两年=24)而非 adminGrant 的 120:admin 是可信来源,
+  // webhook 不是。留一点余量到 24 以应对将来加档位,但绝不留到 120。
+  if (months < 1 || months > MAX_WEBHOOK_MONTHS) {
     // 与 unknown_price 分开:routes.ts 会用 reason 拼审计 action
     // (paddle.unprocessable.<reason>),混在一起会让告警指向错误的原因。
     // 这类失败通常意味着 quantity 异常或白名单配错,不是"没见过这个 price"。

--- a/workers/scout-connect/src/paddle-event.ts
+++ b/workers/scout-connect/src/paddle-event.ts
@@ -47,6 +47,15 @@ export const LIVE_PRICE_MONTHS: PriceMonthsMap = {};
  * 把「白名单没同步」这种可恢复的配置错误变成不可恢复的丢钱。
  * 返回 null 表示「本环境白名单未配置」,调用方必须 fail-closed。
  */
+export function isPriceMapConfigured(
+  map: PriceMonthsMap | undefined,
+): map is PriceMonthsMap {
+  // **空表等同未配置。** 只判 undefined 不够:误注入 `{}` 会让每个真实 price_id
+  // 都走 unknown_price → 200(不可重试)→ 静默丢钱,恰恰是 fail-closed 要防的
+  // 那件事。判据放在一处,webhook 与 checkout 共用,免得两边漂移。
+  return map !== undefined && Object.keys(map).length > 0;
+}
+
 export function priceMonthsFor(environment: string | undefined): PriceMonthsMap | null {
   const env = environment?.trim().toLowerCase();
   if (env === "sandbox") return SANDBOX_PRICE_MONTHS;

--- a/workers/scout-connect/src/paddle-event.ts
+++ b/workers/scout-connect/src/paddle-event.ts
@@ -28,6 +28,32 @@ export interface PriceMonthsMap {
   readonly [priceId: string]: number;
 }
 
+/**
+ * live 的四个 one-time price。**上线前必须填**。
+ *
+ * 空表意味着 live 环境没有任何合法 price_id —— 这是刻意的:见
+ * `priceMonthsFor()`,非 sandbox 环境拿到空表会让调用方 fail-closed(503,
+ * 可重试),而不是把真实付款判成 unknown_price 后返回不可重试的 200。
+ *
+ * sandbox 与 live 的 price_id 完全不同(两套独立环境),所以不能复用。
+ */
+export const LIVE_PRICE_MONTHS: PriceMonthsMap = {};
+
+/**
+ * 按环境选白名单。
+ *
+ * 这里刻意**不做**「缺失就回落 sandbox」:那会让 live 上线后真实 price_id 被判
+ * unknown_price → 返回 200(不可重试)→ Paddle 停止重投 → **真实付款静默丢失**,
+ * 把「白名单没同步」这种可恢复的配置错误变成不可恢复的丢钱。
+ * 返回 null 表示「本环境白名单未配置」,调用方必须 fail-closed。
+ */
+export function priceMonthsFor(environment: string | undefined): PriceMonthsMap | null {
+  const env = environment?.trim().toLowerCase();
+  if (env === "sandbox") return SANDBOX_PRICE_MONTHS;
+  // 非 sandbox(含 undefined,默认按生产处理)必须有显式的 live 白名单。
+  return Object.keys(LIVE_PRICE_MONTHS).length > 0 ? LIVE_PRICE_MONTHS : null;
+}
+
 /** sandbox 的四个 one-time price(2026-07-29 建)。 */
 export const SANDBOX_PRICE_MONTHS: PriceMonthsMap = {
   pri_01kypfzv2jqg2qv0g25bn05v28: 3, // 季度 ¥45

--- a/workers/scout-connect/src/paddle-event.ts
+++ b/workers/scout-connect/src/paddle-event.ts
@@ -37,6 +37,7 @@ export type ParseFailure =
   | "no_items"
   | "unknown_price"
   | "months_out_of_range"
+  | "bad_quantity"
   | "months_mismatch"
   | "no_email";
 
@@ -138,10 +139,21 @@ export function parseTransactionCompleted(
         detail: `price_id=${priceId} whitelist=${mapped} custom_data=${declared}`,
       };
     }
-    const qty = typeof item.quantity === "number" && Number.isInteger(item.quantity) && item.quantity > 0
-      ? item.quantity
-      : 1;
-    months += mapped * qty;
+    // **收钱路径不做"默认放行"。** 早先畸形 quantity(0/负数/小数/字符串)会被
+    // 当成 1 继续发时长 —— 那是在上游或集成异常时替它猜,可能过发。
+    // 一律拒绝并留审计,让人工核对比静默发时长安全。
+    if (
+      typeof item.quantity !== "number" ||
+      !Number.isInteger(item.quantity) ||
+      item.quantity < 1
+    ) {
+      return {
+        ok: false,
+        reason: "bad_quantity",
+        detail: `price_id=${priceId} quantity=${JSON.stringify(item.quantity)}`,
+      };
+    }
+    months += mapped * item.quantity;
   }
   if (months < 1 || months > 120) {
     // 与 unknown_price 分开:routes.ts 会用 reason 拼审计 action

--- a/workers/scout-connect/src/paddle-signature.test.ts
+++ b/workers/scout-connect/src/paddle-signature.test.ts
@@ -159,3 +159,52 @@ describe("verifyPaddleSignature", () => {
     ).toBe(true);
   });
 });
+
+describe("契约:任何失败返回 false,绝不抛错", () => {
+  const BODY2 = '{"a":1}';
+
+  // Math.abs(NaN - x) > tolerance 恒为 false → 时间窗被静默跳过,重放放行。
+  // 这是最隐蔽的一类漏洞:代码看着有检查,实际等于没有。
+  it("nowMs 为 NaN 时拒绝(而不是绕过时间窗)", async () => {
+    const ts = "1700000000";
+    const header = `ts=${ts};h1=${await sign(ts, BODY2)}`;
+    expect(
+      await verifyPaddleSignature({ rawBody: BODY2, header, secret: SECRET, nowMs: NaN }),
+    ).toBe(false);
+  });
+
+  it.each([Infinity, -Infinity])("nowMs 为 %s 时拒绝", async (nowMs) => {
+    const ts = "1700000000";
+    const header = `ts=${ts};h1=${await sign(ts, BODY2)}`;
+    expect(await verifyPaddleSignature({ rawBody: BODY2, header, secret: SECRET, nowMs })).toBe(
+      false,
+    );
+  });
+
+  it("toleranceMs 畸形时拒绝(不可放大成无限窗)", async () => {
+    const nowMs = 1_700_000_000_000;
+    const ts = String(Math.floor(nowMs / 1000));
+    const header = `ts=${ts};h1=${await sign(ts, BODY2)}`;
+    for (const toleranceMs of [NaN, Infinity, -1]) {
+      expect(
+        await verifyPaddleSignature({ rawBody: BODY2, header, secret: SECRET, nowMs, toleranceMs }),
+        `tolerance=${toleranceMs}`,
+      ).toBe(false);
+    }
+  });
+
+  // 契约是"不抛错"。WebCrypto 对某些输入会抛,必须被吞成 false。
+  it("超长密钥等 WebCrypto 异常输入不抛错", async () => {
+    const nowMs = 1_700_000_000_000;
+    const ts = String(Math.floor(nowMs / 1000));
+    const header = `ts=${ts};h1=${"f".repeat(64)}`;
+    await expect(
+      verifyPaddleSignature({
+        rawBody: BODY2,
+        header,
+        secret: "\u0000".repeat(10),
+        nowMs,
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/workers/scout-connect/src/paddle-signature.test.ts
+++ b/workers/scout-connect/src/paddle-signature.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { parsePaddleSignature, verifyPaddleSignature } from "./paddle-signature.js";
+
+const SECRET = "pdl_ntfset_test_secret_key_value";
+const BODY = '{"event_type":"transaction.completed","data":{"id":"txn_1"}}';
+
+/** 用与实现同款的算法造一个合法签名(测试专用)。 */
+async function sign(ts: string, body: string, secret = SECRET): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${ts}:${body}`));
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+describe("parsePaddleSignature", () => {
+  it("解析 ts 与 h1", () => {
+    const r = parsePaddleSignature("ts=1671552777;h1=abc123");
+    expect(r).toEqual({ ts: 1671552777, h1: ["abc123"] });
+  });
+
+  // 密钥轮换期 Paddle 会同时发多个 h1,任一匹配即通过。
+  it("支持多个 h1(密钥轮换)", () => {
+    const r = parsePaddleSignature("ts=100;h1=aaa;h1=bbb");
+    expect(r?.h1).toEqual(["aaa", "bbb"]);
+  });
+
+  it("顺序无关,额外字段忽略", () => {
+    const r = parsePaddleSignature("h1=xyz;other=1;ts=42");
+    expect(r).toEqual({ ts: 42, h1: ["xyz"] });
+  });
+
+  it.each([
+    ["", "空串"],
+    ["ts=abc;h1=xx", "ts 非数字"],
+    ["ts=100", "缺 h1"],
+    ["h1=xx", "缺 ts"],
+    ["garbage", "无法解析"],
+    ["ts=;h1=xx", "ts 为空"],
+    ["ts=100;h1=", "h1 为空"],
+  ])("畸形头返回 null:%s(%s)", (header) => {
+    expect(parsePaddleSignature(header)).toBeNull();
+  });
+});
+
+describe("verifyPaddleSignature", () => {
+  const now = 1_700_000_000_000; // ms
+
+  it("合法签名通过", async () => {
+    const ts = String(Math.floor(now / 1000));
+    const header = `ts=${ts};h1=${await sign(ts, BODY)}`;
+    expect(await verifyPaddleSignature({ rawBody: BODY, header, secret: SECRET, nowMs: now })).toBe(
+      true,
+    );
+  });
+
+  // 签名对象是 `{ts}:{body}`。漏掉 ts: 前缀是最常见的实现错误 ——
+  // HMAC 代码完全正确但签名永远对不上。
+  it("签名对象必须是 ts:body,只签 body 不通过", async () => {
+    const ts = String(Math.floor(now / 1000));
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(SECRET),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const bodyOnly = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(BODY));
+    const hex = [...new Uint8Array(bodyOnly)].map((b) => b.toString(16).padStart(2, "0")).join("");
+    expect(
+      await verifyPaddleSignature({
+        rawBody: BODY,
+        header: `ts=${ts};h1=${hex}`,
+        secret: SECRET,
+        nowMs: now,
+      }),
+    ).toBe(false);
+  });
+
+  it("body 被改动则不通过", async () => {
+    const ts = String(Math.floor(now / 1000));
+    const header = `ts=${ts};h1=${await sign(ts, BODY)}`;
+    expect(
+      await verifyPaddleSignature({
+        rawBody: BODY + " ", // 多一个空格就该失败
+        header,
+        secret: SECRET,
+        nowMs: now,
+      }),
+    ).toBe(false);
+  });
+
+  it("换密钥不通过", async () => {
+    const ts = String(Math.floor(now / 1000));
+    const header = `ts=${ts};h1=${await sign(ts, BODY, "other_secret")}`;
+    expect(await verifyPaddleSignature({ rawBody: BODY, header, secret: SECRET, nowMs: now })).toBe(
+      false,
+    );
+  });
+
+  it("多个 h1 中任一匹配即通过(密钥轮换)", async () => {
+    const ts = String(Math.floor(now / 1000));
+    const good = await sign(ts, BODY);
+    const header = `ts=${ts};h1=${"0".repeat(64)};h1=${good}`;
+    expect(await verifyPaddleSignature({ rawBody: BODY, header, secret: SECRET, nowMs: now })).toBe(
+      true,
+    );
+  });
+
+  // 时间窗防重放。放 5 分钟(官方 SDK 默认 5 秒,但 worker 冷启动 + CF 边缘
+  // 排队可能有秒级延迟,5 秒太紧会误拒真实投递)。
+  it("时间窗内通过,窗外拒绝", async () => {
+    const tsSec = Math.floor(now / 1000);
+    const header = `ts=${tsSec};h1=${await sign(String(tsSec), BODY)}`;
+    const base = { rawBody: BODY, header, secret: SECRET };
+    // 4 分钟前的投递仍接受
+    expect(await verifyPaddleSignature({ ...base, nowMs: now + 4 * 60_000 })).toBe(true);
+    // 6 分钟前的拒绝
+    expect(await verifyPaddleSignature({ ...base, nowMs: now + 6 * 60_000 })).toBe(false);
+    // 未来太多也拒绝(时钟漂移/伪造)
+    expect(await verifyPaddleSignature({ ...base, nowMs: now - 6 * 60_000 })).toBe(false);
+  });
+
+  it("畸形头一律拒绝(不抛错)", async () => {
+    for (const header of ["", "garbage", "ts=x;h1=y"]) {
+      expect(
+        await verifyPaddleSignature({ rawBody: BODY, header, secret: SECRET, nowMs: now }),
+      ).toBe(false);
+    }
+  });
+
+  // fail-closed:密钥没配时绝不能"通过验签"。调用方另有 503 处理,
+  // 但这一层自身也必须安全。
+  it("密钥为空时一律拒绝(fail closed,且不因 WebCrypto 抛错)", async () => {
+    const ts = String(Math.floor(now / 1000));
+    // 空密钥无法导入 HMAC key(WebCrypto: "Zero-length key is not supported"),
+    // 所以这里也造不出合法签名 —— 而这恰恰是重点:实现必须在碰 crypto **之前**
+    // 就返回 false,否则空密钥会变成 500 而不是干净的拒绝。
+    const header = `ts=${ts};h1=${"a".repeat(64)}`;
+    await expect(
+      verifyPaddleSignature({ rawBody: BODY, header, secret: "", nowMs: now }),
+    ).resolves.toBe(false);
+  });
+
+  it("h1 大小写不敏感(hex)", async () => {
+    const ts = String(Math.floor(now / 1000));
+    const upper = (await sign(ts, BODY)).toUpperCase();
+    expect(
+      await verifyPaddleSignature({
+        rawBody: BODY,
+        header: `ts=${ts};h1=${upper}`,
+        secret: SECRET,
+        nowMs: now,
+      }),
+    ).toBe(true);
+  });
+});

--- a/workers/scout-connect/src/paddle-signature.ts
+++ b/workers/scout-connect/src/paddle-signature.ts
@@ -1,0 +1,110 @@
+/**
+ * Paddle webhook 签名验证(HMAC-SHA256)。
+ *
+ * 手写而非用官方 SDK:`@paddle/paddle-node-sdk` 的 `webhooks.unmarshal` 依赖
+ * Node 的 `crypto` 模块,Workers 运行时没有。这里用 WebCrypto 实现同一算法。
+ *
+ * 算法(官方文档 developer.paddle.com/webhooks/about/signature-verification/):
+ *   1. 取 `Paddle-Signature` 头,格式 `ts=<unix秒>;h1=<hex>`
+ *   2. 签名对象是 **`{ts}:{raw_body}`** —— 漏掉 `ts:` 前缀是最常见的实现错误,
+ *      HMAC 代码完全正确但签名永远对不上
+ *   3. HMAC-SHA256(signedPayload, secret),与 h1 做**常量时间**比较
+ *   4. 检查 ts 与当下的差值,防重放
+ *
+ * **raw body 绝不可解析或改动后再验签** —— 加一个空格、重排 JSON 字段都会让
+ * 签名失配。调用方必须传原始文本。
+ */
+
+/** 时间窗。官方 SDK 默认 5 秒,这里放宽到 5 分钟:worker 冷启动加上 CF 边缘
+ *  排队可能有秒级延迟,5 秒太紧会误拒真实投递 —— 而误拒的后果是用户付了钱
+ *  拿不到时长(Paddle 会重试,但重试也可能同样超时)。5 分钟对重放攻击仍足够窄。 */
+export const SIGNATURE_TOLERANCE_MS = 5 * 60_000;
+
+export interface ParsedSignature {
+  /** Unix 秒。 */
+  ts: number;
+  /** 可能多个:密钥轮换期 Paddle 会同时发新旧两个签名,任一匹配即通过。 */
+  h1: string[];
+}
+
+/** 解析 `Paddle-Signature` 头。任何畸形输入返回 null(绝不抛错——
+ *  webhook 端点会被随机扫描,不该因为一个垃圾头就 500)。 */
+export function parsePaddleSignature(header: string): ParsedSignature | null {
+  if (header === "") return null;
+  let ts: number | null = null;
+  const h1: string[] = [];
+  for (const part of header.split(";")) {
+    // 只按**第一个** = 切分:hex 里不会有 =,但真出现畸形值时不该静默截断。
+    const idx = part.indexOf("=");
+    if (idx <= 0) continue;
+    const key = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    if (value === "") continue;
+    if (key === "ts") {
+      // 必须是纯数字:parseInt("abc123") 会得 NaN,但 parseInt("12abc") 会得 12,
+      // 后者是静默接受畸形值,所以用正则先卡形状。
+      if (!/^\d+$/.test(value)) return null;
+      ts = Number(value);
+    } else if (key === "h1") {
+      h1.push(value);
+    }
+  }
+  if (ts === null || h1.length === 0) return null;
+  return { ts, h1 };
+}
+
+/** 常量时间比较 hex 字符串。长度不同直接 false(长度本身不是秘密)。 */
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+function toHex(buf: ArrayBuffer): string {
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export interface VerifyInput {
+  /** **原始**请求体文本,未经任何解析或格式化。 */
+  rawBody: string;
+  /** `Paddle-Signature` 头的值。 */
+  header: string;
+  /** notification destination 的 endpoint secret(pdl_ntfset_ 前缀)。 */
+  secret: string;
+  nowMs: number;
+  toleranceMs?: number;
+}
+
+/** 验签 + 时间窗。任何失败都返回 false,不抛错、不区分原因(不给攻击者信息)。 */
+export async function verifyPaddleSignature(input: VerifyInput): Promise<boolean> {
+  // fail closed:密钥没配时绝不"通过"。调用方另有 503 处理,但这一层自身
+  // 也必须安全 —— 否则将来有人复用这个函数就会裸奔。
+  if (input.secret === "") return false;
+  const parsed = parsePaddleSignature(input.header);
+  if (parsed === null) return false;
+
+  const tolerance = input.toleranceMs ?? SIGNATURE_TOLERANCE_MS;
+  // 双向都要卡:太旧是重放,太新则意味着时钟漂移或伪造。
+  if (Math.abs(input.nowMs - parsed.ts * 1000) > tolerance) return false;
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(input.secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    // 签名对象:ts 与 body 用冒号连接。ts 用头里的原始值(而非重新格式化),
+    // 否则前导零之类的差异会让签名对不上。
+    new TextEncoder().encode(`${parsed.ts}:${input.rawBody}`),
+  );
+  const expected = toHex(mac);
+  // hex 大小写不敏感:统一小写后再常量时间比较。
+  return parsed.h1.some((candidate) => timingSafeEqualHex(candidate.toLowerCase(), expected));
+}

--- a/workers/scout-connect/src/paddle-signature.ts
+++ b/workers/scout-connect/src/paddle-signature.ts
@@ -86,25 +86,36 @@ export async function verifyPaddleSignature(input: VerifyInput): Promise<boolean
   const parsed = parsePaddleSignature(input.header);
   if (parsed === null) return false;
 
+  // **nowMs 必须先卡 finite**:NaN 会让下面的时间窗检查被静默绕过 ——
+  // `Math.abs(NaN - x) > tolerance` 恒为 false,于是任何重放都放行。
+  // 调用方传的是 Date.parse(deps.now()),now() 若返回坏值就是 NaN。
+  if (!Number.isFinite(input.nowMs)) return false;
   const tolerance = input.toleranceMs ?? SIGNATURE_TOLERANCE_MS;
+  if (!Number.isFinite(tolerance) || tolerance < 0) return false;
   // 双向都要卡:太旧是重放,太新则意味着时钟漂移或伪造。
   if (Math.abs(input.nowMs - parsed.ts * 1000) > tolerance) return false;
 
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(input.secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const mac = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    // 签名对象:ts 与 body 用冒号连接。ts 用头里的原始值(而非重新格式化),
-    // 否则前导零之类的差异会让签名对不上。
-    new TextEncoder().encode(`${parsed.ts}:${input.rawBody}`),
-  );
-  const expected = toHex(mac);
-  // hex 大小写不敏感:统一小写后再常量时间比较。
-  return parsed.h1.some((candidate) => timingSafeEqualHex(candidate.toLowerCase(), expected));
+  // WebCrypto 会抛(如密钥长度不被支持)。本函数的契约是「任何失败返回 false,
+  // 不抛错」—— webhook 端点会被随机扫描,一个畸形输入不该变成 500。
+  try {
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(input.secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const mac = await crypto.subtle.sign(
+      "HMAC",
+      key,
+      // 签名对象:ts 与 body 用冒号连接。ts 用头里的原始值(而非重新格式化),
+      // 否则前导零之类的差异会让签名对不上。
+      new TextEncoder().encode(`${parsed.ts}:${input.rawBody}`),
+    );
+    const expected = toHex(mac);
+    // hex 大小写不敏感:统一小写后再常量时间比较。
+    return parsed.h1.some((candidate) => timingSafeEqualHex(candidate.toLowerCase(), expected));
+  } catch {
+    return false;
+  }
 }

--- a/workers/scout-connect/src/paddle-signature.ts
+++ b/workers/scout-connect/src/paddle-signature.ts
@@ -108,8 +108,12 @@ export async function verifyPaddleSignature(input: VerifyInput): Promise<boolean
     const mac = await crypto.subtle.sign(
       "HMAC",
       key,
-      // 签名对象:ts 与 body 用冒号连接。ts 用头里的原始值(而非重新格式化),
-      // 否则前导零之类的差异会让签名对不上。
+      // 签名对象:ts 与 body 用冒号连接。
+      // 注意这里用的是**解析后的数字**(parsed.ts),所以头里若写成带前导零的
+      // "ts=0170..." 会与 Paddle 的签名对不上。实践中 Paddle 永远发规范的
+      // Unix 秒,且 parsePaddleSignature 已用 /^\d+$/ 卡过形状;真要完全保真
+      // 就得把原始文本一路带下来,那对现实收益为零而复杂度实在。
+      // (早先这里的注释写着"用头里的原始值",与实现不符 —— 已纠正。)
       new TextEncoder().encode(`${parsed.ts}:${input.rawBody}`),
     );
     const expected = toHex(mac);

--- a/workers/scout-connect/src/paddle-webhook.test.ts
+++ b/workers/scout-connect/src/paddle-webhook.test.ts
@@ -437,3 +437,62 @@ describe("审计写入必须 best-effort(不可把不可重试的失败变成无
     expect(d.bytes).toBeGreaterThan(body.length);
   });
 });
+
+describe("入账与审计的失败要分开处置", () => {
+  // 入账已成功时,审计写不进去不该推翻既成事实。返回 503 会让 Paddle 重投,
+  // 语义上等于"明明成功了却说失败"。
+  it("入账成功但审计失败 → 仍 200(不让 Paddle 重投)", async () => {
+    const { db, deps } = setup();
+    let calls = 0;
+    const flaky: ConnectDb = {
+      ...db,
+      async insertAudit(row) {
+        calls++;
+        throw new Error("audit unavailable");
+      },
+    };
+    const body = eventBody();
+    const res = await post({ ...deps, db: flaky }, body, await signed(body));
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { applied: boolean }).toMatchObject({ applied: true });
+    expect(calls, "确实尝试过写审计").toBeGreaterThan(0);
+    // 关键:钱真的变成了时长
+    const acct = await db.getAccountByEmail("buyer@example.com");
+    expect((await db.listEntitlements(acct!.id)).length).toBe(1);
+  });
+
+  // 退款事件本身可处理,只是暂时写不进审计 → 503 让重投。退款审计是后续
+  // 停用处置的唯一依据,丢了就查不到某人为什么被停。
+  it("退款事件审计失败 → 503(可重试),而非 unhandled 500", async () => {
+    const { db, deps } = setup();
+    const noAudit: ConnectDb = {
+      ...db,
+      async insertAudit() {
+        throw new Error("audit unavailable");
+      },
+    };
+    const body = JSON.stringify({
+      event_id: "e",
+      event_type: "adjustment.created",
+      data: { id: "adj", transaction_id: "txn_x", action: "refund" },
+    });
+    const res = await post({ ...deps, db: noAudit }, body, await signed(body));
+    expect(res.status).toBe(503);
+    // 契约:不回显内部错误文本。响应文案刻意与内部异常消息不同 ——
+    // 否则将来改了内部消息,这条契约会悄悄失效。
+    const text = await res.text();
+    expect(text).not.toContain("audit unavailable");
+    expect(text).toContain("temporarily unavailable");
+  });
+
+  it("畸形 quantity → 200 + bad_quantity 审计,不入账", async () => {
+    const { db, deps } = setup();
+    const body = eventBody({}, { items: [{ price: { id: YEAR_PRICE }, quantity: 0 }] });
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ unprocessable: "bad_quantity" });
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+    const audits = await db.listAudits();
+    expect(audits.some((a) => a.action === "paddle.unprocessable.bad_quantity")).toBe(true);
+  });
+});

--- a/workers/scout-connect/src/paddle-webhook.test.ts
+++ b/workers/scout-connect/src/paddle-webhook.test.ts
@@ -346,3 +346,94 @@ describe("POST /api/paddle/webhook", () => {
     expect(res.status).toBe(404);
   });
 });
+
+describe("时间基准:用事件的 occurred_at 而非投递到达时刻", () => {
+  // Paddle 重试是指数退避,失败后可能几小时后才成功投递。若按到达时刻算,
+  // 一笔「到期前 1 分钟成交」的续费会被当成「已过期 → 从当下重启」,
+  // 用户白丢那段延迟的时长(延迟 24h 就丢 24h)。
+  it("延迟投递的续费仍从旧到期叠加(不被当成已过期重启)", async () => {
+    const { db, deps } = setup();
+    // 先有一笔到 2026-08-01 到期的时长
+    const acct = await db.insertAccount({
+      id: "act_pre",
+      email: "buyer@example.com",
+      paddle_customer_id: null,
+      created_at: "2026-07-01T00:00:00.000Z",
+      last_login_at: null,
+    });
+    await db.insertEntitlement({
+      id: "ent_pre",
+      account_id: acct.id,
+      expires_at: "2026-08-01T00:00:00.000Z",
+      source: "manual",
+      paddle_transaction_id: null,
+      months: 1,
+      created_at: "2026-07-01T00:00:00.000Z",
+    });
+    // 成交时刻在到期之前;但 now() 是到期之后(模拟投递延迟)
+    const occurred = "2026-07-31T23:00:00.000Z";
+    const body = eventBody({ occurred_at: occurred }, { id: "txn_late" });
+    const lateNow = "2026-08-02T00:00:00.000Z";
+    const res = await post(
+      { ...deps, now: () => lateNow },
+      body,
+      await signed(body, SECRET, Date.parse(lateNow)),
+    );
+    expect(res.status).toBe(200);
+    // 从旧到期 2026-08-01 叠加 12 个月 → 2027-08-01
+    // (若按 lateNow 算会是 2027-08-02,白丢一天)
+    expect((await res.json()) as { expires_at: string }).toMatchObject({
+      expires_at: "2027-08-01T00:00:00.000Z",
+    });
+  });
+
+  it("occurred_at 缺失/畸形时回落 now(不阻断入账)", async () => {
+    for (const occurred of [undefined, "", "not-a-date", 12345]) {
+      const { deps } = setup();
+      const body = eventBody({ occurred_at: occurred }, { id: `txn_${String(occurred)}` });
+      const res = await post(deps, body, await signed(body));
+      expect(res.status, `occurred_at=${String(occurred)}`).toBe(200);
+      expect((await res.json()) as { applied: boolean }).toMatchObject({ applied: true });
+    }
+  });
+
+  // 离谱的 occurred_at 不该把到期推到很远(防上游 bug;payload 已验签,非攻击面)。
+  it("occurred_at 偏离当下过远时回落 now", async () => {
+    const { deps } = setup();
+    const body = eventBody({ occurred_at: "2099-01-01T00:00:00.000Z" }, { id: "txn_future" });
+    const res = await post(deps, body, await signed(body));
+    // 回落 NOW(2026-07-29)+12 个月,而不是 2100
+    expect((await res.json()) as { expires_at: string }).toMatchObject({
+      expires_at: "2027-07-29T12:00:00.000Z",
+    });
+  });
+});
+
+describe("审计写入必须 best-effort(不可把不可重试的失败变成无限重投)", () => {
+  it("解析失败且审计写入也失败时仍返回 200", async () => {
+    const { db, deps } = setup();
+    const noAudit: ConnectDb = {
+      ...db,
+      async insertAudit() {
+        throw new Error("audit unavailable");
+      },
+    };
+    const body = eventBody({}, { items: [{ price: { id: "pri_fake" }, quantity: 1 }] });
+    const res = await post({ ...deps, db: noAudit }, body, await signed(body));
+    expect(res.status, "审计故障不该变成 500 → 那会无限重投").toBe(200);
+    expect(await res.json()).toMatchObject({ unprocessable: "unknown_price" });
+  });
+
+  it("畸形 JSON 的审计记录真实字节数(非 UTF-16 长度)", async () => {
+    const { db, deps } = setup();
+    const body = '{"x":"退款政策"'; // 非 ASCII,字节数 > length
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+    const a = (await db.listAudits()).find(
+      (x) => x.action === "paddle.unprocessable.malformed_json",
+    );
+    const d = JSON.parse(a!.detail_json!) as { bytes: number };
+    expect(d.bytes, "应为真实字节数").toBe(new TextEncoder().encode(body).byteLength);
+    expect(d.bytes).toBeGreaterThan(body.length);
+  });
+});

--- a/workers/scout-connect/src/paddle-webhook.test.ts
+++ b/workers/scout-connect/src/paddle-webhook.test.ts
@@ -531,10 +531,29 @@ describe("白名单未配置时必须 fail-closed(否则 live 上线即丢钱)",
     expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
   });
 
+  // 早先这个用例名说「空对象」而实参传的是 undefined —— 与上一条重复,
+  // 给了空表场景一个**虚假的覆盖感**。空表是独立的失败模式:每个真实
+  // price_id 都会走 unknown_price → 200(不可重试)→ 静默丢钱。
   it("白名单为空对象时同样 503(空表 = 未配置)", async () => {
-    const { deps } = setup({ paddlePriceMonths: undefined });
+    const { deps } = setup({ paddlePriceMonths: {} });
     const body = eventBody();
     expect((await post(deps, body, await signed(body))).status).toBe(503);
+  });
+});
+
+describe("isPriceMapConfigured —— 空表等同未配置", () => {
+  it("空表与 undefined 都算未配置", async () => {
+    const { isPriceMapConfigured } = await import("./paddle-event.js");
+    expect(isPriceMapConfigured(undefined)).toBe(false);
+    expect(isPriceMapConfigured({}), "误注入空表是独立的失败模式").toBe(false);
+  });
+
+  it("非空表算已配置", async () => {
+    const { isPriceMapConfigured, SANDBOX_PRICE_MONTHS: sandbox } = await import(
+      "./paddle-event.js"
+    );
+    expect(isPriceMapConfigured(sandbox)).toBe(true);
+    expect(isPriceMapConfigured({ pri_x: 3 })).toBe(true);
   });
 });
 

--- a/workers/scout-connect/src/paddle-webhook.test.ts
+++ b/workers/scout-connect/src/paddle-webhook.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createMemoryConnectDb, type ConnectDb } from "./db.js";
 import { handleRequest, type RouteDeps } from "./routes.js";
+import { SANDBOX_PRICE_MONTHS } from "./paddle-event.js";
 
 const BASE = "https://mediaryconnect.app";
 const NOW = "2026-07-29T12:00:00.000Z";
@@ -26,6 +27,7 @@ function setup(over: Partial<RouteDeps> = {}): { db: ConnectDb; deps: RouteDeps 
     sessionSecret: "f".repeat(64),
     sendMagicLink: async () => {},
     paddleWebhookSecret: SECRET,
+    paddlePriceMonths: SANDBOX_PRICE_MONTHS,
     ...over,
   };
   return { db, deps };
@@ -513,5 +515,50 @@ describe("入账与审计的失败要分开处置", () => {
     expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
     const audits = await db.listAudits();
     expect(audits.some((a) => a.action === "paddle.unprocessable.bad_quantity")).toBe(true);
+  });
+});
+
+describe("白名单未配置时必须 fail-closed(否则 live 上线即丢钱)", () => {
+  // 原实现在 paddlePriceMonths 缺失时回落 SANDBOX_PRICE_MONTHS。而 index.ts
+  // 压根没注入它 —— 于是 live 上线后真实 price_id 会被判 unknown_price →
+  // 返回 200(不可重试)→ Paddle 停止重投 → **真实付款静默丢失**。
+  // 503 把「白名单没同步」这种可恢复的配置错误,从不可恢复的丢钱里救回来。
+  it("webhook 在白名单缺失时返回 503(可重试),不入账", async () => {
+    const { db, deps } = setup({ paddlePriceMonths: undefined });
+    const body = eventBody();
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(503);
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+  });
+
+  it("白名单为空对象时同样 503(空表 = 未配置)", async () => {
+    const { deps } = setup({ paddlePriceMonths: undefined });
+    const body = eventBody();
+    expect((await post(deps, body, await signed(body))).status).toBe(503);
+  });
+});
+
+describe("priceMonthsFor —— 按环境选白名单,绝不跨环境回落", () => {
+  it("sandbox 得到 sandbox 表", async () => {
+    const { priceMonthsFor, SANDBOX_PRICE_MONTHS: sandbox } = await import("./paddle-event.js");
+    expect(priceMonthsFor("sandbox")).toBe(sandbox);
+    expect(priceMonthsFor(" SANDBOX ")).toBe(sandbox); // 大小写/空白不敏感
+  });
+
+  // live 白名单还没填(上线前必须填)。返回 null 让调用方 fail-closed,
+  // 而不是悄悄用 sandbox 的 price_id —— 那些 id 在 live 根本不存在。
+  it.each([undefined, "production", "live", ""])(
+    "非 sandbox 环境(%s)在 live 表为空时返回 null",
+    async (env) => {
+      const { priceMonthsFor } = await import("./paddle-event.js");
+      expect(priceMonthsFor(env)).toBeNull();
+    },
+  );
+
+  it("绝不把 sandbox 表交给非 sandbox 环境", async () => {
+    const { priceMonthsFor, SANDBOX_PRICE_MONTHS: sandbox } = await import("./paddle-event.js");
+    for (const env of [undefined, "production", "live"]) {
+      expect(priceMonthsFor(env), `env=${String(env)}`).not.toBe(sandbox);
+    }
   });
 });

--- a/workers/scout-connect/src/paddle-webhook.test.ts
+++ b/workers/scout-connect/src/paddle-webhook.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+import { createMemoryConnectDb, type ConnectDb } from "./db.js";
+import { handleRequest, type RouteDeps } from "./routes.js";
+
+const BASE = "https://mediaryconnect.app";
+const NOW = "2026-07-29T12:00:00.000Z";
+const SECRET = "pdl_ntfset_test_secret";
+const YEAR_PRICE = "pri_01kypfzvbkhp0a7npjg87ptxpb"; // 12 个月
+
+function setup(over: Partial<RouteDeps> = {}): { db: ConnectDb; deps: RouteDeps } {
+  const db = createMemoryConnectDb();
+  let n = 0;
+  const deps: RouteDeps = {
+    db,
+    cf: {} as never,
+    adminToken: "admin",
+    rootDomain: "mediaryconnect.app",
+    tokenWrapKeyHex: "a".repeat(64),
+    now: () => NOW,
+    newInviteId: () => `inv_${++n}`,
+    newEndpointId: () => `ep_${n}`,
+    newAuditId: () => `aud_${++n}`,
+    newInviteCode: () => `code_${n}`,
+    newAccountId: () => `act_${++n}`,
+    newEntitlementId: () => `ent_${++n}`,
+    sessionSecret: "f".repeat(64),
+    sendMagicLink: async () => {},
+    paddleWebhookSecret: SECRET,
+    ...over,
+  };
+  return { db, deps };
+}
+
+async function signed(body: string, secret = SECRET, tsMs = Date.parse(NOW)): Promise<string> {
+  const ts = String(Math.floor(tsMs / 1000));
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const mac = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${ts}:${body}`));
+  const hex = [...new Uint8Array(mac)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `ts=${ts};h1=${hex}`;
+}
+
+function eventBody(over: Record<string, unknown> = {}, dataOver: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    event_id: "evt_1",
+    event_type: "transaction.completed",
+    occurred_at: NOW,
+    notification_id: "ntf_1",
+    data: {
+      id: "txn_abc",
+      status: "completed",
+      customer_id: "ctm_1",
+      currency_code: "CNY",
+      custom_data: { account_email: "buyer@example.com" },
+      details: { totals: { total: "10800", grand_total: "10800" } },
+      items: [{ price: { id: YEAR_PRICE, custom_data: { months: 12 } }, quantity: 1 }],
+      ...dataOver,
+    },
+    ...over,
+  });
+}
+
+async function post(
+  deps: RouteDeps,
+  body: string,
+  header?: string,
+): Promise<Response> {
+  return handleRequest(
+    new Request(`${BASE}/api/paddle/webhook`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(header === undefined ? {} : { "paddle-signature": header }),
+      },
+      body,
+    }),
+    deps,
+  );
+}
+
+describe("POST /api/paddle/webhook", () => {
+  it("合法签名的 transaction.completed → 发放时长", async () => {
+    const { db, deps } = setup();
+    const body = eventBody();
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      applied: true,
+      expires_at: "2027-07-29T12:00:00.000Z",
+    });
+    const acct = await db.getAccountByEmail("buyer@example.com");
+    expect(acct).not.toBeNull();
+    const ents = await db.listEntitlements(acct!.id);
+    expect(ents.length).toBe(1);
+    expect(ents[0]?.months).toBe(12);
+    expect(ents[0]?.paddle_transaction_id).toBe("txn_abc");
+    expect(ents[0]?.source).toBe("paddle");
+  });
+
+  // fail closed 的关键:未配密钥必须 503(让 Paddle 重投),绝不 200
+  // —— 200 会让它停止重试,而我们压根没入账,用户付的钱就丢了。
+  it("未配置 secret → 503(让 Paddle 重投,不可 200)", async () => {
+    const { db, deps } = setup({ paddleWebhookSecret: undefined });
+    const body = eventBody();
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(503);
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+  });
+
+  it.each([
+    ["空白 secret", "   "],
+    ["空串 secret", ""],
+  ])("%s 同样 503", async (_name, sec) => {
+    const { deps } = setup({ paddleWebhookSecret: sec });
+    const body = eventBody();
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(503);
+  });
+
+  it("签名错误 → 401,不入账", async () => {
+    const { db, deps } = setup();
+    const body = eventBody();
+    const res = await post(deps, body, await signed(body, "wrong_secret"));
+    expect(res.status).toBe(401);
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+  });
+
+  it("缺签名头 → 401", async () => {
+    const { deps } = setup();
+    const res = await post(deps, eventBody());
+    expect(res.status).toBe(401);
+  });
+
+  // body 改一个字节签名就该失配 —— 证明验签真的覆盖了内容。
+  it("body 被篡改 → 401(哪怕只多一个空格)", async () => {
+    const { db, deps } = setup();
+    const body = eventBody();
+    const header = await signed(body);
+    const res = await post(deps, body + " ", header);
+    expect(res.status).toBe(401);
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+  });
+
+  // 攻击者拿到旧的合法请求重放,时间窗要挡住。
+  it("超出时间窗 → 401", async () => {
+    const { deps } = setup();
+    const body = eventBody();
+    const stale = await signed(body, SECRET, Date.parse(NOW) - 10 * 60_000);
+    expect((await post(deps, body, stale)).status).toBe(401);
+  });
+
+  // 幂等是命门:Paddle 明确会重投,重复入账等于白送时长。
+  it("同一交易重投只入账一次", async () => {
+    const { db, deps } = setup();
+    const body = eventBody();
+    const header = await signed(body);
+    const first = await post(deps, body, header);
+    expect((await first.json()) as { applied: boolean }).toMatchObject({ applied: true });
+    const replay = await post(deps, body, header);
+    expect(replay.status).toBe(200);
+    const rj = (await replay.json()) as { applied: boolean; expires_at: string };
+    expect(rj.applied, "重投必须识别为幂等").toBe(false);
+    // 重投返回的到期时刻必须是已存在的那个,不能又叠加一年
+    expect(rj.expires_at).toBe("2027-07-29T12:00:00.000Z");
+    const acct = await db.getAccountByEmail("buyer@example.com");
+    const ents = await db.listEntitlements(acct!.id);
+    expect(ents.length, "只应有一条时长").toBe(1);
+  });
+
+  it("未知 price_id → 200 + 审计,不入账", async () => {
+    const { db, deps } = setup();
+    const body = eventBody({}, { items: [{ price: { id: "pri_fake" }, quantity: 1 }] });
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ unprocessable: "unknown_price" });
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+    const audits = await db.listAudits();
+    expect(audits.some((a) => a.action === "paddle.unprocessable.unknown_price")).toBe(true);
+  });
+
+  it("月数与白名单不一致 → 200 + 审计,不入账", async () => {
+    const { db, deps } = setup();
+    const body = eventBody(
+      {},
+      { items: [{ price: { id: YEAR_PRICE, custom_data: { months: 999 } }, quantity: 1 }] },
+    );
+    const res = await post(deps, body, await signed(body));
+    expect(await res.json()).toMatchObject({ unprocessable: "months_mismatch" });
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+  });
+
+  // 有人付了钱而系统不知道该给谁 —— 必须留下能追查的审计。
+  it("拿不到邮箱 → 200 但审计里记全 txn id(需人工处理)", async () => {
+    const { db, deps } = setup();
+    const body = eventBody({}, { custom_data: null, customer: null });
+    const res = await post(deps, body, await signed(body));
+    expect(await res.json()).toMatchObject({ unprocessable: "no_email" });
+    const audits = await db.listAudits();
+    const a = audits.find((x) => x.action === "paddle.unprocessable.no_email");
+    expect(a, "必须有审计").toBeDefined();
+    expect(a?.detail_json).toContain("txn_abc");
+  });
+
+  it("非 completed 状态不发时长", async () => {
+    const { db, deps } = setup();
+    const body = eventBody({}, { status: "billed" });
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+  });
+
+  it("adjustment.created(退款)记审计并 200", async () => {
+    const { db, deps } = setup();
+    const body = JSON.stringify({
+      event_id: "evt_adj",
+      event_type: "adjustment.created",
+      data: { id: "adj_1", action: "refund", transaction_id: "txn_abc" },
+    });
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+    const audits = await db.listAudits();
+    expect(audits.some((a) => a.action === "paddle.adjustment")).toBe(true);
+  });
+
+  it("未订阅的事件类型礼貌 200,不入账", async () => {
+    const { db, deps } = setup();
+    const body = JSON.stringify({
+      event_id: "evt_x",
+      event_type: "subscription.created",
+      data: {},
+    });
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ignored: "subscription.created" });
+  });
+
+  it("验签通过但 JSON 畸形 → 200(重投也不会变好)", async () => {
+    const { deps } = setup();
+    const body = "{not json";
+    const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+  });
+
+  // DB 故障是可重试的,必须 503 让 Paddle 重投,否则这笔付款永久丢失。
+  it("入账时 DB 故障 → 503(可重试),不回显内部错误", async () => {
+    const { db, deps } = setup();
+    const failing: ConnectDb = {
+      ...db,
+      async insertEntitlement() {
+        throw new Error("D1_ERROR: connection lost at table entitlements");
+      },
+    };
+    const body = eventBody();
+    const res = await post({ ...deps, db: failing }, body, await signed(body));
+    expect(res.status).toBe(503);
+    const text = await res.text();
+    expect(text).not.toContain("D1_ERROR");
+    expect(text).not.toContain("entitlements");
+  });
+
+  it("续费叠加:第二笔不同交易从旧到期累加", async () => {
+    const { db, deps } = setup();
+    const b1 = eventBody({ event_id: "e1" }, { id: "txn_1" });
+    await post(deps, b1, await signed(b1));
+    const b2 = eventBody({ event_id: "e2" }, { id: "txn_2" });
+    const res = await post(deps, b2, await signed(b2));
+    expect((await res.json()) as { expires_at: string }).toMatchObject({
+      expires_at: "2028-07-29T12:00:00.000Z", // 2027 + 12 个月
+    });
+    const acct = await db.getAccountByEmail("buyer@example.com");
+    expect((await db.listEntitlements(acct!.id)).length).toBe(2);
+  });
+
+  it("live 白名单可注入(sandbox price 在 live 下被拒)", async () => {
+    const { deps } = setup({ paddlePriceMonths: { pri_live_only: 12 } });
+    const body = eventBody();
+    const res = await post(deps, body, await signed(body));
+    expect(await res.json()).toMatchObject({ unprocessable: "unknown_price" });
+  });
+
+  it("GET 不被路由(只接受 POST)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/api/paddle/webhook`), deps);
+    expect(res.status).toBe(404);
+  });
+});

--- a/workers/scout-connect/src/paddle-webhook.test.ts
+++ b/workers/scout-connect/src/paddle-webhook.test.ts
@@ -175,15 +175,34 @@ describe("POST /api/paddle/webhook", () => {
 
   // reason 会被拼成审计 action(paddle.unprocessable.<reason>),
   // 与 unknown_price 混在一起会让告警指向错误的原因。
-  it("累加月数超范围 → 独立的 months_out_of_range,而非 unknown_price", async () => {
-    const { db, deps } = setup();
-    const body = eventBody({}, { items: [{ price: { id: YEAR_PRICE }, quantity: 11 }] });
+  it("白名单值超过 MAX_WEBHOOK_MONTHS → months_out_of_range(独立 reason)", async () => {
+    const { db, deps } = setup({ paddlePriceMonths: { pri_absurd: 36 } });
+    const body = eventBody({}, { items: [{ price: { id: "pri_absurd" }, quantity: 1 }] });
     const res = await post(deps, body, await signed(body));
     expect(await res.json()).toMatchObject({ unprocessable: "months_out_of_range" });
     const audits = await db.listAudits();
     expect(audits.some((a) => a.action === "paddle.unprocessable.months_out_of_range")).toBe(true);
     expect(audits.some((a) => a.action === "paddle.unprocessable.unknown_price")).toBe(false);
   });
+
+  // quantity>1 在更早一道防线被拦(bad_quantity),买 1 年拿 10 年的路径已封。
+  it("quantity=10 被 bad_quantity 拦下,不产生 120 个月", async () => {
+    const { db, deps } = setup();
+    const body = eventBody({}, { items: [{ price: { id: YEAR_PRICE }, quantity: 10 }] });
+    const res = await post(deps, body, await signed(body));
+    expect(await res.json()).toMatchObject({ unprocessable: "bad_quantity" });
+    expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
+  });
+
+  // JSON.parse("null") 返回 null → event.event_type 抛 TypeError → 500 → 无限重投。
+  it.each(['null', '123', '"str"', "[]", "true"])(
+    "非对象 JSON payload(%s)归到畸形分支而非 500",
+    async (raw) => {
+      const { deps } = setup();
+      const res = await post(deps, raw, await signed(raw));
+      expect(res.status, `raw=${raw}`).toBe(200);
+    },
+  );
 
   it("未知 price_id → 200 + 审计,不入账", async () => {
     const { db, deps } = setup();

--- a/workers/scout-connect/src/paddle-webhook.test.ts
+++ b/workers/scout-connect/src/paddle-webhook.test.ts
@@ -173,6 +173,18 @@ describe("POST /api/paddle/webhook", () => {
     expect(ents.length, "只应有一条时长").toBe(1);
   });
 
+  // reason 会被拼成审计 action(paddle.unprocessable.<reason>),
+  // 与 unknown_price 混在一起会让告警指向错误的原因。
+  it("累加月数超范围 → 独立的 months_out_of_range,而非 unknown_price", async () => {
+    const { db, deps } = setup();
+    const body = eventBody({}, { items: [{ price: { id: YEAR_PRICE }, quantity: 11 }] });
+    const res = await post(deps, body, await signed(body));
+    expect(await res.json()).toMatchObject({ unprocessable: "months_out_of_range" });
+    const audits = await db.listAudits();
+    expect(audits.some((a) => a.action === "paddle.unprocessable.months_out_of_range")).toBe(true);
+    expect(audits.some((a) => a.action === "paddle.unprocessable.unknown_price")).toBe(false);
+  });
+
   it("未知 price_id → 200 + 审计,不入账", async () => {
     const { db, deps } = setup();
     const body = eventBody({}, { items: [{ price: { id: "pri_fake" }, quantity: 1 }] });
@@ -215,17 +227,40 @@ describe("POST /api/paddle/webhook", () => {
     expect(await db.getAccountByEmail("buyer@example.com")).toBeNull();
   });
 
-  it("adjustment.created(退款)记审计并 200", async () => {
+  // 只记 event_id 的话,人工核查退款时无法关联到是哪一笔付款、退了多少。
+  it("adjustment.created(退款)审计里记全交易关联信息", async () => {
     const { db, deps } = setup();
     const body = JSON.stringify({
       event_id: "evt_adj",
       event_type: "adjustment.created",
-      data: { id: "adj_1", action: "refund", transaction_id: "txn_abc" },
+      data: {
+        id: "adj_1",
+        action: "refund",
+        transaction_id: "txn_abc",
+        customer_id: "ctm_9",
+      },
     });
     const res = await post(deps, body, await signed(body));
     expect(res.status).toBe(200);
-    const audits = await db.listAudits();
-    expect(audits.some((a) => a.action === "paddle.adjustment")).toBe(true);
+    const a = (await db.listAudits()).find((x) => x.action === "paddle.adjustment");
+    expect(a).toBeDefined();
+    const d = JSON.parse(a!.detail_json!) as Record<string, unknown>;
+    expect(d).toMatchObject({
+      event_id: "evt_adj",
+      adjustment_id: "adj_1",
+      transaction_id: "txn_abc",
+      adjustment_action: "refund",
+      customer_id: "ctm_9",
+    });
+  });
+
+  it("adjustment 缺字段时审计记 null 而不报错", async () => {
+    const { db, deps } = setup();
+    const body = JSON.stringify({ event_id: "e", event_type: "adjustment.created", data: {} });
+    expect((await post(deps, body, await signed(body))).status).toBe(200);
+    const a = (await db.listAudits()).find((x) => x.action === "paddle.adjustment");
+    const d = JSON.parse(a!.detail_json!) as Record<string, unknown>;
+    expect(d.transaction_id).toBeNull();
   });
 
   it("未订阅的事件类型礼貌 200,不入账", async () => {
@@ -240,10 +275,31 @@ describe("POST /api/paddle/webhook", () => {
     expect(await res.json()).toMatchObject({ ignored: "subscription.created" });
   });
 
-  it("验签通过但 JSON 畸形 → 200(重投也不会变好)", async () => {
-    const { deps } = setup();
+  // 200 是对的(重投也解析不出来),但必须留审计 —— 否则只会看到
+  // 「Paddle 说投递成功而我们没入账」却无从查起。
+  it("验签通过但 JSON 畸形 → 200 且留审计(唯一排障线索)", async () => {
+    const { db, deps } = setup();
     const body = "{not json";
     const res = await post(deps, body, await signed(body));
+    expect(res.status).toBe(200);
+    const audits = await db.listAudits();
+    const a = audits.find((x) => x.action === "paddle.unprocessable.malformed_json");
+    expect(a, "必须有审计").toBeDefined();
+    expect(a?.detail_json).toContain("bytes");
+  });
+
+  // 审计不可用时不能把请求变成 500 —— 那会触发对一个永远解析不了的 body 的
+  // 无限重投。
+  it("JSON 畸形且审计写入也失败时仍返回 200", async () => {
+    const { db, deps } = setup();
+    const noAudit: ConnectDb = {
+      ...db,
+      async insertAudit() {
+        throw new Error("audit table unavailable");
+      },
+    };
+    const body = "{not json";
+    const res = await post({ ...deps, db: noAudit }, body, await signed(body));
     expect(res.status).toBe(200);
   });
 

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -13,7 +13,7 @@ import { invitePage, type InvitePageState } from "./html/invite-page.js";
 import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
 import { CAPACITY_LIMIT, isAtCapacityError } from "./capacity.js";
 import { grantEntitlement } from "./grant.js";
-import { parseTransactionCompleted, type PriceMonthsMap } from "./paddle-event.js";
+import { isPriceMapConfigured, parseTransactionCompleted, type PriceMonthsMap } from "./paddle-event.js";
 import { isKnownPriceId, type PaddleApi } from "./paddle-api.js";
 import { verifyPaddleSignature } from "./paddle-signature.js";
 import { buyPage } from "./html/buy-page.js";
@@ -584,7 +584,9 @@ async function createCheckout(request: Request, deps: RouteDeps): Promise<Respon
   // 去结账。只放行白名单里的档位,与 webhook 共用同一份表。
   // 同 webhook:白名单未配置时不回落 sandbox。这里回落的后果是用户拿着 live
   // price_id 结账被判 400「未知档位」,而真正的问题是我方配置没同步。
-  if (deps.paddlePriceMonths === undefined) {
+  if (!isPriceMapConfigured(deps.paddlePriceMonths)) {
+    // 空表时返回 503 而非 400:400 会让用户以为自己选错了档位,而真正的问题
+    // 是我方白名单没同步。
     return json({ error: "checkout not configured" }, 503, { noStore: true });
   }
   if (!isKnownPriceId(priceId, deps.paddlePriceMonths)) {
@@ -757,11 +759,12 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
   // 回落的后果:live 上线后真实 price_id 被判 unknown_price → 返回 200
   // (不可重试)→ Paddle 停止重投 → 真实付款静默丢失。503 让它重投,等白名单
   // 配好后那些付款仍能入账 —— 把不可恢复的丢钱降级成可恢复的配置错误。
-  const priceMonths = deps.paddlePriceMonths;
-  if (priceMonths === undefined) {
+  // 空表也算未配置(见 isPriceMapConfigured):误注入 `{}` 会让每个真实 price_id
+  // 走 unknown_price → 200(不可重试)→ 静默丢钱。
+  if (!isPriceMapConfigured(deps.paddlePriceMonths)) {
     return json({ error: "price map not configured" }, 503, { noStore: true });
   }
-  const parsed = parseTransactionCompleted(event.data, priceMonths);
+  const parsed = parseTransactionCompleted(event.data, deps.paddlePriceMonths);
   if (!parsed.ok) {
     // 这类失败重投也不会变好(未知 price / 月数不一致 / 无邮箱),故 200。
     // 但必须留审计 —— 尤其 no_email:有人付了钱而系统不知道该给谁,要人工处理。

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -12,6 +12,9 @@ import { adminPage } from "./html/admin-page.js";
 import { invitePage, type InvitePageState } from "./html/invite-page.js";
 import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
 import { CAPACITY_LIMIT, isAtCapacityError } from "./capacity.js";
+import { grantEntitlement } from "./grant.js";
+import { parseTransactionCompleted, SANDBOX_PRICE_MONTHS, type PriceMonthsMap } from "./paddle-event.js";
+import { verifyPaddleSignature } from "./paddle-signature.js";
 import { buyPage } from "./html/buy-page.js";
 import { compliancePage, COMPLIANCE_PAGES, type CompliancePageKey } from "./html/compliance-page.js";
 import { RAW_ASSETS } from "./html/assets.gen.js";
@@ -48,6 +51,12 @@ export interface RouteDeps {
   // 「结账未开放」(见 buyPage),绝不白页。
   paddleClientToken?: string | undefined;
   paddleEnvironment?: string | undefined;
+  /** notification destination 的 endpoint secret(pdl_ntfset_ 前缀)。
+   *  **未配置时 webhook 一律 503**(fail closed):没有密钥就无法验签,
+   *  而无法验签的 webhook 绝不能当真 —— 那等于任何人都能凭空发时长。 */
+  paddleWebhookSecret?: string | undefined;
+  /** price_id → 月数白名单。默认 sandbox;live 上线时换成 live 的 id。 */
+  paddlePriceMonths?: PriceMonthsMap | undefined;
   turnstileSecret?: string | undefined;
   // P3: 魔法链接登录
   newAccountId: () => string;
@@ -206,6 +215,9 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
       return htmlPage(betaPage(turnstileSitekeyIfConfigured(deps)));
     }
     return htmlPage(homePage());
+  }
+  if (method === "POST" && path === "/api/paddle/webhook") {
+    return paddleWebhook(request, deps);
   }
   // /buy —— Paddle 的 default payment link 落地页(拼 ?_ptxn= 打开结账窗)。
   if (method === "GET" && path === "/buy") {
@@ -514,6 +526,129 @@ async function selfServeProvision(request: Request, deps: RouteDeps): Promise<Re
   }
 }
 
+/**
+ * `POST /api/paddle/webhook` —— Paddle 付款入账。
+ *
+ * 设计要点(每条都对应一种会真丢钱或真送钱的失败):
+ *
+ * 1. **fail closed**:未配置 secret → 503。绝不 200 —— 200 会让 Paddle 认为
+ *    投递成功并停止重试,而我们压根没入账,用户付了钱拿不到时长。503 会让它重投。
+ * 2. **验签用原始 body 文本**,不经 JSON.parse 再 stringify(那会改变字节)。
+ * 3. **幂等靠 DB**(entitlements 的 paddle_transaction_id 偏唯一索引),不靠
+ *    内存去重 —— worker 是无状态多实例的。
+ * 4. **解析失败一律留审计并返回 200**:这类事件重投一万次结果也一样(未知
+ *    price、月数不一致、拿不到邮箱),让 Paddle 无限重试只会淹掉日志。但
+ *    `no_email` 意味着**有人付了钱而系统不知道给谁**,必须人工介入,所以审计
+ *    里记全 transaction id。
+ * 5. **入账失败(DB 故障)返回 503**:那是可重试的,必须让 Paddle 重投。
+ */
+async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Response> {
+  const secret = deps.paddleWebhookSecret?.trim() ?? "";
+  if (secret === "") {
+    // 没密钥就无法验签。返回 503 而非 200:让 Paddle 重投,等我们配好密钥后
+    // 那些付款仍能入账。返回 200 会让它放弃重试 → 真丢钱。
+    return json({ error: "webhook not configured" }, 503, { noStore: true });
+  }
+
+  // 必须先拿原始文本:任何解析/重新序列化都会让签名失配。
+  const rawBody = await request.text();
+  const header = request.headers.get("paddle-signature") ?? "";
+  const ok = await verifyPaddleSignature({
+    rawBody,
+    header,
+    secret,
+    nowMs: Date.parse(deps.now()),
+  });
+  if (!ok) {
+    // 401 而非 400:这是身份问题。不回显原因(不给攻击者调试信息)。
+    return json({ error: "invalid signature" }, 401, { noStore: true });
+  }
+
+  let event: { event_type?: unknown; event_id?: unknown; data?: unknown };
+  try {
+    event = JSON.parse(rawBody) as typeof event;
+  } catch {
+    // 验签通过却不是合法 JSON —— 理论上不该发生。200 避免无意义重投。
+    return json({ ok: true, ignored: "malformed json" }, 200, { noStore: true });
+  }
+  const eventType = typeof event.event_type === "string" ? event.event_type : "";
+  const eventId = typeof event.event_id === "string" ? event.event_id : "";
+
+  // 退款/调整:释放资源。与到期路径一致 —— 退款是明确的「不要了」,若只删 DNS
+  // 而留着隧道,就会出现「退了款还占着容量配额」(与售罄闸门直接冲突)。
+  if (eventType === "adjustment.created") {
+    await deps.db.insertAudit({
+      id: deps.newAuditId(),
+      at: deps.now(),
+      actor: "paddle",
+      action: "paddle.adjustment",
+      invite_id: null,
+      endpoint_id: null,
+      detail_json: JSON.stringify({ event_id: eventId }),
+    });
+    // 实际停用在 PR-C3 的到期状态机里统一实现(它已有删 DNS + 删隧道的完整
+    // 补偿逻辑)。这里先记审计:漏记等于查不到为什么某人被停用。
+    return json({ ok: true, recorded: "adjustment" }, 200, { noStore: true });
+  }
+
+  if (eventType !== "transaction.completed") {
+    // 我们只订了两种事件;其它一律礼貌 200(可能是后台改了订阅项)。
+    return json({ ok: true, ignored: eventType }, 200, { noStore: true });
+  }
+
+  const parsed = parseTransactionCompleted(
+    event.data,
+    deps.paddlePriceMonths ?? SANDBOX_PRICE_MONTHS,
+  );
+  if (!parsed.ok) {
+    // 这类失败重投也不会变好(未知 price / 月数不一致 / 无邮箱),故 200。
+    // 但必须留审计 —— 尤其 no_email:有人付了钱而系统不知道该给谁,要人工处理。
+    await deps.db.insertAudit({
+      id: deps.newAuditId(),
+      at: deps.now(),
+      actor: "paddle",
+      action: `paddle.unprocessable.${parsed.reason}`,
+      invite_id: null,
+      endpoint_id: null,
+      detail_json: JSON.stringify({ event_id: eventId, detail: parsed.detail }),
+    });
+    return json({ ok: true, unprocessable: parsed.reason }, 200, { noStore: true });
+  }
+
+  try {
+    const r = await grantEntitlement(
+      {
+        email: parsed.grant.email,
+        months: parsed.grant.months,
+        source: parsed.grant.source,
+        paddleTransactionId: parsed.grant.transactionId,
+      },
+      deps,
+    );
+    await deps.db.insertAudit({
+      id: deps.newAuditId(),
+      at: deps.now(),
+      actor: "paddle",
+      action: r.applied ? "paddle.granted" : "paddle.replay",
+      invite_id: null,
+      endpoint_id: null,
+      detail_json: JSON.stringify({
+        event_id: eventId,
+        txn: parsed.grant.transactionId,
+        months: parsed.grant.months,
+        expires_at: r.expiresAt,
+      }),
+    });
+    return json({ ok: true, applied: r.applied, expires_at: r.expiresAt }, 200, {
+      noStore: true,
+    });
+  } catch {
+    // DB 故障是**可重试**的:必须 503 让 Paddle 重投,否则这笔付款永久丢失。
+    // 不回显内部错误文本。
+    return json({ error: "grant failed" }, 503, { noStore: true });
+  }
+}
+
 /** 登录用户为自己的 active endpoint 签发一个短期取件码。code 是 claim purpose
  *  的 signed-token,subject=endpointId,15 分钟过期,窗口内可重复用(脚本重试/
  *  换机器)。D1 零写入——过期由签名自带。 */
@@ -702,25 +837,14 @@ async function adminGrant(request: Request, deps: RouteDeps): Promise<Response> 
     ? body.source
     : "manual";
 
-  // account upsert
-  const account = await upsertAccount(email, deps);
-  // 从当前最新到期时刻叠加
-  const ents = await deps.db.listEntitlements(account.id);
-  let current: string | null = null;
-  for (const e of ents) {
-    if (current === null || Date.parse(e.expires_at) > Date.parse(current)) current = e.expires_at;
-  }
-  const expiresAt = computeExpiry({ currentExpiry: current, months, now: deps.now() });
-  await deps.db.insertEntitlement({
-    id: deps.newEntitlementId(),
-    account_id: account.id,
-    expires_at: expiresAt,
-    source,
-    paddle_transaction_id: null,
-    months,
-    created_at: deps.now(),
-  });
-  return json({ ok: true, account_id: account.id, expires_at: expiresAt });
+  // 与 Paddle webhook 共用同一套发放逻辑(grant.ts):续费叠加语义、账号 upsert
+  // 的竞态处理、幂等判定必须完全一致。此前这里手写了一遍「找最新到期」的 for
+  // 循环,而 entitlement.ts 早就有 latestExpiry() —— 两份实现迟早漂移。
+  const r = await grantEntitlement(
+    { email, months, source, paddleTransactionId: null },
+    deps,
+  );
+  return json({ ok: true, account_id: r.accountId, expires_at: r.expiresAt });
 }
 
 async function createInvite(request: Request, url: URL, deps: RouteDeps): Promise<Response> {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -13,7 +13,7 @@ import { invitePage, type InvitePageState } from "./html/invite-page.js";
 import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
 import { CAPACITY_LIMIT, isAtCapacityError } from "./capacity.js";
 import { grantEntitlement } from "./grant.js";
-import { parseTransactionCompleted, SANDBOX_PRICE_MONTHS, type PriceMonthsMap } from "./paddle-event.js";
+import { parseTransactionCompleted, type PriceMonthsMap } from "./paddle-event.js";
 import { isKnownPriceId, type PaddleApi } from "./paddle-api.js";
 import { verifyPaddleSignature } from "./paddle-signature.js";
 import { buyPage } from "./html/buy-page.js";
@@ -582,7 +582,12 @@ async function createCheckout(request: Request, deps: RouteDeps): Promise<Respon
   const priceId = optString(body.price_id) ?? "";
   // **绝不能让客户端随便传 price_id**:那等于允许任何人拿一个更便宜的 price
   // 去结账。只放行白名单里的档位,与 webhook 共用同一份表。
-  if (!isKnownPriceId(priceId, deps.paddlePriceMonths ?? SANDBOX_PRICE_MONTHS)) {
+  // 同 webhook:白名单未配置时不回落 sandbox。这里回落的后果是用户拿着 live
+  // price_id 结账被判 400「未知档位」,而真正的问题是我方配置没同步。
+  if (deps.paddlePriceMonths === undefined) {
+    return json({ error: "checkout not configured" }, 503, { noStore: true });
+  }
+  if (!isKnownPriceId(priceId, deps.paddlePriceMonths)) {
     throw new HttpError(400, "unknown price");
   }
 
@@ -748,10 +753,15 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
       ? new Date(occurredMs).toISOString()
       : deps.now();
 
-  const parsed = parseTransactionCompleted(
-    event.data,
-    deps.paddlePriceMonths ?? SANDBOX_PRICE_MONTHS,
-  );
+  // **白名单缺失必须 fail-closed(503),不能回落 sandbox。**
+  // 回落的后果:live 上线后真实 price_id 被判 unknown_price → 返回 200
+  // (不可重试)→ Paddle 停止重投 → 真实付款静默丢失。503 让它重投,等白名单
+  // 配好后那些付款仍能入账 —— 把不可恢复的丢钱降级成可恢复的配置错误。
+  const priceMonths = deps.paddlePriceMonths;
+  if (priceMonths === undefined) {
+    return json({ error: "price map not configured" }, 503, { noStore: true });
+  }
+  const parsed = parseTransactionCompleted(event.data, priceMonths);
   if (!parsed.ok) {
     // 这类失败重投也不会变好(未知 price / 月数不一致 / 无邮箱),故 200。
     // 但必须留审计 —— 尤其 no_email:有人付了钱而系统不知道该给谁,要人工处理。

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -101,6 +101,10 @@ export const MAX_JSON_BODY_BYTES = 8 * 1024;
  * 写的正是这个放大漏洞)。
  */
 export const MAX_WEBHOOK_BODY_BYTES = 128 * 1024;
+/** occurred_at 与当下的最大容许偏差。超出则回落 deps.now()。
+ *  7 天足够覆盖 Paddle 最长的重试退避,又不至于让一个离谱的 occurred_at
+ *  把到期时刻推到很远。 */
+export const OCCURRED_AT_MAX_SKEW_MS = 7 * 24 * 60 * 60_000;
 
 /**
  * Cheap pre-read rejection on the DECLARED size. Costs nothing and refuses the
@@ -604,7 +608,12 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
         invite_id: null,
         endpoint_id: null,
         // 只留长度与开头片段:body 可能含敏感字段,且不该把整个畸形串塞进审计。
-        detail_json: JSON.stringify({ bytes: rawBody.length, head: rawBody.slice(0, 120) }),
+        // 用 TextEncoder 数真实字节:rawBody.length 是 UTF-16 code units,
+        // 含非 ASCII 时会明显偏小,排障时按"bytes"读会被误导。
+        detail_json: JSON.stringify({
+          bytes: new TextEncoder().encode(rawBody).byteLength,
+          head: rawBody.slice(0, 120),
+        }),
       });
     } catch {
       // 审计不可用时静默继续:比让 Paddle 无限重投一个永远解析不了的 body 好。
@@ -650,6 +659,22 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
     return json({ ok: true, ignored: eventType }, 200, { noStore: true });
   }
 
+  // **时间基准用事件的 occurred_at,而非投递到达时刻。**
+  // Paddle 重试是指数退避,失败后可能几小时后才成功投递。若用 deps.now(),
+  // 一笔"到期前 1 分钟成交"的续费在延迟投递后会被当成"已过期 → 从当下重启",
+  // 用户白丢那段延迟的时长(实测:延迟 24h 就丢 24h)。
+  // occurred_at 不可信时(缺失/畸形/偏离当下过远)回落 now:宁可少给一点,
+  // 也不能让伪造的 occurred_at 把到期时刻推到很远的未来 —— 但注意 payload
+  // 已通过 HMAC 验签,这里主要防的是上游 bug 而非攻击。
+  const occurredRaw = typeof (event as { occurred_at?: unknown }).occurred_at === "string"
+    ? (event as { occurred_at: string }).occurred_at
+    : "";
+  const occurredMs = occurredRaw === "" ? NaN : Date.parse(occurredRaw);
+  const grantNow =
+    Number.isFinite(occurredMs) && Math.abs(occurredMs - nowMs) <= OCCURRED_AT_MAX_SKEW_MS
+      ? new Date(occurredMs).toISOString()
+      : deps.now();
+
   const parsed = parseTransactionCompleted(
     event.data,
     deps.paddlePriceMonths ?? SANDBOX_PRICE_MONTHS,
@@ -657,15 +682,21 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
   if (!parsed.ok) {
     // 这类失败重投也不会变好(未知 price / 月数不一致 / 无邮箱),故 200。
     // 但必须留审计 —— 尤其 no_email:有人付了钱而系统不知道该给谁,要人工处理。
-    await deps.db.insertAudit({
-      id: deps.newAuditId(),
-      at: deps.now(),
-      actor: "paddle",
-      action: `paddle.unprocessable.${parsed.reason}`,
-      invite_id: null,
-      endpoint_id: null,
-      detail_json: JSON.stringify({ event_id: eventId, detail: parsed.detail }),
-    });
+    // best-effort:审计写入若因 DB 故障抛错,会被 handleError 转成 500 → Paddle
+    // 无限重投一个永远处理不了的事件并淹掉日志,与本分支"重投也不会变好"相悖。
+    try {
+      await deps.db.insertAudit({
+        id: deps.newAuditId(),
+        at: deps.now(),
+        actor: "paddle",
+        action: `paddle.unprocessable.${parsed.reason}`,
+        invite_id: null,
+        endpoint_id: null,
+        detail_json: JSON.stringify({ event_id: eventId, detail: parsed.detail }),
+      });
+    } catch {
+      // 同上:审计不可用不该把"不可重试的失败"变成无限重投。
+    }
     return json({ ok: true, unprocessable: parsed.reason }, 200, { noStore: true });
   }
 
@@ -677,7 +708,8 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
         source: parsed.grant.source,
         paddleTransactionId: parsed.grant.transactionId,
       },
-      deps,
+      // 时间基准换成事件成交时刻(见上)。其余依赖不变。
+      { ...deps, now: () => grantNow },
     );
     await deps.db.insertAudit({
       id: deps.newAuditId(),

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -14,6 +14,7 @@ import { betaPage, normalizeTurnstileSitekey } from "./html/beta-page.js";
 import { CAPACITY_LIMIT, isAtCapacityError } from "./capacity.js";
 import { grantEntitlement } from "./grant.js";
 import { parseTransactionCompleted, SANDBOX_PRICE_MONTHS, type PriceMonthsMap } from "./paddle-event.js";
+import { isKnownPriceId, type PaddleApi } from "./paddle-api.js";
 import { verifyPaddleSignature } from "./paddle-signature.js";
 import { buyPage } from "./html/buy-page.js";
 import { compliancePage, COMPLIANCE_PAGES, type CompliancePageKey } from "./html/compliance-page.js";
@@ -57,6 +58,8 @@ export interface RouteDeps {
   paddleWebhookSecret?: string | undefined;
   /** price_id → 月数白名单。默认 sandbox;live 上线时换成 live 的 id。 */
   paddlePriceMonths?: PriceMonthsMap | undefined;
+  /** Paddle 服务端 API(创建交易)。未配置时 /api/checkout 返回 503。 */
+  paddleApi?: PaddleApi | undefined;
   turnstileSecret?: string | undefined;
   // P3: 魔法链接登录
   newAccountId: () => string;
@@ -238,6 +241,9 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   }
   if (method === "POST" && path === "/api/paddle/webhook") {
     return paddleWebhook(request, deps);
+  }
+  if (method === "POST" && path === "/api/checkout") {
+    return createCheckout(request, deps);
   }
   // /buy —— Paddle 的 default payment link 落地页(拼 ?_ptxn= 打开结账窗)。
   if (method === "GET" && path === "/buy") {
@@ -547,6 +553,59 @@ async function selfServeProvision(request: Request, deps: RouteDeps): Promise<Re
 }
 
 /**
+ * `POST /api/checkout` —— 登录用户发起购买。
+ *
+ * 由**我方**创建 Paddle 交易(而非让 Paddle 自己生成),因为只有这样才能写入
+ * `custom_data.account_email` —— webhook 唯一可靠的「这笔钱属于谁」的载体。
+ * 实测确认 transaction.completed 的 payload 里没有嵌套 customer 对象,
+ * 只有 customer_id;而 custom_data 会原样透传。
+ *
+ * 返回结账 URL,前端跳过去即可(Paddle 会拼上 ?_ptxn=)。
+ */
+async function createCheckout(request: Request, deps: RouteDeps): Promise<Response> {
+  const session = await parseSessionCookie(request.headers.get("cookie"), {
+    secret: deps.sessionSecret,
+    now: Date.parse(deps.now()),
+  });
+  if (!session.ok) throw new HttpError(401, "unauthorized");
+  const account = await deps.db.getAccountById(session.accountId);
+  if (account === null) throw new HttpError(401, "unauthorized");
+
+  const api = deps.paddleApi;
+  if (api === undefined) {
+    // 未配置 Paddle API key:结账尚未开放。503 而非 500 —— 这是配置缺失,
+    // 不是代码故障,且配好之后同样的请求就能成功。
+    return json({ error: "checkout not configured" }, 503, { noStore: true });
+  }
+
+  const body = await readJsonBody(request);
+  const priceId = optString(body.price_id) ?? "";
+  // **绝不能让客户端随便传 price_id**:那等于允许任何人拿一个更便宜的 price
+  // 去结账。只放行白名单里的档位,与 webhook 共用同一份表。
+  if (!isKnownPriceId(priceId, deps.paddlePriceMonths ?? SANDBOX_PRICE_MONTHS)) {
+    throw new HttpError(400, "unknown price");
+  }
+
+  try {
+    const result = await api.createTransaction({
+      priceId,
+      // 用**登录账号**的邮箱,不是用户可填的输入:时长必须落在他登录的账号上
+      // (他可能用公司卡/家人的卡付款)。
+      accountEmail: account.email,
+      checkoutUrl: `${new URL(request.url).origin}/buy`,
+    });
+    return json(
+      { checkout_url: result.checkoutUrl, transaction_id: result.transactionId },
+      200,
+      { noStore: true },
+    );
+  } catch {
+    // 不回显 Paddle 的响应内容。502:上游失败,可重试。
+    return json({ error: "checkout unavailable" }, 502, { noStore: true });
+  }
+}
+
+/**
  * `POST /api/paddle/webhook` —— Paddle 付款入账。
  *
  * 设计要点(每条都对应一种会真丢钱或真送钱的失败):
@@ -593,7 +652,14 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
 
   let event: { event_type?: unknown; event_id?: unknown; data?: unknown };
   try {
-    event = JSON.parse(rawBody) as typeof event;
+    const decoded: unknown = JSON.parse(rawBody);
+    // **必须查 null 与非对象**:JSON.parse("null") 成功返回 null,随后
+    // `event.event_type` 抛 TypeError → 500 → Paddle 无限重投一个永远处理不了
+    // 的 body(实测复现)。"123"/'"s"'/[]/true 走这里也一并归到畸形分支。
+    if (typeof decoded !== "object" || decoded === null || Array.isArray(decoded)) {
+      throw new Error("payload is not a JSON object");
+    }
+    event = decoded as typeof event;
   } catch {
     // 验签通过却不是合法 JSON —— 理论上不该发生(说明上游异常或传输损坏)。
     // 200 避免无意义重投,但**必须留审计**:这是唯一的排障线索,否则只会看到

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -484,11 +484,21 @@ async function requestMagicLink(request: Request, deps: RouteDeps): Promise<Resp
  *  provisionEndpoint 内)→ slug 查重;402/409 级失败绝不烧 CF API 调用
  *  (门禁都在 CF 编排之前)。响应绝不含 token:接入唯一路径是控制台取件码
  *  (决策 #10/#12)。 */
+/** 解析 session cookie,若 deps.now() 畸形则 fail-closed 而不是伪装成"未登录"。
+ *  早先多处裸写 `Date.parse(deps.now())`:now 坏值 → NaN → session 总被判无效 →
+ *  401 误导排障,以为用户没登录而真正的问题是服务器时钟。
+ *  现在一处守卫,四处复用,与别处「non-finite now 视为过期」的守卫契约一致。 */
+async function parseSessionWithValidatedNow(
+  cookie: string | null,
+  deps: Pick<RouteDeps, "sessionSecret" | "now">,
+): Promise<{ ok: false } | { ok: true; accountId: string }> {
+  const nowMs = Date.parse(deps.now());
+  if (!Number.isFinite(nowMs)) throw new HttpError(500, "server time unavailable");
+  return parseSessionCookie(cookie, { secret: deps.sessionSecret, now: nowMs });
+}
+
 async function selfServeProvision(request: Request, deps: RouteDeps): Promise<Response> {
-  const session = await parseSessionCookie(request.headers.get("cookie"), {
-    secret: deps.sessionSecret,
-    now: Date.parse(deps.now()),
-  });
+  const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
   if (!session.ok) throw new HttpError(401, "unauthorized");
   const body = await readJsonBody(request);
   const slugRaw = optString(body.slug);
@@ -563,10 +573,7 @@ async function selfServeProvision(request: Request, deps: RouteDeps): Promise<Re
  * 返回结账 URL,前端跳过去即可(Paddle 会拼上 ?_ptxn=)。
  */
 async function createCheckout(request: Request, deps: RouteDeps): Promise<Response> {
-  const session = await parseSessionCookie(request.headers.get("cookie"), {
-    secret: deps.sessionSecret,
-    now: Date.parse(deps.now()),
-  });
+  const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
   if (!session.ok) throw new HttpError(401, "unauthorized");
   const account = await deps.db.getAccountById(session.accountId);
   if (account === null) throw new HttpError(401, "unauthorized");
@@ -889,10 +896,7 @@ async function exchangeClaimCode(request: Request, deps: RouteDeps): Promise<Res
 
 /** slug 实时查重 + 相似推荐(登录后选 slug 用)。需 session。 */
 async function slugCheckRoute(url: URL, request: Request, deps: RouteDeps): Promise<Response> {
-  const session = await parseSessionCookie(request.headers.get("cookie"), {
-    secret: deps.sessionSecret,
-    now: Date.parse(deps.now()),
-  });
+  const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
   if (!session.ok) throw new HttpError(401, "unauthorized");
   const slug = url.searchParams.get("s") ?? "";
   // 占用判定查所有状态的行(含 revoked/purged):slug 永久保留不释放(决策 #9)。
@@ -959,10 +963,7 @@ async function magicCallback(url: URL, deps: RouteDeps): Promise<Response> {
 }
 
 async function consoleRoute(request: Request, deps: RouteDeps): Promise<Response> {
-  const session = await parseSessionCookie(request.headers.get("cookie"), {
-    secret: deps.sessionSecret,
-    now: Date.parse(deps.now()),
-  });
+  const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
   if (!session.ok) {
     return new Response(null, { status: 302, headers: { location: "/login" } });
   }

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -634,21 +634,28 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
         ? (event.data as { id?: unknown; transaction_id?: unknown; action?: unknown; customer_id?: unknown })
         : {};
     const pick = (v: unknown): string | null => (typeof v === "string" ? v : null);
-    await deps.db.insertAudit({
-      id: deps.newAuditId(),
-      at: deps.now(),
-      actor: "paddle",
-      action: "paddle.adjustment",
-      invite_id: null,
-      endpoint_id: null,
-      detail_json: JSON.stringify({
-        event_id: eventId,
-        adjustment_id: pick(adj.id),
-        transaction_id: pick(adj.transaction_id),
-        adjustment_action: pick(adj.action),
-        customer_id: pick(adj.customer_id),
-      }),
-    });
+    try {
+      await deps.db.insertAudit({
+        id: deps.newAuditId(),
+        at: deps.now(),
+        actor: "paddle",
+        action: "paddle.adjustment",
+        invite_id: null,
+        endpoint_id: null,
+        detail_json: JSON.stringify({
+          event_id: eventId,
+          adjustment_id: pick(adj.id),
+          transaction_id: pick(adj.transaction_id),
+          adjustment_action: pick(adj.action),
+          customer_id: pick(adj.customer_id),
+        }),
+      });
+    } catch {
+      // 与不可重试的解析失败不同:退款事件本身是**可处理**的,只是暂时写不进
+      // 审计。503 让 Paddle 重投(而不是变成 unhandled 500) —— 退款审计是后续
+      // 停用处置的唯一依据,丢了就查不到某人为什么被停。
+      return json({ error: "temporarily unavailable" }, 503, { noStore: true });
+    }
     // 实际停用在 PR-C3 的到期状态机里统一实现(它已有删 DNS + 删隧道的完整
     // 补偿逻辑)。这里先记审计:漏记等于查不到为什么某人被停用。
     return json({ ok: true, recorded: "adjustment" }, 200, { noStore: true });
@@ -700,8 +707,12 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
     return json({ ok: true, unprocessable: parsed.reason }, 200, { noStore: true });
   }
 
+  // 入账与审计**分开 try**:早先共用一个 catch,导致审计失败也报 "grant failed"
+  // 误导排障;更要紧的是入账已成功时若因审计失败返回 503,Paddle 会重投 ——
+  // 虽然幂等能挡住重复入账,但语义是错的(明明成功了却说失败)。
+  let granted;
   try {
-    const r = await grantEntitlement(
+    granted = await grantEntitlement(
       {
         email: parsed.grant.email,
         months: parsed.grant.months,
@@ -711,28 +722,35 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
       // 时间基准换成事件成交时刻(见上)。其余依赖不变。
       { ...deps, now: () => grantNow },
     );
+  } catch {
+    // 入账失败是**可重试**的:必须 503 让 Paddle 重投,否则这笔付款永久丢失。
+    // 不回显内部错误文本。
+    return json({ error: "grant failed" }, 503, { noStore: true });
+  }
+
+  // 到这里钱已经变成时长了。审计写不进去是遗憾但不该推翻既成事实 ——
+  // best-effort,失败也返回 200(否则重投会让日志里出现一堆"重复"记录)。
+  try {
     await deps.db.insertAudit({
       id: deps.newAuditId(),
       at: deps.now(),
       actor: "paddle",
-      action: r.applied ? "paddle.granted" : "paddle.replay",
+      action: granted.applied ? "paddle.granted" : "paddle.replay",
       invite_id: null,
       endpoint_id: null,
       detail_json: JSON.stringify({
         event_id: eventId,
         txn: parsed.grant.transactionId,
         months: parsed.grant.months,
-        expires_at: r.expiresAt,
+        expires_at: granted.expiresAt,
       }),
     });
-    return json({ ok: true, applied: r.applied, expires_at: r.expiresAt }, 200, {
-      noStore: true,
-    });
   } catch {
-    // DB 故障是**可重试**的:必须 503 让 Paddle 重投,否则这笔付款永久丢失。
-    // 不回显内部错误文本。
-    return json({ error: "grant failed" }, 503, { noStore: true });
+    // 入账已成功,不因审计失败而让 Paddle 重投。
   }
+  return json({ ok: true, applied: granted.applied, expires_at: granted.expiresAt }, 200, {
+    noStore: true,
+  });
 }
 
 /** 登录用户为自己的 active endpoint 签发一个短期取件码。code 是 claim purpose

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -91,6 +91,16 @@ export async function handleRequest(request: Request, deps: RouteDeps): Promise<
  * degrades provisioning and revocation, not just the waitlist.
  */
 export const MAX_JSON_BODY_BYTES = 8 * 1024;
+/**
+ * Paddle webhook 的 body 上限,比普通 API 请求宽。
+ *
+ * 真实 transaction.completed payload 粗估约 2KB,但含 receipt_data、payments
+ * 数组、多 line_items 时会明显更大。**上限设太紧会拒掉真实付款通知 —— 那是
+ * 直接丢钱**,所以留足余量。仍然要有上限:webhook 端点公开可打,裸
+ * request.text() 会把 500MB body 全缓存进内存(readBodyTextCapped 的注释里
+ * 写的正是这个放大漏洞)。
+ */
+export const MAX_WEBHOOK_BODY_BYTES = 128 * 1024;
 
 /**
  * Cheap pre-read rejection on the DECLARED size. Costs nothing and refuses the
@@ -98,13 +108,16 @@ export const MAX_JSON_BODY_BYTES = 8 * 1024;
  * because Content-Length is absent under chunked encoding and is attacker-
  * controlled besides. readBodyTextCapped() enforces the real limit.
  */
-function assertDeclaredSizeWithinCap(request: Request): void {
+function assertDeclaredSizeWithinCap(
+  request: Request,
+  cap: number = MAX_JSON_BODY_BYTES,
+): void {
   const declared = request.headers.get("content-length");
   if (declared === null) {
     return;
   }
   const bytes = Number(declared);
-  if (Number.isFinite(bytes) && bytes > MAX_JSON_BODY_BYTES) {
+  if (Number.isFinite(bytes) && bytes > cap) {
     throw new HttpError(413, "body too large");
   }
 }
@@ -120,7 +133,10 @@ function assertDeclaredSizeWithinCap(request: Request): void {
  * code units, so a multibyte payload is up to 3x larger than a post-decode
  * length check would suggest.
  */
-async function readBodyTextCapped(request: Request): Promise<string> {
+async function readBodyTextCapped(
+  request: Request,
+  cap: number = MAX_JSON_BODY_BYTES,
+): Promise<string> {
   const body = request.body;
   if (body === null) {
     return "";
@@ -138,7 +154,7 @@ async function readBodyTextCapped(request: Request): Promise<string> {
         continue;
       }
       total += value.byteLength;
-      if (total > MAX_JSON_BODY_BYTES) {
+      if (total > cap) {
         await reader.cancel();
         throw new HttpError(413, "body too large");
       }
@@ -550,15 +566,22 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
     return json({ error: "webhook not configured" }, 503, { noStore: true });
   }
 
-  // 必须先拿原始文本:任何解析/重新序列化都会让签名失配。
-  const rawBody = await request.text();
+  // body 上限:webhook 端点公开可打,裸 request.text() 会把超大 body 全缓存进
+  // 内存(readBodyTextCapped 的注释写的正是这个放大漏洞)。两道防线都用 webhook
+  // 专用的宽上限 —— 设太紧会拒掉真实付款通知,那是直接丢钱。
+  assertDeclaredSizeWithinCap(request, MAX_WEBHOOK_BODY_BYTES);
+  // 必须拿**原始**文本:任何解析/重新序列化都会让签名失配。
+  const rawBody = await readBodyTextCapped(request, MAX_WEBHOOK_BODY_BYTES);
   const header = request.headers.get("paddle-signature") ?? "";
-  const ok = await verifyPaddleSignature({
-    rawBody,
-    header,
-    secret,
-    nowMs: Date.parse(deps.now()),
-  });
+  // now 只取一次并卡 finite:Date.parse 坏值会得 NaN,而
+  // `Math.abs(NaN - x) > tolerance` 恒为 false —— 时间窗会被静默绕过。
+  // verifyPaddleSignature 内部也有这道守卫(双层),这里提前失败以免白算 HMAC。
+  const nowMs = Date.parse(deps.now());
+  if (!Number.isFinite(nowMs)) {
+    // 时钟坏了是我方故障且可重试 → 503 让 Paddle 重投。
+    return json({ error: "clock unavailable" }, 503, { noStore: true });
+  }
+  const ok = await verifyPaddleSignature({ rawBody, header, secret, nowMs });
   if (!ok) {
     // 401 而非 400:这是身份问题。不回显原因(不给攻击者调试信息)。
     return json({ error: "invalid signature" }, 401, { noStore: true });

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -591,7 +591,24 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
   try {
     event = JSON.parse(rawBody) as typeof event;
   } catch {
-    // 验签通过却不是合法 JSON —— 理论上不该发生。200 避免无意义重投。
+    // 验签通过却不是合法 JSON —— 理论上不该发生(说明上游异常或传输损坏)。
+    // 200 避免无意义重投,但**必须留审计**:这是唯一的排障线索,否则只会看到
+    // 「Paddle 说投递成功而我们没入账」却无从查起。
+    // best-effort:审计写失败也不能让这个请求变 500(那会触发无意义重投)。
+    try {
+      await deps.db.insertAudit({
+        id: deps.newAuditId(),
+        at: deps.now(),
+        actor: "paddle",
+        action: "paddle.unprocessable.malformed_json",
+        invite_id: null,
+        endpoint_id: null,
+        // 只留长度与开头片段:body 可能含敏感字段,且不该把整个畸形串塞进审计。
+        detail_json: JSON.stringify({ bytes: rawBody.length, head: rawBody.slice(0, 120) }),
+      });
+    } catch {
+      // 审计不可用时静默继续:比让 Paddle 无限重投一个永远解析不了的 body 好。
+    }
     return json({ ok: true, ignored: "malformed json" }, 200, { noStore: true });
   }
   const eventType = typeof event.event_type === "string" ? event.event_type : "";
@@ -600,6 +617,14 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
   // 退款/调整:释放资源。与到期路径一致 —— 退款是明确的「不要了」,若只删 DNS
   // 而留着隧道,就会出现「退了款还占着容量配额」(与售罄闸门直接冲突)。
   if (eventType === "adjustment.created") {
+    // 审计必须能对应到**具体交易**:只记 event_id 的话,人工核查退款时无从
+    // 关联到是哪一笔付款、退的是全额还是部分。adjustment 的 action 字段
+    // (refund/chargeback/credit...)也决定后续处置是否相同。
+    const adj =
+      typeof event.data === "object" && event.data !== null
+        ? (event.data as { id?: unknown; transaction_id?: unknown; action?: unknown; customer_id?: unknown })
+        : {};
+    const pick = (v: unknown): string | null => (typeof v === "string" ? v : null);
     await deps.db.insertAudit({
       id: deps.newAuditId(),
       at: deps.now(),
@@ -607,7 +632,13 @@ async function paddleWebhook(request: Request, deps: RouteDeps): Promise<Respons
       action: "paddle.adjustment",
       invite_id: null,
       endpoint_id: null,
-      detail_json: JSON.stringify({ event_id: eventId }),
+      detail_json: JSON.stringify({
+        event_id: eventId,
+        adjustment_id: pick(adj.id),
+        transaction_id: pick(adj.transaction_id),
+        adjustment_action: pick(adj.action),
+        customer_id: pick(adj.customer_id),
+      }),
     });
     // 实际停用在 PR-C3 的到期状态机里统一实现(它已有删 DNS + 删隧道的完整
     // 补偿逻辑)。这里先记审计:漏记等于查不到为什么某人被停用。


### PR DESCRIPTION
PR-C2。此前唯一入账途径是 admin 手工 `POST /api/admin/grant` —— 用户付款**不会**变成时长。

## Sandbox 已按预付时长制重建（实测，非文档臆测）

归档 3 个订阅价（月付¥19 / 年¥199 / 创始¥149）。它们带 `billing_cycle` 会**自动续费**，与条款明写的「预付时长、不自动扣款」直接矛盾——这正是 Paddle 最忌的「网站描述与实际销售不符」。

新建 4 个 one-time price（`billing_cycle: null` 逐个确认）：

| 档位 | 金额 | months |
|---|---|---|
| 季度 | `4500` = ¥45 | 3 |
| 年度 | `10800` = ¥108 | 12 |
| 两年 | `18800` = ¥188 | 24 |
| 创始价 | `8800` = ¥88 | 12 |

`quantity` 上限设为 1（一人一实例，不该能买多份）。产品改名 `Mediary Connect 远程访问`，`tax_category` 保持 `saas`。

**实测确认的四件事**：
- `total = "10800"` → 分为单位换算正确
- `price.custom_data.months` 会出现在交易 payload 里，可做交叉校验
- `custom_data.account_email` 可透传 —— 这是把付款关联到**登录账号**的钩子
- **显式传 `checkout.url` 确实覆盖 default**（default 仍是 `agentmentor.dev`，一动没动）。所以「两个产品各传自己的域名、default 永不生效」这条路走通了，Agent Mentor 完全不受影响

webhook payload 形状从 sandbox 真实通知取得，验签与解析按真结构写。

## grantEntitlement 抽取

与 admin 路径共用。抽出的理由不只是去重——**续费叠加语义、账号 upsert 的竞态处理、幂等判定必须完全一致**。此前 `adminGrant` 里还手写了一遍「找最新到期」的 for 循环，而 `entitlement.ts` 早就有 `latestExpiry()`。

幂等命中时**回读**真实到期时刻，而不是返回「假设本次入账」算出的值——那个值比实际多一个周期，控制台就会显示比真实更长的有效期。

## 验签

手写 WebCrypto：官方 `@paddle/paddle-node-sdk` 的 `webhooks.unmarshal` 依赖 `node:crypto`，Workers 运行时没有。

签名对象是 **`{ts}:{raw_body}`** —— 漏掉 `ts:` 前缀是最常见的实现错误（HMAC 代码完全正确但签名永远对不上）。常量时间比较；支持多个 `h1`（密钥轮换期）；raw body 绝不解析后再验签。

**时间窗放 5 分钟**而非官方 SDK 默认的 5 秒：worker 冷启动加 CF 边缘排队有秒级延迟，5 秒太紧会误拒真实投递——而误拒意味着用户付了钱拿不到时长。5 分钟对重放攻击仍足够窄。

## 月数解析：白名单为权威

`price_id → 月数`**代码白名单是权威**，`custom_data.months` 仅做交叉校验。

- 白名单防「后台被改 / 被入侵凭空多发时长」（后台权限与代码权限是两套）
- 交叉校验抓「后台改了价而代码忘了同步」
- 两者不一致 → 拒绝 + 审计，比静默按其中一个执行安全

## HTTP 语义（每条都对应一种会真丢钱或真送钱的失败）

| 情形 | 响应 | 为什么 |
|---|---|---|
| 未配密钥 | **503** | 200 会让 Paddle 停止重试而我们压根没入账，**用户付的钱就丢了**；503 让它重投，等配好密钥后仍能入账 |
| 验签失败 | 401 | 身份问题，不回显原因 |
| 未知 price / 月数不一致 / 无邮箱 | 200 + 审计 | 重投一万次结果一样，无限重试只会淹掉日志 |
| DB 故障 | **503** | 可重试，否则这笔付款永久丢失 |

`no_email` 特别处理：意味着**有人付了钱而系统不知道该给谁**，审计里记全 transaction id 供人工介入，绝不静默丢弃。

## 测试

+8（grant）+19（签名）+25（事件解析）+20（webhook 路由）。

**TDD 抓到实现的真缺陷**：`months: 999` 原本被 `readMonthsFromCustomData` 的范围检查静默过滤成 `null`，交叉校验直接跳过——而 999 恰恰是最该报警的情形。**「没声明」与「声明了但对不上」必须区分**，范围检查移到累加之后统一做。

反向验证两处：未配密钥改 200 → 3 例转红；验签用重新序列化的 body → 2 例转红。

**2505 测试全绿，三处 tsc + `build:web` 全过。**

## 部署注记

`PADDLE_WEBHOOK_SECRET` 是 **wrangler secret**（不是 vars）—— 它是验签密钥，泄露等于任何人都能凭空发时长。未配置时 webhook 一律 503，所以**先合并部署、再配 secret** 是安全的。

`adjustment.created`（退款）本 PR 只记审计；实际停用在 PR-C3 的到期状态机里统一实现（那里已有删 DNS + 删隧道的完整补偿逻辑）。