### PR TITLE
feat(connect): 诚实显示「上次报到」时间 —— 新开只读端点,不动 204 契约

### DIFF
--- a/apps/web/components/settings/remote-access-section.tsx
+++ b/apps/web/components/settings/remote-access-section.tsx
@@ -6,11 +6,33 @@ import {
   instanceConnectHostname,
   resolveRemoteAccessState,
   accountPasswordHref,
+  formatLastSeen,
   CONNECT_SITE_URL,
   consoleUrl,
 } from "../../lib/remote-access";
 import { PasswordChangeForm } from "../password-change-form";
 import { ConnectLoginForm } from "./connect-login-form";
+
+/**
+ * 「上次从本机报到控制面」一行。
+ *
+ * **措辞是这个组件存在的全部理由。** 它显示的是 `endpoints.last_seen_at`,
+ * 而那个值只在**本容器主动打到 worker** 时更新(出站方向)。用户真正想知道的是
+ * 「外网现在能不能打开我的域名」(入站方向) —— **两个方向的失败模式完全不重叠**:
+ * 容器出站正常但 cloudflared 容器挂了,是最常见的故障,而这个时间戳在那种情况下
+ * 依然显示「刚刚」。
+ *
+ * 所以主语必须是「本机 → 控制面」。**绝不能写成「隧道已连接」「远程访问正常」**
+ * 之类暗示入站可达的说法 —— 那就是拿一个恒真的指标冒充健康检查。
+ * 真正回答入站问题的是「测试连接」按钮(C2)。
+ */
+function LastSeenLine({ label }: { label: string }) {
+  return (
+    <p className="panel-note" style={{ margin: "6px 0 0", opacity: 0.85 }}>
+      本机上次向控制面报到：{label}
+    </p>
+  );
+}
 
 /**
  * 「远程访问」设置 section。
@@ -43,6 +65,10 @@ export async function RemoteAccessSection({
     token: instanceTunnelToken(),
     hostname: localHostname,
   });
+
+  // 「上次报到」只在 active 态有意义 —— 降级态本来就是「拿不到状态」,
+  // 那时摆一个旧时间戳出来只会让人以为它是当前状态。
+  const lastSeenLabel = state.kind === "active" ? formatLastSeen(state.lastSeenAt) : null;
 
   if (state.kind === "not_provisioned") {
     // **双入口**:登录框(主)+ apex 跳转(次)。
@@ -172,15 +198,19 @@ export async function RemoteAccessSection({
             {state.hostname}
           </a>
           <p className="panel-note" style={{ margin: "6px 0 0" }}>
-            隧道连接正常。在任何设备的浏览器打开这个地址即可（收藏它）。
+            在任何设备的浏览器打开这个地址即可（收藏它）。
           </p>
+          {lastSeenLabel ? <LastSeenLine label={lastSeenLabel} /> : null}
         </div>
       ) : state.kind === "active" ? (
         // 早期接入的实例 .env 里没有 MEDIARY_CONNECT_HOSTNAME(connect.sh 后加的)
         // —— 回落到不给链接的旧文案,绝不臆造一个点了 404 的地址。
-        <p className="panel-note" style={{ margin: "0 0 14px" }}>
-          远程访问已开启，隧道连接正常。请使用开通时收到的专属地址访问（浏览器里收藏即可）。
-        </p>
+        <div style={{ margin: "0 0 14px" }}>
+          <p className="panel-note" style={{ margin: 0 }}>
+            远程访问已开启。请使用开通时收到的专属地址访问（浏览器里收藏即可）。
+          </p>
+          {lastSeenLabel ? <LastSeenLine label={lastSeenLabel} /> : null}
+        </div>
       ) : (
         <p className="panel-note" style={{ margin: "0 0 14px" }}>
           远程访问已开启，但暂时联系不上控制面，无法确认隧道状态。

--- a/apps/web/lib/remote-access.test.ts
+++ b/apps/web/lib/remote-access.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  formatLastSeen,
   instanceTunnelToken,
   instanceConnectHostname,
   resolveRemoteAccessState,
@@ -62,7 +63,7 @@ describe("resolveRemoteAccessState", () => {
       token: "tok",
       sendHeartbeat: async () => "ok",
     });
-    expect(state).toEqual({ kind: "active", hostname: null });
+    expect(state).toEqual({ kind: "active", hostname: null, lastSeenAt: null });
   });
 
   it("调用方能提供本地已知 hostname 时透传", async () => {
@@ -71,7 +72,7 @@ describe("resolveRemoteAccessState", () => {
       hostname: "s1.mediaryconnect.app",
       sendHeartbeat: async () => "ok",
     });
-    expect(state).toEqual({ kind: "active", hostname: "s1.mediaryconnect.app" });
+    expect(state).toEqual({ kind: "active", hostname: "s1.mediaryconnect.app", lastSeenAt: null });
   });
 
   it("心跳 401（token 不是我们发的，比如作者自带的旧隧道）→ not_provisioned，露出报名入口", async () => {
@@ -127,15 +128,117 @@ describe("resolveRemoteAccessState", () => {
 
     const state = await resolveRemoteAccessState({ token: "tok-abc" });
 
-    expect(state).toEqual({ kind: "active", hostname: null });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(state).toEqual({ kind: "active", hostname: null, lastSeenAt: null });
+    // 两次请求:先 GET /meta 读旧值,再 POST /status 报到。**顺序不能反** ——
+    // 心跳会把 last_seen_at 写成"现在",读晚了就永远显示「刚刚」。
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [metaUrl] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(metaUrl).toBe("https://connect.test/api/instance/meta");
+    const [url, init] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
     expect(url).toBe("https://connect.test/api/instance/status");
     expect(init.method).toBe("POST");
     expect(init.cache).toBe("no-store");
     // 契约是 Authorization: Bearer <token> 头，不是 JSON body。
     expect(new Headers(init.headers).get("authorization")).toBe("Bearer tok-abc");
     expect(init.body).toBeUndefined();
+  });
+
+  it("先读 /meta 再报到 —— 顺序反了 last_seen_at 就永远是「刚刚」", async () => {
+    // 这是本功能最容易悄悄失效的地方:心跳会把 last_seen_at 写成"现在"。
+    // 读晚一步,显示的就永远是"刚刚",成了一个恒真的假指标 —— 用户看着绿灯
+    // 而隧道早就断了。所以顺序是契约的一部分,不是实现细节。
+    process.env.SCOUT_CONNECT_URL = "https://connect.test";
+    const order: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        order.push(url.endsWith("/api/instance/meta") ? "meta" : "status");
+        return url.endsWith("/api/instance/meta")
+          ? new Response(JSON.stringify({ last_seen_at: "2026-07-30T10:00:00.000Z" }), { status: 200 })
+          : new Response(null, { status: 204 });
+      }),
+    );
+
+    const state = await resolveRemoteAccessState({ token: "tok" });
+
+    expect(order).toEqual(["meta", "status"]);
+    expect(state).toEqual({
+      kind: "active",
+      hostname: null,
+      lastSeenAt: "2026-07-30T10:00:00.000Z",
+    });
+  });
+
+  it("旧 worker 没有 /meta（404）→ lastSeenAt 为 null，开通状态不受影响", async () => {
+    // 向后兼容的关键:容器可以先发布,worker 后发布。这个窗口期里 /meta 会 404,
+    // 但那绝不能把用户的远程访问显示成坏的 —— 只是少显示一行。
+    process.env.SCOUT_CONNECT_URL = "https://connect.test";
+    // ⚠️ body 必须是**合法 JSON**。用 "not found" 这种纯文本时 res.json() 会抛
+    // SyntaxError,被外层 catch 兜住后也返回 null —— 于是测试即便在删掉
+    // `!res.ok` 守卫的情况下依然全绿。那是个假测试(本轮反向验证抓到的)。
+    // 返回合法 JSON 才能真正把「状态码检查」这一条钉住。
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) =>
+        url.endsWith("/api/instance/meta")
+          ? new Response(JSON.stringify({ last_seen_at: "2020-01-01T00:00:00.000Z" }), { status: 404 })
+          : new Response(null, { status: 204 }),
+      ),
+    );
+
+    const state = await resolveRemoteAccessState({ token: "tok" });
+    // 404 就是 404:哪怕 body 里有个看起来能用的时间戳也不能采信。
+    expect(state).toEqual({ kind: "active", hostname: null, lastSeenAt: null });
+  });
+
+  it("/meta 返回垃圾（非 JSON / 字段不是字符串）不炸渲染", async () => {
+    process.env.SCOUT_CONNECT_URL = "https://connect.test";
+    for (const body of ["not json at all", JSON.stringify({ last_seen_at: 12345 }), JSON.stringify(null)]) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) =>
+          url.endsWith("/api/instance/meta")
+            ? new Response(body, { status: 200 })
+            : new Response(null, { status: 204 }),
+        ),
+      );
+      const state = await resolveRemoteAccessState({ token: "tok" });
+      expect(state).toEqual({ kind: "active", hostname: null, lastSeenAt: null });
+    }
+  });
+
+  it("注入了 sendHeartbeat 但没注入 fetchLastSeenAt → 不发任何真实请求", async () => {
+    // 打桩一半是最难查的一类 bug:调用方以为网络已经被隔离,实际还有一条
+    // 跨公网请求在跑,每次卡满 5 秒超时。两者要么都真,要么都假。
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const state = await resolveRemoteAccessState({ token: "tok", sendHeartbeat: async () => "ok" });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(state).toEqual({ kind: "active", hostname: null, lastSeenAt: null });
+  });
+
+  it("/meta 带 Bearer + no-store + 超时，且是 GET（读端点不能改状态）", async () => {
+    process.env.SCOUT_CONNECT_URL = "https://connect.test";
+    const fetchMock = vi.fn(async (url: string) =>
+      url.endsWith("/api/instance/meta")
+        ? new Response(JSON.stringify({ last_seen_at: null }), { status: 200 })
+        : new Response(null, { status: 204 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await resolveRemoteAccessState({ token: "tok-xyz" });
+
+    const metaCall = fetchMock.mock.calls.find((c) =>
+      (c as unknown as [string])[0].endsWith("/api/instance/meta"),
+    ) as unknown as [string, RequestInit];
+    expect(metaCall).toBeDefined();
+    // 没写 method 就是 GET。写成 POST 会变成一个「读的时候顺手改状态」的端点。
+    expect(metaCall[1].method).toBeUndefined();
+    expect(metaCall[1].cache).toBe("no-store");
+    expect(new Headers(metaCall[1].headers).get("authorization")).toBe("Bearer tok-xyz");
+    expect(metaCall[1].signal).toBeDefined();
   });
 
   it("默认心跳 base URL 缺省为生产 worker", async () => {
@@ -145,8 +248,10 @@ describe("resolveRemoteAccessState", () => {
 
     await resolveRemoteAccessState({ token: "tok" });
 
-    const [url] = fetchMock.mock.calls[0] as unknown as [string];
-    expect(url).toBe("https://mediaryconnect.app/api/instance/status");
+    // 断言「所有请求」而不是某一次:意图是 base URL 正确,不是调用顺序。
+    const urls = fetchMock.mock.calls.map((c) => (c as unknown as [string])[0]);
+    expect(urls).toContain("https://mediaryconnect.app/api/instance/status");
+    expect(urls.every((u) => u.startsWith("https://mediaryconnect.app/"))).toBe(true);
   });
 
   it("默认心跳：401（worker 不认这个 token）→ not_provisioned，露出报名入口", async () => {
@@ -220,9 +325,10 @@ describe("scoutConnectBaseUrl（心跳与 waitlist 表单的唯一来源）", ()
     await resolveRemoteAccessState({ token: "tok" });
     // 表单拿的是同一个函数的返回值（见 remote-access-section.tsx 的透传），
     // 所以只要这里对得上，两条路径就不会分叉。
-    expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      `${scoutConnectBaseUrl()}/api/instance/status`,
-    );
+    const urls = fetchMock.mock.calls.map((c) => c[0]);
+    expect(urls).toContain(`${scoutConnectBaseUrl()}/api/instance/status`);
+    // /meta 也必须走同一个 base,否则新端点会成为分叉的第二条路径。
+    expect(urls).toContain(`${scoutConnectBaseUrl()}/api/instance/meta`);
   });
 });
 
@@ -416,5 +522,46 @@ describe("ConnectLoginForm 的异常处理(源码断言)", () => {
     );
     expect(src).toContain('name="email"');
     expect(src).toMatch(/\n\s+required\n/);
+  });
+});
+
+describe("formatLastSeen", () => {
+  const NOW = Date.parse("2026-08-01T12:00:00.000Z");
+  const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+  it("按直觉取整：59s 是秒，61s 进到分钟", () => {
+    expect(formatLastSeen(ago(59_000), NOW)).toBe("59 秒前");
+    expect(formatLastSeen(ago(61_000), NOW)).toBe("1 分钟前");
+  });
+
+  it("向下取整而非四舍五入 —— 不能把还没到的整数说成已经到了", () => {
+    // 反向验证抓到的漏洞:上面那条测试其实盖不住取整方式。59s 走的是
+    // `seconds < 60` 早退分支,把 floor 换成 round 它照样绿。
+    // 真正的边界在**分钟以上**:119s 是"1 分钟前"(floor),不是"2 分钟前"(round)。
+    expect(formatLastSeen(ago(119_000), NOW)).toBe("1 分钟前");
+    expect(formatLastSeen(ago(90 * 60_000), NOW)).toBe("1 小时前"); // 1.5h → 1,不是 2
+    expect(formatLastSeen(ago(36 * 3600_000), NOW)).toBe("1 天前"); // 1.5d → 1,不是 2
+  });
+
+  it("逐级进位", () => {
+    expect(formatLastSeen(ago(0), NOW)).toBe("0 秒前");
+    expect(formatLastSeen(ago(60_000), NOW)).toBe("1 分钟前");
+    expect(formatLastSeen(ago(59 * 60_000), NOW)).toBe("59 分钟前");
+    expect(formatLastSeen(ago(60 * 60_000), NOW)).toBe("1 小时前");
+    expect(formatLastSeen(ago(23 * 3600_000), NOW)).toBe("23 小时前");
+    expect(formatLastSeen(ago(24 * 3600_000), NOW)).toBe("1 天前");
+    expect(formatLastSeen(ago(29 * 24 * 3600_000), NOW)).toBe("29 天前");
+    expect(formatLastSeen(ago(30 * 24 * 3600_000), NOW)).toBe("很久以前");
+  });
+
+  it("未来时间显示「刚刚」，不显示负数", () => {
+    // 两端时钟差几秒很正常。显示「-3 分钟前」会让用户以为系统坏了。
+    expect(formatLastSeen(new Date(NOW + 3 * 60_000).toISOString(), NOW)).toBe("刚刚");
+  });
+
+  it("null / 垃圾串 → null（调用方据此隐掉整行）", () => {
+    expect(formatLastSeen(null, NOW)).toBeNull();
+    expect(formatLastSeen("not a date", NOW)).toBeNull();
+    expect(formatLastSeen("", NOW)).toBeNull();
   });
 });

--- a/apps/web/lib/remote-access.ts
+++ b/apps/web/lib/remote-access.ts
@@ -33,7 +33,16 @@
 
 export type RemoteAccessState =
   | { kind: "not_provisioned" }
-  | { kind: "active"; hostname: string | null }
+  /**
+   * `lastSeenAt`：本机上次成功打到控制面的时间（ISO 串），拿不到就是 null。
+   *
+   * **它证明的是「本机 → 控制面」（出站），不是「外网 → 本机」（入站）。**
+   * 两个方向的失败模式完全不重叠：容器出站正常但 cloudflared 挂了，
+   * 是最常见的故障，而这个时间戳在那种情况下依然显示「刚刚」。
+   * 所以 UI 文案主语必须是「本机到控制面」，**绝不能写成「隧道已连接」
+   * 或「远程访问正常」**。
+   */
+  | { kind: "active"; hostname: string | null; lastSeenAt: string | null }
   | { kind: "active_degraded" };
 
 /** 心跳三态。ok=worker 认这个 token(204);unauthorized=worker 明确不认(401,
@@ -98,6 +107,56 @@ async function defaultSendHeartbeat(token: string): Promise<HeartbeatResult> {
 }
 
 /**
+ * 把 ISO 时间串格成「N 分钟前」。纯函数，注入 now 便于测试。
+ *
+ * **只处理"过去"**：未来时间（两端时钟不同步）显示成「刚刚」而不是
+ * 「-3 分钟前」—— 后者会让用户以为系统坏了，而实际上时钟偏几秒很正常。
+ */
+export function formatLastSeen(iso: string | null, now: number = Date.now()): string | null {
+  if (iso === null) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return null;
+
+  const seconds = Math.floor((now - then) / 1000);
+  if (seconds < 0) return "刚刚";
+  // 取整方向要和用户直觉一致：59s 说「59 秒前」，61s 说「1 分钟前」。
+  if (seconds < 60) return `${seconds} 秒前`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days} 天前`;
+  // 超过一个月就别再算了 —— 那个精度对「上次报到」这件事没有意义。
+  return "很久以前";
+}
+
+/**
+ * 读 `last_seen_at`。**只读，不写** —— worker 侧 GET /api/instance/meta 刻意
+ * 不更新它（一个既读又写的端点会让每次轮询都看起来像新活动）。
+ *
+ * 为什么不复用 POST /api/instance/status：那个端点的契约是 **204 无 body**，
+ * 而且这份严格是刻意的（放宽成 res.ok 会把反代的 200 登录页当成健康）。
+ * worker 与容器走独立发布通道，改 /status 会在滚动升级窗口里让所有存量容器
+ * 显示成降级。所以 worker 那边新开了只读端点，代价是多一次请求。
+ *
+ * 旧 worker 没有这个端点 → 404 → 返回 null（UI 隐掉这一行）。这就是向后兼容：
+ * 容器可以先发，worker 后发，中间不出错。
+ */
+async function defaultFetchLastSeenAt(token: string): Promise<string | null> {
+  const res = await fetch(`${scoutConnectBaseUrl()}/api/instance/meta`, {
+    headers: { authorization: `Bearer ${token}` },
+    cache: "no-store",
+    signal: AbortSignal.timeout(HEARTBEAT_TIMEOUT_MS),
+  });
+  if (!res.ok) return null;
+  const body: unknown = await res.json();
+  if (typeof body !== "object" || body === null) return null;
+  const value = (body as Record<string, unknown>).last_seen_at;
+  return typeof value === "string" ? value : null;
+}
+
+/**
  * `token` 有值即视为已开通（本实例被发过连接凭据）；心跳只决定 active 还是降级。
  *
  * 心跳失败**不**回落成 not_provisioned：那会把「已开通但网络抖动」显示成
@@ -108,6 +167,12 @@ export async function resolveRemoteAccessState(opts: {
   /** 本地已知的公网域名（当前无来源，见文件头注释）。 */
   hostname?: string | null;
   sendHeartbeat?: (token: string) => Promise<HeartbeatResult>;
+  /**
+   * 读 `last_seen_at`（GET /api/instance/meta）。**注意这是心跳之前的值** ——
+   * 心跳本身会把它更新成"现在"，所以必须先读再报到，否则永远显示「刚刚」，
+   * 那就成了一个恒真的假指标。
+   */
+  fetchLastSeenAt?: (token: string) => Promise<string | null>;
 }): Promise<RemoteAccessState> {
   const token = opts.token?.trim();
   if (!token) {
@@ -115,6 +180,20 @@ export async function resolveRemoteAccessState(opts: {
     return { kind: "not_provisioned" };
   }
   const sendHeartbeat = opts.sendHeartbeat ?? defaultSendHeartbeat;
+  // 注入 sendHeartbeat 但没注入 fetchLastSeenAt 时，**不要**回落到真实网络请求。
+  // 那会让「我已经把网络打桩掉了」的调用方（测试、离线渲染）意外发出跨公网
+  // 请求并各卡 5 秒超时。两者要么都是真的，要么都是假的 —— 打桩一半最难查。
+  const fetchLastSeenAt =
+    opts.fetchLastSeenAt ??
+    (opts.sendHeartbeat ? async () => null : defaultFetchLastSeenAt);
+  // 先读后报到：心跳会把 last_seen_at 写成"现在"，读晚了就永远是「刚刚」。
+  // 失败不影响主流程 —— 它只是个附加信息，不能让它决定开通状态。
+  let lastSeenAt: string | null = null;
+  try {
+    lastSeenAt = await fetchLastSeenAt(token);
+  } catch {
+    lastSeenAt = null;
+  }
   try {
     // 捕获一切：这是在渲染路径上做的一次网络调用，worker 挂了不该炸掉设置页。
     // 也刻意不把 error 放进返回值——报错串里可能带着 token（见测试）。
@@ -132,7 +211,7 @@ export async function resolveRemoteAccessState(opts: {
     // 网络炸了按不可达处理:不劝退一个已付出配置成本的用户重新排队。
     return { kind: "active_degraded" };
   }
-  return { kind: "active", hostname: opts.hostname ?? null };
+  return { kind: "active", hostname: opts.hostname ?? null, lastSeenAt };
 }
 
 /**

--- a/workers/scout-connect/src/html/console-page.test.ts
+++ b/workers/scout-connect/src/html/console-page.test.ts
@@ -178,3 +178,40 @@ describe("console page — entitled with active endpoint (v2 prompt-primary)", (
     expect(inactive).not.toContain("navigator.clipboard");
   });
 });
+
+describe("consolePage 报到时间", () => {
+  // 用现成的 base() + 注入的 NOW —— 不猜入参形状,也不依赖真实时钟。
+  const render = (last_seen_at: string | null, now: string = NOW) =>
+    base({ endpoint: { ...endpoint, last_seen_at }, entitlements: [ent("2027-01-01T00:00:00.000Z")], now });
+  const ago = (ms: number) => new Date(Date.parse(NOW) - ms).toISOString();
+
+  it("有报到记录 → 显示相对时间", () => {
+    const html = render(ago(5 * 60_000));
+    expect(html).toContain("你的实例上次向这里报到");
+    expect(html).toContain("5 分钟前");
+  });
+
+  it("从未报到（null）→ 整行不渲染", () => {
+    // 刚开通还没接入的用户看到「从未报到」会以为出错了,而那正是此刻的正常状态。
+    expect(render(null)).not.toContain("上次向这里报到");
+  });
+
+  it("措辞不暗示入站可达 —— 这是这一行存在的全部意义", () => {
+    // last_seen_at 只证明「实例 → 控制面」(出站)。cloudflared 挂了但容器活着时,
+    // 它照样显示「刚刚」。写成「隧道正常」就是拿恒真指标冒充健康检查。
+    const html = render(ago(60_000));
+    for (const lie of ["隧道正常", "隧道已连接", "远程访问正常", "连接正常"]) {
+      expect(html).not.toContain(lie);
+    }
+  });
+
+  it("时钟不同步（未来时间）显示「刚刚」而非负数", () => {
+    const html = render(new Date(Date.parse(NOW) + 5 * 60_000).toISOString());
+    expect(html).toContain("刚刚");
+    expect(html).not.toContain("-5 分钟");
+  });
+
+  it("向下取整：119 秒是「1 分钟前」", () => {
+    expect(render(ago(119_000))).toContain("1 分钟前");
+  });
+});

--- a/workers/scout-connect/src/html/console-page.ts
+++ b/workers/scout-connect/src/html/console-page.ts
@@ -130,6 +130,9 @@ function renderBody(
     account: AccountRow;
     endpoint: EndpointRow | null;
     rootDomain: string;
+    /** 渲染时刻。用它算「上次报到」的相对时间,不用 Date.now() —— 页面其余
+     *  部分(到期日、宽限期)也都走这个值,两套时基会在跨午夜时对不上。 */
+    now: string;
     /** 隧道配额已满(CF 1000 硬上限)。已开通用户不受影响,只挡新开通。 */
     atCapacity: boolean;
   },
@@ -161,6 +164,7 @@ function renderBody(
   // 提示词模板由 renderScript 在客户端脚本里生成(带占位符),点按钮时现取
   // 真码替换。这里不预生成——服务端渲染时页面里的 #prompt 是空的。
   return `<p class="sub">你的专属地址：<span class="addr">${esc(hostname)}</span>（配置好后浏览器打开它即可）</p>
