### PR TITLE
fix(checkout): 轮询不硬超时 + 确认页自动跳控制台

### DIFF
--- a/workers/scout-connect/src/html/buy-page.test.ts
+++ b/workers/scout-connect/src/html/buy-page.test.ts
@@ -183,7 +183,7 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     // 且 close() 必须在 location.href 之前(否则跳转发生时 overlay 还开着)
     const closeIdx = output.indexOf("window.Paddle.Checkout.close()");
     const timeoutIdx = output.indexOf("setTimeout(");
-    const hrefIdx = output.indexOf('window.location.href = "/payment-success"');
+    const hrefIdx = output.indexOf('window.location.href = "/payment-success?txn=');
     expect(closeIdx).toBeGreaterThan(-1);
     expect(timeoutIdx).toBeGreaterThan(-1);
     expect(hrefIdx).toBeGreaterThan(-1);
@@ -195,6 +195,17 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
   it("successUrl 必须带交易 ID(确认页靠它轮询到账后自动跳控制台)", () => {
     const output = buyPage(CONFIGURED);
     expect(output).toMatch(/successUrl:[^,}]*\/payment-success\?txn=/);
+  });
+
+  it("**每一处**跳转都必须带 txn(不带则确认页无法自动跳控制台)", () => {
+    // 用 indexOf 只能找到第一处,漏掉其它跳转路径(Copilot round 1 抓到的
+    // 假覆盖)。改为统计:所有 /payment-success 跳转都必须带 ?txn=。
+    const output = buyPage(CONFIGURED);
+    const bare = (output.match(/window\.location\.href = "\/payment-success"/g) || []).length;
+    const withTxn = (output.match(/window\.location\.href = "\/payment-success\?txn=/g) || []).length;
+    // 轮询 + eventCallback + 预检查,三处跳转都必须带 txn;bare 应为 0。
+    expect(bare).toBe(0);
+    expect(withTxn).toBeGreaterThanOrEqual(3);
   });
 
   it("Checkout.open 必须带 settings.successUrl(微信支付唯一救命参数)", () => {

--- a/workers/scout-connect/src/html/buy-page.test.ts
+++ b/workers/scout-connect/src/html/buy-page.test.ts
@@ -192,6 +192,11 @@ describe("付款完成后必须有出路(真实事故的回归防线)", () => {
     expect(timeoutIdx).toBeLessThan(hrefIdx);
   });
 
+  it("successUrl 必须带交易 ID(确认页靠它轮询到账后自动跳控制台)", () => {
+    const output = buyPage(CONFIGURED);
+    expect(output).toMatch(/successUrl:[^,}]*\/payment-success\?txn=/);
+  });
+
   it("Checkout.open 必须带 settings.successUrl(微信支付唯一救命参数)", () => {
     // **三次真实事故都栽在这一条。** 微信支付付完款,Paddle 把用户带到它自己的
     // 处理域名(redirect-euw1.ppro.com),本页的 eventCallback 完全失效 ——

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -134,7 +134,7 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
           try { window.Paddle.Checkout.close(); } catch (e) { /* 已经关了也无妨 */ }
           
           // 留 1.8 秒让用户看到这句话再跳。跳过去后确认页显示「正在开通」。
-          setTimeout(function () { window.location.href = "/payment-success"; }, 1800);
+          setTimeout(function () { window.location.href = "/payment-success?txn=" + encodeURIComponent(txn); }, 1800);
         } else if (event.name === "checkout.payment.failed") {
           // 付款失败也必须说话。之前这里同样是静默的。
           hint.textContent = "这笔支付没有成功。";
@@ -182,7 +182,7 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
         if (pre.status === 200) {
           var preData = await pre.json();
           if (preData && (preData.status === "paid" || preData.status === "completed")) {
-            window.location.href = "/payment-success";
+            window.location.href = "/payment-success?txn=" + encodeURIComponent(txn);
             return;
           }
         }
@@ -291,7 +291,7 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
             hint.textContent = "支付成功,正在开通…";
             status.textContent = "正在确认到账(微信支付最多需要 10 分钟)。即将前往确认页。";
             try { window.Paddle.Checkout.close(); } catch (e) { /* 已经关了也无妨 */ }
-            setTimeout(function () { window.location.href = "/payment-success"; }, 1800);
+            setTimeout(function () { window.location.href = "/payment-success?txn=" + encodeURIComponent(txn); }, 1800);
           }
         } catch (e) { /* 网络抖动,下次再试 */ } finally {
           // 释放锁:clearInterval 后 finally 仍会跑,但 timer 已停,无副作用。

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -171,12 +171,33 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
     // 指向 /payment-success 而非 /console:微信支付是**延迟捕获**(官方:通常
     // 立刻,但可能长达 10 分钟)。直接跳控制台会看到「尚未开通」—— 那是最伤人
     // 的一幕:刚付完钱,页面告诉你什么都没发生。
-    window.Paddle.Checkout.open({
-      transactionId: txn,
-      settings: { successUrl: location.origin + "/payment-success" },
-    });
-    hint.textContent = "支付窗口已打开。";
-    status.textContent = "";
+    // ---- 打开结账前先查一次状态 ----
+    // 真实事故:刷新 /buy 带 ?_ptxn= 会重新弹结账窗,而交易可能已完成 ——
+    // 用户看到"又回到付款页面"。已完成的交易应直接跳 /payment-success。
+    (async function () {
+      try {
+        var pre = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status", {
+          signal: timeoutSignal(3000),
+        });
+        if (pre.status === 200) {
+          var preData = await pre.json();
+          if (preData && (preData.status === "paid" || preData.status === "completed")) {
+            window.location.href = "/payment-success";
+            return;
+          }
+        }
+      } catch (e) { /* 查询失败就正常弹结账窗,轮询兜底 */ }
+      openCheckout();
+    })();
+    function openCheckout() {
+      window.Paddle.Checkout.open({
+        transactionId: txn,
+        // 带交易 ID:/payment-success 需要它来轮询确认到账后自动跳 /console。
+        settings: { successUrl: location.origin + "/payment-success?txn=" + encodeURIComponent(txn) },
+      });
+      hint.textContent = "支付窗口已打开。";
+      status.textContent = "";
+    }
 
     // ---- 自建轮询:微信支付的唯一可靠出路 ----
     //
@@ -189,8 +210,10 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
     // paid/completed 就关 overlay、跳 /payment-success。这不再依赖 Paddle 前端
     // 是否跳转 —— 只要 Paddle 服务端确认了钱,我们就能把用户接走。
     //
-    // 轮询上限 10 分钟(Paddle 官方延迟捕获上限),之后停轮询,页面显示"稍后
-    // 刷新查看"—— 避免无限请求。交易 ID 来自 URL,归属校验在服务端做。
+    // 轮询不硬超时:微信支付授权可能发生在任意时间(实测:页面 10:44 打开,
+    // 用户 12:13 才付款,12:18 捕获 —— 若 10 分钟就停,付款时轮询早死了)。
+    // 10 分钟后降频到 15 秒继续监听,直到页面关闭或交易完成。
+    // 交易 ID 来自 URL,归属校验在服务端做。
     //
     // AbortSignal.timeout 降级(与 site/main.js 同款):旧浏览器不支持
     // AbortSignal.timeout,直接调用会抛 TypeError → 轮询永远发不出去且被
@@ -208,18 +231,23 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
       // 解析超过 3 秒时下一次 tick 仍会触发 → 并发重叠请求,放大上游抖动与
       // API 调用。上一轮未结束就跳过本轮;结束后释放锁(含异常路径)。
       var inFlight = false;
-      var timer = setInterval(async function () {
+      var timer = null;
+      var intervalMs = 3000;
+      // **不硬超时**(真实事故修复):轮询窗口按页面打开起算,而微信支付授权
+      // 可能发生在任意时间(实测:页面 10:44 打开,用户 12:13 才付款,12:18
+      // 捕获 —— 若 10 分钟就停,付款时轮询早死了)。10 分钟后降频到 15 秒
+      // 继续监听,直到页面关闭。
+      var poll = async function () {
         if (inFlight) return;
         inFlight = true;
         try {
           attempts++;
-          // 3s × 200 = 10 分钟(Paddle 官方延迟捕获上限)。
-          // 超时后停轮询并明确告诉用户下一步,不能无声无息地停。
-          if (attempts > 200) {
+          if (attempts === 201) {
             clearInterval(timer);
+            intervalMs = 15000;
+            timer = setInterval(poll, intervalMs);
             hint.textContent = "支付已提交,正在确认到账…";
-            status.textContent = "如果已经付款,请稍后刷新此页面查看开通状态。你的付款不会丢失 —— 超过 15 分钟仍未开通请联系我们。";
-            return;
+            status.textContent = "付款后页面会自动确认并跳转。如果已经付款,请稍候 —— 你的付款不会丢失;超过 15 分钟仍未开通请联系我们。";
           }
           // AbortSignal.timeout:fetch 挂起不返回时(某些网络条件下不 reject),
           // inFlight 锁会永久占住、轮询永久停住且页面无提示(Copilot round 7)。
@@ -269,7 +297,11 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
           // 释放锁:clearInterval 后 finally 仍会跑,但 timer 已停,无副作用。
           inFlight = false;
         }
-      }, 3000);
+      };
+      // 页面加载立即查一次:付款发生在轮询启动前的场景(如刷新后交易已完成)
+      // 也能马上抓住,不用等第一个 3 秒 tick。
+      poll();
+      timer = setInterval(poll, intervalMs);
     })();
   } catch (e) {
     fail("打开支付窗口失败：" + (e && e.message ? e.message : String(e)));

--- a/workers/scout-connect/src/html/buy-page.ts
+++ b/workers/scout-connect/src/html/buy-page.ts
@@ -298,10 +298,13 @@ ${configured ? '<script src="https://cdn.paddle.com/paddle/v2/paddle.js"></scrip
           inFlight = false;
         }
       };
