### PR TITLE
feat(checkout): 自建轮询 —— 付款成功即时跳转,不再依赖 Paddle 前端

### DIFF
--- a/workers/scout-connect/src/html/buy-page.test.ts
+++ b/workers/scout-connect/src/html/buy-page.test.ts
@@ -135,10 +135,11 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     expect(html()).toContain("eventCallback");
   });
 
-  it("监听 checkout.completed 并跳回控制台", () => {
+  it("监听 checkout.completed 并跳 /payment-success", () => {
+    // 与轮询路径统一跳转目标(确认中间页),不再跳 /console?paid=1(Copilot round 9)。
     const h = html();
     expect(h).toContain("checkout.completed");
-    expect(h).toContain("/console?paid=1");
+    expect(h).toContain("/payment-success");
   });
 
   it("付款失败也说话,并明确「没有扣款」", () => {
@@ -173,7 +174,7 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     // 在 iframe 里执行 —— 被沙箱阻止或被 overlay 挡住,用户仍看到二维码不动。
     //
     // 正确顺序:close() → setTimeout → location.href。这样用户看到 overlay 关闭,
-    // 然后看到页面上的「正在开通」提示,1.8 秒后跳回控制台。
+    // 然后看到页面上的「正在开通」提示,1.8 秒后跳 /payment-success。
     const output = buyPage(CONFIGURED);
     
     // 必须有 close() 调用
@@ -182,7 +183,7 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     // 且 close() 必须在 location.href 之前(否则跳转发生时 overlay 还开着)
     const closeIdx = output.indexOf("window.Paddle.Checkout.close()");
     const timeoutIdx = output.indexOf("setTimeout(");
-    const hrefIdx = output.indexOf('window.location.href = "/console?paid=1"');
+    const hrefIdx = output.indexOf('window.location.href = "/payment-success"');
     expect(closeIdx).toBeGreaterThan(-1);
     expect(timeoutIdx).toBeGreaterThan(-1);
     expect(hrefIdx).toBeGreaterThan(-1);

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -169,6 +169,40 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
     });
     hint.textContent = "支付窗口已打开。";
     status.textContent = "";
+
+    // ---- 自建轮询:微信支付的唯一可靠出路 ----
+    //
+    // 第四次真实事故:微信支付是延迟捕获,授权与 Paddle 确认之间有几分钟窗口。
+    // 窗口内 Paddle 前端不跳转、checkout.completed 不发、successUrl 不触发 ——
+    // 用户看到"付了钱但页面没反应",感觉被骗。上述三条路(Paddle 的 successUrl、
+    // eventCallback、服务端捕获)全都在 Paddle 手里,我们控制不了它的前端轮询。
+    //
+    // 所以**自己轮询**:每 3 秒查一次 /api/transaction/<id>/status,一旦
+    // paid/completed 就关 overlay、跳 /payment-success。这不再依赖 Paddle 前端
+    // 是否跳转 —— 只要 Paddle 服务端确认了钱,我们就能把用户接走。
+    //
+    // 轮询上限 10 分钟(Paddle 官方延迟捕获上限),之后停轮询,页面显示"稍后
+    // 刷新查看"—— 避免无限请求。交易 ID 来自 URL,归属校验在服务端做。
+    (function pollTransaction() {
+      var attempts = 0;
+      var timer = setInterval(async function () {
+        attempts++;
+        if (attempts > 200) { clearInterval(timer); return; }  // 3s × 200 = 10 分钟
+        try {
+          var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status");
+          if (res.status === 401 || res.status === 404) { clearInterval(timer); return; }
+          if (res.status === 503) return;  // Paddle 上游抖动,下次再试
+          var data = await res.json();
+          if (data && (data.status === "paid" || data.status === "completed")) {
+            clearInterval(timer);
+            hint.textContent = "支付成功,正在开通…";
+            status.textContent = "正在确认到账(微信支付最多需要 10 分钟)。即将回到控制台。";
+            try { window.Paddle.Checkout.close(); } catch (e) { /* 已经关了也无妨 */ }
+            setTimeout(function () { window.location.href = "/payment-success"; }, 1800);
+          }
+        } catch (e) { /* 网络抖动,下次再试 */ }
+      }, 3000);
+    })();
   } catch (e) {
     fail("打开支付窗口失败：" + (e && e.message ? e.message : String(e)));
   }`

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -202,7 +202,12 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
             status.textContent = "如果已经付款,请稍后刷新此页面查看开通状态。你的付款不会丢失 —— 超过 15 分钟仍未开通请联系我们。";
             return;
           }
-          var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status");
+          // AbortSignal.timeout:fetch 挂起不返回时(某些网络条件下不 reject),
+          // inFlight 锁会永久占住、轮询永久停住且页面无提示(Copilot round 7)。
+          // 5 秒超时,保证锁一定释放。超时走 catch → 下次 tick 重试。
+          var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status", {
+            signal: AbortSignal.timeout(5000),
+          });
           if (res.status === 401) {
             // 登录过期:继续轮询也没用,明确告诉用户重新登录。
             clearInterval(timer);

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -187,10 +187,30 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
       var attempts = 0;
       var timer = setInterval(async function () {
         attempts++;
-        if (attempts > 200) { clearInterval(timer); return; }  // 3s × 200 = 10 分钟
+        // 3s × 200 = 10 分钟(Paddle 官方延迟捕获上限)。
+        // 超时后停轮询并明确告诉用户下一步,不能无声无息地停。
+        if (attempts > 200) {
+          clearInterval(timer);
+          hint.textContent = "支付已提交,正在确认到账…";
+          status.textContent = "如果已经付款,请稍后刷新此页面查看开通状态。你的付款不会丢失 —— 超过 15 分钟仍未开通请联系我们。";
+          return;
+        }
         try {
           var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status");
-          if (res.status === 401 || res.status === 404) { clearInterval(timer); return; }
+          if (res.status === 401) {
+            // 登录过期:继续轮询也没用,明确告诉用户重新登录。
+            clearInterval(timer);
+            hint.textContent = "登录状态已过期。";
+            status.textContent = "请刷新页面重新登录后,在控制台查看开通状态。你的付款不会丢失。";
+            return;
+          }
+          if (res.status === 404) {
+            // 交易不存在/不属于当前账号:继续轮询没意义。多半是会话换人了。
+            clearInterval(timer);
+            hint.textContent = "这笔交易无法确认。";
+            status.textContent = "请回到控制台重新发起购买;若已付款,请联系我们核对。";
+            return;
+          }
           if (res.status === 503) return;  // Paddle 上游抖动,下次再试
           var data = await res.json();
           if (data && (data.status === "paid" || data.status === "completed")) {

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -183,6 +183,17 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
     //
     // 轮询上限 10 分钟(Paddle 官方延迟捕获上限),之后停轮询,页面显示"稍后
     // 刷新查看"—— 避免无限请求。交易 ID 来自 URL,归属校验在服务端做。
+    //
+    // AbortSignal.timeout 降级(与 site/main.js 同款):旧浏览器不支持
+    // AbortSignal.timeout,直接调用会抛 TypeError → 轮询永远发不出去且被
+    // catch 吞掉,用户又回到"付了钱但页面没反应"。优先用原生,否则
+    // AbortController + setTimeout。
+    function timeoutSignal(ms) {
+      if (typeof AbortSignal.timeout === "function") return AbortSignal.timeout(ms);
+      var controller = new AbortController();
+      setTimeout(function () { controller.abort(); }, ms);
+      return controller.signal;
+    }
     (function pollTransaction() {
       var attempts = 0;
       // **inFlight 锁**(Copilot round 2):setInterval + async 下,某次请求/
@@ -206,7 +217,7 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
           // inFlight 锁会永久占住、轮询永久停住且页面无提示(Copilot round 7)。
           // 5 秒超时,保证锁一定释放。超时走 catch → 下次 tick 重试。
           var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status", {
-            signal: AbortSignal.timeout(5000),
+            signal: timeoutSignal(5000),
           });
           if (res.status === 401) {
             // 登录过期:继续轮询也没用,明确告诉用户重新登录。

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -185,17 +185,23 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
     // 刷新查看"—— 避免无限请求。交易 ID 来自 URL,归属校验在服务端做。
     (function pollTransaction() {
       var attempts = 0;
+      // **inFlight 锁**(Copilot round 2):setInterval + async 下,某次请求/
+      // 解析超过 3 秒时下一次 tick 仍会触发 → 并发重叠请求,放大上游抖动与
+      // API 调用。上一轮未结束就跳过本轮;结束后释放锁(含异常路径)。
+      var inFlight = false;
       var timer = setInterval(async function () {
-        attempts++;
-        // 3s × 200 = 10 分钟(Paddle 官方延迟捕获上限)。
-        // 超时后停轮询并明确告诉用户下一步,不能无声无息地停。
-        if (attempts > 200) {
-          clearInterval(timer);
-          hint.textContent = "支付已提交,正在确认到账…";
-          status.textContent = "如果已经付款,请稍后刷新此页面查看开通状态。你的付款不会丢失 —— 超过 15 分钟仍未开通请联系我们。";
-          return;
-        }
+        if (inFlight) return;
+        inFlight = true;
         try {
+          attempts++;
+          // 3s × 200 = 10 分钟(Paddle 官方延迟捕获上限)。
+          // 超时后停轮询并明确告诉用户下一步,不能无声无息地停。
+          if (attempts > 200) {
+            clearInterval(timer);
+            hint.textContent = "支付已提交,正在确认到账…";
+            status.textContent = "如果已经付款,请稍后刷新此页面查看开通状态。你的付款不会丢失 —— 超过 15 分钟仍未开通请联系我们。";
+            return;
+          }
           var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status");
           if (res.status === 401) {
             // 登录过期:继续轮询也没用,明确告诉用户重新登录。
@@ -211,7 +217,19 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
             status.textContent = "请回到控制台重新发起购买;若已付款,请联系我们核对。";
             return;
           }
-          if (res.status === 503) return;  // Paddle 上游抖动,下次再试
+          if (res.status === 503) {
+            // 503 分两种(见端点):checkout not configured = 配置缺失,重试
+            // 也没用,立即停并提示;temporarily unavailable = 上游抖动,重试。
+            var body503 = null;
+            try { body503 = await res.json(); } catch (e) { /* 读不到就当抖动 */ }
+            if (body503 && body503.error === "checkout not configured") {
+              clearInterval(timer);
+              hint.textContent = "支付通道暂时不可用。";
+              status.textContent = "请稍后刷新页面重试;持续不可用请联系我们。你的付款不会丢失。";
+              return;
+            }
+            return;
+          }
           var data = await res.json();
           if (data && (data.status === "paid" || data.status === "completed")) {
             clearInterval(timer);
@@ -220,7 +238,10 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
             try { window.Paddle.Checkout.close(); } catch (e) { /* 已经关了也无妨 */ }
             setTimeout(function () { window.location.href = "/payment-success"; }, 1800);
           }
-        } catch (e) { /* 网络抖动,下次再试 */ }
+        } catch (e) { /* 网络抖动,下次再试 */ } finally {
+          // 释放锁:clearInterval 后 finally 仍会跑,但 timer 已停,无副作用。
+          inFlight = false;
+        }
       }, 3000);
     })();
   } catch (e) {

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -88,7 +88,6 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
   // (注意:此处注释不能出现回调字样 —— 未配置分支的产物会被测试断言
   //  not.toContain,注释会误命中,本项目已多次栽在这。)
   var redirectScheduled = false;
-  var redirectScheduled = false;
   function fail(msg) {
     hint.textContent = "无法打开支付窗口。";
     status.textContent = msg;

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -234,7 +234,7 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
           if (data && (data.status === "paid" || data.status === "completed")) {
             clearInterval(timer);
             hint.textContent = "支付成功,正在开通…";
-            status.textContent = "正在确认到账(微信支付最多需要 10 分钟)。即将回到控制台。";
+            status.textContent = "正在确认到账(微信支付最多需要 10 分钟)。即将前往确认页。";
             try { window.Paddle.Checkout.close(); } catch (e) { /* 已经关了也无妨 */ }
             setTimeout(function () { window.location.href = "/payment-success"; }, 1800);
           }

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -82,6 +82,13 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
 (function () {
   var hint = document.getElementById("hint");
   var status = document.getElementById("status");
+  // **共享"已安排跳转"标志**(Copilot round 9):页面里的两条完成路径
+  // (Paddle 事件回调 与 轮询命中 paid/completed)都可能触发跳转,必须只跳
+  // 一次 —— 否则两次 location.href 互相覆盖,落点不确定。
+  // (注意:此处注释不能出现回调字样 —— 未配置分支的产物会被测试断言
+  //  not.toContain,注释会误命中,本项目已多次栽在这。)
+  var redirectScheduled = false;
+  var redirectScheduled = false;
   function fail(msg) {
     hint.textContent = "无法打开支付窗口。";
     status.textContent = msg;
@@ -109,9 +116,12 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
       eventCallback: function (event) {
         if (!event || typeof event.name !== "string") return;
         if (event.name === "checkout.completed") {
+          // 与轮询路径统一:只跳一次,都跳 /payment-success(确认中间页)。
+          if (redirectScheduled) return;
+          redirectScheduled = true;
           hint.textContent = "支付成功,正在开通…";
           // 微信支付是延迟捕获,到账可能要几分钟。说清楚,别让人干等。
-          status.textContent = "正在确认到账(微信支付最多需要 10 分钟)。即将回到控制台。";
+          status.textContent = "正在确认到账(微信支付最多需要 10 分钟)。即将前往确认页。";
           
           // ---- 必须先关 overlay,否则跳转会被卡住(真实 bug)----
           //
@@ -124,9 +134,8 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
           // 会以为失败了,重复付款,或者来投诉「钱扣了但没开通」。
           try { window.Paddle.Checkout.close(); } catch (e) { /* 已经关了也无妨 */ }
           
-          // 留 1.8 秒让用户看到这句话再跳。跳过去后控制台会显示「已付款,正在开通」
-          // 那一态(见 console-page 的 pendingPaid),不会再显示「尚未开通」。
-          setTimeout(function () { window.location.href = "/console?paid=1"; }, 1800);
+          // 留 1.8 秒让用户看到这句话再跳。跳过去后确认页显示「正在开通」。
+          setTimeout(function () { window.location.href = "/payment-success"; }, 1800);
         } else if (event.name === "checkout.payment.failed") {
           // 付款失败也必须说话。之前这里同样是静默的。
           hint.textContent = "这笔支付没有成功。";
@@ -248,6 +257,9 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
           }
           var data = await res.json();
           if (data && (data.status === "paid" || data.status === "completed")) {
+            // 与 eventCallback 路径共享标志:只跳一次。
+            if (redirectScheduled) { clearInterval(timer); return; }
+            redirectScheduled = true;
             clearInterval(timer);
             hint.textContent = "支付成功,正在开通…";
             status.textContent = "正在确认到账(微信支付最多需要 10 分钟)。即将前往确认页。";

--- a/workers/scout-connect/src/paddle-api-status.test.ts
+++ b/workers/scout-connect/src/paddle-api-status.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPaddleApi } from "./paddle-api.js";
 
 /**
@@ -10,6 +10,11 @@ import { createPaddleApi } from "./paddle-api.js";
  *   其它非 2xx → throw(上游故障,端点返回 503 可重试)
  */
 describe("getTransactionStatus 错误分类", () => {
+  afterEach(() => {
+    // stubGlobal 会泄漏到其它测试文件,必须恢复(Copilot round 3)。
+    vi.unstubAllGlobals();
+  });
+
   const T = "txn_aaaaaaaaaaaaaaaaaaaaaaaaaa";
   const api = (status: number, body: unknown) => {
     vi.stubGlobal(

--- a/workers/scout-connect/src/paddle-api-status.test.ts
+++ b/workers/scout-connect/src/paddle-api-status.test.ts
@@ -55,9 +55,14 @@ describe("getTransactionStatus 错误分类", () => {
     });
   });
 
-  it("200 但 body 畸形(无 data.id)→ null", async () => {
+  it("200 但缺 data.id → throw(上游异常,不能当交易不存在)", async () => {
     const a = api(200, { data: {} });
-    await expect(a.getTransactionStatus(T)).resolves.toBeNull();
+    await expect(a.getTransactionStatus(T)).rejects.toThrow("missing data.id");
+  });
+
+  it("200 但缺 status → throw(上游异常,不能当交易不存在)", async () => {
+    const a = api(200, { data: { id: T } });
+    await expect(a.getTransactionStatus(T)).rejects.toThrow("missing status");
   });
 
   it("返回的交易 ID 与请求不符 → throw(上游异常,不能带回别人的交易)", async () => {

--- a/workers/scout-connect/src/paddle-api-status.test.ts
+++ b/workers/scout-connect/src/paddle-api-status.test.ts
@@ -59,4 +59,11 @@ describe("getTransactionStatus 错误分类", () => {
     const a = api(200, { data: {} });
     await expect(a.getTransactionStatus(T)).resolves.toBeNull();
   });
+
+  it("返回的交易 ID 与请求不符 → throw(上游异常,不能带回别人的交易)", async () => {
+    const a = api(200, { data: { id: "txn_ffffffffffffffffffffffffff", status: "completed" } });
+    await expect(a.getTransactionStatus("txn_aaaaaaaaaaaaaaaaaaaaaaaaaa")).rejects.toThrow(
+      "id mismatch",
+    );
+  });
 });

--- a/workers/scout-connect/src/paddle-api-status.test.ts
+++ b/workers/scout-connect/src/paddle-api-status.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPaddleApi } from "./paddle-api.js";
+
+/**
+ * getTransactionStatus 的错误分类(实测抓到的真实缺陷):
+ *
+ * 第一版对任何非 2xx 都返回 null —— Paddle 5xx/429 被当成"交易不存在",
+ * 轮询端点据此返回 404,前端停止轮询,用户卡死。正确分类:
+ *   404 → null(交易不存在,合法)
+ *   其它非 2xx → throw(上游故障,端点返回 503 可重试)
+ */
+describe("getTransactionStatus 错误分类", () => {
+  const T = "txn_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const api = (status: number, body: unknown) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(body), { status })),
+    );
+    return createPaddleApi({ apiKey: "k", environment: "production" });
+  };
+
+  it("404 → null(交易不存在)", async () => {
+    const a = api(404, { error: "not found" });
+    await expect(a.getTransactionStatus(T)).resolves.toBeNull();
+  });
+
+  it("500 → throw(上游故障,不能当交易不存在)", async () => {
+    const a = api(500, { error: "boom" });
+    await expect(a.getTransactionStatus(T)).rejects.toThrow("500");
+  });
+
+  it("429 → throw(限流也是可重试的)", async () => {
+    const a = api(429, { error: "rate limited" });
+    await expect(a.getTransactionStatus(T)).rejects.toThrow("429");
+  });
+
+  it("200 → 解析 status/billed_at/account_email", async () => {
+    const a = api(200, {
+      data: {
+        id: T,
+        status: "completed",
+        billed_at: "2026-08-01T06:56:46.198368Z",
+        custom_data: { account_email: "me@example.com" },
+      },
+    });
+    await expect(a.getTransactionStatus(T)).resolves.toEqual({
+      status: "completed",
+      paidAt: "2026-08-01T06:56:46.198368Z",
+      accountEmail: "me@example.com",
+    });
+  });
+
+  it("200 但 body 畸形(无 data.id)→ null", async () => {
+    const a = api(200, { data: {} });
+    await expect(a.getTransactionStatus(T)).resolves.toBeNull();
+  });
+});

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -169,7 +169,12 @@ export function createPaddleApi(input: {
           custom_data?: { account_email?: unknown } | null;
         };
       };
-      if (typeof body.data?.id !== "string") return null;
+      if (typeof body.data?.id !== "string") {
+        // 200 但缺 data.id = 上游/代理异常或协议变更,throw 让上层 503 可重试
+        // (Copilot round 7)。返回 null 会被误判成"交易不存在"→ 404 → 前端
+        // 停止轮询,用户卡死。
+        throw new Error("paddle getTransactionStatus: missing data.id");
+      }
       // **必须校验返回的交易 ID == 请求的 ID**(Copilot round 6)。
       // 上游/缓存/代理异常时若返回了别的交易,会把它的状态/归属邮箱带回,
       // 后续归属校验也会被误导。不匹配 = 上游异常,throw 而非静默返回。
@@ -177,7 +182,10 @@ export function createPaddleApi(input: {
         throw new Error(`paddle getTransactionStatus id mismatch: asked=${transactionId} got=${body.data.id}`);
       }
       const status = typeof body.data.status === "string" ? body.data.status : "";
-      if (status === "") return null;
+      if (status === "") {
+        // 200 但缺 status = 上游异常,同上 throw 而非 null(Copilot round 7)。
+        throw new Error("paddle getTransactionStatus: missing status");
+      }
       const paidAt = typeof body.data.billed_at === "string" ? body.data.billed_at : null;
       const custom = body.data.custom_data;
       const accountEmail =

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -156,7 +156,11 @@ export function createPaddleApi(input: {
         headers: { authorization: `Bearer ${input.apiKey}` },
         signal: AbortSignal.timeout(10_000),
       });
-      if (!res.ok) return null;
+      // 区分错误类型:404 = 交易不存在(合法 null);其它非 2xx(5xx/429)是
+      // 上游故障,必须 throw —— 否则轮询端点会把 Paddle 抖动当成"交易不存在"
+      // 返回 404,前端停止轮询,用户卡死。
+      if (res.status === 404) return null;
+      if (!res.ok) throw new Error(`paddle getTransactionStatus failed: ${res.status}`);
       const body = (await res.json()) as {
         data?: {
           id?: unknown;

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -42,6 +42,20 @@ export interface PaddleApi {
    * 交易状态白拿时长。
    */
   listPaidTransactionIds(accountEmail: string, ourPriceIds: readonly string[]): Promise<string[]>;
+
+  /**
+   * 查单笔交易的状态。供 /buy 页面的轮询用 —— 微信支付是延迟捕获,授权与
+   * Paddle 确认之间可能有几分钟窗口,期间 Paddle 前端不跳转。我们自己轮询
+   * 这个端点,一旦 paid/completed 就关 overlay 跳转。
+   *
+   * 返回 null = 交易不存在(或已取消)。**只返回状态与归属邮箱,不返回任何
+   * 敏感字段。** 归属邮箱(创建交易时写入的 custom_data.account_email)
+   * 用于校验"这笔交易确实属于这个登录用户"—— 防止任何人拿别人的交易 ID
+   * 探测状态。
+   */
+  getTransactionStatus(
+    transactionId: string,
+  ): Promise<{ status: string; paidAt: string | null; accountEmail: string | null } | null>;
 }
 
 /** 真实 Paddle API 客户端。sandbox 与 live 的 base URL 不同。 */
@@ -135,6 +149,32 @@ export function createPaddleApi(input: {
         )
         .map((t) => t.id)
         .filter((id): id is string => typeof id === "string" && id !== "");
+    },
+
+    async getTransactionStatus(transactionId) {
+      const res = await fetch(`${base}/transactions/${encodeURIComponent(transactionId)}`, {
+        headers: { authorization: `Bearer ${input.apiKey}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) return null;
+      const body = (await res.json()) as {
+        data?: {
+          id?: unknown;
+          status?: unknown;
+          billed_at?: unknown;
+          custom_data?: { account_email?: unknown } | null;
+        };
+      };
+      if (typeof body.data?.id !== "string") return null;
+      const status = typeof body.data.status === "string" ? body.data.status : "";
+      if (status === "") return null;
+      const paidAt = typeof body.data.billed_at === "string" ? body.data.billed_at : null;
+      const custom = body.data.custom_data;
+      const accountEmail =
+        typeof custom?.account_email === "string" && custom.account_email !== ""
+          ? custom.account_email
+          : null;
+      return { status, paidAt, accountEmail };
     },
   };
 }

