### PR TITLE
fix(paddle): 切 live + 补上从来不存在的购买按钮

### DIFF
--- a/workers/scout-connect/src/html/console-page.test.ts
+++ b/workers/scout-connect/src/html/console-page.test.ts
@@ -215,3 +215,90 @@ describe("consolePage 报到时间", () => {
     expect(render(ago(119_000))).toContain("1 分钟前");
   });
 });
+
+describe("无时长态 = 购买入口(不是死链)", () => {
+  // 这一整块是补债:线上曾经是 `<a href="/pricing">开通</a>`,而 /pricing 是纯
+  // 说明页、零结账入口 —— 整条付款路径断了,后端 /api/checkout 从来没有调用方。
+  // 用户截图才发现。所有自动化测试当时都是绿的,因为没人测这一态。
+  const TIERS = [
+    { priceId: "pri_q", months: 3, label: "季度", price: "¥45", featured: false, note: "3 个月" },
+    { priceId: "pri_y", months: 12, label: "年度", price: "¥108", featured: true, note: "12 个月 · 折月付 ¥9" },
+    { priceId: "pri_2y", months: 24, label: "两年", price: "¥188", featured: false, note: "24 个月" },
+  ];
+  const noTime = (tiers = TIERS) => base({ entitlements: [], endpoint: null, tiers });
+
+  it("三档都渲染成带 price_id 的按钮", () => {
+    const html = noTime();
+    for (const t of TIERS) {
+      expect(html).toContain(`data-price="${t.priceId}"`);
+      expect(html).toContain(t.price);
+    }
+  });
+
+  it("绝不再出现「跳 /pricing 就算完事」的死链按钮", () => {
+    // 这是本次 bug 的精确复现条件:一个 class="btn" 的链接指向 /pricing。
+    // 页脚那个「定价」文字链是正常的,所以只禁按钮形态。
+    const html = noTime();
+    expect(html).not.toMatch(/class="btn"[^>]*href="\/pricing"/);
+    expect(html).not.toMatch(/href="\/pricing"[^>]*class="btn"/);
+  });
+
+  it("有下单脚本,且真的打 /api/checkout", () => {
+    const html = noTime();
+    expect(html).toContain("/api/checkout");
+    expect(html).toContain("price_id");
+    // 拿到 checkout_url 后必须真跳过去,否则等于建了交易却不结账。
+    expect(html).toContain("checkout_url");
+    expect(html).toContain("window.location.href");
+  });
+
+  it("年度是主推档(用户拍板),且只有一个主推", () => {
+    const html = noTime();
+    // 只数**按钮上**的,不数 CSS 规则里的 —— 样式表里也有 .tier-featured,
+    // 直接数字符串会把它算进去(第一版就踩了)。
+    expect(html).toContain("tier-featured");
+    expect(html.match(/class="tier tier-featured"/g)?.length).toBe(1);
+    // 主推标记必须落在年度那颗按钮上,不能飘到别档。
+    const yearBtn = html.slice(html.indexOf('data-price="pri_y"'));
+    expect(yearBtn.slice(0, 400)).toContain("¥108");
+  });
+
+  it("白名单为空 → 不给假按钮,老实说不可用", () => {
+    // 假按钮点下去必然吃 /api/checkout 的 503。让用户点一下才发现,是最差体验。
+    const html = base({ entitlements: [], endpoint: null, tiers: [] });
+    expect(html).not.toContain("data-price");
+    expect(html).toContain("购买通道暂时不可用");
+    // 也不该注入脚本 —— 那会对不存在的 .tier 做 querySelectorAll(空数组,不崩,
+    // 但白挂一段死代码)。
+    expect(html).not.toContain("/api/checkout");
+  });
+
+  it("三种失败各有不同的下一步动作", () => {
+    const html = noTime();
+    // 「请重试」对 session 过期毫无用处 —— 必须让他重新登录。
+    expect(html).toContain("401");
+    expect(html).toContain("重新登录");
+    expect(html).toContain("503");
+  });
+
+  it("防连点:点击后禁用所有按钮", () => {
+    // 不禁的话用户连点三下就在 Paddle 建三笔 draft 交易。
+    expect(noTime()).toContain("disabled=true");
+  });
+
+  it("已有有效时长时不显示购买按钮", () => {
+    const html = base({
+      entitlements: [ent("2027-01-01T00:00:00.000Z")],
+      endpoint: null,
+      tiers: TIERS,
+    });
+    expect(html).not.toContain("data-price");
+  });
+
+  it("标明预付/不自动续费与退款政策", () => {
+    // 合规与预期管理:这是一次性付款,不是订阅。必须在下单按钮旁边就说清。
+    const html = noTime();
+    expect(html).toContain("不自动续费");
+    expect(html).toContain("/refund");
+  });
+});