+      // 先建 interval 再立即跑一次(Copilot round 3):若先 poll(),首轮命中
+      // 401/404/completed 时 clearInterval(timer) 清不掉 null,interval 仍会
+      // 创建继续请求,覆盖已写入的提示。
+      timer = setInterval(poll, intervalMs);
       // 页面加载立即查一次:付款发生在轮询启动前的场景(如刷新后交易已完成)
       // 也能马上抓住,不用等第一个 3 秒 tick。
       poll();
-      timer = setInterval(poll, intervalMs);
     })();
   } catch (e) {
     fail("打开支付窗口失败：" + (e && e.message ? e.message : String(e)));

--- a/workers/scout-connect/src/html/payment-success-page.test.ts
+++ b/workers/scout-connect/src/html/payment-success-page.test.ts
@@ -33,10 +33,10 @@ describe("payment-success-page", () => {
     const html = paymentSuccessPage();
     expect(html).toContain('aria-hidden="true"');
   });
-});
   it("付款成功后自动轮询交易状态,completed 后跳 /console", () => {
     const html = paymentSuccessPage();
     expect(html).toContain("URLSearchParams(location.search).get(\"txn\")");
     expect(html).toContain("/api/transaction/");
     expect(html).toContain('window.location.href = "/console"');
   });
