### PR TITLE
fix(seo): 私有页面 noindex + worker HSTS（第 2 轮审计 P0/P1）

### DIFF
--- a/docs/seo/SEO-STATE.md
+++ b/docs/seo/SEO-STATE.md
@@ -56,3 +56,42 @@
 2. 在 GSC 注册两站并提交 sitemap（**需要用户账号操作**）
 3. 主站英文版（`/en/`）—— README 已双语，内容成本低；先验证中文版基线数据再做
 4. 机会地图：从「自建/NAS + 网盘自动化 + 追剧」聚类，考虑用例页（如「NAS 自动追剧」「115 自动转存」）——**先等第 1 轮数据，不预先批量造页**
+
+
+## 第 2 轮（2026-08-04）：私有页面索引防护 + HSTS
+
+参照一份外部「技术 SEO 全站审计」清单做交叉检查，只吸收我们真正缺的项（其余
+如 canonical/sitemap/hreflang/结构化数据第 1 轮已完成；转化归因我们有
+Paddle webhook + D1 entitlements，比 GA4 更硬）。
+
+### 审计发现（真实公网复验，绕开本机代理 fake-ip）
+
+| 级别 | 问题 | 证据 |
+|---|---|---|
+| **P0** | `/admin` 未登录返回完整管理页 HTML 且无 noindex | `<title>Mediary Connect Admin</title>`，含「邀请/token」字样 |
+| **P0** | 付费站 `http://` 明文 200，无跳转、无 HSTS | `--resolve mediaryconnect.app:80:104.21.73.181` → `HTTP/1.1 200 OK`，无 Location |
+| **P1** | `/login` 无 noindex | 200 + 无 robots meta |
+| ✅ | `/buy`、`/payment-success` 已有 noindex | 当初想到了，漏了 admin/login |
+| ✅ | `/console` 302 跳转 | 无索引风险 |
+| ✅ | www 子域无解析、主站 http→308+HSTS、图片 alt 齐全、TTFB ~0.44s | 无需处理 |
+
+### 本轮已实施
+
+- `/admin`：`noindex, nofollow, noarchive`（不索引 + 不顺链爬内部路径 + 不留快照）
+- `/login`：`noindex`
+- worker 全站 HTML 响应加 HSTS：`max-age=63072000; includeSubDomains`
+  —— **刻意不加 `preload`**（进预加载列表不可逆，等站点稳定运营后再单独决定）
+
+### 验证证据
+
+- 新增 4 条测试（admin ×2、login ×1、HSTS ×1），逐项反向验证真红：
+  移除 HSTS → 1 红；移除 admin noindex → 2 红；移除 login noindex → 1 红
+- 全量 **2836 passed / 15 skipped**；**四处 tsc**（根 / apps-web / worker / desktop）全干净
+  （第 1 轮教训：只跑两处就下结论，被 CI 抓到两个真实类型错误）
+
+### 待观察
+
+1. GSC「网页索引」里确认 `/admin`、`/login` 不出现在已收录清单（若此前已被收录，noindex 生效需等重新抓取）
+2. 付费站 HTTP 明文：HSTS 只对**回访过 HTTPS 的浏览器**生效；首次 http 访问仍会明文命中。
+   **仍需在 Cloudflare 侧开 “Always Use HTTPS”**（Rules → Settings，一键，零风险）—— 需要账号操作
+3. 主站英文版仍未做（第 1 轮起就在待办，等中文基线数据）

