### PR TITLE
fix(workflow): 光鸭/天翼复用剧集目录时 WRITE_SCOPE_VIOLATION (#210)

### DIFF
--- a/packages/workflow/src/guangya-storage-executor.test.ts
+++ b/packages/workflow/src/guangya-storage-executor.test.ts
@@ -241,6 +241,47 @@ describe("GuangYaStorageExecutor write-scope guard", () => {
     await expect(executor.removeDirectory("stranger")).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
   });
 
+  it("authorizes createDirectory under a show folder REUSED via listChildDirectories (#210 / pan123 #168)", async () => {
+    // Same production shape as pan123 莉可丽丝 / issue #210: ensureMediaLibraryDirectory
+    // reuses an existing show folder from listChildDirectories; without derived-scope
+    // registration createDirectory(Season NN) dies with WRITE_SCOPE_VIOLATION.
+    const fs = new Map<string, GuangYaStorageItem[]>();
+    fs.set(SCOPE, [
+      { fileId: "existing-show", parentId: SCOPE, fileName: "凡人修仙传 (2020)", fileSize: 0, resType: 2 },
+    ]);
+    fs.set("existing-show", []);
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async (p: string) => fs.get(p) ?? []);
+    const createDir = vi.fn<GuangYaStorageClient["createDir"]>(async () => "newdir123");
+    const executor = new GuangYaStorageExecutor({
+      client: fakeClient({ listFiles, createDir }),
+      writeScopeDirectoryIds: [SCOPE],
+    });
+
+    const children = await executor.listChildDirectories(SCOPE);
+    expect(children).toEqual([{ id: "existing-show", name: "凡人修仙传 (2020)" }]);
+
+    await expect(
+      executor.createDirectory({ name: "Season 01", parentId: "existing-show" }),
+    ).resolves.toBe("newdir123");
+  });
+
+  it("does NOT widen scope via listChildDirectories on an OUT-of-scope dir (read ≠ write)", async () => {
+    const fs = new Map<string, GuangYaStorageItem[]>();
+    fs.set("elsewhere", [
+      { fileId: "stranger", parentId: "elsewhere", fileName: "x", fileSize: 0, resType: 2 },
+    ]);
+    const listFiles = vi.fn<GuangYaStorageClient["listFiles"]>(async (p: string) => fs.get(p) ?? []);
+    const executor = new GuangYaStorageExecutor({
+      client: fakeClient({ listFiles }),
+      writeScopeDirectoryIds: [SCOPE],
+    });
+
+    await executor.listChildDirectories("elsewhere");
+    await expect(
+      executor.createDirectory({ name: "Season 01", parentId: "stranger" }),
+    ).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
+  });
+
   it("authorizes writes into runtime-created NESTED dirs (derived scope), still refuses unknown ids", async () => {
     // The real workflow provisions the dir chain TOP-DOWN from a scope root via
     // createDirectory before any write, then transfers/moves into the NESTED leaf —

--- a/packages/workflow/src/guangya-storage-executor.ts
+++ b/packages/workflow/src/guangya-storage-executor.ts
@@ -111,7 +111,8 @@ export class GuangYaStorageExecutor implements StorageExecutor {
   private readonly writeScopeDirectoryIds: Set<string>;
   /** Ids of nested dirs find-or-created under an already-in-scope parent during this
    *  run. They become authorized write targets (光鸭 has no parent-walk API to verify
-   *  them otherwise). Populated by createDirectory; consulted by assertWithinWriteScope. */
+   *  them otherwise). Populated by createDirectory / listChildDirectories /
+   *  listSubdirectories; consulted by assertWithinWriteScope. */
   private readonly derivedScopeIds = new Set<string>();
   private readonly protectedDirectoryIds: Set<string>;
   private readonly minVideoSizeBytes: number;
@@ -441,6 +442,13 @@ export class GuangYaStorageExecutor implements StorageExecutor {
   }
 
   async listChildDirectories(directoryId: string): Promise<Array<{ id: string; name: string }>> {
+    // Derived-scope registration (same rule as the recursive lister / pan123 #168):
+    // a subdir DISCOVERED under an in-scope parent is itself in scope. Without
+    // this, ensureMediaLibraryDirectory reusing an EXISTING show folder returns
+    // an unregistered id and the follow-up createDirectory(Season NN) dies with
+    // WRITE_SCOPE_VIOLATION (issue #210). Listing an OUT-of-scope dir must NOT
+    // widen scope (read ≠ write) — gate on the parent, computed BEFORE listing.
+    const parentInScope = this.isWithinWriteScope(directoryId);
     const items = await this.client.listFiles(directoryId);
     const dirs: Array<{ id: string; name: string }> = [];
     for (const item of items) {
@@ -449,6 +457,9 @@ export class GuangYaStorageExecutor implements StorageExecutor {
       }
       const id = idOf(item);
       if (id) {
+        if (parentInScope) {
+          this.derivedScopeIds.add(normalizeId(id));
+        }
         dirs.push({ id, name: nameOf(item) });
       }
     }

--- a/packages/workflow/src/tianyi-storage-executor.test.ts
+++ b/packages/workflow/src/tianyi-storage-executor.test.ts
@@ -340,6 +340,37 @@ describe("TianyiStorageExecutor write-scope guard (derived scope)", () => {
     await executor.listSubdirectories({ directoryId: "elsewhere" });
     await expect(executor.removeDirectory("stranger")).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
   });
+
+  it("authorizes createDirectory under a show folder REUSED via listChildDirectories (#210 / pan123 #168)", async () => {
+    // Same production shape as pan123 莉可丽丝: ensureMediaLibraryDirectory finds an
+    // existing show folder via listChildDirectories and returns its id — without
+    // derived-scope registration the follow-up createDirectory(Season NN) dies with
+    // WRITE_SCOPE_VIOLATION.
+    const fs = new Map<string, TianyiItem[]>();
+    fs.set(SCOPE, [folder("existing-show", "凡人修仙传 (2020)")]);
+    fs.set("existing-show", []);
+    const listFiles = vi.fn<TianyiClient["listFiles"]>(async (dirId) => fs.get(dirId ?? "") ?? []);
+    const executor = makeExecutor(fakeClient({ listFiles }));
+
+    const children = await executor.listChildDirectories(SCOPE);
+    expect(children).toEqual([{ id: "existing-show", name: "凡人修仙传 (2020)" }]);
+
+    await expect(
+      executor.createDirectory({ name: "Season 01", parentId: "existing-show" }),
+    ).resolves.toBe("newdir123");
+  });
+
+  it("does NOT widen scope via listChildDirectories on an OUT-of-scope dir (read ≠ write)", async () => {
+    const fs = new Map<string, TianyiItem[]>();
+    fs.set("elsewhere", [folder("stranger", "x")]);
+    const listFiles = vi.fn<TianyiClient["listFiles"]>(async (dirId) => fs.get(dirId ?? "") ?? []);
+    const executor = makeExecutor(fakeClient({ listFiles }));
+
+    await executor.listChildDirectories("elsewhere");
+    await expect(
+      executor.createDirectory({ name: "Season 01", parentId: "stranger" }),
+    ).rejects.toThrow(/WRITE_SCOPE_VIOLATION/);
+  });
 });
 
 describe("TianyiStorageExecutor.removeDirectory / recursive-list safety", () => {

--- a/packages/workflow/src/tianyi-storage-executor.ts
+++ b/packages/workflow/src/tianyi-storage-executor.ts
@@ -74,9 +74,10 @@ export class TianyiStorageExecutor implements StorageExecutor {
   private readonly client: TianyiClient;
   private readonly writeScopeDirectoryIds: Set<string>;
   /** Ids of nested dirs find-or-created (createDirectory) or discovered under an
-   *  already-in-scope parent (listSubdirectories, PR#58) during this run. They
-   *  become authorized write targets — 天翼 has no parent-walk API to verify them
-   *  otherwise. Consulted by assertWithinWriteScope / isWithinWriteScope. */
+   *  already-in-scope parent (listChildDirectories, listSubdirectories / PR#58)
+   *  during this run. They become authorized write targets — 天翼 has no parent-walk
+   *  API to verify them otherwise. Consulted by assertWithinWriteScope /
+   *  isWithinWriteScope. */
   private readonly derivedScopeIds = new Set<string>();
   private readonly protectedDirectoryIds: Set<string>;
   private readonly minVideoSizeBytes: number;
@@ -319,6 +320,13 @@ export class TianyiStorageExecutor implements StorageExecutor {
   }
 
   async listChildDirectories(directoryId: string): Promise<Array<{ id: string; name: string }>> {
+    // Derived-scope registration (same rule as the recursive lister above / pan123 #168):
+    // a subdir DISCOVERED under an in-scope parent is itself in scope. Without
+    // this, ensureMediaLibraryDirectory reusing an EXISTING show folder returns
+    // an unregistered id and the follow-up createDirectory(Season NN) dies with
+    // WRITE_SCOPE_VIOLATION (issue #210). Listing an OUT-of-scope dir must NOT
+    // widen scope (read ≠ write) — gate on the parent, computed BEFORE listing.
+    const parentInScope = this.isWithinWriteScope(directoryId);
     const items = await this.client.listFiles(directoryId);
     const dirs: Array<{ id: string; name: string }> = [];
     for (const item of items) {
@@ -327,6 +335,9 @@ export class TianyiStorageExecutor implements StorageExecutor {
       }
       const id = idOf(item);
       if (id) {
+        if (parentInScope) {
+          this.derivedScopeIds.add(normalizeId(id));
+        }
         dirs.push({ id, name: nameOf(item) });
       }
     }


### PR DESCRIPTION
## Summary
- Port pan123 #168's `listChildDirectories` derived-scope registration to 光鸭 and 天翼.
- Fixes #210: reusing an existing show folder (legacy `Title (Year)` or preferred `{tmdb-N}`) via `listChildDirectories` left the id unregistered, so `createDirectory(Season NN)` died with `WRITE_SCOPE_VIOLATION`.
- Registration remains gated on the listed parent being in scope (read ≠ write for out-of-scope dirs).

## Test plan
- [x] New regression: reused show folder via `listChildDirectories` authorizes `createDirectory` under it (光鸭 + 天翼)
- [x] Negative: `listChildDirectories` on an out-of-scope dir does NOT widen scope
- [x] `npx vitest run` on guangya + tianyi executor suites (94 passed previously; scoped listChildDirectories/WRITE_SCOPE green)


Made with [Cursor](https://cursor.com)