+});

--- a/workers/scout-connect/src/html/payment-success-page.test.ts
+++ b/workers/scout-connect/src/html/payment-success-page.test.ts
@@ -34,3 +34,9 @@ describe("payment-success-page", () => {
     expect(html).toContain('aria-hidden="true"');
   });
 });
+  it("付款成功后自动轮询交易状态,completed 后跳 /console", () => {
+    const html = paymentSuccessPage();
+    expect(html).toContain("URLSearchParams(location.search).get(\"txn\")");
+    expect(html).toContain("/api/transaction/");
+    expect(html).toContain('window.location.href = "/console"');
+  });

--- a/workers/scout-connect/src/html/payment-success-page.ts
+++ b/workers/scout-connect/src/html/payment-success-page.ts
@@ -95,20 +95,44 @@ ${BRAND_BAR}
 (function () {
   var txn = new URLSearchParams(location.search).get("txn");
   if (!txn) return;  // 直接访问本页(无交易上下文)不轮询
+  // inFlight 锁 + 超时(Copilot round 1):慢网/挂起时避免并发重叠请求或
+  // fetch 永久挂起让轮询静默停住。5 秒超时保证锁一定释放。
+  function timeoutSignal(ms) {
+    if (typeof AbortSignal.timeout === "function") return AbortSignal.timeout(ms);
+    var c = new AbortController();
+    setTimeout(function () { c.abort(); }, ms);
+    return c.signal;
+  }
   var attempts = 0;
-  var timer = setInterval(async function () {
-    attempts++;
-    if (attempts > 60) { clearInterval(timer); return; }  // 3s × 60 = 3 分钟
+  var inFlight = false;
+  var timer = null;
+  var intervalMs = 3000;
+  var poll = async function () {
+    if (inFlight) return;
+    inFlight = true;
     try {
-      var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status");
+      attempts++;
+      // 微信延迟捕获可到 ~10 分钟:3 分钟后降频继续,不早停(Copilot round 1)。
+      if (attempts === 61) {
+        clearInterval(timer);
+        intervalMs = 15000;
+        timer = setInterval(poll, intervalMs);
+      }
+      var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status", {
+        signal: timeoutSignal(5000),
+      });
       if (res.status !== 200) return;  // 未登录/未到账等,继续等
       var data = await res.json();
       if (data && data.status === "completed") {
         clearInterval(timer);
         window.location.href = "/console";
       }
-    } catch (e) { /* 网络抖动,下次再试 */ }
-  }, 3000);
+    } catch (e) { /* 网络抖动,下次再试 */ } finally {
+      inFlight = false;
+    }
+  };
+  poll();
+  timer = setInterval(poll, intervalMs);
 })();
 </script>
 </body>

