### PR TITLE
fix(apex): hero 海报被裁成横条 —— 高度写死,改用 aspect-ratio 2/3

### DIFF
--- a/workers/scout-connect/src/html/home-page.test.ts
+++ b/workers/scout-connect/src/html/home-page.test.ts
@@ -197,6 +197,23 @@ describe("home page(apex 落地页)", () => {
   // 而是 overflow:hidden 把超出容器的海报**直接裁掉**(实测容器左边界 x=743、
   // 网格从 x=641 开始,中间 102px 被硬裁),裁切边是真实竖线 ——
   // ::after 盖渐变只在容器内部生效,管不到它。必须用 mask 让元素自身淡出。
+  // 用户发现:海报被截断成横条。TMDB 海报是标准 2:3 竖版(实测 342x513),
+  // 而写死 height:104px 会渲染成 159x124(比例 1.28)—— object-fit:cover
+  // 把上下裁掉约 62%,只剩中间一条,海报变成认不出的色块。
+  it("海报用 aspect-ratio 2/3,不写死 height(否则竖版被裁成横条)", () => {
+    const html = homePage();
+    // **断言前必须剥掉 CSS 注释** —— 注释就写在这条声明内部,
+    // 而我的说明文字里含「写死 height:104px」这几个字。开发时连踩两次:
+    // ① 宽正则命中注释;② 缩到声明内仍命中(注释在声明里)。
+    const css = html.replace(/\/\*[\s\S]*?\*\//g, "");
+    const decl = css.match(/\.pw img\{([^}]*)\}/)?.[1] ?? "";
+    expect(decl).toContain("aspect-ratio:2 / 3");
+    expect(decl).toContain("height:auto");
+    expect(decl).not.toMatch(/height:\d+px/);
+    // 窄屏那条也不能写死
+    expect(css).not.toContain(".pw img{height:74px}");
+  });
+
   it("海报墙用 mask-image 四边淡出(渐变盖不住 overflow 裁切边)", () => {
     const html = homePage();
     // 水平 + 垂直两层,相乘

--- a/workers/scout-connect/src/html/home-page.ts
+++ b/workers/scout-connect/src/html/home-page.ts
@@ -162,7 +162,13 @@ ${BRAND_CSS}
 .pw{position:absolute;inset:-8%;display:grid;grid-template-columns:repeat(4,1fr);
   gap:6px;transform:rotate(-2deg) scale(1.14);
   animation:drift 26s ease-in-out infinite alternate}
-.pw img{width:100%;height:104px;object-fit:cover;border-radius:5px;display:block;
+.pw img{width:100%;
+  /* **必须用 aspect-ratio,不能写死 height。** TMDB 海报是标准 2:3 竖版
+     (实测 342x513,比例 0.67),而写死 height:104px 会让它渲染成 159x124
+     (比例 1.28)—— object-fit:cover 于是把上下裁掉约 62%,只剩中间一条,
+     海报变成认不出的色块。让高度跟着宽度按 2:3 算,内容才完整。 */
+  aspect-ratio:2 / 3;height:auto;
+  object-fit:cover;border-radius:5px;display:block;
   /* 压暗:海报是背景,不能抢标题。.52 是配合上面两层调出来的 ——
      mask 右端(92%→100%)只从 #000 淡到 .55、::after 右侧只压 .18,
      也就是右侧遮得很轻;图本身若不压暗就会比左侧亮太多,像两张拼接的图。 */
@@ -351,7 +357,8 @@ ${BRAND_CSS}
             mask-image:linear-gradient(180deg,#000 0%,#000 55%,transparent 100%);
     -webkit-mask-composite:source-over;
             mask-composite:add}
-  .pw img{height:74px}
+  /* 窄屏同理:不写死高度,让 aspect-ratio 继续生效(装饰带靠容器 height 裁) */
+  .pw img{height:auto}
   .hero-r::after{background:linear-gradient(180deg,rgba(17,19,18,.55) 0%,
     rgba(17,19,18,.2) 40%,var(--bg-0) 100%)}
   .gate,.pg,.flow{grid-template-columns:1fr}


### PR DESCRIPTION
## 问题

用户发现海报墙里的海报认不出内容。

## 实测数据

| | 值 |
|---|---|
| TMDB 海报原始 | 342×513，比例 **0.67**（标准 2:3 竖版）|
| 我渲染成 | 159×124，比例 **1.28** |
| 后果 | `object-fit:cover` 把**上下裁掉约 62%**，只剩中间一条 |

根因是我写死了 `height:104px`。

## 修法

`aspect-ratio:2 / 3` + `height:auto`，让高度跟着宽度算。改后实测比例 **0.69**，与原始 0.67 匹配，片名和画面都能看清。

窄屏那条也写死了 `74px`（同样问题），一并改 auto —— 装饰带靠容器的 `height:150px` 裁，不该让图自己变形。

## 测试断言连踩两次坑

值得记下，因为这类问题很隐蔽：

1. `/\.pw img\{[^}]*height:\d+px/` → 命中的是**我自己注释里**的「而写死 height:104px 会…」（注释也在渲染产物里）
2. 缩小到 `[;{]height:\d+px[;}]` → 又命中页面别处**合法**的高度（输入框、按钮）

根因是注释就写在这条声明**内部**，任何范围限定都躲不开。正解是断言前先剥掉 CSS 注释：
```js
const css = html.replace(/\/\*[\s\S]*?\*\//g, "");
```

## 门禁
- 1290 测试 + 三处 tsc 全绿
- 反向验证:改回 `height:104px` → 精确转红
- 浏览器已核对海报完整显示