### PR TITLE
feat(web): 加 runAction —— server action 调用的统一异常边界

### DIFF
--- a/apps/web/lib/run-action.test.ts
+++ b/apps/web/lib/run-action.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { runAction } from "./run-action";
+
+describe("runAction", () => {
+  it("成功时透传返回值，不碰 onError", async () => {
+    const onError = vi.fn();
+    const r = await runAction(async () => ({ saved: true }), onError);
+
+    expect(r).toEqual({ ok: true, value: { saved: true } });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("抛错时返回 ok:false 并给出可读文案", async () => {
+    const onError = vi.fn();
+    const r = await runAction(async () => {
+      throw new Error("boom");
+    }, onError);
+
+    expect(r).toEqual({ ok: false });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("不把异常内容回显给用户", async () => {
+    // 模拟真实泄露风险：DemoReadOnlyError 之类的消息里可能带内部细节。
+    const onError = vi.fn();
+    await runAction(async () => {
+      throw new Error("PGRES: relation acct_secrets does not exist at /srv/app/db.ts:99");
+    }, onError);
+
+    const message = onError.mock.calls[0]?.[0] ?? "";
+    expect(message).not.toContain("PGRES");
+    expect(message).not.toContain("acct_secrets");
+    expect(message).not.toContain("/srv/app");
+    // 而且要是句人话，能指导下一步动作。
+    expect(message).toContain("再试");
+  });
+
+  it("T = undefined 时不与失败混淆（tagged union 的存在理由）", async () => {
+    const onError = vi.fn();
+    // 返回 void 的 action —— 用 `T | undefined` 签名时这里会与抛错无法区分。
+    const r = await runAction<void>(async () => undefined, onError);
+
+    expect(r.ok).toBe(true);
+    expect(onError).not.toHaveBeenCalled();
+
+    // 类型层面也要能收窄：ok 为 true 时 value 可访问。
+    if (r.ok) expect(r.value).toBeUndefined();
+  });
+
+  it("非 Error 抛出物（字符串、null）也能兜住", async () => {
+    // Next.js 的 action 序列化失败时抛的不一定是 Error 实例。
+    for (const thrown of ["plain string", null, undefined, 42]) {
+      const onError = vi.fn();
+      const r = await runAction(async () => {
+        throw thrown;
+      }, onError);
+
+      expect(r).toEqual({ ok: false });
+      expect(onError).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("同步抛出（fn 还没返回 promise 就炸）也算失败", async () => {
+    const onError = vi.fn();
+    const r = await runAction(() => {
+      throw new Error("sync boom");
+    }, onError);
+
+    expect(r).toEqual({ ok: false });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/lib/run-action.ts
+++ b/apps/web/lib/run-action.ts
@@ -1,0 +1,66 @@
+/**
+ * server action 调用的统一异常边界。
+ *
+ * **为什么需要它**：`startTransition(async () => { const r = await someAction(); ... })`
+ * 这个写法在本项目出现了 32 次，其中绝大多数没有 try/catch。而 server action
+ * **会 throw**，来源至少三类：
+ *
+ * 1. demo 门禁 —— `assertNotDemo()` 抛 `DemoReadOnlyError`（actions.ts 里 31 处）
+ * 2. Next.js 运行时错误 —— 序列化失败、action 找不到（部署不一致时常见）
+ * 3. 网络中断 —— 用户点完就断网
+ *
+ * 不 catch 的后果不是"报错"，而是**界面上什么都不会发生**：promise rejection
+ * 未处理，按钮从 pending 复位，没有任何提示。用户只会以为"点了没反应"，
+ * 然后重复点击。这比明确报错更糟。
+ */
+
+/**
+ * 为什么是 tagged union 而不是 `Promise<T | undefined>`。
+ *
+ * 因为 `T` 本身可以是 `undefined` —— 那些返回 `void` 的 action 一旦被包进
+ * `T | undefined`，调用方的 `if (r === undefined) return;` 就**无法区分
+ * 「成功但无返回值」和「抛错了」**。这是签名层面的歧义，不是用法问题，
+ * 加注释也修不好，只能靠类型结构排除。
+ */
+export type RunActionOutcome<T> = { ok: true; value: T } | { ok: false };
+
+/** 兜底文案。不回显异常内容 —— 可能含堆栈、内部路径、SQL 片段。 */
+const FALLBACK_MESSAGE = "操作失败了。刷新页面后再试一次。";
+
+/**
+ * 跑一个 server action，把异常收敛成 `onError` 回调。
+ *
+ * ```ts
+ * startTransition(async () => {
+ *   const r = await runAction(() => saveThingAction(value), (m) => setResult({ ok: false, message: m }));
+ *   if (!r.ok) return;          // ← 但先看下面这条警告
+ *   setResult({ ok: true, message: r.value.message });
+ * });
+ * ```
+ *
+ * **⚠️ 失败时调用方通常还有状态机要复位。** 直接 `if (!r.ok) return;` 会吞掉
+ * 本来在成功路径上做的收尾，例如：
+ *
+ * - `unbind-storage-button`：不复位 `confirming`，按钮永远停在「确认取消绑定」
+ * - `patrol-now-button`：不跑 `router.refresh()`，也不清 note
+ *
+ * 这些不是可选的收尾，是**状态机复位**。每个调用点改造时要单独看一眼，
+ * 该复位的放进 `onError` 或提前到 `finally` 语义的位置。
+ *
+ * @param fn 真正发起 action 的函数。用闭包传参，不在这里做参数转发 ——
+ *           那样会把类型推导搞复杂，收益为零。
+ * @param onError 拿到用户可读文案。**不会**收到异常对象，防止顺手回显。
+ */
+export async function runAction<T>(
+  fn: () => Promise<T>,
+  onError: (message: string) => void,
+): Promise<RunActionOutcome<T>> {
+  try {
+    return { ok: true, value: await fn() };
+  } catch {
+    // 刻意不传异常给 onError：一旦给了，早晚有人 `onError(String(e))`
+    // 把内部细节回显到界面上。想排查问题看服务端日志。
+    onError(FALLBACK_MESSAGE);
+    return { ok: false };
+  }
+}


### PR DESCRIPTION
25 个组件、32 个调用点在 `startTransition` 里裸调 server action，**没有 catch**。

这是 Spec A（顶部通知）与 C2（测试连接按钮）的**共同前置** —— 两者都会新增需要 catch 的调用点，先落 helper 比让它们各手写一遍再回来改更省。

## 为什么这是个真问题

不 catch 的后果**不是"报错"，而是界面上什么都不会发生**：promise rejection 未处理，按钮从 pending 复位，零提示。用户只会以为"点了没反应"然后重复点击 —— 比明确报错更糟。

异常来源至少三类：
1. demo 门禁抛 `DemoReadOnlyError`（`actions.ts` 里 **31 处** `assertNotDemo`）
2. Next 运行时错误 —— 部署不一致时 action 找不到
3. 网络中断

先例是 `connect-login-form.tsx`（PR #214），本 PR 把它的做法抽成可复用的。

## 两个签名层面的决定

**① tagged union，不用 `Promise<T | undefined>`**

因为 `T` 本身可以是 `undefined` —— 返回 `void` 的 action 一旦被包进 `T | undefined`，调用方的 `r === undefined` 就**无法区分「成功但无返回值」和「抛错了」**。这是签名层面的歧义，加注释修不好，只能靠类型结构排除。测试里专门钉了这条。

**② `onError` 刻意不接收异常对象**

一旦给了，早晚有人写 `onError(String(e))` 把堆栈、内部路径、SQL 片段回显到界面。测试用一条含 `PGRES` / 表名 / `/srv/app` 路径的假异常钉住这个边界。

## 注释里记了一个下游陷阱

B1/B2/B3 改造 25 个组件时会反复踩：**失败时调用方通常还有状态机要复位**，直接 `if (!r.ok) return;` 会吞掉成功路径上的收尾。已实测两例：

- `unbind-storage-button` —— 不复位 `confirming`，按钮永远停在「确认取消绑定」
- `patrol-now-button` —— 不跑 `router.refresh()`，也不清 note

这些不是可选收尾，是状态机复位。

## 反向验证（还原在跑完之后）

| 破坏 | 结果 |
|---|---|
| 去掉 try/catch | 4 个测试转红 |
| 把异常内容回显 | 泄露测试转红 |
| 成功时也调 onError | 2 个转红 |

## 验证

- 三处 tsc 全绿（根 / `apps/web` / `workers/scout-connect`）
- 全量 **2695 passed**（基线 2689 + 本次 6），零回归
- 纯新增文件，无现有代码改动 → 不涉及 `build:web` 路由段约束