### PR TITLE
fix(apex): hero 海报墙改用 mask-image 四边淡出 —— 渐变盖不住 overflow 裁切边

### DIFF
--- a/workers/scout-connect/src/html/home-page.test.ts
+++ b/workers/scout-connect/src/html/home-page.test.ts
@@ -202,8 +202,12 @@ describe("home page(apex 落地页)", () => {
     // 水平 + 垂直两层,相乘
     expect(html).toContain("mask-composite:intersect");
     expect(html).toContain("-webkit-mask-composite:source-in");
-    // 四个方向都要淡:只做水平的话上/右边界仍是硬线
-    expect(html).toMatch(/mask-image:\s*\n?\s*linear-gradient\(90deg,transparent/);
+    // 四个方向都要淡:只做水平的话上/右边界仍是硬线。
+    // **正则要排除 -webkit- 前缀**:直接写 /mask-image:/ 会匹配到
+    // `-webkit-mask-image:`(子串包含),那样即便标准属性被删掉测试照样绿,
+    // Firefox 上的退化就测不出来。用负向后顾锁住无前缀那条。
+    expect(html).toMatch(/(?<!-webkit-)mask-image:\s*\n?\s*linear-gradient\(90deg,transparent/);
+    expect(html).toMatch(/-webkit-mask-image:\s*\n?\s*linear-gradient\(90deg,transparent/);
     expect(html).toContain("linear-gradient(180deg,transparent 0%,#000 12%,#000 88%,transparent 100%)");
   });
 

--- a/workers/scout-connect/src/html/home-page.test.ts
+++ b/workers/scout-connect/src/html/home-page.test.ts
@@ -206,9 +206,30 @@ describe("home page(apex 落地页)", () => {
     // **正则要排除 -webkit- 前缀**:直接写 /mask-image:/ 会匹配到
     // `-webkit-mask-image:`(子串包含),那样即便标准属性被删掉测试照样绿,
     // Firefox 上的退化就测不出来。用负向后顾锁住无前缀那条。
-    expect(html).toMatch(/(?<!-webkit-)mask-image:\s*\n?\s*linear-gradient\(90deg,transparent/);
-    expect(html).toMatch(/-webkit-mask-image:\s*\n?\s*linear-gradient\(90deg,transparent/);
-    expect(html).toContain("linear-gradient(180deg,transparent 0%,#000 12%,#000 88%,transparent 100%)");
+    // 断言要落在**同一条声明**内(分号前):否则 toContain 只要文件里任何地方
+    // 出现 180deg 就过,而无前缀的 mask-image 可能只剩水平那层(Firefox 退化)。
+    const decl = (prefix: string) => {
+      const re = new RegExp(`${prefix}mask-image:([^;]*);`);
+      return html.match(re)?.[1] ?? "";
+    };
+    for (const p of ["(?<!-webkit-)", "-webkit-"]) {
+      const d = decl(p);
+      expect(d, `${p}mask-image 缺水平层`).toContain("linear-gradient(90deg,transparent");
+      expect(d, `${p}mask-image 缺垂直层`).toContain("linear-gradient(180deg,transparent");
+    }
+  });
+
+  // Copilot round-3:桌面 mask 是「从左淡入」(让左侧文字区干净),
+  // 但窄屏是单列、海报在文字上方的横条 —— 水平淡入会吃掉横条左半边。
+  // 实测 392px 下若不在 @container 里覆盖,mask 仍带 90deg。
+  it("窄屏覆盖 mask 为纵向淡出(桌面的水平淡入在横条上是错的)", () => {
+    const html = homePage();
+    const i = html.indexOf("@container (max-width:760px)");
+    expect(i).toBeGreaterThan(0);
+    const seg = html.slice(i, i + 2600);
+    expect(seg).toContain("linear-gradient(180deg,#000 0%,#000 55%,transparent 100%)");
+    // 覆盖必须同时给两个前缀,否则 Firefox 仍吃桌面那套
+    expect(seg).toContain("-webkit-mask-image:linear-gradient(180deg");
   });
 
   it("按钮文字色用 .apex 前缀覆盖(否则被 .apex a 的绿色压掉)", () => {

--- a/workers/scout-connect/src/html/home-page.test.ts
+++ b/workers/scout-connect/src/html/home-page.test.ts
@@ -193,6 +193,20 @@ describe("home page(apex 落地页)", () => {
 
   // 线上真 bug(测试全绿但页面坏):.apex a 是类+标签(特异性 0,1,1),
   // 压过纯类 .btn(0,1,0) —— 主 CTA 文字变绿色 = 绿底绿字,按钮看起来是空的。
+  // 用户截图发现:海报墙左边缘是一条硬直线。真因不是渐变曲线不够柔,
+  // 而是 overflow:hidden 把超出容器的海报**直接裁掉**(实测容器左边界 x=743、
+  // 网格从 x=641 开始,中间 102px 被硬裁),裁切边是真实竖线 ——
+  // ::after 盖渐变只在容器内部生效,管不到它。必须用 mask 让元素自身淡出。
+  it("海报墙用 mask-image 四边淡出(渐变盖不住 overflow 裁切边)", () => {
+    const html = homePage();
+    // 水平 + 垂直两层,相乘
+    expect(html).toContain("mask-composite:intersect");
+    expect(html).toContain("-webkit-mask-composite:source-in");
+    // 四个方向都要淡:只做水平的话上/右边界仍是硬线
+    expect(html).toMatch(/mask-image:\s*\n?\s*linear-gradient\(90deg,transparent/);
+    expect(html).toContain("linear-gradient(180deg,transparent 0%,#000 12%,#000 88%,transparent 100%)");
+  });
+
   it("按钮文字色用 .apex 前缀覆盖(否则被 .apex a 的绿色压掉)", () => {
     const html = homePage();
     // 必须带 .apex 前缀才压得住

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -138,6 +138,23 @@ ${BRAND_CSS}
 .hero-l{min-width:0;position:relative;z-index:2}
 .hero-r{position:relative;min-width:0;align-self:stretch;overflow:hidden;
   pointer-events:none;
+  /* **关键**:用 mask 让元素自身淡出,而不是靠 ::after 盖一层渐变。
+     盖渐变解决不了硬边 —— overflow:hidden 会把超出容器的海报**直接裁掉**,
+     裁切边是一条真实的竖线,而渐变只在容器内部生效、管不到它。
+     实测:容器左边界 x=743,海报网格从 x=641 开始,中间 102px 被硬裁。
+     mask 作用在元素合成阶段,连裁切边一起淡掉。 */
+  /* 两层 mask 相乘(mask-composite:intersect):水平从左淡入 + 垂直上下淡出。
+     必须四边都淡 —— 只做水平的话,容器上边界和右边界的裁切边同样是硬线
+     (实测顶部 y=68、右侧 x=1226 各留一条)。右侧留 92% 而非 100%:
+     它贴着 section 边缘,完全不淡会切出直角。 */
+  -webkit-mask-image:
+    linear-gradient(90deg,transparent 0%,rgba(0,0,0,.35) 14%,rgba(0,0,0,.8) 40%,#000 70%,#000 92%,rgba(0,0,0,.55) 100%),
+    linear-gradient(180deg,transparent 0%,#000 12%,#000 88%,transparent 100%);
+  -webkit-mask-composite:source-in;
+          mask-image:
+    linear-gradient(90deg,transparent 0%,rgba(0,0,0,.35) 14%,rgba(0,0,0,.8) 40%,#000 70%,#000 92%,rgba(0,0,0,.55) 100%),
+    linear-gradient(180deg,transparent 0%,#000 12%,#000 88%,transparent 100%);
+          mask-composite:intersect;
   /* 向右出血到 section 边缘。**不能用 calc(50% - 50vw)** —— 那个 50% 相对
      父元素(窄网格子项)算,实测溢出到 right=1573 而视口 1280,会出横向滚动条。 */
   margin-top:calc(var(--s-8) * -1);margin-bottom:calc(var(--s-8) * -1);
@@ -146,17 +163,24 @@ ${BRAND_CSS}
   gap:6px;transform:rotate(-2deg) scale(1.14);
   animation:drift 26s ease-in-out infinite alternate}
 .pw img{width:100%;height:104px;object-fit:cover;border-radius:5px;display:block;
-  opacity:.62}   /* 压暗:海报是背景,不能抢标题 */
+  /* 压暗:海报是背景,不能抢标题。.52 是配合遮罩调出来的 —— 右端遮罩只有
+     .24,若图本身不压暗,右侧会比左侧亮太多,视觉上像两张拼起来的图。 */
+  opacity:.52}
 @keyframes drift{
   from{transform:rotate(-2deg) scale(1.14) translate3d(0,0,0)}
   to{transform:rotate(-2deg) scale(1.14) translate3d(-10px,-16px,0)}}
 @media (prefers-reduced-motion:reduce){.pw{animation:none}}
 /* 双层遮罩:左侧淡出(文字区干净)+ 上下淡出(不与 section 边界打架)。
    单层线性渐变做不到「左+上下」同时淡出。 */
+/* 遮罩:从左到右由实到虚,**必须是连续曲线**。
+   曾经写成 0%→22% 只从 1.0 降到 0.92 —— 那 22% 是一片几乎纯色的挡板,
+   它的右边缘就成了一条肉眼可见的硬直线;而右端只留 .12 遮罩又让海报
+   全亮,两侧反差过大。现在用多段缓降(1 → .97 → .82 → .55 → .34 → .24),
+   每段跨度都足够长,没有任何一段是"平的"。 */
+/* 水平淡出已由上面的 mask 负责;这里只做「整体压暗 + 上下边缘淡出」。
+   两件事分开:mask 管透明度(能吃掉裁切边),这层管色调(把海报拉回底色)。 */
 .hero-r::after{content:"";position:absolute;inset:0;pointer-events:none;
-  background:
-    linear-gradient(90deg,var(--bg-0) 0%,rgba(17,19,18,.92) 22%,rgba(17,19,18,.35) 55%,rgba(17,19,18,.12) 100%),
-    linear-gradient(180deg,var(--bg-0) 0%,transparent 18%,transparent 82%,var(--bg-0) 100%)}
+  background:linear-gradient(90deg,rgba(17,19,18,.5) 0%,rgba(17,19,18,.28) 45%,rgba(17,19,18,.18) 100%)}
 .hero-r::before{content:"";position:absolute;inset:0;z-index:1;pointer-events:none;
   background:radial-gradient(80% 60% at 85% 15%,rgba(30,215,96,.14),transparent 70%)}
 

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -341,9 +341,16 @@ ${BRAND_CSS}
 }
 @container (max-width:760px){
   .hero{grid-template-columns:1fr;padding:var(--s-5) var(--gutter) var(--s-6);gap:var(--s-4)}
-  /* 窄屏海报墙压成顶部装饰带,遮罩改成从上到下淡出 */
+  /* 窄屏:海报墙压成顶部装饰带,遮罩改成**纵向**淡出。
+     必须显式覆盖 mask —— 桌面那套是「从左淡入」(为了让左侧文字区干净),
+     但窄屏是单列、海报在文字**上方**的横条,水平淡入会把横条左半边吃掉。
+     实测 392px 下若不覆盖,mask 仍带 90deg。 */
   .hero-r{order:-1;margin:calc(var(--s-5) * -1) calc(var(--gutter) * -1) var(--s-2);
-    height:150px;align-self:auto}
+    height:150px;align-self:auto;
+    -webkit-mask-image:linear-gradient(180deg,#000 0%,#000 55%,transparent 100%);
+            mask-image:linear-gradient(180deg,#000 0%,#000 55%,transparent 100%);
+    -webkit-mask-composite:source-over;
+            mask-composite:add}
   .pw img{height:74px}
   .hero-r::after{background:linear-gradient(180deg,rgba(17,19,18,.55) 0%,
     rgba(17,19,18,.2) 40%,var(--bg-0) 100%)}

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -163,22 +163,19 @@ ${BRAND_CSS}
   gap:6px;transform:rotate(-2deg) scale(1.14);
   animation:drift 26s ease-in-out infinite alternate}
 .pw img{width:100%;height:104px;object-fit:cover;border-radius:5px;display:block;
-  /* 压暗:海报是背景,不能抢标题。.52 是配合遮罩调出来的 —— 右端遮罩只有
-     .24,若图本身不压暗,右侧会比左侧亮太多,视觉上像两张拼起来的图。 */
+  /* 压暗:海报是背景,不能抢标题。.52 是配合上面两层(mask 的右端保持不透明
+     + ::after 右侧只压 .18)调出来的 —— 右侧遮得轻,图本身若不压暗就会比
+     左侧亮太多,看起来像两张拼接的图。 */
   opacity:.52}
 @keyframes drift{
   from{transform:rotate(-2deg) scale(1.14) translate3d(0,0,0)}
   to{transform:rotate(-2deg) scale(1.14) translate3d(-10px,-16px,0)}}
 @media (prefers-reduced-motion:reduce){.pw{animation:none}}
-/* 双层遮罩:左侧淡出(文字区干净)+ 上下淡出(不与 section 边界打架)。
-   单层线性渐变做不到「左+上下」同时淡出。 */
-/* 遮罩:从左到右由实到虚,**必须是连续曲线**。
-   曾经写成 0%→22% 只从 1.0 降到 0.92 —— 那 22% 是一片几乎纯色的挡板,
-   它的右边缘就成了一条肉眼可见的硬直线;而右端只留 .12 遮罩又让海报
-   全亮,两侧反差过大。现在用多段缓降(1 → .97 → .82 → .55 → .34 → .24),
-   每段跨度都足够长,没有任何一段是"平的"。 */
-/* 水平淡出已由上面的 mask 负责;这里只做「整体压暗 + 上下边缘淡出」。
-   两件事分开:mask 管透明度(能吃掉裁切边),这层管色调(把海报拉回底色)。 */
+/* 压暗层:把海报的色调拉回底色,让它读起来是背景而不是内容。
+   **只管色调,不管边缘** —— 四边淡出全部由 .hero-r 的 mask-image 负责
+   (见那里的注释:渐变盖不住 overflow 的裁切边)。
+   数值从左到右 .5 → .28 → .18:左侧压重是因为文字区在那边,
+   右侧留浅一点让海报还能看清是海报。 */
 .hero-r::after{content:"";position:absolute;inset:0;pointer-events:none;
   background:linear-gradient(90deg,rgba(17,19,18,.5) 0%,rgba(17,19,18,.28) 45%,rgba(17,19,18,.18) 100%)}
 .hero-r::before{content:"";position:absolute;inset:0;z-index:1;pointer-events:none;

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -163,9 +163,9 @@ ${BRAND_CSS}
   gap:6px;transform:rotate(-2deg) scale(1.14);
   animation:drift 26s ease-in-out infinite alternate}
 .pw img{width:100%;height:104px;object-fit:cover;border-radius:5px;display:block;
-  /* 压暗:海报是背景,不能抢标题。.52 是配合上面两层(mask 的右端保持不透明
-     + ::after 右侧只压 .18)调出来的 —— 右侧遮得轻,图本身若不压暗就会比
-     左侧亮太多,看起来像两张拼接的图。 */
+  /* 压暗:海报是背景,不能抢标题。.52 是配合上面两层调出来的 ——
+     mask 右端(92%→100%)只从 #000 淡到 .55、::after 右侧只压 .18,
+     也就是右侧遮得很轻;图本身若不压暗就会比左侧亮太多,像两张拼接的图。 */
   opacity:.52}
 @keyframes drift{
   from{transform:rotate(-2deg) scale(1.14) translate3d(0,0,0)}


### PR DESCRIPTION
## 问题

用户截图:海报墙左边缘一条**硬直线**,右侧海报又几乎全亮。

## 真因不是渐变曲线

`.hero-r` 有 `overflow:hidden`,海报网格用 `inset:-8%` + `scale(1.14)` 故意画得比容器大 —— **超出部分被直接裁掉,裁切边是一条真实的竖线**。而 `::after` 盖的渐变只在容器**内部**生效,管不到它。

实测数据:
```
容器左边界  x = 743
网格左边界  x = 641   ← 中间 102px 被硬裁
```

我第一版试的是「把渐变曲线改得更缓」(`0%→8%→20%→42%→70%`)—— 柔和度确实好了,**硬线照旧**,因为方向从一开始就错了。这个失败尝试记在注释里,免得后人再走一遍。

## 解法

改用 `mask-image` —— 它作用在元素**合成阶段**,连裁切边一起淡掉。

两层相乘(`mask-composite:intersect`):水平从左淡入 + 垂直上下淡出。

**四边都要做**:只加水平 mask 后,实测上边界(y=68)和右边界(x=1226)仍是硬线。

## 配合调的两处

| 值 | 原 | 新 | 原因 |
|---|---|---|---|
| 遮罩右端 | .12 | .18–.2 | 原来右侧几乎无遮罩,与左侧反差过大,像两张拼接的图 |
| 海报 opacity | .62 | .52 | 配合右端遮罩变淡,图本身要压暗才不刺眼 |

## 门禁
- 805 worker+site 测试全绿,三处 tsc 全绿
- 反向验证:去掉 `mask-composite` → 精确转红
- **已在浏览器逐版截图核对**(v2 渐变版仍有硬线 → v3 水平 mask 消掉左边 → v4 四边 mask 全消)