--- a/workers/scout-connect/src/paddle-api.ts
+++ b/workers/scout-connect/src/paddle-api.ts
@@ -170,6 +170,12 @@ export function createPaddleApi(input: {
         };
       };
       if (typeof body.data?.id !== "string") return null;
+      // **必须校验返回的交易 ID == 请求的 ID**(Copilot round 6)。
+      // 上游/缓存/代理异常时若返回了别的交易,会把它的状态/归属邮箱带回,
+      // 后续归属校验也会被误导。不匹配 = 上游异常,throw 而非静默返回。
+      if (body.data.id !== transactionId) {
+        throw new Error(`paddle getTransactionStatus id mismatch: asked=${transactionId} got=${body.data.id}`);
+      }
       const status = typeof body.data.status === "string" ? body.data.status : "";
       if (status === "") return null;
       const paidAt = typeof body.data.billed_at === "string" ? body.data.billed_at : null;

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -542,3 +542,29 @@ describe("GET /api/transaction/:id/status —— 错误路径必须 noStore(Copi
     expect(res.headers.get("cache-control")).toBe("no-store");
   });
 });
+
+describe("GET /api/transaction/:id/status —— D1 命中但归属失败(Copilot round 4)", () => {
+  async function seedMe(db: ConnectDb): Promise<string> {
+    await db.insertAccount({
+      id: "act_me4", email: "me@example.com", paddle_customer_id: null,
+      created_at: NOW, last_login_at: null,
+    });
+    return buildSessionCookie("act_me4", { secret: SECRET, ttlMs: 3600_000, now: Date.parse(NOW) });
+  }
+
+  it("D1 命中但入账给了别人 → 404 且带 no-store", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const { grantEntitlement } = await import("./grant.js");
+    await grantEntitlement(
+      { email: "other@example.com", months: 3, source: "paddle", paddleTransactionId: "txn_zzzzzzzzzzzzzzzzzzzzzzzzzz" },
+      { db: deps.db, now: () => NOW, newAccountId: () => "act_new", newEntitlementId: () => "ent_4" },
+    );
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_zzzzzzzzzzzzzzzzzzzzzzzzzz/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -433,7 +433,11 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
       deps,
     );
     expect(res.status).toBe(200);
-    expect(((await res.json()) as Record<string, unknown>).status).toBe("completed");
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("completed");
+    // paid_at 必须为 null:entitlement.created_at 是 webhook 入账时间,不是
+    // Paddle 的真实捕获时间(billed_at),语义不能骗人(Copilot round 5)。
+    expect(body.paid_at).toBeNull();
     expect(paddleCalled).toBe(false);
   });
 

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -572,3 +572,20 @@ describe("GET /api/transaction/:id/status —— D1 命中但归属失败(Copilo
     expect(res.headers.get("cache-control")).toBe("no-store");
   });
 });
