### PR TITLE
fix(auth): 关闭 Turnstile 门禁(中国大陆不可达)+ 发信入口加限流替代

### DIFF
--- a/workers/scout-connect/src/auth-routes.test.ts
+++ b/workers/scout-connect/src/auth-routes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { handleRequest, type RouteDeps } from "./routes.js";
+import {
+  createRateLimiter,
+  SIGNUP_IP_RATE_LIMIT,
+  SIGNUP_EMAIL_RATE_LIMIT,
+  SIGNUP_RATE_WINDOW_MS,
+} from "./rate-limit.js";
 import { createMemoryConnectDb } from "./db.js";
 import { SESSION_COOKIE, sessionCookieValue } from "./session.js";
 
@@ -25,6 +31,12 @@ function setup(overrides: Partial<RouteDeps> = {}): { deps: RouteDeps; sent: Arr
     sessionSecret: SESSION_SECRET,
     sendMagicLink: async (to: string, url: string) => {
       sent.push({ to, url });
+    },
+    // 每个 setup() 一对全新限流器。不注入就会用模块级单例 —— 同文件里
+    // 前面的测试打满配额,后面的全 429(全量跑时才暴露,单文件跑可能侥幸过)。
+    signupLimiters: {
+      ip: createRateLimiter({ limit: SIGNUP_IP_RATE_LIMIT, windowMs: SIGNUP_RATE_WINDOW_MS, now: () => Date.now() }),
+      email: createRateLimiter({ limit: SIGNUP_EMAIL_RATE_LIMIT, windowMs: SIGNUP_RATE_WINDOW_MS, now: () => Date.now() }),
     },
     ...overrides,
   };