+${lastSeenHtml(input.endpoint.last_seen_at, input.now)}
 <div class="panel">
 <p class="step">接入你的实例</p>
 <p class="lead">把下面这段交给你的 AI 助手</p>
@@ -179,6 +183,54 @@ function renderBody(
 <p class="expire">取件码 15 分钟后失效 · 过期回这里再点一次「获取接入命令」即可</p>
 </div>
 </div>`;
+}
+
+/**
+ * 「上次从实例报到」一行。服务端渲染，**不轮询** —— 用户来这个页面是为了拿
+ * 接入命令，拿到就走；刷新一下就是最新的。
+ *
+ * ## 措辞为什么这么绕
+ *
+ * `last_seen_at` 只在**实例主动打到本控制面**时更新(出站),而用户想知道的是
+ * 「我的域名现在能不能打开」(入站)。**两个方向的失败模式完全不重叠**:
+ * 实例出站正常但 cloudflared 挂了是最常见的故障,那时这个时间戳照样显示「刚刚」。
+ *
+ * 所以这里写「你的实例上次向这里报到」,而**不写**「隧道正常」「在线」「已连接」。
+ * 前者是事实,后者是拿一个恒真指标冒充健康检查 —— 用户照着绿灯去排查,
+ * 只会更晚发现真正的问题。
+ *
+ * null(从未报到)时**整行不渲染**:刚开通还没接入的用户看到「从未报到」
+ * 会以为出了错,而那恰恰是此刻的正常状态。
+ */
+function lastSeenHtml(lastSeenAt: string | null, now: string): string {
+  const label = relativeZh(lastSeenAt, Date.parse(now));
+  if (label === null) return "";
+  return `<p class="lead-sub" style="opacity:.8">你的实例上次向这里报到：${esc(label)}</p>`;
+}
+
+/**
+ * ISO → 「N 分钟前」。与容器侧 `formatLastSeen` 同款取整规则(向下取整:
+ * 119 秒是「1 分钟前」,不是「2 分钟前」——不把还没到的整数说成已经到了)。
+ *
+ * 两份实现是刻意的:worker 与容器是两个独立部署单元,不共享代码。
+ * 改一边时记得看另一边(`apps/web/lib/remote-access.ts`)。
+ */
+function relativeZh(iso: string | null, now: number): string | null {
+  if (iso === null) return null;
+  if (Number.isNaN(now)) return null;
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return null;
+  const seconds = Math.floor((now - then) / 1000);
+  // 时钟不同步时不显示负数 —— 「-3 分钟前」会让人以为系统坏了。
+  if (seconds < 0) return "刚刚";
+  if (seconds < 60) return `${seconds} 秒前`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} 分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} 小时前`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days} 天前`;
+  return "很久以前";
 }
 
 /** active 时才需要客户端脚本:有 endpoint → 取码/复制;无 endpoint → slug

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -432,6 +432,118 @@ describe("handleRequest", () => {
     expect(after.endpoints[0]?.last_seen_at).toBe(NOW);
   });
 
+  // ---- GET /api/instance/meta ----
+  //
+  // The read-only sibling of POST /api/instance/status. It exists because the
+  // container strictly checks 204 on /status (deliberately — a proxy's 200
+  // login page must not read as "healthy"), and worker/container ship through
+  // independent channels, so widening /status would break every existing
+  // container mid-rollout.
+
+  it("GET /api/instance/meta with valid token → 200 with last_seen_at", async () => {
+    const { deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    // Before any heartbeat it's null, not absent — the container needs to tell
+    // "never reported" apart from "field missing / old worker".
+    const fresh = await handleRequest(
+      new Request(`${BASE}/api/instance/meta`, {
+        headers: { authorization: `Bearer ${seeded.token}` },
+      }),
+      deps,
+    );
+    expect(fresh.status).toBe(200);
+    const freshBody = (await fresh.json()) as Record<string, unknown>;
+    expect("last_seen_at" in freshBody).toBe(true);
+    expect(freshBody.last_seen_at).toBeNull();
+
+    await handleRequest(
+      new Request(`${BASE}/api/instance/status`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${seeded.token}` },
+      }),
+      deps,
+    );
+
+    const after = await handleRequest(
+      new Request(`${BASE}/api/instance/meta`, {
+        headers: { authorization: `Bearer ${seeded.token}` },
+      }),
+      deps,
+    );
+    expect(((await after.json()) as Record<string, unknown>).last_seen_at).toBe(NOW);
+  });
+
+  it("GET /api/instance/meta leaks nothing but the timestamp", async () => {
+    // The 204-no-body contract on /status exists so a valid token can't be used
+    // as an oracle for "which domain does this token map to". This endpoint
+    // must preserve that: last_seen_at is the holder's own visit time, which
+    // they already know. Anything else reopens the surface Plan 3 closed.
+    const { deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    const res = await handleRequest(
+      new Request(`${BASE}/api/instance/meta`, {
+        headers: { authorization: `Bearer ${seeded.token}` },
+      }),
+      deps,
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Object.keys(body)).toEqual(["last_seen_at"]);
+
+    // Spelled out so a future "just add hostname, it's convenient" turns red.
+    const raw = JSON.stringify(body);
+    for (const leak of ["hostname", "slug", "cf_tunnel", "token", "account", "expires"]) {
+      expect(raw).not.toContain(leak);
+    }
+  });
+
+  it("GET /api/instance/meta does NOT update last_seen_at", async () => {
+    // A read that also writes would destroy the value's meaning ("last time the
+    // user opened their settings page") and make every poll look like activity.
+    const { deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    await handleRequest(
+      new Request(`${BASE}/api/instance/meta`, {
+        headers: { authorization: `Bearer ${seeded.token}` },
+      }),
+      deps,
+    );
+
+    const adminRes = await handleRequest(adminGet("/api/admin/endpoints"), deps);
+    const admin = (await adminRes.json()) as { endpoints: Array<Record<string, unknown>> };
+    expect(admin.endpoints[0]?.last_seen_at).toBeNull();
+  });
+
+  it("GET /api/instance/meta rejects bad/missing token → 401", async () => {
+    const { deps } = setup();
+    await seedProvisioned(deps);
+
+    for (const headers of [{}, { authorization: "Bearer wrong-token" }, { authorization: "Basic x" }]) {
+      const res = await handleRequest(new Request(`${BASE}/api/instance/meta`, { headers }), deps);
+      expect(res.status).toBe(401);
+    }
+  });
+
+  it("POST /api/instance/status keeps its 204-no-body contract", async () => {
+    // Guard rail, not redundancy: this pins the contract so nobody "saves a
+    // request" by folding meta into /status. Doing that would flip every
+    // existing container to degraded during the rollout window.
+    const { deps } = setup();
+    const seeded = await seedProvisioned(deps);
+
+    const res = await handleRequest(
+      new Request(`${BASE}/api/instance/status`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${seeded.token}` },
+      }),
+      deps,
+    );
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe("");
+  });
+
   it("provision without any slug → 400 slug required", async () => {
     const { deps } = setup();
     const createRes = await createInviteViaApi(deps, { email: "alice@example.com" });

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -488,6 +488,10 @@ describe("handleRequest", () => {
       }),
       deps,
     );
+    // token 作用域的数据不能被中间层缓存。客户端带 cache:"no-store" 不够 ——
+    // 那只约束客户端自己,不约束反代/CDN。
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
     const body = (await res.json()) as Record<string, unknown>;
     expect(Object.keys(body)).toEqual(["last_seen_at"]);
 

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -1849,5 +1849,7 @@ async function reportInstanceStatus(request: Request, deps: RouteDeps): Promise<
  */
 async function getInstanceMeta(request: Request, deps: RouteDeps): Promise<Response> {
   const endpoint = await authenticateInstanceToken(request, deps);
-  return json({ last_seen_at: endpoint.last_seen_at });
+  // noStore:token 作用域的数据,绝不能被任何中间层缓存。worker 里其它 27 处
+  // 敏感 JSON 端点都带这个,漏掉它就是在赌所有中间层配置都正确(Copilot 抓到)。
+  return json({ last_seen_at: endpoint.last_seen_at }, 200, { noStore: true });
 }

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -594,6 +594,9 @@ ${hreflang}
   if (path === "/api/instance/status" && method === "POST") {
     return await reportInstanceStatus(request, deps);
   }
+  if (path === "/api/instance/meta" && method === "GET") {
+    return await getInstanceMeta(request, deps);
+  }
 
   throw new HttpError(404, "not found");
 }
@@ -1772,8 +1775,18 @@ async function saveWaitlistSurvey(request: Request, deps: RouteDeps): Promise<Re
   return new Response(null, { status: 204 });
 }
 
-async function reportInstanceStatus(request: Request, deps: RouteDeps): Promise<Response> {
-  // Extract Bearer token from Authorization header
+/**
+ * Shared Bearer-token auth for the two /api/instance/* endpoints.
+ *
+ * Extracted so the read endpoint can't drift from the write one — in
+ * particular the `status !== "active"` check: an expired or revoked endpoint
+ * must be indistinguishable from a bad token (both 401), otherwise the
+ * response tells an attacker that a given token *was* real.
+ */
+async function authenticateInstanceToken(
+  request: Request,
+  deps: RouteDeps,
+): Promise<NonNullable<Awaited<ReturnType<ConnectDb["getEndpointByTokenSha256"]>>>> {
   const authHeader = request.headers.get("authorization");
   if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
     throw new HttpError(401, "unauthorized");
@@ -1783,18 +1796,58 @@ async function reportInstanceStatus(request: Request, deps: RouteDeps): Promise<
     throw new HttpError(401, "unauthorized");
   }
 
-  // Hash the token and look up the endpoint
   const tokenHash = await sha256Hex(token);
   const endpoint = await deps.db.getEndpointByTokenSha256(tokenHash);
-
-  // Endpoint must exist and be active
   if (endpoint === null || endpoint.status !== "active") {
     throw new HttpError(401, "unauthorized");
   }
+  return endpoint;
+}
+
+async function reportInstanceStatus(request: Request, deps: RouteDeps): Promise<Response> {
+  const endpoint = await authenticateInstanceToken(request, deps);
 
   // Update last_seen_at
   await deps.db.updateEndpointLastSeen(endpoint.id, deps.now());
 
   // Return 204 No Content
   return new Response(null, { status: 204 });
+}
+
+/**
+ * GET /api/instance/meta — read-only sibling of POST /api/instance/status.
+ *
+ * ## Why a new endpoint instead of widening /status to 200 + JSON
+ *
+ * The container **strictly checks 204** (`apps/web/lib/remote-access.ts`,
+ * `defaultSendHeartbeat`), and that strictness is deliberate: widening it to
+ * `res.ok` would make any reverse-proxy or access-gate login page (HTTP 200)
+ * read as "tunnel healthy" — precisely the case that must surface as degraded.
+ * There is a test pinning "200 also fails".
+ *
+ * Worker and container ship through **independent channels** (`wrangler deploy`
+ * vs. each user running `git pull` on their own box), so a contract change on
+ * /status would break every existing container during the rollout window —
+ * flipping them all to "can't reach the control plane" and hiding their
+ * hostname. Adding an endpoint costs one extra request and zero breakage.
+ *
+ * ## Why the response body is only a timestamp
+ *
+ * The 204-no-body contract on /status exists so that holding a valid token
+ * reveals no endpoint metadata — the endpoint can't be used as an oracle for
+ * "which domain does this token map to". This endpoint keeps that property:
+ * `last_seen_at` is something the token holder already knows (it's their own
+ * last visit), so returning it leaks nothing new. **Do not add hostname,
+ * slug, connection counts, or expiry here** — that would reopen the very
+ * surface Plan 3 closed on purpose.
+ *
+ * ## Why this does NOT update last_seen_at
+ *
+ * Writing here would corrupt the value's meaning: "last time the user opened
+ * their settings page" is what makes it displayable at all. A read endpoint
+ * that also writes would make every poll look like fresh activity.
+ */
+async function getInstanceMeta(request: Request, deps: RouteDeps): Promise<Response> {
+  const endpoint = await authenticateInstanceToken(request, deps);
+  return json({ last_seen_at: endpoint.last_seen_at });
 }


### PR DESCRIPTION
Spec C 第一步。控制台与容器设置页原来**完全不显示任何存活信息**，而 D1 里一直有 `endpoints.last_seen_at`。

## 为什么新开端点，而不是把 `/api/instance/status` 改成 200 + JSON

**这是我 spec 原稿的错误设计**，子代理审计抓出来的：

容器侧 `defaultSendHeartbeat` **严格判 204**，注释明确说不能放宽 —— 放宽成 `res.ok` 会把反代/门禁塞回来的 200 登录页当成"隧道健康"，那恰恰是最需要显示为降级的场景。已有测试钉住「200 也算失败」。

而 worker 走 `wrangler deploy`、容器走用户各自 `git pull`，**永远不同步**。改 `/status` 会在滚动窗口里把**所有存量容器**翻成「联系不上控制面」并丢掉域名链接。

所以新增 `GET /api/instance/meta`，204 契约一个字不动。代价是多一次请求。

## 新端点只返回一个时间戳

`remote-access.ts` 文件头写明 204 无 body 是**刻意的泄露防线**：持有 token 也不能用它当"这个 token 对应哪个域名"的预言机。`last_seen_at` 是持有者自己的访问时间，不构成新泄露。

测试用 `Object.keys` 精确断言 + 关键词黑名单钉住，防止将来"顺手加个 hostname"。

## 措辞是这个功能的全部难点

`last_seen_at` 只在实例**主动打到控制面**时更新（**出站**），而用户想知道的是「外网能不能打开我的域名」（**入站**）。

**两个方向的失败模式完全不重叠** —— cloudflared 容器挂了但实例活着是最常见的故障，那时时间戳照样显示「刚刚」。

所以文案写「本机上次向控制面报到」，并**删掉了容器设置页原有的「隧道连接正常」** —— 那句话本来就在说谎。两处都有测试把「隧道正常/已连接/在线」列为黑名单。

## 顺序是契约的一部分

先 `GET /meta` 读旧值，再 `POST /status` 报到。**反了的话**心跳会先把值写成"现在"，于是永远显示「刚刚」—— 一个恒真的假指标。有专门测试钉顺序。

## 顺手修了一个自己埋的坑

注入 `sendHeartbeat` 但没注入 `fetchLastSeenAt` 时，原实现会**回落到真实网络请求** —— 让"以为已经把网络打桩掉"的调用方各卡 5 秒超时（测试里真的出现了）。打桩一半是最难查的一类问题，现在两者同真同假。

## 反向验证抓到两个假测试

本项目第三、四次：

**① 404 兼容测试是假的** —— body 用 `"not found"` 纯文本，`res.json()` 抛 SyntaxError 被外层 catch 兜住也返回 null，所以**删掉 `!res.ok` 守卫它照样绿**。改用合法 JSON 的 404 才真正钉住状态码检查。

**② 取整测试是假的** —— 「59s 是秒 / 61s 是分钟」盖不住取整方式：59s 走的是 `seconds < 60` 早退分支，把 `floor` 换成 `round` 照样绿。补了 119s→「1 分钟前」等分钟以上的边界。

其余反向验证全部转红：

| 破坏 | 结果 |
|---|---|
| meta 也写 `last_seen_at` | 转红 |
| 顺手加 hostname | 转红 |
| 把 `/status` 改 200 | **5 个**转红 |
| 读写顺序反了 | 转红 |
| null 也渲染「从未报到」 | 转红 |
| 措辞改成「隧道正常」 | 2 个转红 |

## 验证

- 三处 tsc 全绿
- `build:web` 通过
- 全量 **2715 passed**（基线 2695 + 本次 20），零回归