### PR TITLE
fix: close Paddle overlay before redirect on WeChat Pay completion

### DIFF
--- a/workers/scout-connect/src/html/buy-page.test.ts
+++ b/workers/scout-connect/src/html/buy-page.test.ts
@@ -181,9 +181,13 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     
     // 且 close() 必须在 location.href 之前(否则跳转发生时 overlay 还开着)
     const closeIdx = html.indexOf("window.Paddle.Checkout.close()");
+    const timeoutIdx = html.indexOf("setTimeout(");
     const hrefIdx = html.indexOf('window.location.href = "/console?paid=1"');
     expect(closeIdx).toBeGreaterThan(-1);
+    expect(timeoutIdx).toBeGreaterThan(-1);
     expect(hrefIdx).toBeGreaterThan(-1);
-    expect(closeIdx).toBeLessThan(hrefIdx);
+    // close() 必须在 setTimeout 外面（立即执行），href 在 setTimeout 里面
+    expect(closeIdx).toBeLessThan(timeoutIdx);
+    expect(timeoutIdx).toBeLessThan(hrefIdx);
   });
 });

--- a/workers/scout-connect/src/html/buy-page.test.ts
+++ b/workers/scout-connect/src/html/buy-page.test.ts
@@ -182,8 +182,8 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     // 且 close() 必须在 location.href 之前(否则跳转发生时 overlay 还开着)
     const closeIdx = html.indexOf("window.Paddle.Checkout.close()");
     const hrefIdx = html.indexOf('window.location.href = "/console?paid=1"');
-    expect(closeIdx).toBeGreaterThan(0);
-    expect(hrefIdx).toBeGreaterThan(0);
+    expect(closeIdx).toBeGreaterThan(-1);
+    expect(hrefIdx).toBeGreaterThan(-1);
     expect(closeIdx).toBeLessThan(hrefIdx);
   });
 });

--- a/workers/scout-connect/src/html/buy-page.test.ts
+++ b/workers/scout-connect/src/html/buy-page.test.ts
@@ -174,15 +174,15 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     //
     // 正确顺序:close() → setTimeout → location.href。这样用户看到 overlay 关闭,
     // 然后看到页面上的「正在开通」提示,1.8 秒后跳回控制台。
-    const html = buyPage(CONFIGURED);
+    const output = buyPage(CONFIGURED);
     
     // 必须有 close() 调用
-    expect(html).toContain("window.Paddle.Checkout.close()");
+    expect(output).toContain("window.Paddle.Checkout.close()");
     
     // 且 close() 必须在 location.href 之前(否则跳转发生时 overlay 还开着)
-    const closeIdx = html.indexOf("window.Paddle.Checkout.close()");
-    const timeoutIdx = html.indexOf("setTimeout(");
-    const hrefIdx = html.indexOf('window.location.href = "/console?paid=1"');
+    const closeIdx = output.indexOf("window.Paddle.Checkout.close()");
+    const timeoutIdx = output.indexOf("setTimeout(");
+    const hrefIdx = output.indexOf('window.location.href = "/console?paid=1"');
     expect(closeIdx).toBeGreaterThan(-1);
     expect(timeoutIdx).toBeGreaterThan(-1);
     expect(hrefIdx).toBeGreaterThan(-1);

--- a/workers/scout-connect/src/html/buy-page.test.ts
+++ b/workers/scout-connect/src/html/buy-page.test.ts
@@ -166,4 +166,24 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     expect(h).not.toContain("eventCallback");
     expect(h).toContain("结账功能尚未开放");
   });
+
+  it("checkout.completed 必须先关 overlay 再跳转(两次真实 bug)", () => {
+    // 第一次事故:没有 eventCallback,用户付完款 overlay 停在原地不动。
+    // 第二次事故:加了 eventCallback 但没关 overlay,setTimeout 里的跳转
+    // 在 iframe 里执行 —— 被沙箱阻止或被 overlay 挡住,用户仍看到二维码不动。
+    //
+    // 正确顺序:close() → setTimeout → location.href。这样用户看到 overlay 关闭,
+    // 然后看到页面上的「正在开通」提示,1.8 秒后跳回控制台。
+    const html = buyPage(CONFIGURED);
+    
+    // 必须有 close() 调用
+    expect(html).toContain("window.Paddle.Checkout.close()");
+    
+    // 且 close() 必须在 location.href 之前(否则跳转发生时 overlay 还开着)
+    const closeIdx = html.indexOf("window.Paddle.Checkout.close()");
+    const hrefIdx = html.indexOf('window.location.href = "/console?paid=1"');
+    expect(closeIdx).toBeGreaterThan(0);
+    expect(hrefIdx).toBeGreaterThan(0);
+    expect(closeIdx).toBeLessThan(hrefIdx);
+  });
 });

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -112,6 +112,18 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
           hint.textContent = "支付成功,正在开通…";
           // 微信支付是延迟捕获,到账可能要几分钟。说清楚,别让人干等。
           status.textContent = "正在确认到账(微信支付最多需要 10 分钟)。即将回到控制台。";
+          
+          // ---- 必须先关 overlay,否则跳转会被卡住(真实 bug)----
+          //
+          // 第二次真实事故:用户微信扫码付款后,Paddle overlay 还停在二维码页,
+          // 「像是我没扫过码付过款一样」。checkout.completed **确实触发了**,
+          // 但 window.location.href 在 overlay 的 iframe 里执行 ——
+          // 跳转被 iframe 沙箱阻止,或者只是 overlay 挡住了整个页面。
+          //
+          // Paddle.Checkout.close() 必须在跳转前调 —— 否则用户看到二维码停着不动,
+          // 会以为失败了,重复付款,或者来投诉「钱扣了但没开通」。
+          try { window.Paddle.Checkout.close(); } catch (e) { /* 已经关了也无妨 */ }
+          
           // 留 1.8 秒让用户看到这句话再跳。跳过去后控制台会显示「已付款,正在开通」
           // 那一态(见 console-page 的 pendingPaid),不会再显示「尚未开通」。
           setTimeout(function () { window.location.href = "/console?paid=1"; }, 1800);


### PR DESCRIPTION
## 问题

真实事故（第二次生产支付）：用户微信扫码付款后，Paddle overlay 停在二维码页不动，「像是我没扫过码付过款一样」。

## 根因

`checkout.completed` 确实触发了，`eventCallback` 也跑了，但 `window.location.href` 在 overlay 还开着时执行 —— 跳转被 overlay 的 iframe 阻止，或者 overlay 挡住了整个页面。

## 修复

在 `setTimeout` 跳转前先调 `Paddle.Checkout.close()`，overlay 关闭后用户能看到页面上的「正在开通」提示，1.8 秒后跳回控制台。

## 测试

新增测试验证 `close()` 在 `location.href` 之前，防止回归。

## Checklist

- [x] 三处 tsc 全绿
- [x] 全量测试 2765 passed
- [x] 新增测试覆盖 overlay 关闭逻辑