--- a/workers/scout-connect/src/rate-limit.ts
+++ b/workers/scout-connect/src/rate-limit.ts
@@ -64,3 +64,24 @@ export function createRateLimiter(input: {
  *  正常用户连点几次查重远到不了这个量;脚本猛刷会立刻撞墙。 */
 export const SLUG_CHECK_RATE_LIMIT = 10;
 export const SLUG_CHECK_RATE_WINDOW_MS = 60_000;
+
+/**
+ * 发信入口(/api/auth/magic、/waitlist)的限流参数。
+ *
+ * **为什么需要**:Turnstile 门禁已在生产关闭 —— `challenges.cloudflare.com`
+ * 在中国大陆不可靠,挡住的是真实用户而非脚本(登录进不去=付不了钱,
+ * 报名进不去=拿不到内测用户)。门禁代码保留(sitekey 一配就恢复),
+ * 但既然它现在不生效,发信入口必须有替代防线,否则这是个公开的
+ * 「触发发邮件」放大面 —— 有人能刷爆 Resend 配额,或拿我们的域名发垃圾邮件。
+ *
+ * **双维度**:
+ * - 按 IP:挡同一来源的脚本猛刷。窗口放宽到 10 分钟 5 次 —— 正常人
+ *   收不到信会重试 1-2 次,家庭 NAT 后可能有几个人共用出口 IP。
+ * - 按邮箱:挡「换 IP 但轰同一个人」的骚扰(用别人邮箱刷登录信)。
+ *   同一邮箱 10 分钟 2 次 —— 魔法链接 15 分钟有效,正常人不需要更多。
+ *
+ * 两个维度**都要过**才放行。内存窗口的分布式局限见本文件顶部说明。
+ */
+export const SIGNUP_IP_RATE_LIMIT = 5;
+export const SIGNUP_EMAIL_RATE_LIMIT = 2;
+export const SIGNUP_RATE_WINDOW_MS = 600_000; // 10 分钟

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1861,6 +1861,34 @@ describe("发信入口限流(Turnstile 关闭后的替代防线)", () => {
     expect(ok.status).toBe(202);
   });
 
+  // Copilot round-1:Turnstile 必须在限流**之前**。否则门禁将来重开时,
+  // 攻击者能用无效 token 反复请求,每次消耗配额,把真实用户锁死在 429(DoS)。
+  it("Turnstile 开启时:无效 token 的请求不消耗限流配额", async () => {
+    const { deps } = setup();
+    deps.turnstileSitekey = "0x4AAAAAAD-test";
+    deps.turnstileSecret = "secret-fixture";
+    // siteverify 一律失败 → 这些请求都该被 Turnstile 拦在限流之前
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ success: false }), { status: 200 })) as typeof fetch;
+    try {
+      for (let i = 0; i < 8; i++) {
+        const res = await handleRequest(
+          post("/api/auth/magic", { email: "victim@example.com", turnstile_token: "bad" }, "4.4.4.4"),
+          deps,
+        );
+        expect(res.status).toBe(403);
+      }
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+    // 8 次失败请求后关掉门禁,真实用户仍应有配额(没被无效请求耗光)
+    deps.turnstileSitekey = undefined;
+    deps.turnstileSecret = undefined;
+    const ok = await handleRequest(post("/api/auth/magic", { email: "victim@example.com" }, "4.4.4.4"), deps);
+    expect(ok.status).toBe(202);
+  });
+
   // 生产已关门禁(wrangler.jsonc 注释掉 sitekey)。这两条钉住「关掉后仍能用」。
   it("sitekey 未配置 → 登录页不注入 Turnstile 脚本(国内可加载)", async () => {
     const { deps } = setup();

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { handleRequest, MAX_JSON_BODY_BYTES, type RouteDeps } from "./routes.js";
+import {
+  createRateLimiter,
+  SIGNUP_IP_RATE_LIMIT,
+  SIGNUP_EMAIL_RATE_LIMIT,
+  SIGNUP_RATE_WINDOW_MS,
+} from "./rate-limit.js";
 import { createMemoryConnectDb, type ConnectDb } from "./db.js";
 import type { CfApi } from "./cf-api.js";
 import { EMAIL_MAX_LENGTH, EMAIL_RE } from "./validation.js";
@@ -80,6 +86,12 @@ function makeDeps(db: ConnectDb, cf: CfApi): RouteDeps {
     newEntitlementId: seq("ent"),
     sessionSecret: "f".repeat(64),
     sendMagicLink: async () => {},
+    // 每个 setup() 拿一对**全新**限流器 —— 模块级单例会让测试互相污染
+    // (一个测试打满配额,后面全 429)。这也是生产代码把它做成可注入的原因。
+    signupLimiters: {
+      ip: createRateLimiter({ limit: SIGNUP_IP_RATE_LIMIT, windowMs: SIGNUP_RATE_WINDOW_MS, now: () => Date.now() }),
+      email: createRateLimiter({ limit: SIGNUP_EMAIL_RATE_LIMIT, windowMs: SIGNUP_RATE_WINDOW_MS, now: () => Date.now() }),
+    },
   };
 }
 
@@ -1800,6 +1812,87 @@ describe("request body size cap", () => {
 });
 
 // Cloudflare Turnstile gate on the public signup funnel (bot protection).
+// 发信入口限流:Turnstile 在生产已关(中国大陆不可达),限流是替代防线。
+// 两个维度都要过:按 IP(挡脚本猛刷)+ 按邮箱(挡轰炸同一个人)。
+describe("发信入口限流(Turnstile 关闭后的替代防线)", () => {
+  function post(path: string, body: unknown, ip: string): Request {
+    return new Request(`${BASE}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "cf-connecting-ip": ip },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("同一 IP 超过 5 次 → 429,且不再发信", async () => {
+    const { deps } = setup();
+    const sent: string[] = [];
+    deps.sendMagicLink = async (to: string) => { sent.push(to); };
+    for (let i = 0; i < 5; i++) {
+      const res = await handleRequest(post("/api/auth/magic", { email: `u${i}@example.com` }, "9.9.9.1"), deps);
+      expect(res.status).toBe(202);
+    }
+    const blocked = await handleRequest(post("/api/auth/magic", { email: "u9@example.com" }, "9.9.9.1"), deps);
+    expect(blocked.status).toBe(429);
+    // 关键:被限流的请求绝不能触发发信(否则限流形同虚设)
+    expect(sent.length).toBe(5);
+  });
+
+  it("同一邮箱超过 2 次 → 429,即使换 IP", async () => {
+    const { deps } = setup();
+    const sent: string[] = [];
+    deps.sendMagicLink = async (to: string) => { sent.push(to); };
+    for (let i = 0; i < 2; i++) {
+      const res = await handleRequest(post("/api/auth/magic", { email: "victim@example.com" }, `8.8.8.${i}`), deps);
+      expect(res.status).toBe(202);
+    }
+    const blocked = await handleRequest(post("/api/auth/magic", { email: "victim@example.com" }, "8.8.8.99"), deps);
+    expect(blocked.status).toBe(429);
+    expect(sent.length).toBe(2);
+  });
+
+  it("限流在邮箱形状校验之后 —— 无效邮箱不消耗配额", async () => {
+    const { deps } = setup();
+    for (let i = 0; i < 8; i++) {
+      const res = await handleRequest(post("/api/auth/magic", { email: "not-an-email" }, "7.7.7.7"), deps);
+      expect(res.status).toBe(400);
+    }
+    // 8 次无效请求后,合法请求仍应放行(配额没被 400 消耗掉)
+    const ok = await handleRequest(post("/api/auth/magic", { email: "real@example.com" }, "7.7.7.7"), deps);
+    expect(ok.status).toBe(202);
+  });
+
+  // 生产已关门禁(wrangler.jsonc 注释掉 sitekey)。这两条钉住「关掉后仍能用」。
+  it("sitekey 未配置 → 登录页不注入 Turnstile 脚本(国内可加载)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/login`), deps);
+    const html = await res.text();
+    // 关键是**不加载外部脚本、不渲染 widget** —— 那才是国内加载不出的东西。
+    // (`.cf-turnstile{}` CSS 规则和 querySelector 兜底代码无论配不配都会输出,
+    //  前者匹配不到元素、后者拿到 null,都无害。断言不该过严。)
+    expect(html).not.toContain("challenges.cloudflare.com");
+    expect(html).not.toContain('class="cf-turnstile"');
+    expect(html).not.toContain("data-sitekey");
+  });
+
+  it("sitekey 未配置 → 发信/报名不需要 turnstile_token 即可通过", async () => {
+    const { deps } = setup();
+    const magic = await handleRequest(post("/api/auth/magic", { email: "cn@example.com" }, "5.5.5.5"), deps);
+    expect(magic.status).toBe(202);
+    const wl = await handleRequest(post("/waitlist", { email: "cn2@example.com" }, "5.5.5.6"), deps);
+    expect([200, 201]).toContain(wl.status);
+  });
+
+  it("/waitlist 同样受限流保护", async () => {
+    const { deps } = setup();
+    for (let i = 0; i < 5; i++) {
+      const res = await handleRequest(post("/waitlist", { email: `w${i}@example.com` }, "6.6.6.6"), deps);
+      expect([200, 201, 202]).toContain(res.status);
+    }
+    const blocked = await handleRequest(post("/waitlist", { email: "w9@example.com" }, "6.6.6.6"), deps);
+    expect(blocked.status).toBe(429);
+  });
+});
+
 // Active ONLY when BOTH turnstileSitekey (public var) and turnstileSecret
 // (wrangler secret) are configured in deps — either missing → the route
 // behaves exactly as before and siteverify is never called.

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -600,16 +600,19 @@ async function requestMagicLink(request: Request, deps: RouteDeps): Promise<Resp
   if (email.length > EMAIL_MAX_LENGTH || !EMAIL_RE.test(email)) {
     throw new HttpError(400, "invalid email");
   }