+
+describe("GET /api/transaction/:id/status —— handler 抛错兜底(Copilot round 6)", () => {
+  it("服务器时钟畸形(session 解析 throw)→ 500 且带 no-store", async () => {
+    // parseSessionWithValidatedNow 在 now 坏值时 throw 500(HttpError)。
+    // 路由分支的兜底必须把它转成带 noStore 的 JSON,不能落外层 handleError。
+    const { deps } = setup();
+    // exactOptionalPropertyTypes:不能把 undefined 赋回必填属性。
+    // 直接替换整个 deps.now(测试私有),不还原 —— 本测试是最后一个用例。
+    (deps as { now: () => string }).now = () => "not-a-date";
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_aaaaaaaaaaaaaaaaaaaaaaaaaa/status`),
+      deps,
+    );
+    expect(res.status).toBe(500);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -22,6 +22,9 @@ function fakeApi(calls: unknown[]): PaddleApi {
     async listPaidTransactionIds() {
       return [];
     },
+    async getTransactionStatus() {
+      return null;
+    },
   };
 }
 
@@ -168,6 +171,9 @@ describe("POST /api/checkout", () => {
         },
         async listPaidTransactionIds() {
           return [];
+        },
+        async getTransactionStatus() {
+          return null;
         },
       },
     });
@@ -329,5 +335,120 @@ describe("服务器时钟畸形时 fail-closed(不伪装成未登录)", () => {
       );
       expect(res.status, `${path} 应 fail-closed`).toBe(500);
     }
+  });
+});
+
+describe("GET /api/transaction/:id/status(结账轮询)", () => {
+  async function seedMe(db: ConnectDb): Promise<string> {
+    await db.insertAccount({
+      id: "act_me", email: "me@example.com", paddle_customer_id: null,
+      created_at: NOW, last_login_at: null,
+    });
+    return buildSessionCookie("act_me", { secret: SECRET, ttlMs: 3600_000, now: Date.parse(NOW) });
+  }
+
+  it("未登录 → 401", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/api/transaction/txn_1/status`), deps);
+    expect(res.status).toBe(401);
+  });
+
+  it("归属校验:不是自己的交易 → 404(不泄露存在性)", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    fake.getTransactionStatus = async () => ({ status: "completed", paidAt: NOW, accountEmail: "other@example.com" });
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_other/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("自己的交易 completed → 200 返回状态与 paid_at", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    fake.getTransactionStatus = async () => ({ status: "completed", paidAt: NOW, accountEmail: "me@example.com" });
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_mine/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("completed");
+    expect(body.paid_at).toBe(NOW);
+  });
+
+  it("ready(微信确认前)→ 200 返回 ready,前端继续轮询", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    fake.getTransactionStatus = async () => ({ status: "ready", paidAt: null, accountEmail: "me@example.com" });
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_mine/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Record<string, unknown>).status).toBe("ready");
+  });
+
+  it("Paddle 上游抖动 → 503", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    fake.getTransactionStatus = async () => { throw new Error("upstream boom"); };
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_mine/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("交易不存在 → 404", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    fake.getTransactionStatus = async () => null;
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_ghost/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("D1 入账记录(webhook 观测结果)→ completed,不查 Paddle", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    let paddleCalled = false;
+    fake.getTransactionStatus = async () => { paddleCalled = true; return null; };
+    const { grantEntitlement } = await import("./grant.js");
+    await grantEntitlement(
+      { email: "me@example.com", months: 3, source: "paddle", paddleTransactionId: "txn_paid" },
+      { db: deps.db, now: () => NOW, newAccountId: () => "act_new", newEntitlementId: () => "ent_1" },
+    );
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_paid/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Record<string, unknown>).status).toBe("completed");
+    expect(paddleCalled).toBe(false);
+  });
+
+  it("入账给了别人 → 404", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const { grantEntitlement } = await import("./grant.js");
+    await grantEntitlement(
+      { email: "other@example.com", months: 3, source: "paddle", paddleTransactionId: "txn_other" },
+      { db: deps.db, now: () => NOW, newAccountId: () => "act_new", newEntitlementId: () => "ent_2" },
+    );
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/txn_other/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -500,3 +500,45 @@ describe("GET /api/transaction/:id/status —— 边界(Copilot round 1)", () =>
     expect(res.status).toBe(503);
   });
 });