--- a/workers/scout-connect/src/html/payment-success-page.ts
+++ b/workers/scout-connect/src/html/payment-success-page.ts
@@ -121,7 +121,13 @@ ${BRAND_BAR}
       var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status", {
         signal: timeoutSignal(5000),
       });
-      if (res.status !== 200) return;  // 未登录/未到账等,继续等
+      if (res.status === 401 || res.status === 404) {
+        // 未登录/交易不存在:继续轮询没意义,与 /buy 轮询一致 fail-fast
+        // (Copilot round 2)。否则无意义请求直到页面关闭。
+        clearInterval(timer);
+        return;
+      }
+      if (res.status !== 200) return;  // 503 等可重试状态,继续等
       var data = await res.json();
       if (data && data.status === "completed") {
         clearInterval(timer);

--- a/workers/scout-connect/src/html/payment-success-page.ts
+++ b/workers/scout-connect/src/html/payment-success-page.ts
@@ -137,8 +137,10 @@ ${BRAND_BAR}
       inFlight = false;
     }
   };
-  poll();
+  // 先建 interval 再立即跑一次(Copilot round 3):首轮 401/404/completed 时
+  // clearInterval 才能清掉真实 timer,否则 interval 仍会创建继续请求。
   timer = setInterval(poll, intervalMs);
+  poll();
 })();
 </script>
 </body>

--- a/workers/scout-connect/src/html/payment-success-page.ts
+++ b/workers/scout-connect/src/html/payment-success-page.ts
@@ -86,6 +86,31 @@ ${BRAND_BAR}
 14 天内无条件全额退款 —— 见<a href="/refund">退款政策</a>。
 </p>
 </main>
+<script>
+// ---- 到账后自动进入控制台 ----
+// 用户付款后停在这个确认页。时长在 Paddle 捕获完成(webhook 入账)后到账,
+// 这里轮询交易状态,completed 一到就自动跳 /console —— 用户不用手动点。
+// 到达 /console 时若 webhook 尚未入账,控制台会显示「已付款 · 正在开通」
+// 的兜底态,不会出现"尚未开通"。
+(function () {
+  var txn = new URLSearchParams(location.search).get("txn");
+  if (!txn) return;  // 直接访问本页(无交易上下文)不轮询
+  var attempts = 0;
+  var timer = setInterval(async function () {
+    attempts++;
+    if (attempts > 60) { clearInterval(timer); return; }  // 3s × 60 = 3 分钟
+    try {
+      var res = await fetch("/api/transaction/" + encodeURIComponent(txn) + "/status");
+      if (res.status !== 200) return;  // 未登录/未到账等,继续等
+      var data = await res.json();
+      if (data && data.status === "completed") {
+        clearInterval(timer);
+        window.location.href = "/console";
+      }
+    } catch (e) { /* 网络抖动,下次再试 */ }
+  }, 3000);
+})();
+</script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
真实事故复盘：交易 10:44 创建（轮询 10 分钟窗口 10:54 耗尽），用户 12:13 才付款，12:18 捕获 —— **付款时轮询早已停止**，所以"付了钱页面没反应"。

这不是捕获不到，是**轮询窗口在付款前就死了**（窗口按页面打开起算，而微信支付授权可发生在任意时间点）。

## 修复

1. **轮询不硬超时**：10 分钟后降频到 15 秒继续监听，直到页面关闭或交易完成
2. **刷新/返回永不回付款页**：`Checkout.open` 前先查一次交易状态，已 `paid/completed` 直接跳 `/payment-success`，不弹结账窗（修"刷新又回付款页"）
3. **`/payment-success` 自动跳 `/console`**：successUrl 带交易 ID，确认页轮询交易状态，`completed` 一到自动跳 `/console`（用户不用手动点）

## 完整链路

```
捕获 paid/completed → /payment-success(明确成功信号)
  → 自动轮询 → completed → 自动 /console(目的地)
  → 到达时若 webhook 尚未入账 → 控制台 pendingPaid 态兜底「已付款·正在开通」
```

## 验证

- 反向验证：successUrl 去 txn → 转红；确认页去自动跳转 → 转红
- 全量 2809 passed，三处 tsc 全绿
- 已部署生产 `147b6d28`，curl 确认新链路就位