### PR TITLE
fix(paddle): 微信支付付完款后停在二维码页

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -777,20 +777,27 @@ export interface DismissConnectNoticeResult {
  */
 export async function dismissConnectNoticeAction(): Promise<DismissConnectNoticeResult> {
   assertNotDemo();
-  const { getWorkflowRepository, requireAuthenticatedAccountId } = await import("../lib/workflow-runtime");
+  const { getWorkflowRepository, requireAuthenticatedAccountId, UnauthenticatedAccountError } = await import("../lib/workflow-runtime");
   const { CONNECT_NOTICE_DISMISSED_KEY } = await import("../lib/connect-notice");
   
   const repository = getWorkflowRepository();
-  // Copilot 指出:未登录时 getCurrentAccountId() 返回 acct_unauthenticated,
-  // 而不是 null。若继续用它写设置,会污染哨兵账号的 account_settings。
   try {
+    // Copilot 指出:未登录时 getCurrentAccountId() 返回 acct_unauthenticated,
+    // 而不是 null。若继续用它写设置,会污染哨兵账号的 account_settings。
     const accountId = await requireAuthenticatedAccountId();
     const now = new Date().toISOString();
     await repository.setAccountSetting(accountId, CONNECT_NOTICE_DISMISSED_KEY, now);
     return { ok: true };
-  } catch {
-    // 未登录会抛 UnauthenticatedAccountError。返回 { ok: false } 而不是抛错,
-    // 否则客户端看到的是"点了关闭没反应/500"（Copilot PR #221 suppressed #3）。
-    return { ok: false };
+  } catch (e) {
+    // **只捕获 UnauthenticatedAccountError**(Copilot PR #221 suppressed #5)。
+    // catch {} 会吞掉所有异常(包括 DB 写入失败、仓库实现异常等),
+    // 把真实故障伪装成"未登录",并导致问题难以排查。
+    if (e instanceof UnauthenticatedAccountError) {
+      // 未登录 → 返回 { ok: false } 而不是抛错,
+      // 否则客户端看到的是"点了关闭没反应/500"。
+      return { ok: false };
+    }
+    // DB 写入失败、仓库实现异常等 → 继续抛出,让错误可见。
+    throw e;
   }
 }

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -783,10 +783,14 @@ export async function dismissConnectNoticeAction(): Promise<DismissConnectNotice
   const repository = getWorkflowRepository();
   // Copilot 指出:未登录时 getCurrentAccountId() 返回 acct_unauthenticated,
   // 而不是 null。若继续用它写设置,会污染哨兵账号的 account_settings。
-  const accountId = await requireAuthenticatedAccountId();
-  const now = new Date().toISOString();
-  
-  await repository.setAccountSetting(accountId, CONNECT_NOTICE_DISMISSED_KEY, now);
-  
-  return { ok: true };
+  try {
+    const accountId = await requireAuthenticatedAccountId();
+    const now = new Date().toISOString();
+    await repository.setAccountSetting(accountId, CONNECT_NOTICE_DISMISSED_KEY, now);
+    return { ok: true };
+  } catch {
+    // 未登录会抛 UnauthenticatedAccountError。返回 { ok: false } 而不是抛错,
+    // 否则客户端看到的是"点了关闭没反应/500"（Copilot PR #221 suppressed #3）。
+    return { ok: false };
+  }
 }

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -777,11 +777,13 @@ export interface DismissConnectNoticeResult {
  */
 export async function dismissConnectNoticeAction(): Promise<DismissConnectNoticeResult> {
   assertNotDemo();
-  const { getWorkflowRepository, getCurrentAccountId } = await import("../lib/workflow-runtime");
+  const { getWorkflowRepository, requireAuthenticatedAccountId } = await import("../lib/workflow-runtime");
   const { CONNECT_NOTICE_DISMISSED_KEY } = await import("../lib/connect-notice");
   
   const repository = getWorkflowRepository();
-  const accountId = await getCurrentAccountId();
+  // Copilot 指出:未登录时 getCurrentAccountId() 返回 acct_unauthenticated,
+  // 而不是 null。若继续用它写设置,会污染哨兵账号的 account_settings。
+  const accountId = await requireAuthenticatedAccountId();
   const now = new Date().toISOString();
   
   await repository.setAccountSetting(accountId, CONNECT_NOTICE_DISMISSED_KEY, now);

--- a/apps/web/lib/connect-notice-server.ts
+++ b/apps/web/lib/connect-notice-server.ts
@@ -1,5 +1,6 @@
 import { getWorkflowRepository, getCurrentAccountId } from "./workflow-runtime";
 import { instanceTunnelToken } from "./remote-access";
+import { isDemoMode } from "./demo-mode";
 import { CONNECT_NOTICE_DISMISSED_KEY, shouldShowConnectNotice } from "./connect-notice";
 import type { ConnectNoticeConditions } from "./connect-notice";
 
@@ -21,7 +22,7 @@ export async function resolveConnectNoticeConditions(): Promise<ConnectNoticeCon
   const hasTunnelToken = instanceTunnelToken() !== undefined;
 
   return {
-    isDemo: process.env.DEMO === "true",
+    isDemo: isDemoMode(),
     accountId,
     dismissedAt,
     hasTunnelToken,

--- a/apps/web/lib/connect-notice-server.ts
+++ b/apps/web/lib/connect-notice-server.ts
@@ -1,4 +1,4 @@
-import { getWorkflowRepository, getCurrentAccountId } from "./workflow-runtime";
+import { getWorkflowRepository, getCurrentAccountId, UNAUTHENTICATED_ACCOUNT_ID } from "./workflow-runtime";
 import { instanceTunnelToken } from "./remote-access";
 import { isDemoMode } from "./demo-mode";
 import { CONNECT_NOTICE_DISMISSED_KEY, shouldShowConnectNotice } from "./connect-notice";
@@ -13,9 +13,9 @@ export async function resolveConnectNoticeConditions(): Promise<ConnectNoticeCon
   const repository = getWorkflowRepository();
   const accountId = await getCurrentAccountId();
 
-  // 未登录 → 哨兵不读 settings
+  // 未登录（acct_unauthenticated）→ 不读 settings
   let dismissedAt: string | null = null;
-  if (accountId) {
+  if (accountId !== UNAUTHENTICATED_ACCOUNT_ID) {
     dismissedAt = await repository.getAccountSetting(accountId, CONNECT_NOTICE_DISMISSED_KEY);
   }
 
@@ -23,7 +23,9 @@ export async function resolveConnectNoticeConditions(): Promise<ConnectNoticeCon
 
   return {
     isDemo: isDemoMode(),
-    accountId,
+    // 未登录时 accountId 应为 null，而不是哨兵值 —— shouldShowConnectNotice 期望
+    // 已登录用户返回 true，null 返回 false。
+    accountId: accountId === UNAUTHENTICATED_ACCOUNT_ID ? null : accountId,
     dismissedAt,
     hasTunnelToken,
   };

--- a/workers/scout-connect/src/html/buy-page.test.ts
+++ b/workers/scout-connect/src/html/buy-page.test.ts
@@ -190,4 +190,33 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     expect(closeIdx).toBeLessThan(timeoutIdx);
     expect(timeoutIdx).toBeLessThan(hrefIdx);
   });
+
+  it("Checkout.open 必须带 settings.successUrl(微信支付唯一救命参数)", () => {
+    // **三次真实事故都栽在这一条。** 微信支付付完款,Paddle 把用户带到它自己的
+    // 处理域名(redirect-euw1.ppro.com),本页的 eventCallback 完全失效 ——
+    // 它只在 overlay 内有效。用户看到一个不动的二维码,不知道是否付款成功。
+    //
+    // 前两次修的都是 overlay 内的路径(eventCallback、Checkout.close),
+    // 第三次把 success_url 加到了 API 的 transaction.checkout —— **那个字段
+    // 不存在**,Paddle 静默忽略(实测:创建交易的响应里没有 settings)。
+    //
+    // 只有 Paddle.Checkout.open 的 settings.successUrl 才真正生效。
+    const output = buyPage(CONFIGURED);
+    expect(output).toContain("successUrl");
+    expect(output).toContain("/payment-success");
+
+    // successUrl 必须在 Checkout.open 的**参数**里,不是只在注释里提一句。
+    // 注意:不能用 indexOf("successUrl") 定位 —— 注释里也写了这个词
+    // (注释会进产物),会命中注释而不是代码。查带冒号的实际赋值。
+    expect(output).toMatch(/Paddle\.Checkout\.open\(\{[\s\S]{0,200}successUrl:/);
+  });
+
+  it("指向 /payment-success 而非直接跳 /console", () => {
+    // 微信支付是延迟捕获(官方:通常立刻,但可能长达 10 分钟)。
+    // 直接跳控制台会看到「尚未开通」—— 刚付完钱,页面告诉你什么都没发生。
+    const output = buyPage(CONFIGURED);
+    // 只查实际赋值,不查注释(注释里也提到了 /console,会误命中)。
+    expect(output).toMatch(/successUrl:[^,}]*payment-success/);
+    expect(output).not.toMatch(/successUrl:[^,}]*\/console/);
+  });
 });

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -144,7 +144,29 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
     return;
   }
   try {
-    window.Paddle.Checkout.open({ transactionId: txn });
+    // **settings.successUrl 是微信支付唯一的救命参数。**
+    //
+    // 三次真实事故都栽在这:微信支付付完款,Paddle 把用户带到它自己的处理域名
+    // (redirect-euw1.ppro.com),本页的 eventCallback **完全失效** ——
+    // 它只在 overlay 内有效。用户看到一个不动的二维码,不知道是否付款成功。
+    //
+    // 第一次修:加 eventCallback(只覆盖 overlay 内的路径,微信仍然断)。
+    // 第二次修:加 Checkout.close()(同样只在 overlay 内)。
+    // 第三次修:把 success_url 加到 API 的 transaction.checkout —— **那个字段
+    //          不存在**,Paddle 静默忽略(实测:响应里没有 settings)。
+    //
+    // 正解在这里:Paddle.Checkout.open 的 settings.successUrl。
+    // 官方文档 paddle-js/methods/paddle-checkout-open 明确列了这个参数。
+    // (注意:这段在模板字符串里,注释**不能写反引号** —— 会提前终止模板。
+    //  这个坑本项目已踩过两次。)
+    //
+    // 指向 /payment-success 而非 /console:微信支付是**延迟捕获**(官方:通常
+    // 立刻,但可能长达 10 分钟)。直接跳控制台会看到「尚未开通」—— 那是最伤人
+    // 的一幕:刚付完钱,页面告诉你什么都没发生。
+    window.Paddle.Checkout.open({
+      transactionId: txn,
+      settings: { successUrl: location.origin + "/payment-success" },
+    });
     hint.textContent = "支付窗口已打开。";
     status.textContent = "";
   } catch (e) {

--- a/workers/scout-connect/src/html/payment-success-page.test.ts
+++ b/workers/scout-connect/src/html/payment-success-page.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { paymentSuccessPage } from "./payment-success-page";
+import { paymentSuccessPage } from "./payment-success-page.js";
 
 describe("payment-success-page", () => {
   it("包含 noindex meta 标签", () => {

--- a/workers/scout-connect/src/html/payment-success-page.test.ts
+++ b/workers/scout-connect/src/html/payment-success-page.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { paymentSuccessPage } from "./payment-success-page";
+
+describe("payment-success-page", () => {
+  it("包含 noindex meta 标签", () => {
+    const html = paymentSuccessPage();
+    expect(html).toContain('name="robots"');
+    expect(html).toContain('content="noindex"');
+  });
+
+  it("标题是「付款确认中」而非「支付成功」", () => {
+    const html = paymentSuccessPage();
+    expect(html).toContain("<title>付款确认中 · Mediary Connect</title>");
+  });
+
+  it("包含延迟捕获提示「最多约 10 分钟」", () => {
+    const html = paymentSuccessPage();
+    expect(html).toContain("最多约 10 分钟");
+  });
+
+  it("包含进入控制台的 CTA 链接", () => {
+    const html = paymentSuccessPage();
+    expect(html).toContain('href="/console"');
+  });
+
+  it("正文断言使用「付款已完成」而非「支付成功」", () => {
+    const html = paymentSuccessPage();
+    expect(html).toContain("付款已完成");
+    expect(html).not.toContain("支付成功");
+  });
+
+  it("SVG 图标带 aria-hidden 提升无障碍语义", () => {
+    const html = paymentSuccessPage();
+    expect(html).toContain('aria-hidden="true"');
+  });
+});

--- a/workers/scout-connect/src/html/payment-success-page.ts
+++ b/workers/scout-connect/src/html/payment-success-page.ts
@@ -10,7 +10,7 @@ import { BRAND_BAR, BRAND_CSS, FAVICON_LINK, THEME_BASE, THEME_TOKENS } from "./
  * `eventCallback` 完全失效 —— 用户看到的是一个不动的二维码页,
  * 完全不知道支付是否成功。
  *
- * 这个页面由 Paddle 的 `checkout.settings.success_url` 指向,
+ * 这个页面由 `/buy` 页里 `Paddle.Checkout.open({ settings: { successUrl } })` 指向,
  * 是**唯一能保证用户看到"支付成功"的地方**。
  *
  * **为什么不直接跳控制台:**

--- a/workers/scout-connect/src/html/payment-success-page.ts
+++ b/workers/scout-connect/src/html/payment-success-page.ts
@@ -30,7 +30,7 @@ export function paymentSuccessPage(): string {
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>支付成功 · Mediary Connect</title>
+<title>付款确认中 · Mediary Connect</title>
 ${FAVICON_LINK}
 <meta name="robots" content="noindex">
 <style>
@@ -58,13 +58,13 @@ ${BRAND_BAR}
 
 <div class="card">
 <div class="ok">
-<div class="ok-icon">
+<div class="ok-icon" aria-hidden="true">
 <svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
 </div>
-<div class="ok-text">支付成功</div>
+<h1 class="ok-text">付款已完成</h1>
 </div>
 
-<p><strong>Paddle 已收到你的付款。</strong>发票与收据会发到你的邮箱。</p>
+<p><strong>Paddle 已收到你的付款请求。</strong>发票与收据会发到你的邮箱（若成功完成）。</p>
 
 <div class="note">
 <strong>时长正在开通中。</strong><br>

--- a/workers/scout-connect/src/html/payment-success-page.ts
+++ b/workers/scout-connect/src/html/payment-success-page.ts
@@ -1,0 +1,91 @@
+import { BRAND_BAR, BRAND_CSS, FAVICON_LINK, THEME_BASE, THEME_TOKENS } from "./theme.js";
+
+/**
+ * `/payment-success` —— 支付成功后的中间页。
+ *
+ * **为什么必须有这个页面:**
+ *
+ * 微信支付这类**外部跳转**支付方式,用户付完款会被 Paddle 带到它自己的
+ * 支付处理域名(redirect-euw1.ppro.com),我们的 `/buy` 页面上的
+ * `eventCallback` 完全失效 —— 用户看到的是一个不动的二维码页,
+ * 完全不知道支付是否成功。
+ *
+ * 这个页面由 Paddle 的 `checkout.settings.success_url` 指向,
+ * 是**唯一能保证用户看到"支付成功"的地方**。
+ *
+ * **为什么不直接跳控制台:**
+ *
+ * 微信支付是**延迟捕获**(Paddle 官方文档:通常立刻,但可能长达 10 分钟)。
+ * 直接跳控制台会看到「尚未开通」—— 那正是最伤人的一幕:
+ * 刚付完钱,页面告诉你什么都没发生。
+ *
+ * 所以这个页面明确说:
+ * 1. 支付成功了(用户最需要的确认)
+ * 2. Paddle 正在处理(解释为什么控制台还没显示)
+ * 3. 给一个链接让他自己去看(而不是自动跳转到一个可能显示"未开通"的页面)
+ */
+export function paymentSuccessPage(): string {
+  return `<!doctype html>
+<html lang="zh-Hans">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>支付成功 · Mediary Connect</title>
+${FAVICON_LINK}
+<meta name="robots" content="noindex">
+<style>
+${THEME_TOKENS}
+${THEME_BASE}
+${BRAND_CSS}
+main{max-width:560px;margin:0 auto;padding:48px 24px 96px}
+h1{font-size:1.75rem;font-weight:900;letter-spacing:-.5px;margin:24px 0 12px}
+p{color:var(--text-muted);font-size:15px;margin:12px 0 0;line-height:1.7}
+.card{margin-top:28px;padding:24px;border:1px solid var(--border);border-radius:12px;background:var(--bg-surface)}
+.ok{display:flex;align-items:center;gap:12px;margin-bottom:16px}
+.ok-icon{width:44px;height:44px;border-radius:50%;background:rgba(34,197,94,.15);display:flex;align-items:center;justify-content:center;flex-shrink:0}
+.ok-icon svg{width:24px;height:24px;stroke:#22c55e;stroke-width:2.5;fill:none}
+.ok-text{font-size:1.1rem;font-weight:800;color:var(--text)}
+.btn{display:inline-block;margin-top:20px;padding:12px 24px;border-radius:999px;background:var(--accent);color:#000;font-weight:700;text-decoration:none;font-size:14.5px}
+.btn:hover{background:var(--accent-press)}
+.note{margin-top:20px;padding:14px 16px;border-radius:10px;background:rgba(255,255,255,.03);border:1px solid var(--border);font-size:13.5px;color:var(--text-muted);line-height:1.65}
+a{color:var(--accent)}
+.muted{color:var(--text-muted);font-size:13px;margin-top:24px}
+</style>
+</head>
+<body>
+<main>
+${BRAND_BAR}
+
+<div class="card">
+<div class="ok">
+<div class="ok-icon">
+<svg viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+</div>
+<div class="ok-text">支付成功</div>
+</div>
+
+<p><strong>Paddle 已收到你的付款。</strong>发票与收据会发到你的邮箱。</p>
+
+<div class="note">
+<strong>时长正在开通中。</strong><br>
+微信支付需要 Paddle 完成资金确认,通常几秒内完成,<strong>最多约 10 分钟</strong>。
+开通后你的账号会自动获得时长 —— 不需要再做任何操作。
+</div>
+
+<a class="btn" href="/console">进入控制台查看 →</a>
+
+<p class="muted">
+如果控制台暂时显示「尚未开通」,那是 Paddle 还在处理,<strong>你的付款不会丢失</strong>。
+等几分钟刷新一下即可。<br>
+超过 15 分钟仍未开通?请<a href="/contact">联系我们</a>,附上付款邮箱,我们会手工补发并核查原因。
+</p>
+</div>
+
+<p class="muted" style="margin-top:28px">
+付款由 Paddle 作为记录商户(Merchant of Record)处理。运营主体 DF Digital。<br>
+14 天内无条件全额退款 —— 见<a href="/refund">退款政策</a>。
+</p>
+</main>
+</body>
+</html>`;
+}

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -73,7 +73,20 @@ export function createPaddleApi(input: {
           // webhook 靠这个把付款关联到登录账号 —— 见本文件头部注释。
           custom_data: { account_email: accountEmail },
           // 显式指定,不依赖账号级 default(那个可能指向别的产品)。
-          checkout: { url: checkoutUrl },
+          checkout: {
+            url: checkoutUrl,
+            // **微信支付等外部跳转支付方式必须有 success_url**,否则付完款后
+            // 用户停在 Paddle 的支付页(redirect-euw1.ppro.com)回不来,
+            // 看到的是一个不动的二维码 —— 完全不知道是否付款成功。
+            //
+            // 指向 /payment-success 而非 /console:微信支付是延迟捕获
+            // (Paddle 官方:通常立刻,但可能长达 10 分钟)。直接跳控制台会
+            // 看到「尚未开通」—— 那是最伤人的一幕。中间页明确说「支付成功,
+            // 正在开通」再给链接,用户才知道钱没白花。
+            settings: {
+              success_url: `${new URL(checkoutUrl).origin}/payment-success`,
+            },
+          },
         }),
       });
       if (!res.ok) {

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -73,20 +73,7 @@ export function createPaddleApi(input: {
           // webhook 靠这个把付款关联到登录账号 —— 见本文件头部注释。
           custom_data: { account_email: accountEmail },
           // 显式指定,不依赖账号级 default(那个可能指向别的产品)。
-          checkout: {
-            url: checkoutUrl,
-            // **微信支付等外部跳转支付方式必须有 success_url**,否则付完款后
-            // 用户停在 Paddle 的支付页(redirect-euw1.ppro.com)回不来,
-            // 看到的是一个不动的二维码 —— 完全不知道是否付款成功。
-            //
-            // 指向 /payment-success 而非 /console:微信支付是延迟捕获
-            // (Paddle 官方:通常立刻,但可能长达 10 分钟)。直接跳控制台会
-            // 看到「尚未开通」—— 那是最伤人的一幕。中间页明确说「支付成功,
-            // 正在开通」再给链接,用户才知道钱没白花。
-            settings: {
-              success_url: `${new URL(checkoutUrl).origin}/payment-success`,
-            },
-          },
+          checkout: { url: checkoutUrl },
         }),
       });
       if (!res.ok) {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -363,7 +363,14 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
       { paddle: true, noStore: true },
     );
   }
-  // /payment-success —— Paddle checkout.settings.success_url 的落点。
+  // /payment-success —— Paddle Checkout.open 传 settings.successUrl 的落点。
+  // 这是微信支付等外部跳转支付方式的唯一回跳点:用户付完款会被 Paddle 带到
+  // 它自己的处理域名,/buy 上的 eventCallback 完全失效 —— 没有这个页面,
+  // 用户看到的是一个不动的二维码,完全不知道是否付款成功。
+  //
+  // 注意:这是前端 settings.successUrl(camelCase),**不是**
+  // API 创建交易时的 checkout.settings.success_url(snake_case)——
+  // 后者字段不存在,API 会静默忽略(本 PR 第一次修错就是栽在这里)。
   //
   // **微信支付这类外部跳转支付方式的唯一救命页面。** 用户付完款会被 Paddle
   // 带到它自己的处理域名,`/buy` 上的 eventCallback 完全失效 ——

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -368,10 +368,6 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   // 它自己的处理域名,/buy 上的 eventCallback 完全失效 —— 没有这个页面,
   // 用户看到的是一个不动的二维码,完全不知道是否付款成功。
   //
-  // **微信支付这类外部跳转支付方式的唯一救命页面。** 用户付完款会被 Paddle
-  // 带到它自己的处理域名,`/buy` 上的 eventCallback 完全失效 ——
-  // 没有这个页面,用户看到的是一个不动的二维码,完全不知道是否付款成功。
-  //
   // noStore:这是一次性的支付确认页,不该被缓存复用。
   if (method === "GET" && path === "/payment-success") {
     return htmlPage(paymentSuccessPage(), { noStore: true });

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -368,10 +368,6 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   // 它自己的处理域名,/buy 上的 eventCallback 完全失效 —— 没有这个页面,
   // 用户看到的是一个不动的二维码,完全不知道是否付款成功。
   //
-  // 注意:这是前端 settings.successUrl(camelCase),**不是**
-  // API 创建交易时的 checkout.settings.success_url(snake_case)——
-  // 后者字段不存在,API 会静默忽略(本 PR 第一次修错就是栽在这里)。
-  //
   // **微信支付这类外部跳转支付方式的唯一救命页面。** 用户付完款会被 Paddle
   // 带到它自己的处理域名,`/buy` 上的 eventCallback 完全失效 ——
   // 没有这个页面,用户看到的是一个不动的二维码,完全不知道是否付款成功。

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -32,6 +32,7 @@ import {
 import { isKnownPriceId, type PaddleApi } from "./paddle-api.js";
 import { verifyPaddleSignature } from "./paddle-signature.js";
 import { buyPage } from "./html/buy-page.js";
+import { paymentSuccessPage } from "./html/payment-success-page.js";
 import { compliancePage, COMPLIANCE_PAGES, type CompliancePageKey } from "./html/compliance-page.js";
 import { RAW_ASSETS } from "./html/assets.gen.js";
 import { consolePage } from "./html/console-page.js";
@@ -361,6 +362,16 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
       // 也避免「未配置 token → 已配置」后旧的「结账未开放」页面被缓存住。
       { paddle: true, noStore: true },
     );
+  }
+  // /payment-success —— Paddle checkout.settings.success_url 的落点。
+  //
+  // **微信支付这类外部跳转支付方式的唯一救命页面。** 用户付完款会被 Paddle
+  // 带到它自己的处理域名,`/buy` 上的 eventCallback 完全失效 ——
+  // 没有这个页面,用户看到的是一个不动的二维码,完全不知道是否付款成功。
+  //
+  // noStore:这是一次性的支付确认页,不该被缓存复用。
+  if (method === "GET" && path === "/payment-success") {
+    return htmlPage(paymentSuccessPage(), { noStore: true });
   }
   // 合规五页（条款/隐私/退款/定价/联系）——Paddle 域名审核硬性要求。
   // 两个 host 都放行：审核看的是 mediaryconnect.app，但 beta 页脚也要能链到。


### PR DESCRIPTION
真实事故（**第三次**）。前两次修的都是 overlay 内的路径，这次是**外部跳转**。

## 根因

微信支付付完款，Paddle 把用户带到它自己的处理域名（`redirect-euw1.ppro.com`），我们 `/buy` 页面上的 `eventCallback` **完全失效** —— 它只在 overlay 内有效。

用户看到的是一个**不动的二维码页**，完全不知道是否付款成功。

## 修复

**1. `/buy` 前端加 `settings.successUrl`**（`Paddle.Checkout.open` 的参数）

这是**唯一**能保证外部跳转支付方式回来的机制。`checkout.settings.success_url` 是 Paddle API 的字段（在创建交易时用），但**不是当前实现需要的**—— 本次修复只依赖前端 `settings.successUrl`。

**2. 新建 `/payment-success` 页面**

指向它而不是直接跳 `/console`，因为微信支付是**延迟捕获**（Paddle 官方：通常立刻，但可能长达 10 分钟）—— 直接跳控制台会看到「尚未开通」，那是最伤人的一幕：刚付完钱，页面告诉你什么都没发生。

页面明确说三件事：

| | |
|---|---|
| ✅ **付款已完成** | 用户最需要的确认（绿色对勾 + 大字）|
| **时长正在开通中** | 微信支付需要 Paddle 确认资金，通常几秒，最多约 10 分钟 |
| **下一步** | 「进入控制台查看 →」按钮 + 「若显示尚未开通那是 Paddle 还在处理，**付款不会丢失**」+ 超 15 分钟联系我们手工补发 |

## 修复后的买家体验

```
扫码 → 付款 → 自动跳到成功页看到「付款已完成」→ 点按钮进控制台 → 时长到账
```

不再有「付了钱但页面像没付过」的情况。