### PR TITLE
fix(web): B3 —— 操作按钮类 11 组件 14 调用点接入 runAction

### DIFF
--- a/apps/web/components/account-admin-panel.tsx
+++ b/apps/web/components/account-admin-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { LoaderCircle } from "lucide-react";
 import { resetUserPasswordAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 interface ManagedAccount {
   id: string;
@@ -34,7 +35,12 @@ function AccountAdminRow({ account }: { account: ManagedAccount }) {
   const submit = () => {
     setMsg(null);
     startTransition(async () => {
-      const res = await resetUserPasswordAction(account.id, pw);
+      const r = await runAction(
+        () => resetUserPasswordAction(account.id, pw),
+        (msg) => setMsg({ ok: false, text: msg }),
+      );
+      if (!r.ok) return;
+      const res = r.value;
       if (res.ok) {
         setMsg({ ok: true, text: `已重置「${account.username}」的密码，请把新密码交给 TA。` });
         setOpen(false);

--- a/apps/web/components/connect-notice-banner.tsx
+++ b/apps/web/components/connect-notice-banner.tsx
@@ -13,6 +13,9 @@ export function ConnectNoticeBanner() {
   if (dismissed) return null;
 
   function handleDismiss() {
+    // 重试前复位 failed,否则上次的「关闭失败」提示会残留到本次尝试
+    // (Copilot round 4)。
+    setFailed(false);
     startTransition(async () => {
       // 必须 catch(见 runAction 注释)。
       // 失败时**不关闭**:让用户看到 banner 还在 = 关闭没生效,会再点一次。

--- a/apps/web/components/connect-notice-banner.tsx
+++ b/apps/web/components/connect-notice-banner.tsx
@@ -7,17 +7,20 @@ import { runAction } from "../lib/run-action";
 
 export function ConnectNoticeBanner() {
   const [dismissed, setDismissed] = useState(false);
+  const [failed, setFailed] = useState(false);
   const [isPending, startTransition] = useTransition();
 
   if (dismissed) return null;
 
   function handleDismiss() {
     startTransition(async () => {
-      // 必须 catch(见 runAction 注释):dismiss 失败不能静默 ——
-      // 否则用户以为关了,下次刷新又出现。
+      // 必须 catch(见 runAction 注释)。
+      // 失败时**不关闭**:让用户看到 banner 还在 = 关闭没生效,会再点一次。
+      // 乐观关闭会与「下次刷新又出现」矛盾 —— 用户以为关了却没关掉
+      // (Copilot round 3)。
       const r = await runAction(
         () => dismissConnectNoticeAction(),
-        () => setDismissed(true),  // 乐观关闭:写 DB 失败本次会话也隐藏
+        () => setFailed(true),
       );
       if (!r.ok) return;
       setDismissed(true);
@@ -46,6 +49,11 @@ export function ConnectNoticeBanner() {
           >
             了解详情
           </a>
+          {failed ? (
+            <span className="push-help tone-amber" role="alert">
+              关闭失败，请重试
+            </span>
+          ) : null}
           <button
             onClick={handleDismiss}
             disabled={isPending}

--- a/apps/web/components/connect-notice-banner.tsx
+++ b/apps/web/components/connect-notice-banner.tsx
@@ -3,6 +3,7 @@
 import { X } from "lucide-react";
 import { useState, useTransition } from "react";
 import { dismissConnectNoticeAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 export function ConnectNoticeBanner() {
   const [dismissed, setDismissed] = useState(false);
@@ -12,10 +13,14 @@ export function ConnectNoticeBanner() {
 
   function handleDismiss() {
     startTransition(async () => {
-      const result = await dismissConnectNoticeAction();
-      if (result.ok) {
-        setDismissed(true);
-      }
+      // 必须 catch(见 runAction 注释):dismiss 失败不能静默 ——
+      // 否则用户以为关了,下次刷新又出现。
+      const r = await runAction(
+        () => dismissConnectNoticeAction(),
+        () => setDismissed(true),  // 乐观关闭:写 DB 失败本次会话也隐藏
+      );
+      if (!r.ok) return;
+      setDismissed(true);
     });
   }
 

--- a/apps/web/components/daily-sweep-form.tsx
+++ b/apps/web/components/daily-sweep-form.tsx
@@ -23,6 +23,9 @@ export function DailySweepForm({ initial, max }: { initial: string[]; max: numbe
       const r = await runAction(
         () => saveDailySweepTimesAction(next),
         (msg) => {
+          // 组件注释承诺「失败回滚」:异常时也要 setTimes(previous),
+          // 否则 UI 显示未持久化的最新值(Copilot round 3)。
+          setTimes(previous);
           setNote(`❌ ${msg}`);
           setTimeout(() => setNote(null), 3000);
         },

--- a/apps/web/components/daily-sweep-form.tsx
+++ b/apps/web/components/daily-sweep-form.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { LoaderCircle, Plus, X } from "lucide-react";
 import { saveDailySweepTimesAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 /**
  * 巡检时间点 chips（1~6 个，北京时间）。即改即存：添加/删除立即持久化整个列表，
@@ -18,7 +19,16 @@ export function DailySweepForm({ initial, max }: { initial: string[]; max: numbe
 
   const persist = (next: string[], previous: string[]) => {
     startTransition(async () => {
-      const res = await saveDailySweepTimesAction(next);
+      // 必须 catch(见 runAction 注释)。B2 漏网的调用点,此处补上。
+      const r = await runAction(
+        () => saveDailySweepTimesAction(next),
+        (msg) => {
+          setNote(`❌ ${msg}`);
+          setTimeout(() => setNote(null), 3000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       if (!res.success) {
         setTimes(previous);
         setNote(`❌ ${res.message}`);

--- a/apps/web/components/foreign-work-import-form.tsx
+++ b/apps/web/components/foreign-work-import-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { Film } from "lucide-react";
 import { importForeignWorkAction, type ForeignWorkImportActionResult } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 export function ForeignWorkImportForm({
   providerFileIds,
@@ -26,13 +27,16 @@ export function ForeignWorkImportForm({
       onSubmit={(event) => {
         event.preventDefault();
         startTransition(async () => {
-          setResult(
-            await importForeignWorkAction({
+          const r = await runAction(
+            () => importForeignWorkAction({
               providerFileIds,
               movieTitle,
               year: Number(year),
             }),
+            (msg) => setResult({ status: "failed", message: msg }),
           );
+          if (!r.ok) return;
+          setResult(r.value);
         });
       }}
     >

--- a/apps/web/components/llm-test-connection-button.tsx
+++ b/apps/web/components/llm-test-connection-button.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { testLlmConnectionAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 /**
  * Settings → AI 模型 的「测试连接」:对**已保存**的 LLM 配置真发一发最小请求,通/
@@ -20,7 +21,12 @@ export function LlmTestConnectionButton() {
         disabled={pending}
         onClick={() =>
           startTransition(async () => {
-            setResult(await testLlmConnectionAction());
+            const r = await runAction(
+              () => testLlmConnectionAction(),
+              (msg) => setResult({ ok: false, message: msg }),
+            );
+            if (!r.ok) return;
+            setResult(r.value);
           })
         }
       >

--- a/apps/web/components/password-change-form.tsx
+++ b/apps/web/components/password-change-form.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { LoaderCircle } from "lucide-react";
 import { changePasswordAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 /** Self-service password change. On success all sessions are revoked server-side,
  *  so we send the user back to /login to sign in with the new password. */
@@ -16,7 +17,12 @@ export function PasswordChangeForm() {
   const submit = () => {
     setError(null);
     startTransition(async () => {
-      const res = await changePasswordAction(current, next);
+      const r = await runAction(
+        () => changePasswordAction(current, next),
+        (msg) => setError(msg),
+      );
+      if (!r.ok) return;
+      const res = r.value;
       if (res.ok) {
         setDone(true);
         setTimeout(() => {

--- a/apps/web/components/patrol-now-button.tsx
+++ b/apps/web/components/patrol-now-button.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { LoaderCircle, Radar } from "lucide-react";
 import { runPatrolNowAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 /** 手动触发一次全量巡检（force：不占用定时计划）。 */
 export function PatrolNowButton() {
@@ -13,7 +14,18 @@ export function PatrolNowButton() {
 
   const run = () => {
     startTransition(async () => {
-      const res = await runPatrolNowAction();
+      // 必须 catch(见 runAction 注释)。router.refresh 与清 note 在失败时
+      // 也要执行 —— 否则抛错后界面既不刷新也不清提示(spec B 点名的陷阱)。
+      const r = await runAction(
+        () => runPatrolNowAction(),
+        (msg) => {
+          setNote(`❌ ${msg}`);
+          router.refresh();
+          setTimeout(() => setNote(null), 6000);
+        },
+      );
+      if (!r.ok) return;
+      const res = r.value;
       setNote(res.success ? `✅ 巡检完成，检查了 ${res.checked ?? 0} 项` : `❌ ${res.message}`);
       router.refresh();
       setTimeout(() => setNote(null), 6000);

--- a/apps/web/components/request-series-button.tsx
+++ b/apps/web/components/request-series-button.tsx
@@ -3,6 +3,7 @@
 import { Check, Layers, LoaderCircle } from "lucide-react";
 import { useState, useTransition } from "react";
 import { requestSeriesAction, type RequestTrackingActionResult } from "../app/actions";
+import { runAction } from "../lib/run-action";
 import { AcquireResultNotice, isLockedResult } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
 import { DemoAcquirePlayback } from "./demo-acquire-playback";
@@ -55,7 +56,12 @@ export function RequestSeriesButton({
             return;
           }
           startTransition(async () => {
-            setResult(await requestSeriesAction({ candidateId, storageId }));
+            const r = await runAction(
+              () => requestSeriesAction({ candidateId, storageId }),
+              (msg) => setResult({ status: "unsupported", message: msg }),
+            );
+            if (!r.ok) return;
+            setResult(r.value);
           });
         }}
       >

--- a/apps/web/components/request-track-button.tsx
+++ b/apps/web/components/request-track-button.tsx
@@ -4,6 +4,7 @@ import { CalendarClock, Check, LoaderCircle, Plus } from "lucide-react";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { requestTrackingAction, type RequestTrackingActionResult } from "../app/actions";
+import { runAction } from "../lib/run-action";
 // Import the type from the narrow subpath, NOT the root barrel: the barrel
 // `export *`s ./postgres.js (pg), and Turbopack intermittently fails to erase a
 // type-only barrel import, dragging pg into THIS client bundle → "pg in Client
@@ -133,13 +134,16 @@ export function RequestTrackButton({
             return;
           }
           startTransition(async () => {
-            setResult(
-              await requestTrackingAction({
-                ...(candidateId ? { candidateId } : {}),
-                currentState: actionState,
-                ...(storageId ? { storageId } : {}),
-              }),
+            const r = await runAction(
+              () => requestTrackingAction({
+                  ...(candidateId ? { candidateId } : {}),
+                  currentState: actionState,
+                  ...(storageId ? { storageId } : {}),
+                }),
+              (msg) => setResult({ status: "unsupported", message: msg }),
             );
+            if (!r.ok) return;
+            setResult(r.value);
             // Re-fetch so the now-queued run mounts the AcquiringPoller, which
             // then flips this card to 已获取 when the run finishes.
             router.refresh();

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -8,6 +8,7 @@ import {
   requestSeasonAction,
   type RequestTrackingActionResult,
 } from "../app/actions";
+import { runAction } from "../lib/run-action";
 import { AcquireResultNotice, isLockedResult } from "./request-state";
 import { AcquireProgressBadge } from "./acquire-progress-badge";
 import { isDemoModeClient } from "../lib/demo-mode";
@@ -95,12 +96,18 @@ export function SeasonRequestMenu({
     }
     setRequestedSeason(selected);
     startTransition(async () => {
+      // setOpen(false) 必须先关菜单(状态机);失败也要关,否则菜单卡住。
       setOpen(false);
-      setResult(
-        selected === "all"
-          ? await requestRemainingAction({ tmdbId, storageId })
-          : await requestSeasonAction({ tmdbId, seasonNumber: selected, storageId }),
+      // 必须 catch(见 runAction 注释)。失败走 onError 显示固定文案。
+      const r = await runAction(
+        () =>
+          selected === "all"
+            ? requestRemainingAction({ tmdbId, storageId })
+            : requestSeasonAction({ tmdbId, seasonNumber: selected, storageId }),
+        (msg) => setResult({ status: "unsupported", message: msg }),
       );
+      if (!r.ok) return;
+      setResult(r.value);
       // Re-fetch so the queued run mounts the AcquiringPoller; once it finishes,
       // the acquired season leaves untrackedSeasons and this menu unmounts.
       router.refresh();

--- a/apps/web/components/season-request-menu.tsx
+++ b/apps/web/components/season-request-menu.tsx
@@ -133,7 +133,17 @@ export function SeasonRequestMenu({
             }
             setRequestedSeason(onlySeason);
             startTransition(async () => {
-              setResult(await requestSeasonAction({ tmdbId, seasonNumber: onlySeason, storageId }));
+              // 与多季路径保持一致:必须 catch,失败也 refresh 清锁
+              // (Copilot round 2 抓到的漏网调用点)。
+              const r = await runAction(
+                () => requestSeasonAction({ tmdbId, seasonNumber: onlySeason, storageId }),
+                (msg) => {
+                  setResult({ status: "unsupported", message: msg });
+                  router.refresh();
+                },
+              );
+              if (!r.ok) return;
+              setResult(r.value);
               router.refresh();
             });
           }}

--- a/apps/web/components/test-connection-button.tsx
+++ b/apps/web/components/test-connection-button.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { testStorageConnectionAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 
 /** Per-drive "测试连接" button (settings). Probes the cookie; a dead one freezes
  *  the drive server-side, and the result message tells the user to re-bind. */
@@ -17,8 +18,12 @@ export function TestConnectionButton({ storageId }: { storageId: string }) {
         disabled={pending}
         onClick={() =>
           startTransition(async () => {
-            const r = await testStorageConnectionAction(storageId);
-            setResult({ ok: r.ok, message: r.message });
+            const r = await runAction(
+              () => testStorageConnectionAction(storageId),
+              (msg) => setResult({ ok: false, message: msg }),
+            );
+            if (!r.ok) return;
+            setResult({ ok: r.value.ok, message: r.value.message });
           })
         }
       >

--- a/apps/web/components/title-action-buttons.tsx
+++ b/apps/web/components/title-action-buttons.tsx
@@ -8,6 +8,7 @@ import {
   requestSeasonAction,
   type RequestTrackingActionResult,
 } from "../app/actions";
+import { runAction } from "../lib/run-action";
 import { useAcquisitionLock } from "./acquisition-lock";
 import { AcquireResultNotice, isLockedResult } from "./request-state";
 import { isDemoModeClient } from "../lib/demo-mode";
@@ -74,7 +75,12 @@ export function RequestSeasonButton({
           }
           lock?.lock(scope);
           startTransition(async () => {
-            setResult(await requestSeasonAction({ tmdbId, seasonNumber, storageId }));
+            const r = await runAction(
+              () => requestSeasonAction({ tmdbId, seasonNumber, storageId }),
+              (msg) => setResult({ status: "unsupported", message: msg }),
+            );
+            if (!r.ok) return;
+            setResult(r.value);
             router.refresh();
           });
         }}
@@ -150,7 +156,12 @@ export function RequestRemainingButton({
           }
           lock?.lock(scope);
           startTransition(async () => {
-            setResult(await requestRemainingAction({ tmdbId, storageId }));
+            const r = await runAction(
+              () => requestRemainingAction({ tmdbId, storageId }),
+              (msg) => setResult({ status: "unsupported", message: msg }),
+            );
+            if (!r.ok) return;
+            setResult(r.value);
             router.refresh();
           });
         }}

--- a/apps/web/components/title-action-buttons.tsx
+++ b/apps/web/components/title-action-buttons.tsx
@@ -77,7 +77,12 @@ export function RequestSeasonButton({
           startTransition(async () => {
             const r = await runAction(
               () => requestSeasonAction({ tmdbId, seasonNumber, storageId }),
-              (msg) => setResult({ status: "unsupported", message: msg }),
+              (msg) => {
+                setResult({ status: "unsupported", message: msg });
+                // 必须 refresh:lock.acquiring 是前端 state,靠重挂载重置。
+                // 失败不刷新,锁永远卡住,兄弟按钮全禁用(Copilot round 1)。
+                router.refresh();
+              },
             );
             if (!r.ok) return;
             setResult(r.value);
@@ -158,7 +163,11 @@ export function RequestRemainingButton({
           startTransition(async () => {
             const r = await runAction(
               () => requestRemainingAction({ tmdbId, storageId }),
-              (msg) => setResult({ status: "unsupported", message: msg }),
+              (msg) => {
+                setResult({ status: "unsupported", message: msg });
+                // 同上一处:失败必须 refresh 清锁,否则 sibling 全禁用。
+                router.refresh();
+              },
             );
             if (!r.ok) return;
             setResult(r.value);

--- a/apps/web/components/untrack-button.tsx
+++ b/apps/web/components/untrack-button.tsx
@@ -4,6 +4,7 @@ import { LoaderCircle, Trash2 } from "lucide-react";
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { untrackTitleAction } from "../app/actions";
+import { runAction } from "../lib/run-action";
 import { isDemoModeClient } from "../lib/demo-mode";
 
 /**
@@ -44,12 +45,24 @@ export function UntrackButton({
 
   const run = () => {
     startTransition(async () => {
-      const result = await untrackTitleAction({
-        tmdbId,
-        storageId,
-        mediaKind,
-        ...(seasonNumber !== undefined ? { seasonNumber } : {}),
-      });
+      // 必须 catch(见 runAction 注释)。setConfirming(false) 失败也要复位,
+      // 否则按钮卡在确认态。
+      const r = await runAction(
+        () =>
+          untrackTitleAction({
+            tmdbId,
+            storageId,
+            mediaKind,
+            ...(seasonNumber !== undefined ? { seasonNumber } : {}),
+          }),
+        (msg) => {
+          setMessage(msg);
+          setConfirming(false);
+          router.refresh();
+        },
+      );
+      if (!r.ok) return;
+      const result = r.value;
       if (result.status === "untracked" && seasonNumber === undefined) {
         // Whole-show untracked → it's gone from the library; go there to show it.
         router.push(`${basePath}?tab=library`);


### PR DESCRIPTION
Spec B 最后一批：patrol-now / test-connection / llm-test-connection / untrack / request-track / request-series / season-request-menu(2) / title-action-buttons(2) / account-admin / password-change / foreign-work-import。

## 状态机复位陷阱（spec 点名，全部处理）

- `patrol-now`：`router.refresh` + 清 note 失败时也执行
- `untrack`：`setConfirming(false)` 失败也复位
- `season-request`：`setOpen(false)` 先关菜单，失败也关
- `account-admin`：`setOpen(false)`/`setPw("")` 仅成功时（保持原逻辑）

## 失败态建模（每处按 result 类型构造 onError）

- `{ok, message}` 型 → `{ ok: false, message: msg }`
- `RequestTrackingActionResult` 型 → `{ status: "unsupported", message: msg }`
- `ForeignWorkImportActionResult` 型 → `{ status: "failed", message: msg }`
- 显式 res 型 → 各自 `setMsg`/`setNote`/`setError`

业务错误（`success:false` / status 非预期）仍走原逻辑，异常由 `runAction` 拦下。

## 验证

- apps/web tsc 全绿
- apps/web 测试 522 passed
- build:web 通过