+
+describe("GET /api/transaction/:id/status —— 错误路径必须 noStore(Copilot round 3)", () => {
+  async function seedMe(db: ConnectDb): Promise<string> {
+    await db.insertAccount({
+      id: "act_me3", email: "me@example.com", paddle_customer_id: null,
+      created_at: NOW, last_login_at: null,
+    });
+    return buildSessionCookie("act_me3", { secret: SECRET, ttlMs: 3600_000, now: Date.parse(NOW) });
+  }
+  const T26 = "txn_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  it("401 带 cache-control: no-store(轮询端点不能被缓存卡死)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/api/transaction/${T26}/status`), deps);
+    expect(res.status).toBe(401);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("畸形 ID 的 404 带 cache-control: no-store", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/not-a-txn/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("归属失败的 404 带 cache-control: no-store", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    fake.getTransactionStatus = async () => ({ status: "paid", paidAt: NOW, accountEmail: "other@example.com" });
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/${T26}/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/workers/scout-connect/src/paddle-checkout.test.ts
+++ b/workers/scout-connect/src/paddle-checkout.test.ts
@@ -349,7 +349,7 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
 
   it("未登录 → 401", async () => {
     const { deps } = setup();
-    const res = await handleRequest(new Request(`${BASE}/api/transaction/txn_1/status`), deps);
+    const res = await handleRequest(new Request(`${BASE}/api/transaction/txn_aaaaaaaaaaaaaaaaaaaaaaaaaa/status`), deps);
     expect(res.status).toBe(401);
   });
 
@@ -359,7 +359,7 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
     const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
     fake.getTransactionStatus = async () => ({ status: "completed", paidAt: NOW, accountEmail: "other@example.com" });
     const res = await handleRequest(
-      new Request(`${BASE}/api/transaction/txn_other/status`, { headers: { cookie } }),
+      new Request(`${BASE}/api/transaction/txn_bbbbbbbbbbbbbbbbbbbbbbbbbb/status`, { headers: { cookie } }),
       deps,
     );
     expect(res.status).toBe(404);
@@ -371,7 +371,7 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
     const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
     fake.getTransactionStatus = async () => ({ status: "completed", paidAt: NOW, accountEmail: "me@example.com" });
     const res = await handleRequest(
-      new Request(`${BASE}/api/transaction/txn_mine/status`, { headers: { cookie } }),
+      new Request(`${BASE}/api/transaction/txn_cccccccccccccccccccccccccc/status`, { headers: { cookie } }),
       deps,
     );
     expect(res.status).toBe(200);
@@ -386,7 +386,7 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
     const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
     fake.getTransactionStatus = async () => ({ status: "ready", paidAt: null, accountEmail: "me@example.com" });
     const res = await handleRequest(
-      new Request(`${BASE}/api/transaction/txn_mine/status`, { headers: { cookie } }),
+      new Request(`${BASE}/api/transaction/txn_cccccccccccccccccccccccccc/status`, { headers: { cookie } }),
       deps,
     );
     expect(res.status).toBe(200);
@@ -399,7 +399,7 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
     const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
     fake.getTransactionStatus = async () => { throw new Error("upstream boom"); };
     const res = await handleRequest(
-      new Request(`${BASE}/api/transaction/txn_mine/status`, { headers: { cookie } }),
+      new Request(`${BASE}/api/transaction/txn_cccccccccccccccccccccccccc/status`, { headers: { cookie } }),
       deps,
     );
     expect(res.status).toBe(503);
@@ -411,7 +411,7 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
     const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
     fake.getTransactionStatus = async () => null;
     const res = await handleRequest(
-      new Request(`${BASE}/api/transaction/txn_ghost/status`, { headers: { cookie } }),
+      new Request(`${BASE}/api/transaction/txn_dddddddddddddddddddddddddd/status`, { headers: { cookie } }),
       deps,
     );
     expect(res.status).toBe(404);
@@ -425,11 +425,11 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
     fake.getTransactionStatus = async () => { paddleCalled = true; return null; };
     const { grantEntitlement } = await import("./grant.js");
     await grantEntitlement(
-      { email: "me@example.com", months: 3, source: "paddle", paddleTransactionId: "txn_paid" },
+      { email: "me@example.com", months: 3, source: "paddle", paddleTransactionId: "txn_eeeeeeeeeeeeeeeeeeeeeeeeee" },
       { db: deps.db, now: () => NOW, newAccountId: () => "act_new", newEntitlementId: () => "ent_1" },
     );
     const res = await handleRequest(
-      new Request(`${BASE}/api/transaction/txn_paid/status`, { headers: { cookie } }),
+      new Request(`${BASE}/api/transaction/txn_eeeeeeeeeeeeeeeeeeeeeeeeee/status`, { headers: { cookie } }),
       deps,
     );
     expect(res.status).toBe(200);
@@ -442,13 +442,61 @@ describe("GET /api/transaction/:id/status(结账轮询)", () => {
     const cookie = await seedMe(deps.db);
     const { grantEntitlement } = await import("./grant.js");
     await grantEntitlement(
-      { email: "other@example.com", months: 3, source: "paddle", paddleTransactionId: "txn_other" },
+      { email: "other@example.com", months: 3, source: "paddle", paddleTransactionId: "txn_bbbbbbbbbbbbbbbbbbbbbbbbbb" },
       { db: deps.db, now: () => NOW, newAccountId: () => "act_new", newEntitlementId: () => "ent_2" },
     );
     const res = await handleRequest(
-      new Request(`${BASE}/api/transaction/txn_other/status`, { headers: { cookie } }),
+      new Request(`${BASE}/api/transaction/txn_bbbbbbbbbbbbbbbbbbbbbbbbbb/status`, { headers: { cookie } }),
       deps,
     );
     expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/transaction/:id/status —— 边界(Copilot round 1)", () => {
+  async function seedMe(db: ConnectDb): Promise<string> {
+    await db.insertAccount({
+      id: "act_me2", email: "me@example.com", paddle_customer_id: null,
+      created_at: NOW, last_login_at: null,
+    });
+    return buildSessionCookie("act_me2", { secret: SECRET, ttlMs: 3600_000, now: Date.parse(NOW) });
+  }
+  const T26 = "txn_aaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+  it("畸形交易 ID(非 txn_ 格式)→ 404 而非 500", async () => {
+    // decodeURIComponent 对畸形百分号编码会抛 URIError。格式校验在前,
+    // 客户端错误不该变 500。
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/%E0%A4%A/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("accountEmail 为 null(异常/伪造)→ 404,不让猜 ID 的人查", async () => {
+    // 创建交易必写 custom_data.account_email。null 只可能是异常,拒绝。
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    fake.getTransactionStatus = async () => ({ status: "paid", paidAt: NOW, accountEmail: null });
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/${T26}/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("Paddle 5xx → 503 而非 404(上游故障要可重试)", async () => {
+    const { deps } = setup();
+    const cookie = await seedMe(deps.db);
+    const fake = deps.paddleApi as unknown as { getTransactionStatus: () => unknown };
+    fake.getTransactionStatus = async () => { throw new Error("paddle getTransactionStatus failed: 500"); };
+    const res = await handleRequest(
+      new Request(`${BASE}/api/transaction/${T26}/status`, { headers: { cookie } }),
+      deps,
+    );
+    expect(res.status).toBe(503);
   });
 });

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -777,10 +777,6 @@ async function selfServeProvision(request: Request, deps: RouteDeps): Promise<Re
  * 返回结账 URL,前端跳过去即可(Paddle 会拼上 ?_ptxn=)。
  */
 async function createCheckout(request: Request, deps: RouteDeps): Promise<Response> {
-  // **错误路径全部显式 JSON + noStore,不走 HttpError**(Copilot round 3)。
-  // 这个端点被高频轮询且状态随时间变化:HttpError 经 handleError() 的响应
-  // 不带 cache-control: no-store,中间层/浏览器缓存住 401/404 会提前停掉
-  // 轮询,用户卡死。成功/503 路径本就带 noStore,错误路径必须一致。
   const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
   if (!session.ok) return json({ error: "unauthorized" }, 401, { noStore: true });
   const account = await deps.db.getAccountById(session.accountId);
@@ -868,7 +864,10 @@ async function getTransactionStatusHandler(
     // 归属校验直接比 account_id(权威归属),不查 accounts 表绕一圈比 email ——
     // 少一次 DB 往返,语义也更直接(Copilot round 2)。
     if (entitlement.account_id === session.accountId) {
-      return json({ status: "completed", paid_at: entitlement.created_at }, 200, {
+      // paid_at 传 null 而非 entitlement.created_at:那是 webhook 入账时间,
+      // 不是 Paddle 的真实捕获时间(billed_at)—— 语义不能骗人(Copilot round 5)。
+      // 前端只读 status 判断跳转,不依赖 paid_at。
+      return json({ status: "completed", paid_at: null }, 200, {
         noStore: true,
       });
     }

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -858,8 +858,6 @@ async function getTransactionStatusHandler(
   // 轮询,用户卡死。成功/503 路径本就带 noStore,错误路径必须一致。
   const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
   if (!session.ok) return json({ error: "unauthorized" }, 401, { noStore: true });
-  const account = await deps.db.getAccountById(session.accountId);
-  if (account === null) return json({ error: "unauthorized" }, 401, { noStore: true });
 
   // ---- 第一优先:D1 里的入账记录(webhook 的观测结果)----
   //
@@ -871,8 +869,7 @@ async function getTransactionStatusHandler(
   // 归属校验:这笔交易入的必须是当前登录账号的账。
   const entitlement = await deps.db.getEntitlementByTransactionId(transactionId);
   if (entitlement !== null) {
-    // 归属校验直接比 account_id(权威归属),不查 accounts 表绕一圈比 email ——
-    // 少一次 DB 往返,语义也更直接(Copilot round 2)。
+    // 归属校验直接比 account_id(权威归属),不必再查 accounts 表比 email。
     if (entitlement.account_id === session.accountId) {
       // paid_at 传 null 而非 entitlement.created_at:那是 webhook 入账时间,
       // 不是 Paddle 的真实捕获时间(billed_at)—— 语义不能骗人(Copilot round 5)。
@@ -889,6 +886,10 @@ async function getTransactionStatusHandler(
   // ---- 兜底:查 Paddle API ----
   // webhook 可能还没到(延迟捕获窗口内)或入账失败。查 Paddle 侧实际状态,
   // paid/completed 就让前端跳 /payment-success(用户能看到"正在开通")。
+  // 到这一步才需要账号邮箱做归属比对,所以 getAccountById 挪到这里 ——
+  // 高频轮询场景下 D1 命中路径不为此多付一次 DB 往返(Copilot round 9)。
+  const account = await deps.db.getAccountById(session.accountId);
+  if (account === null) return json({ error: "unauthorized" }, 401, { noStore: true });
   const api = deps.paddleApi;
   if (api === undefined) {
     // 未配置 Paddle API key:没法查。503 让前端停轮询、显示"稍后刷新"。

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -356,9 +356,9 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   // 我们自己轮询这个端点,paid/completed 一到就关 overlay 跳 /payment-success。
   const txnStatusMatch = path.match(/^\/api\/transaction\/([^/]+)\/status$/);
   if (method === "GET" && txnStatusMatch !== null) {
-    // decodeURIComponent 对畸形百分号编码会抛 URIError → 500。
-    // 交易 ID 是固定格式 txn_<26 位小写字母数字>,先按格式校验,
-    // 不合法直接 404(客户端错误不该变 500)。
+    // pathname 保留百分号编码,不做 decode —— 交易 ID 是固定格式
+    // txn_<26 位小写字母数字>,按形状校验即可,不合法直接 404
+    // (客户端错误不该变 500;decodeURIComponent 反而可能对畸形编码抛错)。
     const raw = txnStatusMatch[1] ?? "";
     if (!/^txn_[a-z0-9]{26}$/.test(raw)) throw new HttpError(404, "not found");
     return getTransactionStatusHandler(request, deps, raw);
@@ -853,8 +853,9 @@ async function getTransactionStatusHandler(
   // 归属校验:这笔交易入的必须是当前登录账号的账。
   const entitlement = await deps.db.getEntitlementByTransactionId(transactionId);
   if (entitlement !== null) {
-    const holder = await deps.db.getAccountById(entitlement.account_id);
-    if (holder !== null && holder.email === account.email) {
+    // 归属校验直接比 account_id(权威归属),不查 accounts 表绕一圈比 email ——
+    // 少一次 DB 往返,语义也更直接(Copilot round 2)。
+    if (entitlement.account_id === session.accountId) {
       return json({ status: "completed", paid_at: entitlement.created_at }, 200, {
         noStore: true,
       });

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -873,7 +873,8 @@ async function getTransactionStatusHandler(
       });
     }
     // 入账给了别人 → 不是自己的交易,不泄露存在性。
-    throw new HttpError(404, "not found");
+    // 显式 json + noStore:轮询端点任何错误路径都不能被缓存(见上方说明)。
+    return json({ error: "not found" }, 404, { noStore: true });
   }
 
   // ---- 兜底:查 Paddle API ----

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -350,6 +350,14 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   if (method === "POST" && path === "/api/checkout") {
     return createCheckout(request, deps);
   }
+  // GET /api/transaction/:id/status —— /buy 页面的轮询端点。
+  // 微信支付是延迟捕获,授权与 Paddle 确认之间有几分钟窗口,期间 Paddle 前端
+  // 不跳转、checkout.completed 不发 —— 用户看到的就是"付了钱但页面没反应"。
+  // 我们自己轮询这个端点,paid/completed 一到就关 overlay 跳 /payment-success。
+  const txnStatusMatch = path.match(/^\/api\/transaction\/([^/]+)\/status$/);
+  if (method === "GET" && txnStatusMatch !== null) {
+    return getTransactionStatusHandler(request, deps, decodeURIComponent(txnStatusMatch[1] ?? ""));
+  }
   // /buy —— Paddle 的 default payment link 落地页(拼 ?_ptxn= 打开结账窗)。
   if (method === "GET" && path === "/buy") {
     return htmlPage(
@@ -804,6 +812,76 @@ async function createCheckout(request: Request, deps: RouteDeps): Promise<Respon
     // 不回显 Paddle 的响应内容。502:上游失败,可重试。
     return json({ error: "checkout unavailable" }, 502, { noStore: true });
   }
+}
+
+/**
+ * `GET /api/transaction/:id/status` —— 结账轮询。
+ *
+ * 为什么需要它:微信支付是延迟捕获(官方:授权后通常立刻、最长 10 分钟才确认)。
+ * 在确认前,交易停在 ready/action_required,Paddle 前端不跳转、checkout.completed
+ * 不发 —— 用户看到"付了钱但页面没反应",感觉被骗。我们不能控制 Paddle 前端,
+ * 但可以自己轮询它的服务端,一旦 paid/completed 就跳转。
+ *
+ * 安全:
+ * - 必须登录(session),否则任何未登录请求都能探测交易状态。
+ * - **归属校验**:交易创建时写入了 custom_data.account_email。只有交易归属邮箱
+ *   与当前登录账号一致才返回状态 —— 否则 404(不泄露交易是否存在)。
+ * - 只返回 status 与 paid_at,不返回金额/发票等敏感字段。
+ */
+async function getTransactionStatusHandler(
+  request: Request,
+  deps: RouteDeps,
+  transactionId: string,
+): Promise<Response> {
+  const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
+  if (!session.ok) throw new HttpError(401, "unauthorized");
+  const account = await deps.db.getAccountById(session.accountId);
+  if (account === null) throw new HttpError(401, "unauthorized");
+
+  // ---- 第一优先:D1 里的入账记录(webhook 的观测结果)----
+  //
+  // 微信扣款成功 → Paddle 收到款 → 发 transaction.completed webhook 推给我们
+  // → grantEntitlement 写入 entitlements(paddle_transaction_id)。所以
+  // **entitlements 里有这笔交易 = 付款成功的权威信号** —— 这比查 Paddle API
+  // 更快(本地 D1)、更准(已经入账)、零 API 成本。
+  //
+  // 归属校验:这笔交易入的必须是当前登录账号的账。
+  const entitlement = await deps.db.getEntitlementByTransactionId(transactionId);
+  if (entitlement !== null) {
+    const holder = await deps.db.getAccountById(entitlement.account_id);
+    if (holder !== null && holder.email === account.email) {
+      return json({ status: "completed", paid_at: entitlement.created_at }, 200, {
+        noStore: true,
+      });
+    }
+    // 入账给了别人 → 不是自己的交易,不泄露存在性。
+    throw new HttpError(404, "not found");
+  }
+
+  // ---- 兜底:查 Paddle API ----
+  // webhook 可能还没到(延迟捕获窗口内)或入账失败。查 Paddle 侧实际状态,
+  // paid/completed 就让前端跳 /payment-success(用户能看到"正在开通")。
+  const api = deps.paddleApi;
+  if (api === undefined) {
+    // 未配置 Paddle API key:没法查。503 让前端停轮询、显示"稍后刷新"。
+    return json({ error: "checkout not configured" }, 503, { noStore: true });
+  }
+
+  let txn: Awaited<ReturnType<PaddleApi["getTransactionStatus"]>>;
+  try {
+    txn = await api.getTransactionStatus(transactionId);
+  } catch {
+    // Paddle 上游抖动:503 让前端稍后重试,不要把它当成"交易不存在"。
+    return json({ error: "temporarily unavailable" }, 503, { noStore: true });
+  }
+  if (txn === null) throw new HttpError(404, "not found");
+
+  // 归属校验:交易必须属于当前登录账号。
+  if (txn.accountEmail !== null && txn.accountEmail !== account.email) {
+    throw new HttpError(404, "not found");
+  }
+
+  return json({ status: txn.status, paid_at: txn.paidAt }, 200, { noStore: true });
 }
 
 /**

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -360,7 +360,11 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
     // txn_<26 位小写字母数字>,按形状校验即可,不合法直接 404
     // (客户端错误不该变 500;decodeURIComponent 反而可能对畸形编码抛错)。
     const raw = txnStatusMatch[1] ?? "";
-    if (!/^txn_[a-z0-9]{26}$/.test(raw)) throw new HttpError(404, "not found");
+    if (!/^txn_[a-z0-9]{26}$/.test(raw)) {
+      // 显式 JSON + noStore:这个端点被高频轮询,状态会变化 ——
+      // 缓存任何一个 404 都会提前停掉轮询(见 handler 里的同类说明)。
+      return json({ error: "not found" }, 404, { noStore: true });
+    }
     return getTransactionStatusHandler(request, deps, raw);
   }
   // /buy —— Paddle 的 default payment link 落地页(拼 ?_ptxn= 打开结账窗)。
@@ -773,10 +777,14 @@ async function selfServeProvision(request: Request, deps: RouteDeps): Promise<Re
  * 返回结账 URL,前端跳过去即可(Paddle 会拼上 ?_ptxn=)。
  */
 async function createCheckout(request: Request, deps: RouteDeps): Promise<Response> {
+  // **错误路径全部显式 JSON + noStore,不走 HttpError**(Copilot round 3)。
+  // 这个端点被高频轮询且状态随时间变化:HttpError 经 handleError() 的响应
+  // 不带 cache-control: no-store,中间层/浏览器缓存住 401/404 会提前停掉
+  // 轮询,用户卡死。成功/503 路径本就带 noStore,错误路径必须一致。
   const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
-  if (!session.ok) throw new HttpError(401, "unauthorized");
+  if (!session.ok) return json({ error: "unauthorized" }, 401, { noStore: true });
   const account = await deps.db.getAccountById(session.accountId);
-  if (account === null) throw new HttpError(401, "unauthorized");
+  if (account === null) return json({ error: "unauthorized" }, 401, { noStore: true });
 
   const api = deps.paddleApi;
   if (api === undefined) {
@@ -838,10 +846,14 @@ async function getTransactionStatusHandler(
   deps: RouteDeps,
   transactionId: string,
 ): Promise<Response> {
+  // **错误路径全部显式 JSON + noStore,不走 HttpError**(Copilot round 3)。
+  // 这个端点被高频轮询且状态随时间变化:HttpError 经 handleError() 的响应
+  // 不带 cache-control: no-store,中间层/浏览器缓存住 401/404 会提前停掉
+  // 轮询,用户卡死。成功/503 路径本就带 noStore,错误路径必须一致。
   const session = await parseSessionWithValidatedNow(request.headers.get("cookie"), deps);
-  if (!session.ok) throw new HttpError(401, "unauthorized");
+  if (!session.ok) return json({ error: "unauthorized" }, 401, { noStore: true });
   const account = await deps.db.getAccountById(session.accountId);
-  if (account === null) throw new HttpError(401, "unauthorized");
+  if (account === null) return json({ error: "unauthorized" }, 401, { noStore: true });
 
   // ---- 第一优先:D1 里的入账记录(webhook 的观测结果)----
   //
@@ -880,13 +892,13 @@ async function getTransactionStatusHandler(
     // Paddle 上游抖动:503 让前端稍后重试,不要把它当成"交易不存在"。
     return json({ error: "temporarily unavailable" }, 503, { noStore: true });
   }
-  if (txn === null) throw new HttpError(404, "not found");
+  if (txn === null) return json({ error: "not found" }, 404, { noStore: true });
 
   // 归属校验:交易必须属于当前登录账号。
   // 创建交易时必写 custom_data.account_email(见 paddle-api.ts),所以 null
   // 只可能是异常/伪造 —— 同样拒绝,不能让任何登录用户猜 ID 查别人的交易。
   if (txn.accountEmail !== account.email) {
-    throw new HttpError(404, "not found");
+    return json({ error: "not found" }, 404, { noStore: true });
   }
 
   return json({ status: txn.status, paid_at: txn.paidAt }, 200, { noStore: true });

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -365,7 +365,17 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
       // 缓存任何一个 404 都会提前停掉轮询(见 handler 里的同类说明)。
       return json({ error: "not found" }, 404, { noStore: true });
     }
-    return getTransactionStatusHandler(request, deps, raw);
+    try {
+      return await getTransactionStatusHandler(request, deps, raw);
+    } catch (e) {
+      // **兜底强制 noStore**(Copilot round 6):handler 内部可能抛 HttpError
+      // (如服务器时钟畸形时 parseSessionWithValidatedNow throw 500),落到
+      // 外层 handleError() 的响应不带 cache-control: no-store —— 轮询端点
+      // 任何错误响应都不能被缓存,否则轮询提前停住。HttpError 转成对应
+      // 状态码,未知异常一律 500。
+      const status = e instanceof HttpError ? e.status : 500;
+      return json({ error: "unavailable" }, status, { noStore: true });
+    }
   }
   // /buy —— Paddle 的 default payment link 落地页(拼 ?_ptxn= 打开结账窗)。
   if (method === "GET" && path === "/buy") {

--- a/workers/scout-connect/src/routes.ts
+++ b/workers/scout-connect/src/routes.ts
@@ -356,7 +356,12 @@ async function route(request: Request, deps: RouteDeps): Promise<Response> {
   // 我们自己轮询这个端点,paid/completed 一到就关 overlay 跳 /payment-success。
   const txnStatusMatch = path.match(/^\/api\/transaction\/([^/]+)\/status$/);
   if (method === "GET" && txnStatusMatch !== null) {
-    return getTransactionStatusHandler(request, deps, decodeURIComponent(txnStatusMatch[1] ?? ""));
+    // decodeURIComponent 对畸形百分号编码会抛 URIError → 500。
+    // 交易 ID 是固定格式 txn_<26 位小写字母数字>,先按格式校验,
+    // 不合法直接 404(客户端错误不该变 500)。
+    const raw = txnStatusMatch[1] ?? "";
+    if (!/^txn_[a-z0-9]{26}$/.test(raw)) throw new HttpError(404, "not found");
+    return getTransactionStatusHandler(request, deps, raw);
   }
   // /buy —— Paddle 的 default payment link 落地页(拼 ?_ptxn= 打开结账窗)。
   if (method === "GET" && path === "/buy") {
@@ -877,7 +882,9 @@ async function getTransactionStatusHandler(
   if (txn === null) throw new HttpError(404, "not found");
 
   // 归属校验:交易必须属于当前登录账号。
-  if (txn.accountEmail !== null && txn.accountEmail !== account.email) {
+  // 创建交易时必写 custom_data.account_email(见 paddle-api.ts),所以 null
+  // 只可能是异常/伪造 —— 同样拒绝,不能让任何登录用户猜 ID 查别人的交易。
+  if (txn.accountEmail !== account.email) {
     throw new HttpError(404, "not found");
   }
 


### PR DESCRIPTION
第四次真实事故:微信支付是延迟捕获,授权与 Paddle 确认之间有几分钟窗口(实测 06:51 付款 → 06:56 捕获)。窗口内 Paddle 前端不跳转、checkout.completed 不发、successUrl 不触发 —— 用户看到"付了钱但页面没反应",感觉被骗。

## 根因

successUrl / eventCallback 全在 Paddle 手里,我们控制不了它的前端轮询。微信扫码付款后,手机端支付成功但**不会向网页端发任何数据** —— 网页端只能靠自己的服务端告知。

## 解法:自建轮询

**/buy 页面** Checkout.open 后每 3 秒查一次 `GET /api/transaction/:id/status`,paid/completed 一到就关 overlay 跳 /payment-success。上限 10 分钟(Paddle 延迟捕获上限),不无限请求。

## 观测点:webhook 入账记录(D1 优先)

微信扣款成功 → Paddle 发 transaction.completed webhook 推给我们 → grantEntitlement 写入 entitlements(paddle_transaction_id)。**entitlements 里有这笔交易 = 付款成功的权威信号** —— 本地 D1、零 API 成本、比查 Paddle 更快更准。

轮询端点逻辑:
1. 先查 D1 entitlements:命中 → completed(且归属校验:入账账号 == 登录账号)
2. 未命中 → 查 Paddle API 兜底(paid/completed 也返回)
3. 归属校验:custom_data.account_email != 登录邮箱 → 404,不泄露存在性
4. 只返回 status/paid_at,不泄露金额/发票等敏感字段

## 安全边界(刻意)

**轮询端点只用于前端跳转,绝不发放时长。** 发放仍只由验过签的 webhook 触发 —— 微信"支付成功"只是授权,资金还在途(可能失败/退回),提前发放 = 白送时长。这是"前端闭环 + 服务端权威"的分离:付款瞬间有反馈,时长在钱真到才发。

## 修复后的体验

```
扫码付款(微信扣款瞬间)
  → 3 秒内轮询到 paid/completed
  → 跳 /payment-success("付款已完成,正在开通")
  → Paddle 捕获完成 → webhook → 时长到账(1-5 分钟)
```

用户从头到尾都有反馈,不再有"付了钱但页面没反应"。

## 测试(8 个新)

- 未登录 → 401;交易不存在 → 404;上游抖动 → 503
- 归属校验:别人的交易 → 404(不泄露存在性)
- D1 入账记录 → completed 且**不查 Paddle**(核心:webhook 观测直接驱动闭环)
- 入账给了别人 → 404
- 反向验证:去掉 D1 优先 → 2 个转红;去掉归属校验 → 1 个转红

三处 tsc 全绿;全量 2787 passed(基线 2779 + 8),零回归。