### PR TITLE
fix(apex): 修两个线上 bug —— 海报被 CSP 挡成裂图 + 主 CTA 绿底绿字

### DIFF
--- a/workers/scout-connect/src/html/home-page.test.ts
+++ b/workers/scout-connect/src/html/home-page.test.ts
@@ -191,6 +191,15 @@ describe("home page(apex 落地页)", () => {
     expect(iClose).toBeLessThan(iFoot);
   });
 
+  // 线上真 bug(测试全绿但页面坏):.apex a 是类+标签(特异性 0,1,1),
+  // 压过纯类 .btn(0,1,0) —— 主 CTA 文字变绿色 = 绿底绿字,按钮看起来是空的。
+  it("按钮文字色用 .apex 前缀覆盖(否则被 .apex a 的绿色压掉)", () => {
+    const html = homePage();
+    // 必须带 .apex 前缀才压得住
+    expect(html).toContain(".apex .btn{color:var(--brand-ink)}");
+    expect(html).toContain(".apex .btn2{color:var(--tx-1)}");
+  });
+
   it("页脚合规五链接与运营主体齐全(Paddle MoR 要求)", () => {
     const html = homePage();
     for (const p of ["/pricing", "/terms", "/privacy", "/refund", "/contact"]) {

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -79,6 +79,14 @@ ${BRAND_CSS}
 }
 .apex{max-width:var(--shell);margin:0 auto;line-height:1.75}
 .apex a{color:var(--brand);text-decoration:none}
+/* **必须用 .apex 前缀**:上面的「.apex a」(类+标签,特异性 0,1,1)会压过
+   纯类选择器(0,1,0)。线上实测主 CTA 的文字变成绿色 = 绿底绿字,整个按钮
+   看起来是空的。同一个特异性坑在本文件已踩过第三次(h2 reset、a、btn),
+   凡是要覆盖「.apex a」的规则都得带 .apex 前缀。 */
+.apex .btn{color:var(--brand-ink)}
+.apex .btn2{color:var(--tx-1)}
+.apex .lg{color:var(--tx-1)}
+.apex .gh{color:var(--tx-2)}
 .apex a:hover{text-decoration:underline}
 .apex .num{font-variant-numeric:tabular-nums}
 

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -41,13 +41,23 @@ const PADDLE_CSP_SOURCES = {
   style: "https://cdn.paddle.com",
 } as const;
 
+/**
+ * 首页 hero 海报墙的图片来源(TMDB 代理,与主站同一个)。
+ * 单独成常量:CSP 里出现的每个外部来源都该有名有姓、可被搜索到。
+ */
+export const POSTER_IMG_SOURCE = "https://tmdb-proxy.mediaryscout.app";
+
 export function htmlPage(
   body: string,
-  opts: { status?: number; noStore?: boolean; paddle?: boolean } = {},
+  opts: { status?: number; noStore?: boolean; paddle?: boolean; posters?: boolean } = {},
 ): Response {
   const status = opts.status ?? 200;
   // /buy 才放行 Paddle 来源;其余页面维持最严策略。
   const p = opts.paddle === true;
+  // 首页 hero 的海报墙走 TMDB 图片代理(跨域)。**只给首页放行这一个来源** ——
+  // 默认 img-src 只有 'self' data:,加海报时漏了这条,线上 28 张图全被 CSP
+  // 挡成裂图(curl 能拿到,浏览器不行 —— 这类 bug 只有真在浏览器里看才发现)。
+  const posters = opts.posters === true;
   const csp = [
     "default-src 'none'",
     `style-src 'unsafe-inline'${p ? ` ${PADDLE_CSP_SOURCES.style}` : ""}`,
@@ -58,7 +68,7 @@ export function htmlPage(
     // (theme.ts 的 FAVICON_LINK),而 default-src 'none' 会把它挡掉。
     // 这是本次之前就存在的缺陷,先前只给 /buy 加 img-src 反而让它更显眼。
     // 'self' 供将来的同源图标;data: 不产生网络请求,不放宽攻击面。
-    `img-src 'self' data:${p ? ` ${PADDLE_CSP_SOURCES.img}` : ""}`,
+    `img-src 'self' data:${p ? ` ${PADDLE_CSP_SOURCES.img}` : ""}${posters ? ` ${POSTER_IMG_SOURCE}` : ""}`,
     "base-uri 'none'",
     "form-action 'self'",
     // 结账 iframe 由 paddle.js 在**本页**创建,不需要放宽 frame-ancestors

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -149,6 +149,29 @@ describe("handleRequest", () => {
   // HEAD 此前没有任何处理,一路落到末尾的 404 JSON —— 线上实测
   // `HEAD /` 返回 content-type: application/json,而 `GET /` 返回 text/html。
   // 部分抓取器/链接校验器先发 HEAD,会把首页误判成非 HTML 资源。
+  // 线上真 bug:hero 海报走 TMDB 代理(跨域),而默认 CSP 是
+  // `img-src 'self' data:` —— 28 张图全被挡成裂图。curl 拿得到、浏览器不行,
+  // 这类问题只有真在浏览器里看才会发现,所以补一条头断言钉住。
+  it("GET / 的 CSP 放行 TMDB 图片代理(hero 海报墙)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/`), deps);
+    const csp = res.headers.get("content-security-policy") ?? "";
+    expect(csp).toContain("https://tmdb-proxy.mediaryscout.app");
+    const imgSrc = csp.split(";").find((d) => d.trim().startsWith("img-src")) ?? "";
+    expect(imgSrc).toContain("tmdb-proxy");
+    // 放宽只限 img-src,其余指令不受影响
+    expect(csp).toContain("default-src 'none'");
+  });
+
+  it("其它页面维持最严 img-src(不放行跨域图片)", async () => {
+    const { deps } = setup();
+    for (const path of ["/pricing", "/terms", "/login"]) {
+      const res = await handleRequest(new Request(`${BASE}${path}`), deps);
+      const csp = res.headers.get("content-security-policy") ?? "";
+      expect(csp, path).not.toContain("tmdb-proxy");
+    }
+  });
+
   it("HEAD / → 200 且 content-type 与 GET 一致(text/html),body 为空", async () => {
     const { deps } = setup();
     const res = await handleRequest(new Request(`${BASE}/`, { method: "HEAD" }), deps);

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -326,7 +326,9 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
     if (url.hostname.toLowerCase() === betaHost) {
       return htmlPage(betaPage(turnstileSitekeyIfConfigured(deps)));
     }
-    return htmlPage(homePage());
+    // posters:true 放行 TMDB 图片代理(hero 海报墙)。只首页需要 ——
+    // 其余页面维持 img-src 'self' data: 的最严策略。
+    return htmlPage(homePage(), { posters: true });
   }
   if (method === "POST" && path === "/api/paddle/webhook") {
     return paddleWebhook(request, deps);


### PR DESCRIPTION
## 两个都是「测试全绿但线上坏」

用户截图发现的。只有真在浏览器里打开生产页才会暴露 —— 这是我验证方式的盲区。

## ① 28 张海报全部裂图(CSP 漏配)

hero 海报走 `tmdb-proxy.mediaryscout.app`(跨域),而默认 CSP 是:
```
default-src 'none'; img-src 'self' data:
```
全部被挡。**`curl` 拿得到 `200 image/jpeg`,浏览器一张都加载不出来** —— 所以服务端断言全绿。

修:`htmlPage` 加 `posters` 开关,**只给首页**放行这一个来源,其余页面维持最严 `img-src`。

## ② 主 CTA 是绿底绿字(按钮看起来是空的)

`.apex a{color:var(--brand)}` 是**类+标签**(特异性 0,1,1),压过纯类 `.btn{color:var(--brand-ink)}`(0,1,0)。线上实测按钮 `color = rgb(30,215,96)`,与背景同色。

设计稿没暴露,是因为那份用的是 `body a{...}`(0,0,1,更弱)。

修:所有要覆盖 `.apex a` 的规则都带 `.apex` 前缀(`.btn`/`.btn2`/`.lg`/`.gh`)。

## 两个重复踩的坑,已写进注释

| 坑 | 第几次 |
|---|---|
| 「类+标签」特异性压过纯类 | **第 3 次**(h2 reset → a → btn) |
| CSS 注释里写反引号(那段 CSS 在模板字符串内,反引号直接终止字符串) | 第 2 次 |

## 门禁
- 795 worker+site 测试全绿,三处 tsc 全绿
- 新增 3 条测试,其中 CSP 那两条是**响应头断言** —— 补的正是「服务端 HTML 正确但浏览器渲染失败」这类盲区
- 反向验证:去掉 `.apex .btn` → 转红;首页不传 `posters` → 转红

## 部署后必须在浏览器里验(不能只 curl)
```
按钮文字色 ≠ 背景色
28 张海报 naturalWidth > 0
```