--- a/workers/scout-connect/src/html/admin-page.test.ts
+++ b/workers/scout-connect/src/html/admin-page.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { adminPage } from "./admin-page.js";
+
+describe("admin page", () => {
+  // SEO 审计 P0(真实发现):/admin 未登录即返回完整管理页 HTML(标题
+  // 「Mediary Connect Admin」、含「邀请/token」字样),且**没有任何 noindex**。
+  // 数据本身有 API 鉴权,但页面进索引等于对外公布管理入口 —— 搜一下就能发现。
+  it("有 noindex —— 管理页绝不能进搜索索引(P0)", () => {
+    // 用正则而不是精确字符串:content 里还有 nofollow/noarchive,
+    // 精确匹配会在加指令时误红(而加指令是更严格、不是更宽松)。
+    expect(adminPage()).toMatch(/name="robots" content="noindex\b/);
+  });
+
+  it("noindex 同时禁止跟随链接与快照(nofollow/noarchive)", () => {
+    // 管理页里的链接不该被爬,历史快照也不该被留存。
+    const html = adminPage();
+    expect(html).toMatch(/name="robots" content="[^"]*nofollow/);
+    expect(html).toMatch(/name="robots" content="[^"]*noarchive/);
+  });
+});

--- a/workers/scout-connect/src/html/admin-page.ts
+++ b/workers/scout-connect/src/html/admin-page.ts
@@ -8,6 +8,10 @@ export function adminPage(): string {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Mediary Connect Admin</title>
+<!-- SEO 审计 P0:未登录也会返回这整页 HTML(数据靠 API 鉴权,页面本身是公开的)。
+     页面进索引等于对外公布管理入口 —— 搜一下就能找到。noindex 挡索引,
+     nofollow 挡顺着链接爬内部路径,noarchive 挡历史快照留存。 -->
+<meta name="robots" content="noindex, nofollow, noarchive">
 <style>
 body{font-family:system-ui,sans-serif;max-width:1000px;margin:2rem auto;padding:0 1rem;color:#222;font-size:14px}
 input,button{font:inherit;padding:.35rem .5rem}

--- a/workers/scout-connect/src/html/login-page.test.ts
+++ b/workers/scout-connect/src/html/login-page.test.ts
@@ -5,7 +5,10 @@ describe("login page", () => {
   // SEO 审计 P1:登录页此前无 noindex —— 它进索引后,用户从 SERP 落到
   // 一个要登录的页面而不是首页,而且登录页对搜索引擎毫无内容价值。
   it("有 noindex —— 登录页绝不该进搜索索引", () => {
-    expect(loginPage()).toContain('name="robots" content="noindex"');
+    // 正则而非精确字符串(Copilot #232 抑制评论):将来给登录页加更严格的
+    // 指令(nofollow/noarchive)时,精确匹配会误红 —— 而那是变严格、不是变宽松。
+    // admin-page.test 已用同一手法,这里同步。
+    expect(loginPage()).toMatch(/name="robots" content="noindex\b/);
   });
 
   it("is a full dark-themed document with brand bar and favicon", () => {

--- a/workers/scout-connect/src/html/login-page.test.ts
+++ b/workers/scout-connect/src/html/login-page.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 import { loginPage } from "./login-page.js";
 
 describe("login page", () => {
+  // SEO 审计 P1:登录页此前无 noindex —— 它进索引后,用户从 SERP 落到
+  // 一个要登录的页面而不是首页,而且登录页对搜索引擎毫无内容价值。
+  it("有 noindex —— 登录页绝不该进搜索索引", () => {
+    expect(loginPage()).toContain('name="robots" content="noindex"');
+  });
+
   it("is a full dark-themed document with brand bar and favicon", () => {
     const html = loginPage();
     expect(html).toContain("<!doctype html>");

--- a/workers/scout-connect/src/html/login-page.ts
+++ b/workers/scout-connect/src/html/login-page.ts
@@ -26,6 +26,9 @@ export function loginPage(sitekeyRaw?: string): string {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>登录 · Mediary Connect</title>
+<!-- SEO 审计 P1:登录页进索引 = 用户从 SERP 落到一个要登录的页面而不是首页,
+     且登录页对搜索引擎无内容价值。 -->
+<meta name="robots" content="noindex">
 ${FAVICON_LINK}${tsScript}
 <style>
 ${THEME_TOKENS}

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -100,10 +100,16 @@ export function htmlPage(
       "referrer-policy": "no-referrer",
       // HSTS(SEO/安全审计 P0):真实公网复验发现 http://mediaryconnect.app/
       // 直接 200 明文响应 —— Google 会把 http:// 与 https:// 当两套地址
-      // (重复内容 + 规范分裂),用户也会明文打开登录页。这个头让浏览器此后
-      // 只走 HTTPS。两年 max-age + 子域覆盖是 hstspreload.org 的门槛值;
-      // 刻意不加 preload —— 那是不可逆的(进了预加载列表就无法快速退出),
-      // 等站点稳定运营一段时间再单独决定。
+      // (重复内容 + 规范分裂),用户也会明文打开登录页。
+      //
+      // 生效边界(别高估它):浏览器**必须先通过 HTTPS 收到过这个头**才会缓存
+      // 并强制后续请求走 HTTPS —— 首次就用 http:// 访问的请求依然是明文命中。
+      // 要挡住首次明文,还需在 Cloudflare 开 Always Use HTTPS(见 SEO 台账待办)。
+      //
+      // 参数选择:max-age 两年是我们自己的保守选择,不是任何规范的门槛。
+      // (hstspreload.org 的预加载门槛是 max-age ≥ 31536000 即 1 年 +
+      //  includeSubDomains + preload 三者齐备。)
+      // 刻意不加 preload —— 进预加载列表**不可逆**,等站点稳定运营后再单独决定。
       "strict-transport-security": "max-age=63072000; includeSubDomains",
   };
   if (opts.noStore) headers["cache-control"] = "no-store";

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -98,6 +98,13 @@ export function htmlPage(
       // is the legacy header that actually blocks framing in older browsers.
       "x-frame-options": "DENY",
       "referrer-policy": "no-referrer",
+      // HSTS(SEO/安全审计 P0):真实公网复验发现 http://mediaryconnect.app/
+      // 直接 200 明文响应 —— Google 会把 http:// 与 https:// 当两套地址
+      // (重复内容 + 规范分裂),用户也会明文打开登录页。这个头让浏览器此后
+      // 只走 HTTPS。两年 max-age + 子域覆盖是 hstspreload.org 的门槛值;
+      // 刻意不加 preload —— 那是不可逆的(进了预加载列表就无法快速退出),
+      // 等站点稳定运营一段时间再单独决定。
+      "strict-transport-security": "max-age=63072000; includeSubDomains",
   };
   if (opts.noStore) headers["cache-control"] = "no-store";
   return new Response(body, { status, headers });

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -250,6 +250,18 @@ describe("handleRequest", () => {
 
   // robots.txt 此前由 Cloudflare 给一份纯注释样板(去注释后零有效指令),
   // 且没有 Sitemap 声明。worker 接管,给出真指令。
+  // SEO/安全审计 P0(真实公网复验,绕开本机代理):http://mediaryconnect.app/
+  // 直接 200 明文响应,无 301/308 跳转、无 HSTS —— Google 会把 http:// 与
+  // https:// 视为两套地址(重复内容 + 规范分裂),用户也会明文访问登录页。
+  // 主站(Vercel)本来就有 308 + HSTS,只有 worker 这边缺。
+  it("HTML 响应带 HSTS(强制后续走 HTTPS)", async () => {
+    const { deps } = setup();
+    const res = await handleRequest(new Request(`${BASE}/`), deps);
+    const hsts = res.headers.get("strict-transport-security") ?? "";
+    expect(hsts).toMatch(/max-age=\d{7,}/); // 至少 ~4 个月,别设个几十秒的假 HSTS
+    expect(hsts).toContain("includeSubDomains");
+  });
+
   it("GET /robots.txt → 200 纯文本,含 Allow 与 Sitemap 声明", async () => {
     const { deps } = setup();
     const res = await handleRequest(new Request(`${BASE}/robots.txt`), deps);

--- a/workers/scout-connect/src/routes.test.ts
+++ b/workers/scout-connect/src/routes.test.ts
@@ -258,7 +258,11 @@ describe("handleRequest", () => {
     const { deps } = setup();
     const res = await handleRequest(new Request(`${BASE}/`), deps);
     const hsts = res.headers.get("strict-transport-security") ?? "";
-    expect(hsts).toMatch(/max-age=\d{7,}/); // 至少 ~4 个月,别设个几十秒的假 HSTS
+    // 解析出秒数做**数值**下限校验(Copilot #232):正则 \d{7,} 的最小值是
+    // 1000000 秒 ≈ 11.6 天,远低于注释声称的下限 —— 那样「把 HSTS 改成
+    // 11 天」的回归也能蒙过测试。这里按 1 年(31536000 秒)卡死。
+    const maxAge = Number(/max-age=(\d+)/.exec(hsts)?.[1] ?? 0);
+    expect(maxAge).toBeGreaterThanOrEqual(31_536_000);
     expect(hsts).toContain("includeSubDomains");
   });
 


### PR DESCRIPTION
第 2 轮 SEO 审计。参照一份外部「技术 SEO 全站审计」清单做交叉检查，**只吸收我们真正缺的项**（canonical/sitemap/hreflang/结构化数据第 1 轮已完成；转化归因我们有 Paddle webhook + D1 entitlements，比 GA4 更硬）。

所有证据均用 `--resolve` 真实公网 IP 复验，**绕开本机代理的 fake-ip**（第 1 轮踩过这个坑：本机 curl 全绿是假象）。

## 发现

| 级别 | 问题 | 证据 |
|---|---|---|
| **P0** | `/admin` 未登录即返回完整管理页 HTML，且**无任何 noindex** | `<title>Mediary Connect Admin</title>`，含「邀请 / token」字样 |
| **P0** | 付费站 `http://` **明文 200**，无跳转、无 HSTS | `--resolve mediaryconnect.app:80:104.21.73.181` → `HTTP/1.1 200 OK`，无 `Location` |
| **P1** | `/login` 无 noindex | 200 + 无 robots meta |

已合格、无需处理：`/buy` 和 `/payment-success` 早有 noindex（当初想到了，漏了 admin/login）、`/console` 302、www 子域无解析、主站 `http→308`+HSTS、图片 alt 齐全、TTFB ~0.44s。

## 改动

- **`/admin`**：`noindex, nofollow, noarchive` —— 不索引 + 不顺着链接爬内部路径 + 不留历史快照。数据本身有 API 鉴权，但页面进索引等于**对外公布管理入口**
- **`/login`**：`noindex`
- **worker 全站 HTML**：`strict-transport-security: max-age=63072000; includeSubDomains`
  - **刻意不加 `preload`** —— 进预加载列表**不可逆**，等站点稳定运营后再单独决定

## TDD 与反向验证

4 条新测试，逐项破坏实现：

| 破坏点 | 结果 |
|---|---|
| 移除 HSTS | 1 红 ✅ |
| 移除 admin noindex | 2 红 ✅ |
| 移除 login noindex | 1 红 ✅ |

admin 的断言用**正则**而非精确字符串：`content` 里还有 `nofollow/noarchive`，精确匹配会在「加更严格指令」时误红。

## 验证

- 全量 **2836 passed / 15 skipped**
- **四处 tsc 全干净**（根 / apps-web / worker / desktop）—— 第 1 轮只跑两处就下结论，被 CI 抓到两个真实类型错误，这次不重犯

## 仍需账号操作（无法用代码解决）

HSTS 只对**回访过 HTTPS 的浏览器**生效；**首次** http 访问仍会明文命中。需要在 Cloudflare 侧开 **Rules → Settings → Always Use HTTPS**（一键、零风险）。已记入台账待办。