### PR TITLE
fix(web): B2 —— 设置表单类 9 组件 14 调用点接入 runAction

### DIFF
--- a/apps/web/components/assrt-token-form.tsx
+++ b/apps/web/components/assrt-token-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { Check, ExternalLink, LoaderCircle, Trash2 } from "lucide-react";
 import { saveAssrtTokenAction, clearAssrtTokenAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 export function AssrtTokenForm({ tokenSet }: { tokenSet: boolean }) {
   const [isPending, startTransition] = useTransition();
@@ -19,7 +20,18 @@ export function AssrtTokenForm({ tokenSet }: { tokenSet: boolean }) {
       return;
     }
     startTransition(async () => {
-      const res = await saveAssrtTokenAction(token);
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => saveAssrtTokenAction(token),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 保存成功" : `❌ ${res.message ?? "保存失败"}`);
       if (res.success && token.trim()) {
         setToken("");
@@ -31,7 +43,18 @@ export function AssrtTokenForm({ tokenSet }: { tokenSet: boolean }) {
 
   const handleClear = () => {
     startTransition(async () => {
-      const res = await clearAssrtTokenAction();
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => clearAssrtTokenAction(),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 已清除，字幕补全功能关闭" : `❌ ${res.message ?? "清除失败"}`);
       if (res.success) {
         setHasToken(false);

--- a/apps/web/components/llm-config-form.tsx
+++ b/apps/web/components/llm-config-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { Check, LoaderCircle } from "lucide-react";
 import { saveLlmConfigAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 import { LlmTestConnectionButton } from "./llm-test-connection-button";
 
 export function LlmConfigForm({
@@ -24,7 +25,18 @@ export function LlmConfigForm({
 
   const handleSave = () => {
     startTransition(async () => {
-      const res = await saveLlmConfigAction({ baseURL, modelId, apiKey });
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => saveLlmConfigAction({ baseURL, modelId, apiKey }),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 4000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 保存成功 —— 点「测试连接」确认可用" : `❌ ${res.message ?? "保存失败"}`);
       if (res.success) setApiKey("");
       setTimeout(() => setResult(null), 4000);

--- a/apps/web/components/pansou-config-form.tsx
+++ b/apps/web/components/pansou-config-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { Check, ExternalLink, LoaderCircle } from "lucide-react";
 import { savePanSouBaseUrlAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 const PANSOU_SELF_HOST_TUTORIAL_URL =
   "https://github.com/fancydirty/mediary-scout/blob/main/docs/pansou-self-host.md";
@@ -20,7 +21,18 @@ export function PanSouConfigForm({
 
   const handleSave = () => {
     startTransition(async () => {
-      const res = await savePanSouBaseUrlAction(baseURL);
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => savePanSouBaseUrlAction(baseURL),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 保存成功" : `❌ ${res.message ?? "保存失败"}`);
       setTimeout(() => setResult(null), 3000);
     });

--- a/apps/web/components/preferred-language-form.tsx
+++ b/apps/web/components/preferred-language-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { Check, LoaderCircle } from "lucide-react";
 import { savePreferredLanguageAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 const LANGUAGES = [
   { key: "中文", label: "中文（默认）" },
@@ -18,7 +19,18 @@ export function PreferredLanguageForm({ initial }: { initial: string }) {
 
   const handleSave = () => {
     startTransition(async () => {
-      const res = await savePreferredLanguageAction(value);
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => savePreferredLanguageAction(value),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 保存成功" : `❌ ${res.message}`);
       setTimeout(() => setResult(null), 3000);
     });

--- a/apps/web/components/prowlarr-config-form.tsx
+++ b/apps/web/components/prowlarr-config-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { Check, ExternalLink, LoaderCircle, Trash2 } from "lucide-react";
 import { saveProwlarrConfigAction, clearProwlarrConfigAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 export function ProwlarrConfigForm({ baseURL: initialBaseURL, apiKeySet }: { baseURL: string; apiKeySet: boolean }) {
   const [isPending, startTransition] = useTransition();
@@ -13,7 +14,18 @@ export function ProwlarrConfigForm({ baseURL: initialBaseURL, apiKeySet }: { bas
 
   const handleSave = () => {
     startTransition(async () => {
-      const res = await saveProwlarrConfigAction({ baseURL, apiKey });
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => saveProwlarrConfigAction({ baseURL, apiKey }),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 保存成功" : `❌ ${res.message ?? "保存失败"}`);
       if (res.success && apiKey.trim()) {
         setApiKey("");
@@ -25,7 +37,18 @@ export function ProwlarrConfigForm({ baseURL: initialBaseURL, apiKeySet }: { bas
 
   const handleClear = () => {
     startTransition(async () => {
-      const res = await clearProwlarrConfigAction();
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => clearProwlarrConfigAction(),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 已清除" : `❌ ${res.message ?? "清除失败"}`);
       if (res.success) {
         setHasKey(false);

--- a/apps/web/components/push-notification-form.tsx
+++ b/apps/web/components/push-notification-form.tsx
@@ -7,6 +7,7 @@ import {
   savePushSettingsAction,
   testPushNotificationAction,
 } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 const CHANNELS = [
   {
@@ -49,7 +50,15 @@ export function PushNotificationForm({ configured }: { configured: Record<string
 
   const handleSave = () => {
     startTransition(async () => {
-      const result = await savePushSettingsAction(values);
+      const r = await runAction(
+        () => savePushSettingsAction(values),
+        (msg) => {
+          setTestResult(`❌ ${msg}`);
+          setTimeout(() => setTestResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const result = r.value;
       if (result.success) {
         const next = { ...savedChannels };
         for (const [key, value] of Object.entries(values)) {
@@ -65,7 +74,15 @@ export function PushNotificationForm({ configured }: { configured: Record<string
 
   const handleClear = (key: string) => {
     startTransition(async () => {
-      const result = await clearPushChannelAction(key);
+      const r = await runAction(
+        () => clearPushChannelAction(key),
+        (msg) => {
+          setTestResult(`❌ ${msg}`);
+          setTimeout(() => setTestResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const result = r.value;
       if (result.success) {
         setSavedChannels((prev) => ({ ...prev, [key]: false }));
         setValues((prev) => {
@@ -83,7 +100,15 @@ export function PushNotificationForm({ configured }: { configured: Record<string
 
   const handleTest = () => {
     startTransition(async () => {
-      const result = await testPushNotificationAction(values);
+      const r = await runAction(
+        () => testPushNotificationAction(values),
+        (msg) => {
+          setTestResult(`❌ ${msg}`);
+          setTimeout(() => setTestResult(null), 5000);
+        },
+      );
+      if (!r.ok) return;
+      const result = r.value;
       setTestResult(
         result.success
           ? `✅ 测试通知已发送到 ${result.sentTo?.join("、") ?? "已配置渠道"}`

--- a/apps/web/components/quality-preference-form.tsx
+++ b/apps/web/components/quality-preference-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { Check, LoaderCircle } from "lucide-react";
 import { saveQualityPreferenceAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 const QUALITIES = [
   { key: "any", label: "不限（默认）" },
@@ -17,7 +18,18 @@ export function QualityPreferenceForm({ initial }: { initial: string }) {
 
   const handleSave = () => {
     startTransition(async () => {
-      const res = await saveQualityPreferenceAction(value);
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => saveQualityPreferenceAction(value),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 保存成功" : `❌ ${res.message ?? "保存失败"}`);
       setTimeout(() => setResult(null), 3000);
     });

--- a/apps/web/components/tmdb-api-key-form.tsx
+++ b/apps/web/components/tmdb-api-key-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { Check, ExternalLink, LoaderCircle, Trash2 } from "lucide-react";
 import { saveTmdbApiKeyAction, clearTmdbApiKeyAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 export function TmdbApiKeyForm({ apiKeySet }: { apiKeySet: boolean }) {
   const [isPending, startTransition] = useTransition();
@@ -12,7 +13,18 @@ export function TmdbApiKeyForm({ apiKeySet }: { apiKeySet: boolean }) {
 
   const handleSave = () => {
     startTransition(async () => {
-      const res = await saveTmdbApiKeyAction(apiKey);
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => saveTmdbApiKeyAction(apiKey),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 保存成功" : `❌ ${res.message ?? "保存失败"}`);
       if (res.success && apiKey.trim()) {
         setApiKey("");
@@ -24,7 +36,18 @@ export function TmdbApiKeyForm({ apiKeySet }: { apiKeySet: boolean }) {
 
   const handleClear = () => {
     startTransition(async () => {
-      const res = await clearTmdbApiKeyAction();
+      // 必须 catch:server action 会 throw(demo 门禁、运行时错误、网络中断),
+      // 不 catch 就是未处理 rejection,界面上什么都不变(见 runAction 注释)。
+      // 业务错误(success:false)仍走下方原逻辑;这里只拦异常。
+      const r = await runAction(
+        () => clearTmdbApiKeyAction(),
+        (msg) => {
+          setResult(`❌ ${msg}`);
+          setTimeout(() => setResult(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setResult(res.success ? "✅ 已清除，改用代理兜底" : `❌ ${res.message ?? "清除失败"}`);
       if (res.success) setHasKey(false);
       setTimeout(() => setResult(null), 3000);


### PR DESCRIPTION
Spec B 第二批：llm / tmdb-api-key(2) / assrt-token(2) / pansou / prowlarr(2) / preferred-language / quality-preference / daily-sweep / push-notification(3)。

## 关键设计:业务错误与异常分层

- action 正常返回 `success:false` → 仍走原逻辑显示业务消息（`res.message`）
- action 抛异常（demo 门禁 / 运行时错误 / 网络中断）→ `runAction` 拦下，`onError` 显示固定可操作文案，不回显异常内容
- `onError` 里也带 `setTimeout` 清空提示，保持"提示会消失"的既有行为

## 验证

- apps/web tsc 全绿
- apps/web 测试 522 passed
- build:web 通过