### PR TITLE
fix(agent): 把 LLM 429 限流翻成可操作中文提示 (#229)

### DIFF
--- a/packages/workflow/src/agent-error.test.ts
+++ b/packages/workflow/src/agent-error.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { LLM_AUTH_GUIDANCE, describeAgentRunError, summarizeErrorForNotification } from "./agent-error.js";
+import {
+  LLM_AUTH_GUIDANCE,
+  LLM_RATE_LIMIT_GUIDANCE,
+  describeAgentRunError,
+  summarizeErrorForNotification,
+} from "./agent-error.js";
 
 describe("describeAgentRunError", () => {
   it("maps a bare 'Unauthorized' error to the actionable LLM-auth guidance", () => {
@@ -39,6 +44,103 @@ describe("describeAgentRunError", () => {
 
   it("maps an 'incorrect api key' message to the guidance", () => {
     expect(describeAgentRunError(new Error("Incorrect API key provided"))).toBe(LLM_AUTH_GUIDANCE);
+  });
+
+  // ---- LLM 限流(429) ----
+  //
+  // issue #229 的真实现场:用户的 123网盘 与 光鸭 两个任务同时报
+  // 「Failed after 3 attempts. Last error: Too Many Requests」。两个独立网盘商
+  // 不可能同时限流 —— 429 来自它们共同的上游:agent 调用的 LLM。AI SDK 把 429
+  // 视为可重试错误(默认 maxRetries: 2 → 共 3 次尝试),全部失败后抛 RetryError,
+  // message 就是那句英文。原样透传会让用户以为是网盘或本程序坏了(他因此提了
+  // issue),必须给出「这是你的 LLM 渠道在限流」的可操作指引。
+  it("maps the AI SDK RetryError text (429 exhausted) to the rate-limit guidance", () => {
+    // 这就是 issue #229 用户界面上出现的原文
+    expect(
+      describeAgentRunError(new Error("Failed after 3 attempts. Last error: Too Many Requests")),
+    ).toBe(LLM_RATE_LIMIT_GUIDANCE);
+  });
+
+  it("maps a 429 status-code APICallError-shaped error to the rate-limit guidance", () => {
+    const apiError = Object.assign(new Error("Too Many Requests"), { statusCode: 429 });
+    expect(describeAgentRunError(apiError)).toBe(LLM_RATE_LIMIT_GUIDANCE);
+  });
+
+  it("maps a 'rate limit exceeded' message to the rate-limit guidance", () => {
+    expect(describeAgentRunError(new Error("Rate limit exceeded"))).toBe(LLM_RATE_LIMIT_GUIDANCE);
+  });
+
+  it("maps a 'quota exceeded' message to the rate-limit guidance", () => {
+    expect(describeAgentRunError(new Error("RESOURCE_EXHAUSTED: Quota exceeded"))).toBe(
+      LLM_RATE_LIMIT_GUIDANCE,
+    );
+  });
+
+  it("detects a 429 wrapped in the error cause chain (AI SDK wrapping)", () => {
+    const inner = Object.assign(new Error("Too Many Requests"), { statusCode: 429 });
+    const outer = new Error("Failed after 3 attempts");
+    (outer as { cause?: unknown }).cause = inner;
+    expect(describeAgentRunError(outer)).toBe(LLM_RATE_LIMIT_GUIDANCE);
+  });
+
+  // ---- 绝不把网盘的限流当成 LLM 限流 ----
+  //
+  // 网盘自己也会限流(115「请求过于频繁」、夸克「访问频繁」),那是网盘侧问题,
+  // 指引用户去换 LLM 渠道会把他引向完全错误的方向 —— 与 401 侧同款教训
+  // (BRAND_AUTH_MARKERS 的存在原因)。
+  it("never maps a 115 rate-limit error to the LLM rate-limit guidance", () => {
+    const err = new Error("PAN115_TRANSFER_FAILED: 请求过于频繁，请稍后再试");
+    expect(describeAgentRunError(err)).toBe(err.message);
+  });
+
+  it("never maps a Quark rate-limit error to the LLM rate-limit guidance", () => {
+    const err = new Error("QUARK_TRANSFER_FAILED: 访问频繁");
+    expect(describeAgentRunError(err)).toBe(err.message);
+  });
+
+  it("never maps a bare Chinese 网盘 throttle message (no brand prefix) to the LLM guidance", () => {
+    // 反向验证发现的假覆盖:上面两条靠消息里的品牌名(pan115/quark)就被
+    // BRAND_AUTH_MARKERS 挡住了,并没有真的测到「网盘限流短路」。网盘的
+    // 转存失败常常只带中文提示、没有品牌前缀 —— 这才是 BRAND_RATE_LIMIT_MARKERS
+    // 唯一负责的场景。删掉那份标记表,本用例必须转红。
+    const err = new Error("转存失败:请求过于频繁，请稍后再试");
+    expect(describeAgentRunError(err)).toBe(err.message);
+  });
+
+  it("never maps 「访问频繁」 (bare, no brand prefix) to the LLM guidance", () => {
+    const err = new Error("访问频繁，请稍后重试");
+    expect(describeAgentRunError(err)).toBe(err.message);
+  });
+
+  it("never maps a 网盘 gateway's ENGLISH 429 text to the LLM guidance", () => {
+    // 探针实测的真误判:网盘网关也会返回英文 "Too Many Requests"。只看英文文案
+    // 会把「转存被网盘限流」判成「你的 LLM 渠道限流」,用户照指引去换模型渠道
+    // 完全无效。转存/分享类前缀必须短路 —— 删掉那些标记,本用例转红。
+    const err = new Error("转存失败: Too Many Requests (drive gateway)");
+    expect(describeAgentRunError(err)).toBe(err.message);
+  });
+
+  it("never maps a Chinese throttle carrying English 429 text to the LLM guidance", () => {
+    // 同时含中文「频繁」与英文 429 文案 —— 这条能真正区分「中文标记短路」是否生效
+    // (纯中文消息本来也不匹配英文 patterns,无法区分)。
+    const err = new Error("请求过于频繁 (Too Many Requests)");
+    expect(describeAgentRunError(err)).toBe(err.message);
+  });
+
+  it("never maps a brand 429 status code to the LLM rate-limit guidance", () => {
+    // 网盘 API 自己返回 429 时同样不能改写(品牌标记优先)
+    const err = Object.assign(new Error("Pan123AuthError: too many requests"), { statusCode: 429 });
+    expect(describeAgentRunError(err)).toBe(err.message);
+  });
+
+  it("rate-limit guidance is actionable: names the LLM channel and rules out 网盘/程序", () => {
+    expect(LLM_RATE_LIMIT_GUIDANCE).toContain("429");
+    expect(LLM_RATE_LIMIT_GUIDANCE).toContain("AI 模型");
+    expect(LLM_RATE_LIMIT_GUIDANCE).toContain("网盘");
+  });
+
+  it("auth and rate-limit guidance are distinct messages", () => {
+    expect(LLM_RATE_LIMIT_GUIDANCE).not.toBe(LLM_AUTH_GUIDANCE);
   });
 
   it("never mentions MiMo in the auth guidance", () => {

--- a/packages/workflow/src/agent-error.ts
+++ b/packages/workflow/src/agent-error.ts
@@ -18,6 +18,20 @@
 export const LLM_AUTH_GUIDANCE =
   "AI 模型鉴权失败(401):请到 设置 → AI 模型 检查 API Key 是否有效、模型是否有权限(任意 OpenAI 兼容服务,自带 key)。";
 
+/**
+ * Shown when the agent's LLM calls exhaust the AI SDK's retries on 429.
+ *
+ * issue #229 的真实现场:用户看到「Failed after 3 attempts. Last error: Too Many
+ * Requests」,而且**多个网盘任务同时报同一句** —— 因为 429 不是网盘返回的,是它们
+ * 共同上游(agent 调用的 LLM)返回的。AI SDK 把 429 当可重试错误(默认 maxRetries:
+ * 2 → 共 3 次尝试),全失败后抛 RetryError,那句英文就是它的 message。
+ *
+ * 原样透传的代价:用户以为网盘坏了或本程序坏了(他因此提了 issue),而真正该做的是
+ * 换一个额度充足的模型渠道或稍后重试。所以这条指引必须明确「与网盘和本程序无关」。
+ */
+export const LLM_RATE_LIMIT_GUIDANCE =
+  "AI 模型被限流(429):你配置的模型渠道正在限流或额度已用尽 —— 与网盘和本程序无关。请稍后重试,或到 设置 → AI 模型 换一个额度充足的渠道(免费额度的模型很容易触发)。";
+
 // LLM-SPECIFIC auth markers (case-insensitive). Deliberately NOT the bare numeric
 // "401"/"403" substrings — those over-match netdisk (brand) auth errors whose
 // messages carry the status number (e.g. "GUANGYA_AUTH_FAILED: 401 after refresh")
@@ -32,12 +46,44 @@ const LLM_AUTH_PATTERNS = [
   "authentication",
 ];
 
+// LLM rate-limit markers (case-insensitive). Same discipline as LLM_AUTH_PATTERNS:
+// no bare "429" substring — a netdisk message can carry that number and would be
+// misreported as an AI-模型 problem. These are what OpenAI-compatible endpoints
+// (and the AI SDK's RetryError wrapper) actually say when throttled.
+const LLM_RATE_LIMIT_PATTERNS = [
+  "too many requests",
+  "rate limit",
+  "rate_limit",
+  "quota exceeded",
+  "resource_exhausted",
+  "requests per minute",
+  "insufficient_quota",
+];
+
 // Netdisk (storage brand) auth errors are a TOKEN problem with the user's drive,
 // not the AI model. They are thrown as Pan115AuthError / QuarkAuthError /
 // GuangYaAuthError / TianyiAuthError / Pan123AuthError with these message prefixes
 // (and class names). If any of these markers is present anywhere in the error (or
 // its cause chain), it is NEVER an LLM-auth error — even if it carries a 401/403
 // statusCode or the word in its text.
+// Netdisk-side markers that must SHORT-CIRCUIT the LLM rate-limit mapping.
+//
+// 两类:
+//  1. 中文限流提示(115「请求过于频繁」/夸克「访问频繁」)——网盘侧限流;
+//  2. **转存/网盘动作前缀**——探针实测:网盘网关也会返回英文「Too Many Requests」
+//     (例如 "转存失败: Too Many Requests"),只匹配英文 429 文案会把它误判成
+//     「换 LLM 渠道」,把用户引向完全错误的方向(与 BRAND_AUTH_MARKERS 同款教训)。
+const BRAND_RATE_LIMIT_MARKERS = [
+  "频繁",
+  "访问过快",
+  "操作过于频繁",
+  "转存",
+  "transfer_failed",
+  "transfer failed",
+  "分享",
+  "share link",
+];
+
 const BRAND_AUTH_MARKERS = [
   "guangya",
   "quark",
@@ -105,14 +151,55 @@ export function isLlmAuthError(error: unknown, depth = 0): boolean {
   return cause === undefined ? false : isLlmAuthError(cause, depth + 1);
 }
 
+/** True if this error is a netdisk brand error (auth OR rate limit) — those must
+ *  never be reported as an AI-模型 problem. */
+function isBrandError(error: unknown): boolean {
+  const msg = messageOf(error);
+  return (
+    BRAND_AUTH_MARKERS.some((marker) => msg.includes(marker)) ||
+    BRAND_RATE_LIMIT_MARKERS.some((marker) => msg.includes(marker))
+  );
+}
+
 /**
- * Map a captured agent-run error to a USER-FACING message. LLM auth/401 failures
- * become actionable, provider-agnostic guidance; every other error keeps its
- * original message. Does NOT touch the original error — logs keep the raw detail.
+ * True if `error` (or anything in its `cause` chain — the AI SDK wraps the real
+ * error) is an LLM rate-limit failure: a 429 statusCode, or a message matching a
+ * throttling marker (including the AI SDK's own "Failed after N attempts. Last
+ * error: Too Many Requests"). A netdisk (brand) error short-circuits to false —
+ * even with a 429 statusCode — so a drive throttle is never mislabeled an
+ * AI-模型 problem. Recursion-bounded.
+ */
+export function isLlmRateLimitError(error: unknown, depth = 0): boolean {
+  if (error === null || error === undefined || depth > 5) {
+    return false;
+  }
+  // A netdisk error anywhere short-circuits: NOT an LLM rate-limit error.
+  if (isBrandError(error)) {
+    return false;
+  }
+  if (statusCodeOf(error) === 429) {
+    return true;
+  }
+  const msg = messageOf(error);
+  if (LLM_RATE_LIMIT_PATTERNS.some((pattern) => msg.includes(pattern))) {
+    return true;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  return cause === undefined ? false : isLlmRateLimitError(cause, depth + 1);
+}
+
+/**
+ * Map a captured agent-run error to a USER-FACING message. LLM auth/401 and
+ * rate-limit/429 failures become actionable, provider-agnostic guidance; every
+ * other error keeps its original message. Does NOT touch the original error —
+ * logs keep the raw detail.
  */
 export function describeAgentRunError(error: unknown): string {
   if (isLlmAuthError(error)) {
     return LLM_AUTH_GUIDANCE;
+  }
+  if (isLlmRateLimitError(error)) {
+    return LLM_RATE_LIMIT_GUIDANCE;
   }
   if (error instanceof Error) {
     return error.message;


### PR DESCRIPTION
## 现场（issue #229）

用户的 **123网盘 与 光鸭两个任务同时**报：

> Failed after 3 attempts. Last error: Too Many Requests

## 诊断

两个独立网盘商不可能同时限流 —— 429 来自它们**共同的上游**：agent 调用的 LLM。

```
用户的 LLM 渠道返回 429
  → AI SDK 视为可重试错误（默认 maxRetries: 2 → 共 3 次尝试）
  → 3 次全 429 → 抛 RetryError（message 就是那句英文）
  → describeAgentRunError() 只分类了 401/403 → 429 原样透传
  → 用户以为网盘/本程序坏了 → 提 issue
```

真正该做的是**换额度充足的模型渠道或稍后重试**，而原文案没有给出任何方向。

## 改动

- **`LLM_RATE_LIMIT_GUIDANCE`**：明说「与网盘和本程序无关」+ 去哪改（设置 → AI 模型）+ 点出免费额度易触发
- **`isLlmRateLimitError`**：429 statusCode / 限流文案 / cause 链递归（与 auth 侧同款纪律：**不匹配裸 `429` 数字**，免得吞掉网盘消息里的状态号）
- **网盘侧短路 `BRAND_RATE_LIMIT_MARKERS`**：中文「频繁」类 + 转存/分享前缀 —— 探针实测网盘网关**也会返回英文 `Too Many Requests`**，只看英文文案会把「网盘限流」误判成「换 LLM 渠道」，把用户引向完全错误的方向

## TDD 与反向验证

1. 先写测试 → **6 红**
2. 实现 → 绿
3. **反向验证第一轮暴露假覆盖**：「网盘限流不得误判」的三条用例其实靠消息里的品牌名（`pan115`/`quark`）就通过了，与短路表无关；清空短路表测试依然全绿
4. 补两条**可区分**用例（「中文频繁 + 英文 429 文案」、「转存失败 + 英文 429」）
5. 反向验证第二轮：清空短路表 → **2 红**；移除 429 分类 → **5 红**；还原 → 41 绿

## 验证

- `packages/workflow/src/agent-error.test.ts`：41 passed
- 全量：**2826 passed / 15 skipped**
- 三处 tsc 干净（根 typecheck + apps/web + desktop）

Closes #229