-  // 限流在邮箱形状校验之后(无效邮箱不消耗配额),且在 Turnstile 之前 ——
-  // Turnstile 在生产已关(challenges.cloudflare.com 在中国大陆不可靠,
-  // 挡住的是真实用户而非脚本),限流是它的替代防线。
-  if (signupRateLimited(request, email, deps)) {
-    return json({ error: "too many requests" }, 429, { noStore: true });
-  }
   // 与 /waitlist 同一条防滥用规则:Turnstile 成对配置时,发信入口也要过人机
   // 校验——否则这是个公开的「触发发邮件」放大面。校验在邮箱形状之后:
   // 一次性 token 不浪费在注定 400 的请求上。
+  // **生产已关**(challenges.cloudflare.com 在中国大陆不可靠),此时直接放行。
   await requireTurnstileIfEnabled(request, body, deps);
+  // 限流:在邮箱形状校验之后(无效邮箱不消耗配额),且**在 Turnstile 之后**。
+  //
+  // 顺序不能反:若限流在前,门禁将来重开时攻击者能用无效 token 反复请求,
+  // 每次消耗 IP/邮箱配额,把真实用户锁死在 429 —— 那些请求本该先被
+  // Turnstile 拦掉、根本不该计入配额。与 /waitlist 的顺序保持一致。
+  if (signupRateLimited(request, email, deps)) {
+    return json({ error: "too many requests" }, 429, { noStore: true });
+  }
   // 注册即登录:不论邮箱是否已存在都发信,不泄露注册状态。账号在 callback
   // 落地时才创建(避免未验证邮箱污染 accounts 表)。
   const token = await signToken(

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -5,7 +5,15 @@ import { requireAdmin } from "./auth.js";
 import { provisionEndpoint } from "./provision.js";
 import { revokeEndpoint } from "./revoke.js";
 import { revealByCode } from "./reveal.js";
-import { SLUG_CHECK_RATE_LIMIT, SLUG_CHECK_RATE_WINDOW_MS, createRateLimiter } from "./rate-limit.js";
+import type { RateLimiter } from "./rate-limit.js";
+import {
+  SLUG_CHECK_RATE_LIMIT,
+  SLUG_CHECK_RATE_WINDOW_MS,
+  SIGNUP_IP_RATE_LIMIT,
+  SIGNUP_EMAIL_RATE_LIMIT,
+  SIGNUP_RATE_WINDOW_MS,
+  createRateLimiter,
+} from "./rate-limit.js";
 import { assertSlug } from "./slug.js";
 import { checkSlug, type IsTaken } from "./slug-availability.js";
 import { homePage } from "./html/home-page.js";
@@ -36,6 +44,15 @@ const LOGO_SVG =
 export interface RouteDeps {
   db: ConnectDb;
   cf: CfApi;
+  /**
+   * 发信入口限流器(可注入)。省略时用模块级单例(生产行为)。
+   *
+   * **为什么必须可注入**:限流器是有状态的模块单例,测试之间会互相污染
+   * (一个测试打满配额,后面的测试全 429)。这不只是测试便利问题 ——
+   * 不可注入的有状态单例本身就是设计缺陷:既无法隔离验证,
+   * 也无法在同一 worker 里给不同用途配不同额度。
+   */
+  signupLimiters?: { ip: RateLimiter; email: RateLimiter } | undefined;
   adminToken: string;
   rootDomain: string;
   tokenWrapKeyHex: string;
@@ -77,6 +94,49 @@ const slugCheckLimiter = createRateLimiter({
   windowMs: SLUG_CHECK_RATE_WINDOW_MS,
   now: () => Date.now(),
 });
+
+// 发信入口限流(Turnstile 在生产已关 —— 见 rate-limit.ts 的说明)。
+// 两个独立限流器:IP 维度挡脚本猛刷,邮箱维度挡「换 IP 轰同一个人」。
+const signupIpLimiter = createRateLimiter({
+  limit: SIGNUP_IP_RATE_LIMIT,
+  windowMs: SIGNUP_RATE_WINDOW_MS,
+  now: () => Date.now(),
+});
+const signupEmailLimiter = createRateLimiter({
+  limit: SIGNUP_EMAIL_RATE_LIMIT,
+  windowMs: SIGNUP_RATE_WINDOW_MS,
+  now: () => Date.now(),
+});
+
+/**
+ * 发信入口的限流闸(magic link / waitlist 共用)。
+ *
+ * **调用位置必须在邮箱形状校验之后**:否则一串 `not-an-email` 就能把正常用户
+ * 的配额耗光(拒绝服务),而那些请求本来就注定 400。
+ *
+ * 两个维度都要过。IP 缺失时(理论上 CF 总会给 cf-connecting-ip)只走邮箱维度 ——
+ * 不因为拿不到 IP 就放弃全部防护,也不因此误伤(邮箱维度仍在)。
+ *
+ * 返回 429 而不是静默丢弃:让脚本作者知道撞墙了,也让正常用户看到明确原因。
+ */
+/** 只判 IP 维度。给 /waitlist 用 —— 见那里的注释(邮箱维度会误杀幂等重提交)。 */
+function signupIpRateLimited(request: Request, deps: RouteDeps): boolean {
+  const ipLimiter = deps.signupLimiters?.ip ?? signupIpLimiter;
+  const ip = request.headers.get("cf-connecting-ip")?.trim() || "";
+  if (ip === "") return false;
+  return !ipLimiter.allow(`ip:${ip}`);
+}
+
+function signupRateLimited(request: Request, email: string, deps: RouteDeps): boolean {
+  const ipLimiter = deps.signupLimiters?.ip ?? signupIpLimiter;
+  const emailLimiter = deps.signupLimiters?.email ?? signupEmailLimiter;
+  const ip = request.headers.get("cf-connecting-ip")?.trim() || "";
+  // 顺序重要:两个 allow() 都有副作用(消耗配额)。先判 IP —— IP 被限时
+  // 不该再消耗邮箱配额,否则攻击者能用一个 IP 把受害者邮箱的配额也耗掉。
+  if (ip !== "" && !ipLimiter.allow(`ip:${ip}`)) return true;
+  if (!emailLimiter.allow(`em:${email}`)) return true;
+  return false;
+}
 
 export async function handleRequest(request: Request, deps: RouteDeps): Promise<Response> {
   try {
@@ -539,6 +599,12 @@ async function requestMagicLink(request: Request, deps: RouteDeps): Promise<Resp
   const email = emailRaw.trim().toLowerCase();
   if (email.length > EMAIL_MAX_LENGTH || !EMAIL_RE.test(email)) {
     throw new HttpError(400, "invalid email");
+  }
+  // 限流在邮箱形状校验之后(无效邮箱不消耗配额),且在 Turnstile 之前 ——
+  // Turnstile 在生产已关(challenges.cloudflare.com 在中国大陆不可靠,
+  // 挡住的是真实用户而非脚本),限流是它的替代防线。
+  if (signupRateLimited(request, email, deps)) {
+    return json({ error: "too many requests" }, 429, { noStore: true });
   }
   // 与 /waitlist 同一条防滥用规则:Turnstile 成对配置时,发信入口也要过人机
   // 校验——否则这是个公开的「触发发邮件」放大面。校验在邮箱形状之后:
@@ -1505,6 +1571,7 @@ async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Respons
 
   // Turnstile 门(成对配置时启用)。位置刻意在邮箱形状校验之后:一次性
   // token 不浪费在注定 400 的请求上。与 /api/auth/magic 共用同一 helper。
+  // **生产已关**:sitekey 未配置 → 此 helper 直接放行。见 rate-limit.ts。
   await requireTurnstileIfEnabled(request, body, deps);
 
   const batch = WAITLIST_BATCH;
@@ -1524,6 +1591,19 @@ async function addToWaitlist(request: Request, deps: RouteDeps): Promise<Respons
       { already_exists: true, id: existing.id, position: await waitlistPosition(deps, existing) },
       200,
     );
+  }
+
+  // 限流:**只限 IP,不限邮箱**,且放在「重复提交快路径」之后。
+  //
+  // 为什么不限邮箱:报名本身是幂等的(同邮箱只会有一行),邮箱维度挡不住任何
+  // 真实滥用;而真并发时 5 个同邮箱请求会一起穿过快路径(那时还没有行),
+  // 邮箱限额 2 次会把其中 3 个误杀成 429 —— 直接破坏「双击提交不出错」
+  // 的幂等保证(TOCTOU 测试:1 个 201 + 4 个 200)。
+  //
+  // 发信入口(/api/auth/magic)则**两个维度都要**:那里邮箱维度是防「换 IP
+  // 轰同一个人」的邮件骚扰,而报名不发信,没有这个面。
+  if (signupIpRateLimited(request, deps)) {
+    return json({ error: "too many requests" }, 429, { noStore: true });
   }
 
   // Founding-batch seat cap — checked AFTER the repeat-submit fast path, so

--- a/workers/scout-connect/wrangler.jsonc
+++ b/workers/scout-connect/wrangler.jsonc
@@ -22,11 +22,19 @@
   },
   "vars": {
     "CONNECT_ROOT_DOMAIN": "mediaryconnect.app",
-    // Public Turnstile sitekey for the beta signup widget (safe to commit —
-    // sitekeys ship in page HTML by design). The paired TURNSTILE_SECRET stays
-    // a `wrangler secret`. The gate activates only when BOTH are configured;
-    // either missing → no widget, no verification (src/routes.ts).
-    "TURNSTILE_SITEKEY": "0x4AAAAAAD-wkGraJigl3YK0",
+    // Turnstile sitekey —— **刻意留空以关闭人机验证门禁**。
+    //
+    // 为什么关:`challenges.cloudflare.com` 在中国大陆不可靠。挡住的不是脚本,
+    // 是**真实用户** —— 登录页过不去 = 付不了钱,报名页过不去 = 拿不到内测
+    // 用户(waitlist 长期只有 1 个报名,很可能就是被它挡住的)。
+    //
+    // 门禁代码**完整保留**(gate 需 sitekey + secret 成对配置才激活,
+    // 见 src/routes.ts 的 turnstileGateEnabled)。想恢复只需把这行填回来 ——
+    // TURNSTILE_SECRET 仍在 wrangler secret 里,不用重新申请。
+    //
+    // 替代防线:发信入口(/api/auth/magic、/waitlist)已加限流,
+    // 见 src/rate-limit.ts 的 SIGNUP_* 参数与那里对取舍的说明。
+    // "TURNSTILE_SITEKEY": "0x4AAAAAAD-wkGraJigl3YK0",
     // Paddle 环境(sandbox|production)。决定 priceMonthsFor 选哪份白名单:
     // 不设 = undefined = priceMonthsFor 返回 null → webhook 一律 503。
     // 上线时改 "production",并在 paddle-event.ts 填 LIVE_PRICE_MONTHS。


### PR DESCRIPTION
## 问题

`challenges.cloudflare.com` 在中国大陆不可靠。生产的登录页与报名页都注入了 Turnstile,`/api/auth/magic` 与 `/waitlist` 都强制校验 —— **挡住的不是脚本,是真实用户**:

- 登录过不去 = **付不了钱**(整条付费链路在国内断掉)
- 报名过不去 = 拿不到内测用户

waitlist 长期只有 1 个报名,很可能就是被它挡住的。

> 说明:我一开始 curl `challenges.cloudflare.com` 得到 302 想说「能通」,但查出口 IP 在美国(HostPapa)——那个测试不能代表国内用户,已作废。

## 做法

注释掉 `wrangler.jsonc` 的 `TURNSTILE_SITEKEY`。**门禁代码完整保留**(gate 需 sitekey + secret 成对配置才激活,见 `turnstileGateEnabled`),想恢复只需把那行填回来 —— `TURNSTILE_SECRET` 仍在 wrangler secret 里,不必重新申请。

## 替代防线:发信入口限流

发信入口本是个公开的「触发发邮件」放大面(能刷爆 Resend 配额、拿我们域名发垃圾邮件),而 `/api/auth/magic` **原先没有任何限流**(限流器只用在 `slug/check`)。

| 端点 | 维度 | 额度 | 理由 |
|---|---|---|---|
| `/api/auth/magic` | IP + 邮箱 | 10 分钟 5 / 2 次 | 邮箱维度防「换 IP 轰同一个人」的邮件骚扰 |
| `/waitlist` | **只限 IP** | 10 分钟 5 次 | 见下 |

**两个实现中被测试抓出来的坑:**

1. **`/waitlist` 不能限邮箱。** 报名是幂等的(同邮箱只有一行),邮箱维度挡不住任何真实滥用;而真并发时 5 个同邮箱请求会一起穿过「重复提交快路径」(那时还没有行),邮箱限额 2 次会把其中 3 个误杀成 429 —— **直接打破「双击提交不出错」的幂等保证**(TOCTOU 测试要求 1 个 201 + 4 个 200)。

2. **限流必须在邮箱形状校验之后。** 否则一串 `not-an-email` 就能耗光正常用户配额(拒绝服务),而那些请求本来注定 400。

**先判 IP 再判邮箱**也是刻意的:IP 被限时不该再消耗邮箱配额,否则攻击者能用一个 IP 把受害者邮箱的配额也耗掉。

## 顺带修的设计缺陷

限流器原本是**不可注入的模块级有状态单例** —— 测试之间互相污染(一个测试打满配额,后面全 429),也无法给不同用途配不同额度。改为 `RouteDeps` 可选注入,缺省仍用单例(生产行为不变)。

这个缺陷**只在全量跑 vitest 时暴露**(`auth-routes.test.ts` 有自己的 setup),单文件跑会侥幸通过。

## 门禁

- 743 worker 测试全绿
- 三处 tsc 全绿
- `wrangler deploy --dry-run` 通过
- 反向验证:去掉 magic 限流 → 精确转红;waitlist 改回也判邮箱 → TOCTOU 精确转红

## 部署后要验的
```
curl -sSL https://mediaryconnect.app/login | grep -c challenges.cloudflare.com   # 期望 0
curl -sS -X POST https://mediaryconnect.app/waitlist -H 'content-type: application/json' \
  -d '{"email":"probe@example.com"}' -w '\n[%{http_code}]\n'                     # 期望 200/201,不再 400
```