### PR TITLE
fix(seo): HEAD content-type + robots/sitemap 接管 + beta noindex + 三站互链

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -20,6 +20,10 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         {isDemoMode() ? (
           <div className="demo-banner">
             🔭 只读演示 · 数据为示例 · 不执行真实获取 ·{" "}
+            {/* 回链主站:demo 站已被 Google 索引却零回链,权重完全没回流。
+                锚文本用「官网」是刻意的 —— 两站都叫 Mediary Scout,这个词
+                帮搜索引擎判断哪个域名是主实体,消除实体混淆。 */}
+            <a href="https://mediaryscout.app">Mediary Scout 官网</a> ·{" "}
             <a href="https://github.com/fancydirty/mediary-scout" target="_blank" rel="noreferrer">
               想真用 → GitHub 自部署
             </a>

--- a/docs/cf-tunnel-resale-permission-email.md
+++ b/docs/cf-tunnel-resale-permission-email.md
@@ -1,0 +1,106 @@
+# 给 Cloudflare 的隧道转售书面许可申请邮件（草稿）
+
+发送对象建议：Cloudflare Sales / Partnerships（不是 support ticket——ticket 只会
+回「请查阅 self-serve ToS」，拿不到书面许可）。入口：
+- https://www.cloudflare.com/plans/enterprise/contact/ （表单，选 Partnership）
+- 或已有客户经理时直接回信给他
+
+主题（英文更容易转到对的团队）：
+
+Request for written permission: reselling Cloudflare Tunnel as part of a paid
+self-hosted product (Mediary Connect)
+
+---
+
+## 正文（英文，可直接发）
+
+Hello Cloudflare team,
+
+I operate a small software product and I would like to obtain written
+confirmation about an intended use of Cloudflare Tunnel before I start charging
+customers, rather than after.
+
+**What the product is**
+
+Mediary Scout is a self-hosted media-acquisition agent that users run on their
+own hardware (typically a home NAS or a small router-class Linux box). It is
+free and open to self-host.
+
+I am launching a paid add-on called Mediary Connect. Its only function is to
+give a self-hosted instance a stable public HTTPS address so the owner can
+reach *their own* instance from outside their home network, without opening
+router ports or configuring dynamic DNS.
+
+**How Cloudflare is involved**
+
+- Each paying customer's instance gets its own Cloudflare Tunnel, created via
+  the Cloudflare API under **my** Cloudflare account.
+- Each tunnel is bound to one hostname on a domain I own
+  (`<customer-slug>.mediaryconnect.app`).
+- The tunnel connector (`cloudflared`) runs on the customer's own machine.
+- Traffic is HTTP to the customer's own instance, plus optionally SSH to the
+  same machine for maintenance.
+- Customers do not get Cloudflare accounts, Cloudflare dashboard access, or
+  Cloudflare API credentials. They never interact with Cloudflare directly.
+- I charge for prepaid time (roughly USD 6 per quarter to USD 26 for two
+  years), and the fee covers the whole product experience, not Cloudflare
+  capacity as a metered line item.
+
+**Why I am asking**
+
+I am aware that the self-serve Terms restrict reselling or providing
+Cloudflare services to third parties, and that Section 2.8 of the Self-Serve
+Subscription Terms addresses serving non-HTML content and reselling. I do not
+want to interpret this in my own favour and discover later that I built a paid
+business on a prohibited pattern.
+
+**My specific questions**
+
+1. Does the arrangement above constitute "reselling" Cloudflare services under
+   my current self-serve plan?
+2. If it does, what is the correct path to make it compliant — a specific plan,
+   a partner or reseller agreement, or Enterprise terms?
+3. Is there a limit on the number of tunnels or DNS records per account that I
+   should design against? I currently assume approximately 1,000 tunnels per
+   account and have implemented a hard capacity gate so that I never sell
+   capacity I cannot deliver.
+4. If this is permitted, may I have that confirmation in writing so I can keep
+   it on file?
+
+**Current scale and intent**
+
+I have not sold anything yet. I have one instance running (my own) and one
+person on the waiting list. I am deliberately asking before taking any
+payments. If the answer is that this requires different terms, I would rather
+sign the correct agreement than proceed and be shut off later — my customers
+would lose access to their own machines, which is exactly the outcome I want to
+avoid.
+
+Happy to provide architecture details, the provisioning code path, or a demo.
+
+Thank you for your time.
+
+Best regards,
+<你的名字>
+DF Digital
+<你的邮箱>
+mediaryconnect.app
+
+---
+
+## 给 Codex 的交付说明（你转发时附上）
+
+这封邮件的**目的不是拿到「可以」**，而是拿到一个**有据可依的答复**。三种结果都算成功：
+1. 「允许」+ 书面确认 → 存档，可以正式收钱。
+2. 「需要 Enterprise / Partner 协议」→ 知道确切代价，再决定商业模式是否成立。
+3. 「不允许」→ **在收钱之前**知道，避免给付费用户断网。
+
+关键事实（别改错）：
+- 隧道建在**我们**的 CF 账号下，不是客户的账号。
+- 客户拿不到任何 CF 凭证或后台权限。
+- 收的是「预付时长」的产品费，**不是**按 CF 流量/容量计费的转卖。
+- 容量闸门已实现（PR #201），假设上限约 1000 隧道/账号。
+- 目前**零销售**，1 个 waitlist 报名，是在收钱前主动问的。
+
+语气要点：主动合规、不装不懂、给对方容易回答的封闭式问题（4 条编号问题）。
+不要写成「我已经在做了，你们看着办」——那容易直接触发封号审查。

--- a/docs/seo-interlink-findings.md
+++ b/docs/seo-interlink-findings.md
@@ -1,0 +1,143 @@
+# 三站互链 / SEO / 隐私防护 —— 已实测的发现与待办
+
+日期 2026-07-30。以下每条都由我亲自 curl 实证，不是子代理转述。
+
+## 🔴 P0 隐私风险（已实证，未修复）
+
+**用户私有实例子域完全没有 noindex 防护。**
+
+实测 `https://dirtyfancy.mediaryconnect.app/`：
+- `X-Robots-Tag` 响应头：**无**
+- `<meta name="robots">`：**无**
+- `/robots.txt`：**307 跳转到 /login** —— 爬虫拿不到任何 robots 指令
+
+后果：每个付费用户的私有实例都可能被 Google 索引。slug 是用户自选（可能含真名），
+被索引即隐私事件，且移除有滞后、信任损失不可逆。
+
+**关键认知（Google 官方）**：`robots.txt` 的 `Disallow: /` **不能**阻止索引 ——
+被屏蔽的 URL 仍可能因外链被索引，只是显示无描述；而且屏蔽后爬虫**读不到** noindex。
+所以 slug 主机上**绝对不要** `Disallow: /`，必须是「允许抓取 + noindex」。
+来源 https://developers.google.com/search/docs/crawling-indexing/block-indexing
+
+### 为什么我修不了（已查证）
+`wrangler.jsonc` 的 routes 只挂 `mediaryconnect.app` + `beta.mediaryconnect.app`，
+**slug 子域流量直接进 Cloudflare 隧道、不经过 worker**，所以 worker 代码加不了这个头。
+
+且 `token.txt` 第 17 行的 provisioner token（键名 `scout-connect-provisioner-token`，
+注意键名带连字符，用 `awk -F= 'NR==17{print substr($0,index($0,"=")+1)}'` 取，
+`sed 's/^[A-Z_]*=//'` 取不到）**只有 Tunnel + DNS 权限，没有 Zone Rules 权限** ——
+读 `http_response_headers_transform` entrypoint 返回 `Authentication error`。
+
+### 两条修复路径（择一或都做）
+
+**路径 A（推荐，边缘生效，不依赖用户升级）** —— 需用户在 CF 后台操作，
+或给一个带 `Zone > Config Rules / Transform Rules > Edit` 权限的 token。
+
+zone `mediaryconnect.app` (`d2680d74d4f6c2d555f07b149338d10c`)
+→ Rules → Transform Rules → Modify Response Header → Create rule
+
+表达式（排除营销主机，其余全部命中）:
+```
+(http.host wildcard "*.mediaryconnect.app")
+and not (http.host in {"mediaryconnect.app" "www.mediaryconnect.app" "beta.mediaryconnect.app"})
+```
+动作: Set static → `X-Robots-Tag` = `noindex, nofollow, noarchive, nosnippet`
+
+优点:对所有 slug 主机、所有响应(HTML/JSON/静态/登录页/错误页)统一加头,
+**与用户跑的 Scout 版本无关** —— 旧镜像也受保护。
+
+**路径 B（补充，需用户升级镜像）** —— `apps/web` 对所有响应加
+`X-Robots-Tag: noindex, nofollow`。与 A 重复是有意的:A 可能被误删或表达式写错,
+B 是第二道;且 B 能保护「用户自带域名裸奔部署」(那时没有我们的 CF zone 兜底)。
+
+### 验收（没跑过不算做完）
+```bash
+curl -sSI https://dirtyfancy.mediaryconnect.app/ | grep -i x-robots-tag
+# 期望: x-robots-tag: noindex, nofollow, noarchive, nosnippet
+```
+
+### 附带风险提示
+若用 CF for SaaS 逐主机签证书,每个 slug 会**公开出现在 CT 日志**(crt.sh 可查)。
+通配证书则不会。若 slug 由用户自选可能含个人信息,文案应提示「slug 会公开可查,别用真名」。
+
+---
+
+## 🟠 P1 已实证的其他问题
+
+**① 主站唯一的 Connect 链接指向 beta,不是 apex(权重灌错地方)**
+实测 `mediaryscout.app` 里 `href="https://beta.mediaryconnect.app"` × 1,
+指向 apex 的 **0 条**。而 beta 是应该 noindex 的报名表单页。
+→ 改指 apex(正文句内锚文本带品牌+关系语义),beta 那条加 `rel="nofollow"`。
+
+**② apex 的 HEAD 请求返回 JSON(真 bug)**
+```
+HEAD https://mediaryconnect.app/ → content-type: application/json; charset=utf-8
+GET  https://mediaryconnect.app/ → content-type: text/html; charset=utf-8
+```
+Worker 的 HEAD 路径掉进 API 分支。部分抓取器/校验器先发 HEAD,会误判为非 HTML。
+修法:HEAD 走与 GET 相同 handler,只丢弃 body。
+
+**③ apex 的 SEO 基础设施全空(实测)**
+无 `meta description`、无任何 OG、无 `twitter:card`、无 `canonical`、无 JSON-LD;
+`<title>` 仅「Mediary Connect」7 字符;`/sitemap.xml` 404;
+`/robots.txt` 200 但**去注释后零有效指令**(纯 CF content-signals 样板注释)。
+→ 后果:连品牌词搜索都拿不稳。有人在 GitHub/周刊看到后去搜「mediary connect」,
+SERP 返回一个无描述裸标题。这是漏斗上最廉价的漏。
+
+**④ beta 报名页未 noindex**(实测无 `X-Robots-Tag`、无 `meta robots`)
+→ 加 `<meta name="robots" content="noindex, nofollow">` + HTTP 头双保险。
+robots.txt 仍须 `Allow: /`(否则读不到 noindex)。
+
+**⑤ demo 站零回链**(子代理实测,我未复验)
+`demo.mediaryscout.app` 已被索引,但全站唯一出站链接是 GitHub,
+**没有任何链接回主站**。已索引站的权重完全没回流。
+→ demo banner 加 `<a href="https://mediaryscout.app">Mediary Scout 官网</a>`。
+「官网」这个词帮 Google 判断哪个域名是主实体(现在两站都叫 Mediary Scout,存在实体混淆)。
+
+---
+
+## ⚠️ 对「互链一定能增强流量」的诚实评估
+
+用户假设:「这俩站已获索引,链上去一定也能增强我们的流量」。
+**跨域链接传权重是真的**(Google 不因同一所有者折扣),但推理有两处断裂:
+
+1. **被索引 ≠ 有权威度可传。** 主站自己的权威度主要来自阮一峰周刊 + HelloGitHub 收录
+   + GitHub 仓库,是**个位数量级**可传递权重,不是可再分配的储备。链给 Connect 只会让它
+   **被发现和被索引** —— 而这一步提交 sitemap 也能做到。
+
+2. **被索引和有流量之间隔着搜索需求量。** Connect 的核心词需要「先知道 Mediary Scout 存在」,
+   **Connect 的自然流量天花板 ≈ Scout 的品牌知名度**,不是 SEO 技术问题。
+   互链改善的是「已在 Scout 生态内、有远程访问痛点」的转化路径 —— 那是**站内导流**,
+   不是搜索流量增强。
+
+**现实预期**:做完全套技术方案,3 个月内 Connect 从自然搜索获得的点击量级是
+**每天 0-5 次**。互链对这个数字的贡献接近 0;它的真实价值是
+①让主站已有访客找到 Connect ②让品牌词搜索正确返回定价页。
+
+**link scheme 风险可忽略** —— 3 个同产品家族域名的导航型互链是正常产品站结构,
+与 PBN 不在一个量级。但要避免:每站页脚塞 5-8 条重复锚文本;锚文本全写成目标关键词。
+当前方案锚文本分布:品牌词 5、功能描述式 3、导航式 2、零 exact-match 堆砌 —— 安全。
+
+---
+
+## 优先级（子代理建议 + 我的判断，一致）
+
+| 序 | 事项 | 理由 |
+|---|---|---|
+| **1** | slug 子域 noindex 边缘规则 | **唯一「不做会有真实损害」的**;其余都只是「不做则少赚」。分钟级、不依赖代码、不依赖用户升级。风险收益比极端不对称 |
+| **2** | apex 的 title + description + canonical | 当前连品牌词都吃不住。改一段 HTML 字符串,收益即时确定。比互链更优先 —— metadata 是「让已找到你的人正确理解你」(转化率高一个量级),互链是「让没找到的人可能找到」(绝对量级近 0) |
+| **3** | 主站 banner 改指 apex + demo 加回链 | 互链方案里唯一有实质效果的部分,都是一行改动 |
+
+其余(sitemap、JSON-LD、hreflang、法务页 noindex、内容资产)正确但收益递减,可等。
+**特别是 JSON-LD**:`Service` 类型在 Google 没有对应富结果,不会带来任何 SERP 装饰,
+它的收益只是实体消歧 + AI 摘要取材准确。别被「结构化数据」名头骗去排前三。
+
+## schema 类型选择（若做 JSON-LD）
+- ❌ `SoftwareApplication` 作主类型错误:Connect 不是软件,用户不下载不安装。
+  误用会让 Google 把 Connect 和 Scout 当成两个**竞争**软件实体。
+- ✅ `Service`(主) + `Offer`(四档) + **`isRelatedTo → SoftwareApplication`**(关键一笔,
+  这是「我是 Scout 的附加服务」在结构化数据层的表达)。
+- 价格用 `UnitPriceSpecification.billingDuration` + `unitCode: MON` 表达「预付 N 个月」,
+  **不要**用 `Subscription`/`priceType: subscription` —— 那声明周期性扣款,与「无自动续费」冲突。
+- 创始价用 `LimitedAvailability` + `inventoryLevel: 100`,**售完必须改 `SoldOut` 或移除**。
+- 不要 `aggregateRating`/`review`:没真实评价不能造(违反 Google 结构化数据政策)。

--- a/site/index.html
+++ b/site/index.html
@@ -265,9 +265,10 @@
       <div class="connect-banner">
         <div class="connect-text">
           <b>Mediary Connect</b>
-          <p>部署在内网 / NAS？一条加密隧道，就能在任何设备的浏览器打开你家的面板 —— 无需公网 IP、无需端口转发，入口由应用自身的访问密码把守。内容全程留在你自己的设备上。</p>
+          <p>部署在内网 / NAS？<a href="https://mediaryconnect.app">Mediary Connect 是 Scout 的可选付费附加服务</a>，一条加密隧道就能在任何设备的浏览器打开你家的面板 —— 无需公网 IP、无需端口转发，入口由应用自身的访问密码把守。它不托管你的实例，内容全程留在你自己的设备上。</p>
         </div>
-        <a class="pill cta-outline" href="https://beta.mediaryconnect.app">了解 / 申请内测 →</a>
+        <a class="pill cta-outline" href="https://mediaryconnect.app">了解 Mediary Connect →</a>
+        <a class="pill cta-outline" href="https://beta.mediaryconnect.app" rel="nofollow">申请内测 →</a>
       </div>
     </div>
   </section>

--- a/workers/scout-connect/src/html/beta-page.ts
+++ b/workers/scout-connect/src/html/beta-page.ts
@@ -71,6 +71,10 @@ export function betaPage(turnstileSitekey?: string): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<!-- 报名表单不该进索引:内测结束即失效、Googlebot 抓到的是交互失败的空表单
+     (Turnstile 挡着)、且与 apex 讲同一件事会稀释主题聚焦。
+     注意 robots.txt 必须保持 Allow —— 屏蔽了爬虫就读不到这行 noindex。 -->
+<meta name="robots" content="noindex, nofollow">
 <title>Mediary Connect 远程访问 · 内测</title>${tsScript}
 ${FAVICON_LINK}
 <style>

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -146,6 +146,72 @@ describe("handleRequest", () => {
     expect(await res.text()).toContain("Mediary Connect");
   });
 
+  // HEAD 此前没有任何处理,一路落到末尾的 404 JSON —— 线上实测
+  // `HEAD /` 返回 content-type: application/json,而 `GET /` 返回 text/html。
+  // 部分抓取器/链接校验器先发 HEAD,会把首页误判成非 HTML 资源。
+  it("HEAD / → 200 且 content-type 与 GET 一致(text/html),body 为空", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/`, { method: "HEAD" }), deps);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(await res.text()).toBe("");
+  });
+
+  it("HEAD /pricing → 200 text/html(合规页同样要能被 HEAD 探测)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/pricing`, { method: "HEAD" }), deps);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+  });
+
+  it("HEAD 不存在的路径 → 404(不是 200)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/nope-not-here`, { method: "HEAD" }), deps);
+    expect(res.status).toBe(404);
+  });
+
+  // robots.txt 此前由 Cloudflare 给一份纯注释样板(去注释后零有效指令),
+  // 且没有 Sitemap 声明。worker 接管,给出真指令。
+  it("GET /robots.txt → 200 纯文本,含 Allow 与 Sitemap 声明", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/robots.txt`), deps);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    const body = await res.text();
+    expect(body).toContain("User-agent: *");
+    expect(body).toContain("Allow: /");
+    expect(body).toContain("Sitemap: https://mediaryconnect.app/sitemap.xml");
+    // 绝不能出现 Disallow: / —— 那会让爬虫读不到页面上的 noindex,
+    // 已索引的 URL 反而会留在索引里(Google: block-indexing)。
+    expect(body).not.toContain("Disallow: /");
+  });
+
+  it("GET /sitemap.xml → 200 XML,含 apex 与 pricing 双语", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/sitemap.xml`), deps);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("xml");
+    const body = await res.text();
+    expect(body).toContain("<loc>https://mediaryconnect.app/</loc>");
+    expect(body).toContain("<loc>https://mediaryconnect.app/pricing</loc>");
+    // 法务页不进 sitemap(它们是给人看的,不该竞争索引配额)。
+    expect(body).not.toContain("/terms");
+  });
+
+  it("beta 页带 noindex(报名表单不该被索引:内测结束即失效 + 与 apex 语义重复)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(
+      new Request("https://beta.mediaryconnect.app/", {
+        headers: { host: "beta.mediaryconnect.app" },
+      }),
+      deps,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('name="robots"');
+    expect(body).toContain("noindex");
+  });
+
   it("GET / on the beta subdomain serves the signup page (canonical URL is the bare host)", async () => {
     const { deps } = setup();
     // beta.mediaryconnect.app 就是规范地址——"beta.…/beta" 是结巴。

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -80,6 +80,27 @@ const slugCheckLimiter = createRateLimiter({
 
 export async function handleRequest(request: Request, deps: RouteDeps): Promise<Response> {
   try {
+    // HEAD 按 RFC 9110 必须与 GET 返回**相同的头**、只是没有 body。此前
+    // 没有任何 HEAD 分支,于是所有 HEAD 一路落到末尾的 404 JSON —— 线上
+    // 实测 `HEAD /` 是 application/json 而 `GET /` 是 text/html。部分抓取器
+    // 和链接校验器先发 HEAD,会把首页误判成非 HTML 资源。
+    //
+    // 做法:用同一个 URL 造一个 GET 走完整路由,再把 body 换成 null。
+    // 这样头(content-type / cache-control / X-Robots-Tag …)天然与 GET 一致,
+    // 不需要在每个页面分支里各写一遍,也不会漏掉将来新增的路由。
+    if (request.method === "HEAD") {
+      const asGet = new Request(request.url, {
+        method: "GET",
+        headers: request.headers,
+      });
+      const res = await route(asGet, deps);
+      // 复用原 Response 的 status/headers,只丢 body。
+      return new Response(null, {
+        status: res.status,
+        statusText: res.statusText,
+        headers: res.headers,
+      });
+    }
     return await route(request, deps);
   } catch (e) {
     return handleError(e);
@@ -280,6 +301,62 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
       const lang = url.searchParams.get("lang")?.trim().toLowerCase() === "en" ? "en" : "zh";
       return htmlPage(compliancePage(key as CompliancePageKey, lang));
     }
+  }
+  // robots.txt —— worker 接管。此前是 Cloudflare 的纯注释样板(去注释后
+  // **零有效指令**),既没声明 Sitemap,也没显式 Allow。
+  //
+  // **必须是 Allow,绝不能 Disallow。** 被 robots.txt 屏蔽的 URL 仍可能因外链
+  // 被索引(只是显示无描述),而且屏蔽后爬虫**读不到**页面上的 noindex ——
+  // 想让某页不被索引,唯一可靠的组合是「允许抓取 + noindex」。
+  // 见 https://developers.google.com/search/docs/crawling-indexing/block-indexing
+  if (method === "GET" && path === "/robots.txt") {
+    const root = deps.rootDomain.trim().toLowerCase();
+    const body = [
+      "User-agent: *",
+      "Allow: /",
+      "",
+      `Sitemap: https://${root}/sitemap.xml`,
+      "",
+    ].join("\n");
+    return new Response(body, {
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  }
+  // sitemap.xml —— 只放**该被索引且有搜索价值**的页:首页 + 定价(中英)。
+  // 法务五页不进:它们对搜索用户零价值,进 sitemap 只是稀释抓取配额。
+  // 用户实例子域(<slug>.…)**永远不进** —— 那是私有实例,slug 可能含真名,
+  // 被索引即隐私事件(边缘已加 X-Robots-Tag: noindex 兜底)。
+  if (method === "GET" && path === "/sitemap.xml") {
+    const root = deps.rootDomain.trim().toLowerCase();
+    const base = `https://${root}`;
+    // 两个语言版本共用同一组 hreflang,且**每组都包含自己**(Google 要求
+    // alternate 集合自含,否则算「无返回标记」错误)。x-default 指中文 ——
+    // 主受众是中文用户。
+    const hreflang = [
+      `    <xhtml:link rel="alternate" hreflang="zh-Hans" href="${base}/pricing"/>`,
+      `    <xhtml:link rel="alternate" hreflang="en" href="${base}/pricing?lang=en"/>`,
+      `    <xhtml:link rel="alternate" hreflang="x-default" href="${base}/pricing"/>`,
+    ].join("\n");
+    // `?lang=en` 里的 & 若将来出现须转义成 &amp;(当前只有单参数,无此问题)。
+    const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>${base}/</loc>
+  </url>
+  <url>
+    <loc>${base}/pricing</loc>
+${hreflang}
+  </url>
+  <url>
+    <loc>${base}/pricing?lang=en</loc>
+${hreflang}
+  </url>
+</urlset>
+`;
+    return new Response(body, {
+      headers: { "content-type": "application/xml; charset=utf-8" },
+    });
   }
   if (method === "GET" && path === "/healthz") {
     return new Response("ok", {


### PR DESCRIPTION
线上实测发现的四个技术问题,逐个修。均为「不需产品拍板」的修复。

## 修了什么

| # | 问题 | 实测证据 | 修法 |
|---|---|---|---|
| ① | **HEAD 返回 JSON** | `HEAD /` → `application/json`,`GET /` → `text/html` | 入口把 HEAD 转成 GET 走完整路由再丢 body,头天然与 GET 一致 |
| ② | **robots.txt 零有效指令** | 去注释后一行指令都没有,无 Sitemap 声明 | worker 接管,给 `User-agent`/`Allow`/`Sitemap` |
| ③ | **`/sitemap.xml` 404** | — | 新增,含 apex + pricing 中英 + 自含 hreflang |
| ④ | **beta 页可被索引** | 无 `X-Robots-Tag`、无 `meta robots` | 加 `noindex, nofollow` |
| ⑤ | **主站唯一 Connect 链接指向 beta** | 指 apex 的 **0** 条,指 beta 的 1 条 | 改指 apex,beta 降 nofollow |
| ⑤ | **demo 站零回链** | 已被索引但无任何链接回主站 | banner 加「Mediary Scout 官网」 |

## 两个反直觉但关键的点

**robots 必须 `Allow` 不能 `Disallow`。** 被 robots.txt 屏蔽的 URL 仍可能因外链被索引(只显示无描述),而且屏蔽后爬虫**读不到**页面上的 `noindex`。想让某页不进索引,唯一可靠组合是「允许抓取 + noindex」。测试里显式断言 `not.toContain("Disallow: /")` 钉住这条。

**demo banner 的锚文本用「官网」是刻意的。** 主站和 demo 站都叫 Mediary Scout,存在实体混淆;「官网」这个词帮搜索引擎判断哪个域名是主实体。

## 门禁
- 737 worker 测试全绿
- 三处 tsc 全绿(root / workers / apps-web)
- `build:web` 通过(本 PR 动了 `apps/web/app/layout.tsx`)
- 反向验证:去掉 HEAD 分支 → 精确转红;robots 改 `Disallow` → 精确转红

## 同期的边缘侧修复(不在本 PR,已生效并验证)
Cloudflare Transform Rule:所有 `<slug>.mediaryconnect.app` 响应加
`X-Robots-Tag: noindex, nofollow, noarchive, nosnippet`。用户私有实例的 slug
由用户自选、可能含真名,被索引即隐私事件。已验证 apex 与 beta **未**被误伤。