--- a/workers/scout-connect/src/html/console-page.ts
+++ b/workers/scout-connect/src/html/console-page.ts
@@ -20,6 +20,15 @@ import { BRAND_BAR, BRAND_CSS, esc, FAVICON_LINK, THEME_BASE, THEME_TOKENS } fro
  * 客户端点「获取接入命令」时才 POST /api/claim-code 拿 15 分钟有效的真码,
  * 把占位符替换成真码——提示词天然是临时生成的(码短命),token 从不出现。
  */
+export interface PurchasableTier {
+  priceId: string;
+  months: number;
+  label: string;
+  price: string;
+  featured: boolean;
+  note: string;
+}
+
 export function consolePage(input: {
   account: AccountRow;
   entitlements: EntitlementRow[];
@@ -29,6 +38,8 @@ export function consolePage(input: {
    *  推:控制台可从 beta 子域访问,host 会是 beta.<root>,后缀就错了。 */
   rootDomain: string;
   now: string;
+  /** 可下单档位。空数组 = 购买通道未配置(白名单空),页面不给假按钮。 */
+  tiers?: readonly PurchasableTier[];
   /** 隧道配额是否已满(CF 1000 硬上限)。只影响「已付费未开通」态:满了就不给
    *  slug 表单,免得用户填完名字才吃 503。已开通用户完全不受影响。 */
   atCapacity?: boolean;
@@ -93,6 +104,18 @@ h1{font-size:1.5rem;font-weight:900;letter-spacing:-.5px;margin:0}
 .copy-btn{width:100%;margin-top:14px}
 .helprow{display:flex;gap:8px;align-items:center;color:#8f8f8f;font-size:12.5px;margin-top:14px}
 .helprow svg{color:var(--accent);flex:none}
+/* 档位卡片。auto-fit + minmax:窄屏自动堆成一列,不用写 @media。 */
+.tiers{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-top:18px}
+.tier{position:relative;display:flex;flex-direction:column;gap:4px;align-items:flex-start;text-align:left;font:inherit;cursor:pointer;padding:16px 18px;border-radius:14px;border:1px solid var(--line);background:rgba(255,255,255,.02);color:var(--text);transition:transform .15s ease,border-color .15s ease,background .15s ease}
+.tier:hover:not(:disabled){transform:translateY(-2px);border-color:rgba(30,215,96,.5)}
+.tier:disabled{opacity:.5;cursor:default;transform:none}
+/* 主推档:实心绿。用户已拍板年度 ¥108 为主推。 */
+.tier-featured{background:var(--accent);border-color:var(--accent);color:#000}
+.tier-featured:hover:not(:disabled){border-color:var(--accent)}
+.tier-tag{position:absolute;top:-9px;right:12px;font-size:.68rem;font-weight:700;letter-spacing:.04em;padding:2px 8px;border-radius:500px;background:#000;color:var(--accent)}
+.tier-name{font-size:.86rem;opacity:.75}
+.tier-price{font-size:1.5rem;font-weight:800;line-height:1.1}
+.tier-note{font-size:.76rem;opacity:.7}
 .msg{font-size:.9rem;margin-top:12px;color:var(--text-muted)}
 .msg.err{color:var(--err)}
 .msg.ok{color:var(--accent)}
@@ -117,7 +140,7 @@ details[open] summary .chev{transform:rotate(90deg)}
 ${BRAND_BAR}
 <p class="email-line">${esc(input.account.email)}</p>
 <div class="status-row"><h1>远程访问</h1>${statusBadge}</div>
-${renderBody({ ...input, atCapacity: input.atCapacity === true }, active)}
+${renderBody({ ...input, atCapacity: input.atCapacity === true, tiers: input.tiers ?? [] }, active)}
 <div class="footer"><a href="/pricing">定价</a> · <a href="/terms">服务条款</a> · <a href="/privacy">隐私政策</a> · <a href="/refund">退款政策</a> · <a href="/contact">联系我们</a></div>
 </main>
 ${renderScript({ ...input, atCapacity: input.atCapacity === true }, active)}
@@ -135,12 +158,36 @@ function renderBody(
     now: string;
     /** 隧道配额已满(CF 1000 硬上限)。已开通用户不受影响,只挡新开通。 */
     atCapacity: boolean;
+    /** 可下单档位(来自价格白名单,空数组=购买通道未配置)。 */
+    tiers: readonly PurchasableTier[];
   },
   active: boolean,
 ): string {
   if (!active) {
+    // **真按钮,不是跳 /pricing。** 原来这里是 `<a href="/pricing">开通</a>`,
+    // 而 /pricing 是纯说明页、一个结账入口都没有 —— 整条付款路径断在这里,
+    // 后端 /api/checkout 从来没有任何调用方(用户截图发现)。
+    if (input.tiers.length === 0) {
+      // 白名单未配置(如环境变量漏了):不给假按钮,老实说不可用。
+      return `<p class="sub">你还没有有效时长。</p>
+<p class="lead-sub">购买通道暂时不可用,请稍后再试或<a href="/contact">联系我们</a>。</p>`;
+    }
     return `<p class="sub">你还没有有效时长。开通后即可为自托管实例生成专属远程访问地址。</p>
-<a class="btn" href="/pricing">开通</a>`;
+<div class="tiers">
+${input.tiers
+  .map(
+    (t) => `<button class="tier${t.featured ? " tier-featured" : ""}" type="button" data-price="${esc(t.priceId)}">
+${t.featured ? `<span class="tier-tag">推荐</span>` : ""}
+<span class="tier-name">${esc(t.label)}</span>
+<span class="tier-price">${esc(t.price)}</span>
+<span class="tier-note">${esc(t.note)}</span>
+</button>`,
+  )
+  .join("\n")}
+</div>
+<p class="msg" id="buymsg" hidden></p>
+<p class="lead-sub" style="margin-top:14px">预付时长,不自动续费。买多次会叠加到同一个账号,到期日往后延。<br>
+支持 微信支付 · 银行卡 · Apple Pay · Google Pay。14 天内无条件全额退款 —— 见<a href="/refund">退款政策</a>。</p>`;
   }
   if (input.endpoint === null && input.atCapacity) {
     // 满容量:**不渲染表单**。让用户输完名字、点开通、再吃 503 是最差的体验
@@ -183,6 +230,56 @@ ${lastSeenHtml(input.endpoint.last_seen_at, input.now)}
 <p class="expire">取件码 15 分钟后失效 · 过期回这里再点一次「获取接入命令」即可</p>
 </div>
 </div>`;
+}
+
+/**
+ * 档位按钮 → 下单 → 跳 Paddle 结账。
+ *
+ * ## 为什么是整页跳转而不是内嵌 Paddle.js
+ *
+ * `/api/checkout` 返回的 `checkout_url` 已经是
+ * `mediaryconnect.app/buy?_ptxn=<txn>` —— `/buy` 那个页面本来就加载了 Paddle.js
+ * 并根据 `_ptxn` 自动弹结账窗(那是它存在的唯一理由)。在这里再引一份 Paddle.js
+ * 等于维护两处环境/token 配置,而 sandbox/production 配错的代价是结账 100% 失败
+ * (刚刚就踩过:live token 配 sandbox 环境)。**配置只在一个地方,少一处能配错。**
+ *
+ * ## 失败必须说话
+ *
+ * 三种真实失败:503(购买通道未配置)、502(Paddle 上游挂)、401(session 过期)。
+ * 每种都给不同的下一步动作 —— 「请重试」对 session 过期毫无用处。
+ * 不回显后端的原始错误(可能含内部细节)。
+ */
+function buyScript(): string {
+  return `<script type="module">
+const msg=document.getElementById("buymsg");
+const btns=[...document.querySelectorAll(".tier")];
+function fail(text){msg.textContent=text;msg.className="msg err";msg.hidden=false;btns.forEach(b=>b.disabled=false);}
+btns.forEach((btn)=>btn.addEventListener("click",async()=>{
+  msg.hidden=true;msg.className="msg";
+  // 全部禁用:防连点建出多笔 draft 交易。
+  btns.forEach(b=>b.disabled=true);
+  btn.dataset.busy="1";
+  try{
+    const res=await fetch("/api/checkout",{
+      method:"POST",
+      headers:{"content-type":"application/json"},
+      body:JSON.stringify({price_id:btn.dataset.price}),
+    });
+    if(res.status===401){fail("登录状态已过期。刷新页面重新登录后再试。");return;}
+    if(res.status===503){fail("购买通道暂时不可用。请稍后再试,或联系我们。");return;}
+    if(!res.ok){fail("发起支付失败了。稍后再试一次;若一直失败请联系我们。");return;}
+    const data=await res.json();
+    if(typeof data.checkout_url!=="string"||data.checkout_url===""){
+      fail("发起支付失败了。稍后再试一次;若一直失败请联系我们。");return;
+    }
+    // 整页跳转到 /buy?_ptxn=... —— 那边的 Paddle.js 会自动弹结账窗。
+    window.location.href=data.checkout_url;
+  }catch{
+    // 网络断了/请求被拦。不能静默 —— 用户会以为按钮坏了然后反复点。
+    fail("网络请求没成功。检查网络后再试一次。");
+  }
+}));
+</script>`;
 }
 
 /**
@@ -236,10 +333,20 @@ function relativeZh(iso: string | null, now: number): string | null {
 /** active 时才需要客户端脚本:有 endpoint → 取码/复制;无 endpoint → slug
  *  选择表单(实时查重 + 开通)。 */
 function renderScript(
-  input: { endpoint: EndpointRow | null; baseUrl: string; rootDomain: string; atCapacity?: boolean },
+  input: {
+    endpoint: EndpointRow | null;
+    baseUrl: string;
+    rootDomain: string;
+    atCapacity?: boolean;
+    tiers?: readonly PurchasableTier[];
+  },
   active: boolean,
 ): string {
-  if (!active) return "";
+  // 无有效时长 = 购买态。**原来这里直接 return ""**,于是页面上连脚本都没有 ——
+  // 因为当时那一态只有个跳 /pricing 的死链。现在要下单,必须有脚本。
+  if (!active) {
+    return (input.tiers ?? []).length === 0 ? "" : buyScript();
+  }
   // 满容量时 renderBody 不渲染 #slug/#provision,注入表单脚本会对 null 调
   // addEventListener 直接抛错、整段脚本崩掉。条件必须与 renderBody 的分支一致。
   if (input.endpoint === null && input.atCapacity === true) return "";

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -9,7 +9,13 @@
  * customer 对象**,只有 `customer_id`。所以「从 payload 直接拿邮箱」这条路不存在;
  * 而 `custom_data` 确实会原样透传到 webhook。
  *
- * 另一件实测确认的事:**显式传 `checkout.url` 会覆盖账号级的 default payment
+ * 另一件实测确认的事(2026-08-01 在 **live** 复验):**显式传 `checkout.url` 会
+ * 覆盖账号级的 default payment link**,这行不能删 —— 本 Paddle 账号的 default
+ * 指向另一个产品(agentmentor.dev),不传就会把用户送去那边一个不认识本交易的页面。
+ * live 只接受**已审批**域名(sandbox 自动批准,所以这条只能在 live 验证);
+ * mediaryconnect.app 已批准,实测返回 mediaryconnect.app/buy?_ptxn=...。
+ *
+ * 原注释:显式传 `checkout.url` 会覆盖账号级的 default payment
  * link**。这让同一个 Paddle 账号能承载多个产品 —— 各自传自己的域名,default
  * 填谁都不生效。
  */

--- a/workers/scout-connect/src/paddle-event.test.ts
+++ b/workers/scout-connect/src/paddle-event.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  LIVE_PRICE_MONTHS,
+  MAX_WEBHOOK_MONTHS,
   parseTransactionCompleted,
   SANDBOX_PRICE_MONTHS,
   type PriceMonthsMap,
@@ -255,8 +257,10 @@ describe("parseTransactionCompleted", () => {
 });
 
 describe("SANDBOX_PRICE_MONTHS", () => {
-  it("四个档位与定价页一致(季3/年12/两年24/创始12)", () => {
-    expect(Object.values(SANDBOX_PRICE_MONTHS).sort((a, b) => a - b)).toEqual([3, 12, 12, 24]);
+  it("三个档位与定价页一致(季3/年12/两年24)", () => {
+    // 原来是四档(含创始价 ¥88 → 12 个月)。创始价从未真正实现(无席位计数、
+    // entitlements 不记录成交价),PR #209 已从所有页面撤下,现在白名单也关闭。
+    expect(Object.values(SANDBOX_PRICE_MONTHS).sort((a, b) => a - b)).toEqual([3, 12, 24]);
   });
 });
 
@@ -304,4 +308,35 @@ describe("items 元素为 null 不得抛错(500 → 无限重投)", () => {
       expect(r.ok).toBe(false);
     },
   );
+});
+
+describe("价格白名单 = 最后一道闸", () => {
+  const FOUNDING_LIVE = "pri_01kyrw1773tc65xxdtgqcqyfpk";
+  const FOUNDING_SANDBOX = "pri_01kypfzvyvgmytaefznh4npsz7";
+
+  it("创始价 ¥88 不在任何白名单里", () => {
+    // 它在 Paddle 侧仍是 active,所以只要白名单放它进来就真能被买 ——
+    // ¥88 买 12 个月,比年度档便宜 ¥20,而我们既不知情也拦不住。
+    // 产品侧从未实现席位计数,entitlements 也不记录成交价,「前 100 席」无法执行。
+    expect(LIVE_PRICE_MONTHS).not.toHaveProperty(FOUNDING_LIVE);
+    expect(SANDBOX_PRICE_MONTHS).not.toHaveProperty(FOUNDING_SANDBOX);
+  });
+
+  it("live 与 sandbox 档位一一对应", () => {
+    // 两边月数集合必须相同。不一致会让 sandbox 测通的路径到 live 变成 400,
+    // 那类差异最难查 —— 因为所有自动化测试都是绿的。
+    expect(Object.values(SANDBOX_PRICE_MONTHS).sort()).toEqual(
+      Object.values(LIVE_PRICE_MONTHS).sort(),
+    );
+  });
+
+  it("只有三档,且是 3 / 12 / 24 个月", () => {
+    expect(Object.values(LIVE_PRICE_MONTHS).sort((a, b) => a - b)).toEqual([3, 12, 24]);
+  });
+
+  it("每档月数都在 webhook 上限内", () => {
+    for (const months of Object.values(LIVE_PRICE_MONTHS)) {
+      expect(months).toBeLessThanOrEqual(MAX_WEBHOOK_MONTHS);
+    }
+  });
 });

--- a/workers/scout-connect/src/paddle-event.ts
+++ b/workers/scout-connect/src/paddle-event.ts
@@ -29,22 +29,27 @@ export interface PriceMonthsMap {
 }
 
 /**
- * live 的四个 one-time price。**上线前必须填**。
+ * live 的三个 one-time price(季/年/两年)。
  *
- * 空表意味着 live 环境没有任何合法 price_id —— 这是刻意的:见
+ * 空表意味着本环境没有任何合法 price_id —— 这是刻意的:见
  * `priceMonthsFor()`,非 sandbox 环境拿到空表会让调用方 fail-closed(503,
  * 可重试),而不是把真实付款判成 unknown_price 后返回不可重试的 200。
  *
  * sandbox 与 live 的 price_id 完全不同(两套独立环境),所以不能复用。
  */
 export const LIVE_PRICE_MONTHS: PriceMonthsMap = {
-  // 用户在 live 后台所建(2026-07-30),price_id 由用户截图提供。
-  // **必须经过一次真实 live webhook 端到端验证**才视为生效 —— 这些 id 没经过
-  // live API 直接核对(我们的 paddle 工具只能访问 sandbox)。见 PR #202 的部署注记。
-  pri_01kyrvxr4kwqq8sz1bnkbwge7r: 3, // 季度 ¥45
-  pri_01kyrvywnxzj5se3vevghz3sym: 12, // 年度 ¥108
-  pri_01kyrvzv3ya0dgg30r8ngcm3tc: 24, // 两年 ¥188
-  pri_01kyrw1773tc65xxdtgqcqyfpk: 12, // 创始价 ¥88(前 100 席)
+  // 已用 live API 直接核对(2026-08-01,GET https://api.paddle.com/prices):
+  // 三个 id 存在、status=active、金额与档位一一对上。
+  pri_01kyrvxr4kwqq8sz1bnkbwge7r: 3, // 季度 ¥45  (live: 4500 CNY, 45cny-3months)
+  pri_01kyrvywnxzj5se3vevghz3sym: 12, // 年度 ¥108 (live: 10800 CNY, 108cny-1year)
+  pri_01kyrvzv3ya0dgg30r8ngcm3tc: 24, // 两年 ¥188 (live: 18800 CNY, 188cny-2years)
+  // **创始价 ¥88 已从白名单移除**(pri_01kyrw1773tc65xxdtgqcqyfpk)。
+  // 它在 Paddle 侧仍是 active(88cny-launch100),但产品侧从未真正实现 ——
+  // 没有已售席位计数,entitlements 也不记录成交价,所以「前 100 席」根本无法执行,
+  // PR #209 已把它从所有页面撤下。留在白名单里的后果是:任何人拿到这个 price_id
+  // 仍能以 ¥88 买到 12 个月(比年度档便宜 ¥20),而我们既不知情也拦不住。
+  // 白名单是最后一道闸 —— 页面撤了但闸没关,等于没撤。
+  // 若将来要恢复,先实现席位计数,再同时改这里和页面。
 };
 
 /**
@@ -64,6 +69,48 @@ export function isPriceMapConfigured(
   return map !== undefined && Object.keys(map).length > 0;
 }
 
+/**
+ * 售卖档位的**展示顺序与文案**。价格 ID 从白名单取(单一来源),这里只管
+ * 「哪一档主推」「显示什么字」。
+ *
+ * 顺序 = 页面上的顺序。年度放中间且 `featured`,因为它折月付 ¥9,比季付便宜
+ * 33% —— 用户已拍板以它为主推档。
+ *
+ * **月数不写死在这里**:从传入的白名单查,避免两处漂移。
+ */
+export const TIER_DISPLAY: ReadonlyArray<{
+  months: number;
+  label: string;
+  price: string;
+  featured: boolean;
+  note: string;
+}> = [
+  { months: 3, label: "季度", price: "¥45", featured: false, note: "3 个月" },
+  { months: 12, label: "年度", price: "¥108", featured: true, note: "12 个月 · 折月付 ¥9" },
+  { months: 24, label: "两年", price: "¥188", featured: false, note: "24 个月 · 折月付 ¥7.8" },
+];
+
+/**
+ * 把白名单翻成「可下单的档位列表」。
+ *
+ * 只输出**白名单里真有**的档位 —— 白名单是最后一道闸,页面不能显示一个下单会
+ * 被 400 拒掉的按钮。所以创始价撤掉后,这里自动就不再有它。
+ */
+export function purchasableTiers(
+  map: PriceMonthsMap | undefined,
+): ReadonlyArray<{ priceId: string; months: number; label: string; price: string; featured: boolean; note: string }> {
+  if (!isPriceMapConfigured(map)) return [];
+  const byMonths = new Map<number, string>();
+  for (const [priceId, months] of Object.entries(map)) {
+    // 同月数出现多次时保留第一个(理论上不该发生;真发生了也不能崩)。
+    if (!byMonths.has(months)) byMonths.set(months, priceId);
+  }
+  return TIER_DISPLAY.flatMap((tier) => {
+    const priceId = byMonths.get(tier.months);
+    return priceId === undefined ? [] : [{ priceId, ...tier }];
+  });
+}
+
 export function priceMonthsFor(environment: string | undefined): PriceMonthsMap | null {
   const env = environment?.trim().toLowerCase();
   if (env === "sandbox") return SANDBOX_PRICE_MONTHS;
@@ -71,12 +118,13 @@ export function priceMonthsFor(environment: string | undefined): PriceMonthsMap 
   return Object.keys(LIVE_PRICE_MONTHS).length > 0 ? LIVE_PRICE_MONTHS : null;
 }
 
-/** sandbox 的四个 one-time price(2026-07-29 建)。 */
+/** sandbox 的三个 one-time price(2026-07-29 建,档位与 live 对齐)。 */
 export const SANDBOX_PRICE_MONTHS: PriceMonthsMap = {
   pri_01kypfzv2jqg2qv0g25bn05v28: 3, // 季度 ¥45
   pri_01kypfzvbkhp0a7npjg87ptxpb: 12, // 年度 ¥108
   pri_01kypfzvpf02z5731sbnva3n82: 24, // 两年 ¥188
-  pri_01kypfzvyvgmytaefznh4npsz7: 12, // 创始价 ¥88
+  // sandbox 也不留创始价:两边档位必须一致,否则 sandbox 能测通的路径
+  // 到 live 就 400,而那种差异最难查。
 };
 
 export type ParseFailure =

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -23,7 +23,12 @@ import { invitePage, type InvitePageState } from "./html/invite-page.js";
 
 import { CAPACITY_LIMIT, isAtCapacityError } from "./capacity.js";
 import { grantEntitlement } from "./grant.js";
-import { isPriceMapConfigured, parseTransactionCompleted, type PriceMonthsMap } from "./paddle-event.js";
+import {
+  isPriceMapConfigured,
+  parseTransactionCompleted,
+  purchasableTiers,
+  type PriceMonthsMap,
+} from "./paddle-event.js";
 import { isKnownPriceId, type PaddleApi } from "./paddle-api.js";
 import { verifyPaddleSignature } from "./paddle-signature.js";
 import { buyPage } from "./html/buy-page.js";
@@ -1176,6 +1181,9 @@ async function consoleRoute(request: Request, deps: RouteDeps): Promise<Response
       rootDomain: deps.rootDomain.trim().toLowerCase(),
       now,
       atCapacity,
+      // 档位来自价格白名单(单一来源)。白名单空 → 空数组 → 页面不给假按钮,
+      // 因为那种按钮点下去必然被 /api/checkout 的 503 拒掉。
+      tiers: purchasableTiers(deps.paddlePriceMonths),
     }),
     { noStore: true }, // 用户专属页面,不可缓存(Copilot round 3)
   );

--- a/workers/scout-connect/wrangler.jsonc
+++ b/workers/scout-connect/wrangler.jsonc
@@ -37,8 +37,24 @@
     // "TURNSTILE_SITEKEY": "0x4AAAAAAD-wkGraJigl3YK0",
     // Paddle 环境(sandbox|production)。决定 priceMonthsFor 选哪份白名单:
     // 不设 = undefined = priceMonthsFor 返回 null → webhook 一律 503。
-    // 上线时改 "production",并在 paddle-event.ts 填 LIVE_PRICE_MONTHS。
-    "PADDLE_ENVIRONMENT": "sandbox"
+    //
+    // **2026-08-01 切 production。** 之前留在 sandbox 是个真实故障:
+    // PADDLE_CLIENT_TOKEN 早已是 live token(live_f688...),而 /buy 页面按这个
+    // 变量给 Paddle.js 注入 `Environment.set("sandbox")` —— live 凭据打沙箱环境,
+    // 结账窗必然失败。**站已上线,任何人点购买都付不了款**,而且不会有任何
+    // 服务端错误日志(失败发生在浏览器里的 Paddle.js)。
+    //
+    // 切换的前提都已满足:
+    //  - LIVE_PRICE_MONTHS 三档已用 live API 直接核对(见 paddle-event.ts)
+    //  - live webhook 已配置且 active,指向 /api/paddle/webhook
+    //  - PADDLE_API_KEY 已设为 pdl_live_*(secret,不在本文件)。没它 /api/checkout
+    //    恒 503;换环境时**必须同时换 key**,sandbox key 配 production 会 401。
+    //  - mediaryconnect.app 已通过 live 的 checkout domain 审批 —— 实测传
+    //    checkout.url 建交易成功,返回 mediaryconnect.app/buy?_ptxn=...。
+    //    (live 只接受已审批域名;sandbox 是自动批准的,所以这条只能在 live 验。
+    //     账号级 default payment link 指向另一个产品 agentmentor.dev,
+    //     靠 paddle-api.ts 每次显式传 checkout.url 覆盖 —— 那行不能删。)
+    "PADDLE_ENVIRONMENT": "production"
   }
   // EXPIRY_SWEEP_LIVE 用 `wrangler secret put` 或 dashboard 设 —— 它是行为开关
   // (true 才真删生产资源),刻意不放 vars 防误开。见 src/index.ts 的注释。


### PR DESCRIPTION
用户截图发现：登录后控制台的「开通」是个 `<a href="/pricing">`，而 `/pricing` 是**纯说明页、零结账入口**。

也就是说 **`POST /api/checkout` 从来没有任何前端调用方** —— 后端付款能力齐全，UI 上却没有任何按钮能触发它。整条付款路径断了。

> 这也解释了为什么线上一直挂在 sandbox 也没人反馈：**根本没人走得到付款那一步。**

## 三处配置不一致（每一处都会让付款 100% 失败）

| # | 问题 | 后果 |
|---|---|---|
| 1 | `PADDLE_ENVIRONMENT = "sandbox"` | client token 早已是 **live**（`live_f688...`），`/buy` 却按这个变量注入 `Environment.set("sandbox")` → live 凭据打沙箱，结账窗必然失败，**且无任何服务端日志**（失败在浏览器里）|
| 2 | `PADDLE_API_KEY` **从未设置** | `/api/checkout` 恒 503 |
| 3 | live 白名单留着已下架的创始价 ¥88 | 页面早在 #209 撤了，但**白名单是最后一道闸** —— 闸没关等于没撤：拿到那个 price_id 仍能 ¥88 买 12 个月（比年度便宜 ¥20），我们既不知情也拦不住 |

sandbox 表同步删掉创始价 —— 两边档位必须一致，否则 sandbox 测通的路径到 live 变 400，那类差异最难查（所有测试都是绿的）。

## live 侧亲自核对（不靠截图采信）

- `GET api.paddle.com/prices` → 三个 id 存在、`active`、金额一一对上（4500 / 10800 / 18800 CNY）。原注释写「没经过 live API 核对」，现在核对了。
- live webhook 已配置且 active，指向 `/api/paddle/webhook`。
- **checkout domain 已批准** —— 传 `checkout.url` 建交易成功，返回 `mediaryconnect.app/buy?_ptxn=...`。这条只能在 live 验（sandbox 自动批准所有域名）。

  ⚠️ 我一开始**误报**「结账链接指向 agentmentor.dev」—— 那是因为**我的 curl 自己没传 `checkout.url`**，回落到了账号级 default payment link。代码是每次显式传的。已在 `paddle-api.ts` 补上「这行不能删」的理由与 live 复验记录。
- 两笔 draft 测试交易已 cancel，从未产生扣款。

## 购买按钮（你拍板：控制台内三档，年度 ¥108 主推）

- 档位由 `purchasableTiers()` 从**价格白名单**生成 —— 单一来源，页面不会显示一个下单必被 400 的按钮；创始价撤掉后自动不再出现
- 白名单为空 → **不给假按钮**，直说「购买通道暂时不可用」。让用户点一下才发现是最差体验
- 整页跳 `checkout_url`，不在控制台内嵌第二份 Paddle.js：**配置只在 `/buy` 一处，少一处能配错** —— 刚才那个 live-token-打-sandbox 就是代价
- 三种失败各给不同动作：401 让重新登录（「请重试」对 session 过期毫无用处）、503 说通道不可用、502/网络说稍后再试
- 点击后禁用全部按钮：不禁的话连点三下就在 Paddle 建三笔 draft 交易

## 测试：这块之前一个都没有（所以 bug 才溜到线上）

新增 10 个，含一条**精确复现原始 bug** 的：禁止出现 `class="btn" href="/pricing"` 形态的按钮。

| 反向验证 | 结果 |
|---|---|
| 把代码退回死链 | **5 个**转红 |
| 拿到 `checkout_url` 不跳转 | 转红 |
| 空白名单给假按钮 | 转红 |
| 创始价加回白名单 | 3 个转红 |

顺带修了一个自己写的假断言：数 `tier-featured` 次数会把 CSS 规则算进去，改数 `class="tier tier-featured"`。

## 验证

- 三处 tsc 全绿
- 全量 **2728 passed**（基线 2719 + 本次 9），零回归
- 已部署 `37757cbf`，用真实 `LIVE_PRICE_MONTHS` 渲染核对：三个 `data-price` 与 live API 返回的 id **逐字一致**，主推档 1 个，创始价与死链均为 0