### PR TITLE
fix(workflow): 搜索源故障不再伪装成「暂未找到可用资源」

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -653,9 +653,16 @@ export async function savePanSouBaseUrlAction(baseURL: string): Promise<PushSett
       await repository.setAccountSetting(accountId, PANSOU_HEALTH_SETTING_KEY, "");
       return { success: true };
     }
+    // 先做便宜的格式校验再花 8s 探活:少了它,一个漏写 scheme 的地址会拿到
+    // 「连不上」这种含糊回复,而真正的问题是格式。agent API 侧本来就有这条校验,
+    // 两个入口理应一致。
+    const { probePanSou, validatePanSouBaseUrlFormat } = await import("../lib/pansou-probe");
+    const format = validatePanSouBaseUrlFormat(trimmed);
+    if (!format.ok) {
+      return { success: false, message: format.message };
+    }
     // 存之前先真打一次。以前只校验 ^https?:// ,于是一个打不通的地址会被欣然
     // 保存,之后每次获取都静默失败并报成「未找到资源」——事故里这样活了 6 天。
-    const { probePanSou } = await import("../lib/pansou-probe");
     const probe = await probePanSou(trimmed);
     if (!probe.ok) {
       return { success: false, message: probe.message };

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -641,9 +641,27 @@ export async function clearAssrtTokenAction(): Promise<PushSettingsActionResult>
 export async function savePanSouBaseUrlAction(baseURL: string): Promise<PushSettingsActionResult> {
   assertNotDemo();
   try {
-    const { getWorkflowRepository, getCurrentAccountId, PANSOU_BASE_URL_SETTING_KEY } = await import("../lib/workflow-runtime");
+    const { getWorkflowRepository, getCurrentAccountId, PANSOU_BASE_URL_SETTING_KEY, PANSOU_HEALTH_SETTING_KEY } = await import("../lib/workflow-runtime");
+    const repository = getWorkflowRepository();
+    const accountId = await getCurrentAccountId();
+    const trimmed = baseURL.trim();
     // Empty = clear the override → falls back to env / public default.
-    await getWorkflowRepository().setAccountSetting(await getCurrentAccountId(), PANSOU_BASE_URL_SETTING_KEY, baseURL.trim());
+    // 清空是正当操作,不必探活;顺手把上次的探活结论也清掉,否则设置页会对着一个
+    // 已经不存在的自建源继续告警。
+    if (!trimmed) {
+      await repository.setAccountSetting(accountId, PANSOU_BASE_URL_SETTING_KEY, "");
+      await repository.setAccountSetting(accountId, PANSOU_HEALTH_SETTING_KEY, "");
+      return { success: true };
+    }
+    // 存之前先真打一次。以前只校验 ^https?:// ,于是一个打不通的地址会被欣然
+    // 保存,之后每次获取都静默失败并报成「未找到资源」——事故里这样活了 6 天。
+    const { probePanSou } = await import("../lib/pansou-probe");
+    const probe = await probePanSou(trimmed);
+    if (!probe.ok) {
+      return { success: false, message: probe.message };
+    }
+    await repository.setAccountSetting(accountId, PANSOU_BASE_URL_SETTING_KEY, trimmed);
+    await repository.setAccountSetting(accountId, PANSOU_HEALTH_SETTING_KEY, "ok");
     return { success: true };
   } catch (error) {
     return { success: false, message: `保存失败：${String(error)}` };

--- a/apps/web/components/settings-action-inbox.tsx
+++ b/apps/web/components/settings-action-inbox.tsx
@@ -15,12 +15,14 @@ const KIND_ICON: Record<AttentionKind, typeof Rocket> = {
   update_available: Rocket,
   frozen_drive: AlertTriangle,
   missing_llm: CircleAlert,
+  search_source_unreachable: CircleAlert,
 };
 
 const KIND_CLASS: Record<AttentionKind, string> = {
   update_available: "kind-info",
   frozen_drive: "kind-blocker",
   missing_llm: "kind-warning",
+  search_source_unreachable: "kind-warning",
 };
 
 export function SettingsActionInbox({ items }: { items: SettingsAttentionItem[] }) {

--- a/apps/web/lib/agent-api/config-io.ts
+++ b/apps/web/lib/agent-api/config-io.ts
@@ -13,6 +13,7 @@ import {
   PREFERRED_LANGUAGE_SETTING_KEY,
   DAILY_SWEEP_TIME_SETTING_KEY,
   PANSOU_BASE_URL_SETTING_KEY,
+  PANSOU_HEALTH_SETTING_KEY,
   PROWLARR_BASE_URL_SETTING_KEY,
   PROWLARR_API_KEY_SETTING_KEY,
   TMDB_API_KEY_SETTING_KEY,
@@ -198,7 +199,18 @@ export async function writeAgentConfig(
     if (trimmed && !/^https?:\/\//.test(trimmed)) {
       return { ok: false, field: "pansouBaseUrl", message: "baseURL 需以 http(s):// 开头" };
     }
+    if (trimmed) {
+      // 与设置页同一条规矩:存之前真打一次,打不通/不是 PanSou 就不存。
+      // agent 走这条路径改配置时同样不能把一个坏地址写进去。
+      const { probePanSou } = await import("../pansou-probe");
+      const probe = await probePanSou(trimmed);
+      if (!probe.ok) {
+        return { ok: false, field: "pansouBaseUrl", message: probe.message };
+      }
+    }
     await setAccount(PANSOU_BASE_URL_SETTING_KEY, trimmed);
+    // 清空时一并清掉探活结论,免得设置页对着不存在的自建源继续告警。
+    await setAccount(PANSOU_HEALTH_SETTING_KEY, trimmed ? "ok" : "");
     updated.push("pansouBaseUrl");
   }
 

--- a/apps/web/lib/agent-api/config-io.ts
+++ b/apps/web/lib/agent-api/config-io.ts
@@ -196,13 +196,16 @@ export async function writeAgentConfig(
 
   if (input.pansouBaseUrl !== undefined) {
     const trimmed = input.pansouBaseUrl.trim();
-    if (trimmed && !/^https?:\/\//.test(trimmed)) {
-      return { ok: false, field: "pansouBaseUrl", message: "baseURL 需以 http(s):// 开头" };
-    }
     if (trimmed) {
+      // 格式校验与设置页共用同一 helper(validatePanSouBaseUrlFormat),免得两条
+      // 入口的校验与文案再次漂移(Copilot 评审)。
+      const { probePanSou, validatePanSouBaseUrlFormat } = await import("../pansou-probe");
+      const format = validatePanSouBaseUrlFormat(trimmed);
+      if (!format.ok) {
+        return { ok: false, field: "pansouBaseUrl", message: format.message };
+      }
       // 与设置页同一条规矩:存之前真打一次,打不通/不是 PanSou 就不存。
       // agent 走这条路径改配置时同样不能把一个坏地址写进去。
-      const { probePanSou } = await import("../pansou-probe");
       const probe = await probePanSou(trimmed);
       if (!probe.ok) {
         return { ok: false, field: "pansouBaseUrl", message: probe.message };

--- a/apps/web/lib/pansou-chain.test.ts
+++ b/apps/web/lib/pansou-chain.test.ts
@@ -1,6 +1,25 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { FallbackResourceProvider, PanSouResourceProvider } from "@media-track/workflow";
-import { buildPanSouProviderChain, DEFAULT_PANSOU_BASE_URL, resolveUserPanSouBaseUrl } from "./pansou-chain";
+import {
+  buildPanSouProviderChain,
+  observeHealth,
+  DEFAULT_PANSOU_BASE_URL,
+  resolveUserPanSouBaseUrl,
+} from "./pansou-chain";
+
+const healthySnapshot = {
+  id: "s1",
+  provider: "pansou",
+  keyword: "k",
+  candidates: [],
+  createdAt: "2026-08-06T00:00:00.000Z",
+  sourceHealth: { status: "healthy" as const, unhealthySources: [] },
+};
+
+let seen: boolean[] = [];
+beforeEach(() => {
+  seen = [];
+});
 
 describe("buildPanSouProviderChain", () => {
   it("returns a bare PanSou provider when the user configured no custom source", () => {
@@ -48,5 +67,68 @@ describe("resolveUserPanSouBaseUrl", () => {
 
   it("returns empty when neither tier is configured", () => {
     expect(resolveUserPanSouBaseUrl(null, {})).toBe("");
+  });
+});
+
+describe("observeHealth（告警能否在生产触发的唯一信号来源）", () => {
+  it("答话且健康 → 报 healthy=true，快照原样返回", async () => {
+    const wrapped = observeHealth(
+      { search: async () => healthySnapshot },
+      (healthy) => seen.push(healthy),
+    );
+
+    const out = await wrapped.search({ keyword: "k" });
+
+    expect(seen).toEqual([true]);
+    expect(out).toBe(healthySnapshot);
+  });
+
+  it("自报 unreachable → 报 healthy=false", async () => {
+    // 保存时探活只会写 "ok"，而事故正是「保存时好的、之后才挂」——
+    // 没有这条回写，设置页告警在生产中永远不会亮（Copilot 评审指出）。
+    const wrapped = observeHealth(
+      {
+        search: async () => ({
+          ...healthySnapshot,
+          sourceHealth: { status: "unreachable" as const, unhealthySources: ["自建搜索源"] },
+        }),
+      },
+      (healthy) => seen.push(healthy),
+    );
+
+    await wrapped.search({ keyword: "k" });
+
+    expect(seen).toEqual([false]);
+  });
+
+  it("degraded 仍算可用（确实答了话）", async () => {
+    const wrapped = observeHealth(
+      {
+        search: async () => ({
+          ...healthySnapshot,
+          sourceHealth: { status: "degraded" as const, unhealthySources: ["prowlarr"] },
+        }),
+      },
+      (healthy) => seen.push(healthy),
+    );
+
+    await wrapped.search({ keyword: "k" });
+
+    expect(seen).toEqual([true]);
+  });
+
+  it("抛错 → 报 false，且异常原样重抛（fallback 层要靠它分类病因）", async () => {
+    const boom = new Error("connect ECONNREFUSED");
+    const wrapped = observeHealth(
+      {
+        search: async () => {
+          throw boom;
+        },
+      },
+      (healthy) => seen.push(healthy),
+    );
+
+    await expect(wrapped.search({ keyword: "k" })).rejects.toBe(boom);
+    expect(seen).toEqual([false]);
   });
 });

--- a/apps/web/lib/pansou-chain.test.ts
+++ b/apps/web/lib/pansou-chain.test.ts
@@ -3,6 +3,7 @@ import { FallbackResourceProvider, PanSouResourceProvider } from "@media-track/w
 import {
   buildPanSouProviderChain,
   observeHealth,
+  normalizePanSouBaseUrl,
   DEFAULT_PANSOU_BASE_URL,
   resolveUserPanSouBaseUrl,
 } from "./pansou-chain";
@@ -38,6 +39,17 @@ describe("buildPanSouProviderChain", () => {
   it("ignores surrounding whitespace when comparing against the official source", () => {
     expect(
       buildPanSouProviderChain({ userBaseURL: `  ${DEFAULT_PANSOU_BASE_URL}  `, allowedTypes: [] }),
+    ).toBeInstanceOf(PanSouResourceProvider);
+  });
+
+  it("treats the official URL WITH a trailing slash as official, not custom", () => {
+    // 尾随斜杠很常见。字符串直比会误判成自建源,于是白包一层 fallback:失败时
+    // 跑两遍、还把结果标 degraded(Copilot suppressed 意见)。
+    expect(
+      buildPanSouProviderChain({ userBaseURL: `${DEFAULT_PANSOU_BASE_URL}/`, allowedTypes: [] }),
+    ).toBeInstanceOf(PanSouResourceProvider);
+    expect(
+      buildPanSouProviderChain({ userBaseURL: `${DEFAULT_PANSOU_BASE_URL}//`, allowedTypes: [] }),
     ).toBeInstanceOf(PanSouResourceProvider);
   });
 
@@ -130,5 +142,19 @@ describe("observeHealth（告警能否在生产触发的唯一信号来源）", 
 
     await expect(wrapped.search({ keyword: "k" })).rejects.toBe(boom);
     expect(seen).toEqual([false]);
+  });
+});
+
+describe("normalizePanSouBaseUrl", () => {
+  it("使带/不带尾随斜杠的同一地址判为同一个源", () => {
+    expect(normalizePanSouBaseUrl("https://x/")).toBe("https://x");
+    expect(normalizePanSouBaseUrl("  https://x//  ")).toBe("https://x");
+    expect(normalizePanSouBaseUrl("https://x")).toBe("https://x");
+  });
+
+  it("空/未配返回空串（hasCustom 要靠它区分）", () => {
+    expect(normalizePanSouBaseUrl("")).toBe("");
+    expect(normalizePanSouBaseUrl(null)).toBe("");
+    expect(normalizePanSouBaseUrl(undefined)).toBe("");
   });
 });

--- a/apps/web/lib/pansou-chain.test.ts
+++ b/apps/web/lib/pansou-chain.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { FallbackResourceProvider, PanSouResourceProvider } from "@media-track/workflow";
+import { buildPanSouProviderChain, DEFAULT_PANSOU_BASE_URL, resolveUserPanSouBaseUrl } from "./pansou-chain";
+
+describe("buildPanSouProviderChain", () => {
+  it("returns a bare PanSou provider when the user configured no custom source", () => {
+    expect(buildPanSouProviderChain({ userBaseURL: "", allowedTypes: [] })).toBeInstanceOf(
+      PanSouResourceProvider,
+    );
+  });
+
+  it("returns a bare PanSou provider when the user's source IS the official one", () => {
+    // Nothing to fall back TO — wrapping would just double every failed search.
+    expect(
+      buildPanSouProviderChain({ userBaseURL: DEFAULT_PANSOU_BASE_URL, allowedTypes: [] }),
+    ).toBeInstanceOf(PanSouResourceProvider);
+  });
+
+  it("ignores surrounding whitespace when comparing against the official source", () => {
+    expect(
+      buildPanSouProviderChain({ userBaseURL: `  ${DEFAULT_PANSOU_BASE_URL}  `, allowedTypes: [] }),
+    ).toBeInstanceOf(PanSouResourceProvider);
+  });
+
+  it("wraps user + official in a fallback chain when a custom source is configured", () => {
+    expect(
+      buildPanSouProviderChain({ userBaseURL: "http://192.168.1.10:8899", allowedTypes: [] }),
+    ).toBeInstanceOf(FallbackResourceProvider);
+  });
+});
+
+/** 这些用例守的是一个「测试抓不到、只有生产会疼」的回归：装配链若只读 DB 一层，
+ *  compose 自带的 pansou 容器（只经 env PANSOU_BASE_URL 注入，DB 为空）会被
+ *  静默换成官方公共源。getPanSouBaseUrl 的既有测试仍然全绿 —— 因为那个函数没被
+ *  改坏，只是在真正的检索路径上被绕过了。 */
+describe("resolveUserPanSouBaseUrl", () => {
+  it("prefers the DB setting over env", () => {
+    expect(
+      resolveUserPanSouBaseUrl(" http://db.example ", { PANSOU_BASE_URL: "http://env.example" }),
+    ).toBe("http://db.example");
+  });
+
+  it("keeps the env tier when the DB setting is blank (compose 自带 pansou 走这条)", () => {
+    expect(resolveUserPanSouBaseUrl(null, { PANSOU_BASE_URL: " http://pansou " })).toBe(
+      "http://pansou",
+    );
+  });
+
+  it("returns empty when neither tier is configured", () => {
+    expect(resolveUserPanSouBaseUrl(null, {})).toBe("");
+  });
+});

--- a/apps/web/lib/pansou-chain.ts
+++ b/apps/web/lib/pansou-chain.ts
@@ -1,0 +1,60 @@
+import {
+  FallbackResourceProvider,
+  PanSouResourceProvider,
+  type ResourceProvider,
+  type ResourceType,
+} from "@media-track/workflow";
+
+/** 官方公共 PanSou。用户留空时的默认，也是自建源挂掉时的退路。 */
+export const DEFAULT_PANSOU_BASE_URL = "https://so.252035.xyz";
+
+/**
+ * 解析「用户自己的源」：DB 设置 > env PANSOU_BASE_URL > 空。
+ *
+ * env 这一层不能省。compose 用 `PANSOU_BASE_URL: http://pansou` 把自带容器注进来，
+ * 而 DB 设置是空的；只读 DB 会让每个自部署实例悄悄改用官方公共源 —— 既没了自带
+ * 容器，也没了 fallback 兜底，正是本 PR 要消灭的那类静默降级。
+ *
+ * 注意与 getPanSouBaseUrl 的分工：那个函数把三层压成「最终用哪个地址」，这里要的是
+ * 「用户到底配没配」—— 空串与官方地址必须可区分，否则 hasCustom 判不出来。
+ */
+export function resolveUserPanSouBaseUrl(
+  dbValue: string | null | undefined,
+  env: Record<string, string | undefined> = process.env,
+): string {
+  return dbValue?.trim() || env.PANSOU_BASE_URL?.trim() || "";
+}
+
+/**
+ * 装配 PanSou 检索链。抽成纯函数是为了让「什么时候该包 fallback」可以被单测
+ * —— 这个判断以前埋在 getWorkerResourceProvider 里，测不到。
+ *
+ * 只有用户配了**自己的**源才需要 fallback：没配（或配的就是官方源）时无处可退，
+ * 包一层只会让每次失败白跑两遍。
+ */
+export function buildPanSouProviderChain(input: {
+  userBaseURL: string;
+  allowedTypes: ResourceType[];
+}): ResourceProvider {
+  const user = input.userBaseURL.trim();
+  const hasCustom = user !== "" && user !== DEFAULT_PANSOU_BASE_URL;
+  if (!hasCustom) {
+    return new PanSouResourceProvider({
+      baseURL: user || DEFAULT_PANSOU_BASE_URL,
+      allowedTypes: input.allowedTypes,
+    });
+  }
+  return new FallbackResourceProvider({
+    primary: {
+      name: "自建搜索源",
+      provider: new PanSouResourceProvider({ baseURL: user, allowedTypes: input.allowedTypes }),
+    },
+    secondary: {
+      name: "官方搜索源",
+      provider: new PanSouResourceProvider({
+        baseURL: DEFAULT_PANSOU_BASE_URL,
+        allowedTypes: input.allowedTypes,
+      }),
+    },
+  });
+}

--- a/apps/web/lib/pansou-chain.ts
+++ b/apps/web/lib/pansou-chain.ts
@@ -35,6 +35,13 @@ export function resolveUserPanSouBaseUrl(
 export function buildPanSouProviderChain(input: {
   userBaseURL: string;
   allowedTypes: ResourceType[];
+  /** 每次搜索后把「自建源这次行不行」记下来。设置页徽章每 8s 轮询,绝不能在那条
+   *  路径上真打网络,所以只能由真实搜索顺手回写。
+   *
+   *  没有这个回调,告警在生产中永远不会触发 —— 保存时探活只会写 "ok",而
+   *  **本次事故正是「保存时是好的、之后才挂」**:源工作了一段时间、然后死了
+   *  6 天,而没有任何一条路径会把那个失败记下来。Copilot 评审指出了这一点。 */
+  onSourceHealth?: (healthy: boolean) => void;
 }): ResourceProvider {
   const user = input.userBaseURL.trim();
   const hasCustom = user !== "" && user !== DEFAULT_PANSOU_BASE_URL;
@@ -44,10 +51,13 @@ export function buildPanSouProviderChain(input: {
       allowedTypes: input.allowedTypes,
     });
   }
+  const primary = new PanSouResourceProvider({ baseURL: user, allowedTypes: input.allowedTypes });
   return new FallbackResourceProvider({
     primary: {
       name: "自建搜索源",
-      provider: new PanSouResourceProvider({ baseURL: user, allowedTypes: input.allowedTypes }),
+      provider: input.onSourceHealth
+        ? observeHealth(primary, input.onSourceHealth)
+        : primary,
     },
     secondary: {
       name: "官方搜索源",
@@ -57,4 +67,28 @@ export function buildPanSouProviderChain(input: {
       }),
     },
   });
+}
+
+/**
+ * 包一层只做一件事:把主源这次搜索的健康结论回报出去,不改变任何行为。
+ * 导出仅为可测:这是「告警能否在生产触发」的唯一信号来源,必须被直接钉住。
+ * 抛出的异常原样重抛(fallback 层需要看到它来分类病因),绝不吞。
+ */
+export function observeHealth(
+  provider: ResourceProvider,
+  report: (healthy: boolean) => void,
+): ResourceProvider {
+  return {
+    search: async (searchInput) => {
+      try {
+        const snapshot = await provider.search(searchInput);
+        const status = snapshot.sourceHealth?.status ?? "healthy";
+        report(status === "healthy" || status === "degraded");
+        return snapshot;
+      } catch (error) {
+        report(false);
+        throw error; // 原样重抛:上层 fallback 要靠它分类 unreachable / protocol_error
+      }
+    },
+  };
 }

--- a/apps/web/lib/pansou-chain.ts
+++ b/apps/web/lib/pansou-chain.ts
@@ -5,6 +5,11 @@ import {
   type ResourceType,
 } from "@media-track/workflow";
 
+/** 去掉首尾空白与尾随斜杠,使 `https://x` 与 `https://x/` 判为同一个源。 */
+export function normalizePanSouBaseUrl(baseURL: string | null | undefined): string {
+  return (baseURL ?? "").trim().replace(/\/+$/, "");
+}
+
 /** 官方公共 PanSou。用户留空时的默认，也是自建源挂掉时的退路。 */
 export const DEFAULT_PANSOU_BASE_URL = "https://so.252035.xyz";
 
@@ -43,7 +48,9 @@ export function buildPanSouProviderChain(input: {
    *  6 天,而没有任何一条路径会把那个失败记下来。Copilot 评审指出了这一点。 */
   onSourceHealth?: (healthy: boolean) => void;
 }): ResourceProvider {
-  const user = input.userBaseURL.trim();
+  // 归一化后再比:用户把官方地址填成带尾斜杠的 `.../`(很常见)时,字符串直比会
+  // 误判成「自建源」,于是白包一层 fallback —— 失败时跑两遍、还把结果标 degraded。
+  const user = normalizePanSouBaseUrl(input.userBaseURL);
   const hasCustom = user !== "" && user !== DEFAULT_PANSOU_BASE_URL;
   if (!hasCustom) {
     return new PanSouResourceProvider({

--- a/apps/web/lib/pansou-probe.test.ts
+++ b/apps/web/lib/pansou-probe.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { probePanSou } from "./pansou-probe";
+
+/** PanSou 正常响应的最小形状:data.results 是数组。探活只看形状,不看命中。 */
+function pansouResponse(body: unknown = { data: { results: [] } }, status = 200): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+}
+
+describe("probePanSou", () => {
+  it("accepts a PanSou-shaped 200", async () => {
+    const result = await probePanSou("http://192.168.1.10:8899", {
+      fetchImpl: pansouResponse({ data: { results: [{ title: "x" }] } }),
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("POSTs to /api/search on the given base URL, tolerating a trailing slash", async () => {
+    let seenUrl = "";
+    let seenMethod = "";
+    const result = await probePanSou("http://192.168.1.10:8899/", {
+      fetchImpl: (async (url: string, init: RequestInit) => {
+        seenUrl = url;
+        seenMethod = init.method ?? "";
+        return new Response(JSON.stringify({ data: { results: [] } }), { status: 200 });
+      }) as unknown as typeof fetch,
+    });
+    expect(seenUrl).toBe("http://192.168.1.10:8899/api/search");
+    expect(seenMethod).toBe("POST");
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports unreachable when the connection is refused", async () => {
+    const result = await probePanSou("http://192.168.1.10:8899", {
+      fetchImpl: (async () => {
+        throw Object.assign(new Error("fetch failed"), { code: "ECONNREFUSED" });
+      }) as unknown as typeof fetch,
+    });
+    expect(result).toMatchObject({ ok: false, reason: "unreachable" });
+  });
+
+  it("reports not_pansou when the address answers with something else (e.g. HTML)", async () => {
+    // 这是「填成了别的服务」的真实形态:能连上、200,但不是 PanSou 接口。
+    const result = await probePanSou("http://192.168.1.10:8899", {
+      fetchImpl: (async () =>
+        new Response("<!doctype html><html><body>nginx</body></html>", {
+          status: 200,
+          headers: { "Content-Type": "text/html" },
+        })) as unknown as typeof fetch,
+    });
+    expect(result).toMatchObject({ ok: false, reason: "not_pansou" });
+  });
+
+  it("reports not_pansou when JSON parses but lacks data.results", async () => {
+    const result = await probePanSou("http://192.168.1.10:8899", {
+      fetchImpl: pansouResponse({ data: { total: 0 } }),
+    });
+    expect(result).toMatchObject({ ok: false, reason: "not_pansou" });
+  });
+
+  it("reports http_error on a 502", async () => {
+    const result = await probePanSou("http://192.168.1.10:8899", {
+      fetchImpl: pansouResponse({ data: { results: [] } }, 502),
+    });
+    expect(result).toMatchObject({ ok: false, reason: "http_error" });
+    if (!result.ok) expect(result.message).toContain("502");
+  });
+
+  it("gives every failure a non-empty human-readable message", async () => {
+    // 保存被拒时用户必须知道「为什么」——这正是原事故里缺失的那句话。
+    const failures = await Promise.all([
+      probePanSou("http://x", {
+        fetchImpl: (async () => {
+          throw new Error("boom");
+        }) as unknown as typeof fetch,
+      }),
+      probePanSou("http://x", { fetchImpl: pansouResponse({ nope: true }) }),
+      probePanSou("http://x", { fetchImpl: pansouResponse({ data: { results: [] } }, 502) }),
+    ]);
+    for (const failure of failures) {
+      expect(failure.ok).toBe(false);
+      if (!failure.ok) {
+        expect(failure.message.trim().length).toBeGreaterThan(0);
+        expect(failure.message).toContain("未保存");
+      }
+    }
+  });
+});

--- a/apps/web/lib/pansou-probe.test.ts
+++ b/apps/web/lib/pansou-probe.test.ts
@@ -106,3 +106,27 @@ describe("validatePanSouBaseUrlFormat", () => {
     expect(validatePanSouBaseUrlFormat("  http://pansou:8899  ").ok).toBe(true);
   });
 });
+
+describe("probePanSou timeout classification", () => {
+  it("把 TimeoutError 归成超时而非泛泛的连不上", async () => {
+    // AbortSignal.timeout 到期时 fetch 抛 TimeoutError(见 remote-access.test.ts)。
+    // 若只认 AbortError,用户会拿到「请检查地址端口」而非「超时了」。
+    const r = await probePanSou("http://slow.test", {
+      fetchImpl: async () => {
+        throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain("无响应");
+  });
+
+  it("仍认 AbortError(手动 abort 的旧路径)", async () => {
+    const r = await probePanSou("http://slow.test", {
+      fetchImpl: async () => {
+        throw new DOMException("aborted", "AbortError");
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain("无响应");
+  });
+});

--- a/apps/web/lib/pansou-probe.test.ts
+++ b/apps/web/lib/pansou-probe.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { probePanSou } from "./pansou-probe";
+import { probePanSou, validatePanSouBaseUrlFormat } from "./pansou-probe";
 
 /** PanSou 正常响应的最小形状:data.results 是数组。探活只看形状,不看命中。 */
 function pansouResponse(body: unknown = { data: { results: [] } }, status = 200): typeof fetch {
@@ -87,5 +87,22 @@ describe("probePanSou", () => {
         expect(failure.message).toContain("未保存");
       }
     }
+  });
+});
+
+describe("validatePanSouBaseUrlFormat", () => {
+  it("拒绝漏写 scheme 的地址（否则要白等 8s 探活才拿到含糊回复）", () => {
+    const r = validatePanSouBaseUrlFormat("localhost:8899");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain("http://");
+  });
+
+  it("接受 http 与 https", () => {
+    expect(validatePanSouBaseUrlFormat("http://pansou:8899").ok).toBe(true);
+    expect(validatePanSouBaseUrlFormat("https://so.example.com").ok).toBe(true);
+  });
+
+  it("容忍首尾空白", () => {
+    expect(validatePanSouBaseUrlFormat("  http://pansou:8899  ").ok).toBe(true);
   });
 });

--- a/apps/web/lib/pansou-probe.ts
+++ b/apps/web/lib/pansou-probe.ts
@@ -50,7 +50,12 @@ export async function probePanSou(
     }
     return { ok: true };
   } catch (error) {
-    const aborted = error instanceof Error && error.name === "AbortError";
+    // AbortSignal.timeout 到期时 fetch 抛的是 TimeoutError(仓库既有测试
+    // remote-access.test.ts 断言的就是这个),不是 AbortError。两个都认,
+    // 否则超时会被误归成「连不上」的泛泛提示。
+    const aborted =
+      error instanceof Error &&
+      (error.name === "TimeoutError" || error.name === "AbortError");
     return {
       ok: false,
       reason: "unreachable",

--- a/apps/web/lib/pansou-probe.ts
+++ b/apps/web/lib/pansou-probe.ts
@@ -18,16 +18,17 @@ export async function probePanSou(
   options: { fetchImpl?: typeof fetch } = {},
 ): Promise<PanSouProbeResult> {
   const fetchImpl = options.fetchImpl ?? fetch;
-  const url = `${baseURL.replace(/\/+$/, "")}/api/search`;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  // trim 后再拼:首尾空白会拼出非法请求地址。
+  const url = `${baseURL.trim().replace(/\/+$/, "")}/api/search`;
   try {
     const response = await fetchImpl(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       // 探活用一个无意义关键词：命中与否不重要，响应形状才重要。
       body: JSON.stringify({ kw: "__probe__", res: "all" }),
-      signal: controller.signal,
+      // 与仓库其余处一致(fetch-with-timeout.ts / remote-access-probe.ts):
+      // 用 AbortSignal.timeout 而不是手搓 controller + setTimeout。
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
     if (!response.ok) {
       return {
@@ -57,8 +58,6 @@ export async function probePanSou(
         ? `搜索源 ${PROBE_TIMEOUT_MS / 1000} 秒内无响应，未保存；若想先跑起来，清空本项即可回落官方源。`
         : "连不上该搜索源，未保存。请检查地址、端口与容器是否在运行；若想先跑起来，清空本项即可回落官方源。",
     };
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/apps/web/lib/pansou-probe.ts
+++ b/apps/web/lib/pansou-probe.ts
@@ -54,8 +54,8 @@ export async function probePanSou(
       ok: false,
       reason: "unreachable",
       message: aborted
-        ? `搜索源 ${PROBE_TIMEOUT_MS / 1000} 秒内无响应，未保存。`
-        : "连不上该搜索源，未保存。请检查地址、端口与容器是否在运行。",
+        ? `搜索源 ${PROBE_TIMEOUT_MS / 1000} 秒内无响应，未保存；若想先跑起来，清空本项即可回落官方源。`
+        : "连不上该搜索源，未保存。请检查地址、端口与容器是否在运行；若想先跑起来，清空本项即可回落官方源。",
     };
   } finally {
     clearTimeout(timer);

--- a/apps/web/lib/pansou-probe.ts
+++ b/apps/web/lib/pansou-probe.ts
@@ -68,3 +68,12 @@ function isPanSouShaped(payload: unknown): boolean {
   if (typeof data !== "object" || data === null) return false;
   return Array.isArray((data as { results?: unknown }).results);
 }
+
+/** 保存前的便宜格式校验。抽出来是为了两个保存入口(设置页 action / agent API)共用
+ *  同一条规则并能被直接单测 —— 少了它,一个漏写 scheme 的地址会花 8s 探活然后
+ *  拿到「连不上」这种含糊回复,而真正的问题是格式(Copilot 评审指出两侧不一致)。 */
+export function validatePanSouBaseUrlFormat(baseURL: string): { ok: true } | { ok: false; message: string } {
+  return /^https?:\/\//.test(baseURL.trim())
+    ? { ok: true }
+    : { ok: false, message: "地址需以 http:// 或 https:// 开头，未保存。" };
+}

--- a/apps/web/lib/pansou-probe.ts
+++ b/apps/web/lib/pansou-probe.ts
@@ -1,0 +1,70 @@
+/**
+ * 保存自建搜索源地址时的一次性探活。用户此前只被校验 `^https?://`，于是一个
+ * 打不通的地址（或一个根本不是 PanSou 的服务）会被欣然保存，之后每一次获取
+ * 都静默失败，还报成「未找到资源」——真实案例里这样活了 6 天。
+ *
+ * 只在**保存**时打这一次网络。设置页徽章每 8s 轮询一次，绝不能在那条路径上探活。
+ */
+export type PanSouProbeFailure = "unreachable" | "not_pansou" | "http_error";
+
+export type PanSouProbeResult =
+  | { ok: true }
+  | { ok: false; reason: PanSouProbeFailure; message: string };
+
+const PROBE_TIMEOUT_MS = 8000;
+
+export async function probePanSou(
+  baseURL: string,
+  options: { fetchImpl?: typeof fetch } = {},
+): Promise<PanSouProbeResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const url = `${baseURL.replace(/\/+$/, "")}/api/search`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      // 探活用一个无意义关键词：命中与否不重要，响应形状才重要。
+      body: JSON.stringify({ kw: "__probe__", res: "all" }),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return {
+        ok: false,
+        reason: "http_error",
+        message: `搜索源返回 HTTP ${response.status}，未保存。`,
+      };
+    }
+    // 非 JSON（nginx 欢迎页之类）在这里变成 null，随后被判为 not_pansou。
+    // 这不是「吞掉错误」：解析失败本身就是「这不是 PanSou」的证据，
+    // 而它会带着可读原因回给用户，不会消失。
+    const payload: unknown = await response.json().catch(() => null);
+    if (!isPanSouShaped(payload)) {
+      return {
+        ok: false,
+        reason: "not_pansou",
+        message: "该地址能访问，但返回的不是 PanSou 接口格式（是不是填成了别的服务？），未保存。",
+      };
+    }
+    return { ok: true };
+  } catch (error) {
+    const aborted = error instanceof Error && error.name === "AbortError";
+    return {
+      ok: false,
+      reason: "unreachable",
+      message: aborted
+        ? `搜索源 ${PROBE_TIMEOUT_MS / 1000} 秒内无响应，未保存。`
+        : "连不上该搜索源，未保存。请检查地址、端口与容器是否在运行。",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function isPanSouShaped(payload: unknown): boolean {
+  if (typeof payload !== "object" || payload === null) return false;
+  const data = (payload as { data?: unknown }).data;
+  if (typeof data !== "object" || data === null) return false;
+  return Array.isArray((data as { results?: unknown }).results);
+}

--- a/apps/web/lib/settings-attention-server.test.ts
+++ b/apps/web/lib/settings-attention-server.test.ts
@@ -247,7 +247,8 @@ describe("loadSettingsAttentionSummary — per-account state", () => {
     expect(summary.items.map((i) => i.kind)).not.toContain("search_source_unreachable");
   });
 
-  it("demo mode returns empty without touching the repository", async () => {    (isDemoMode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+  it("demo mode returns empty without touching the repository", async () => {
+    (isDemoMode as ReturnType<typeof vi.fn>).mockReturnValue(true);
     const { repository } = makeRepository([{ id: "cs1", provider: "quark", label: null, status: "frozen" }]);
     const summary = await loadSettingsAttentionSummary({ origin: "https://o.example" });
     expect(summary).toEqual({ count: 0, severity: null, items: [] });

--- a/apps/web/lib/settings-attention-server.test.ts
+++ b/apps/web/lib/settings-attention-server.test.ts
@@ -8,6 +8,8 @@ vi.mock("./workflow-runtime", () => ({
   getLlmConfig: vi.fn(async () => ({ baseURL: "https://llm.example", modelId: "m" })),
   getWorkflowRepository: vi.fn(),
   isMultiUserEnabled: vi.fn(() => false),
+  PANSOU_BASE_URL_SETTING_KEY: "pansou_base_url",
+  PANSOU_HEALTH_SETTING_KEY: "pansou_last_probe",
   UNAUTHENTICATED_ACCOUNT_ID: "acct_unauthenticated",
 }));
 
@@ -19,6 +21,7 @@ import {
   markSettingsAttentionSeen,
 } from "./settings-attention-server";
 import {
+  getAccountScopedSettings,
   getCurrentAccountId,
   getLlmConfig,
   getWorkflowRepository,
@@ -67,6 +70,10 @@ beforeEach(() => {
   });
   (loadDeploymentUpdateState as ReturnType<typeof vi.fn>).mockResolvedValue(null);
   (isMultiUserEnabled as ReturnType<typeof vi.fn>).mockReturnValue(false);
+  // clearAllMocks 会连声明处的实现一起清掉,这里补回默认值:没配自建搜索源。
+  (getAccountScopedSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+    getSetting: async () => null,
+  });
 });
 
 describe("loadSettingsAttentionSummary — per-account state", () => {
@@ -195,8 +202,50 @@ describe("loadSettingsAttentionSummary — per-account state", () => {
     expect(repository.setAccountSetting).not.toHaveBeenCalled();
   });
 
-  it("demo mode returns empty without touching the repository", async () => {
-    (isDemoMode as ReturnType<typeof vi.fn>).mockReturnValue(true);
+  /** 自建搜索源告警的数据来源必须是**存下来的**探活结论,不能现打网络:
+   *  这个函数在徽章轮询路径上,每 8s 跑一次。 */
+  it("warns from the STORED probe verdict, without probing the network", async () => {
+    const settings = new Map<string, string>([
+      ["pansou_base_url", "http://192.168.1.10:8899"],
+      ["pansou_last_probe", "unreachable"],
+    ]);
+    (getAccountScopedSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      getSetting: async (key: string) => settings.get(key) ?? null,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    makeRepository([]);
+
+    const summary = await loadSettingsAttentionSummary({ origin: "https://o.example" });
+
+    expect(summary.items.map((i) => i.kind)).toContain("search_source_unreachable");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("stays quiet when the stored verdict is ok", async () => {
+    const settings = new Map<string, string>([
+      ["pansou_base_url", "http://192.168.1.10:8899"],
+      ["pansou_last_probe", "ok"],
+    ]);
+    (getAccountScopedSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      getSetting: async (key: string) => settings.get(key) ?? null,
+    });
+    makeRepository([]);
+    const summary = await loadSettingsAttentionSummary({ origin: "https://o.example" });
+    expect(summary.items.map((i) => i.kind)).not.toContain("search_source_unreachable");
+  });
+
+  it("stays quiet for a custom source that has never been probed (老用户不该被假警报打扰)", async () => {
+    const settings = new Map<string, string>([["pansou_base_url", "http://192.168.1.10:8899"]]);
+    (getAccountScopedSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      getSetting: async (key: string) => settings.get(key) ?? null,
+    });
+    makeRepository([]);
+    const summary = await loadSettingsAttentionSummary({ origin: "https://o.example" });
+    expect(summary.items.map((i) => i.kind)).not.toContain("search_source_unreachable");
+  });
+
+  it("demo mode returns empty without touching the repository", async () => {    (isDemoMode as ReturnType<typeof vi.fn>).mockReturnValue(true);
     const { repository } = makeRepository([{ id: "cs1", provider: "quark", label: null, status: "frozen" }]);
     const summary = await loadSettingsAttentionSummary({ origin: "https://o.example" });
     expect(summary).toEqual({ count: 0, severity: null, items: [] });

--- a/apps/web/lib/settings-attention-server.test.ts
+++ b/apps/web/lib/settings-attention-server.test.ts
@@ -207,7 +207,9 @@ describe("loadSettingsAttentionSummary — per-account state", () => {
   it("warns from the STORED probe verdict, without probing the network", async () => {
     const settings = new Map<string, string>([
       ["pansou_base_url", "http://192.168.1.10:8899"],
-      ["pansou_last_probe", "unreachable"],
+      // 真实合约只有 "ok" | "unhealthy" | ""(workflow-runtime.ts);"unreachable"
+      // 不是写入方会存的值。用真值让测试与生产行为对齐,免得将来收紧校验时碎掉。
+      ["pansou_last_probe", "unhealthy"],
     ]);
     (getAccountScopedSettings as ReturnType<typeof vi.fn>).mockReturnValue({
       getSetting: async (key: string) => settings.get(key) ?? null,

--- a/apps/web/lib/settings-attention-server.test.ts
+++ b/apps/web/lib/settings-attention-server.test.ts
@@ -204,6 +204,23 @@ describe("loadSettingsAttentionSummary — per-account state", () => {
 
   /** 自建搜索源告警的数据来源必须是**存下来的**探活结论,不能现打网络:
    *  这个函数在徽章轮询路径上,每 8s 跑一次。 */
+  it("warns for an env-injected source even when the DB setting is empty", async () => {
+    // compose 用 PANSOU_BASE_URL 注入自带容器,DB 是空的。只看 DB 会把 env-only
+    // 场景误判成未配置,于是 recordPanSouHealth 写了 unhealthy、徽章却不亮。
+    const settings = new Map<string, string>([
+      // 注意:pansou_base_url 留空(env 注入场景),只有健康结论被写下。
+      ["pansou_last_probe", "unhealthy"],
+    ]);
+    (getAccountScopedSettings as ReturnType<typeof vi.fn>).mockReturnValue({
+      getSetting: async (key: string) => settings.get(key) ?? null,
+    });
+
+    const summary = await loadSettingsAttentionSummary();
+
+    const item = summary.items.find((i) => i.kind === "search_source_unreachable");
+    expect(item).toBeDefined();
+  });
+
   it("warns from the STORED probe verdict, without probing the network", async () => {
     const settings = new Map<string, string>([
       ["pansou_base_url", "http://192.168.1.10:8899"],

--- a/apps/web/lib/settings-attention-server.ts
+++ b/apps/web/lib/settings-attention-server.ts
@@ -93,8 +93,8 @@ export async function loadSettingsAttentionSummary(options?: {
   ]);
 
   // 自建搜索源:**只读 DB,绝不探活**。这个函数在徽章轮询路径上(每 8s 一次),
-  // 在这里打网络等于每 8s 捶一遍用户的 PanSou。探活只在保存时做一次,结论存在
-  // PANSOU_HEALTH_SETTING_KEY 里,这里读它。
+  // 在这里打网络等于每 8s 捶一遍用户的 PanSou。健康态有两个写入方:保存时探活
+  // 与每次真实搜索后的运行时回写(recordPanSouHealth)。这里只读结论。
   //
   // custom 只认 DB 设置(不含 env PANSOU_BASE_URL):env 配的源从不经过保存探活,
   // reachable 对它没有意义,拿一个从没被探过的源告警只会是假警报。

--- a/apps/web/lib/settings-attention-server.ts
+++ b/apps/web/lib/settings-attention-server.ts
@@ -23,6 +23,8 @@ import {
   getLlmConfig,
   getWorkflowRepository,
   isMultiUserEnabled,
+  PANSOU_BASE_URL_SETTING_KEY,
+  PANSOU_HEALTH_SETTING_KEY,
   UNAUTHENTICATED_ACCOUNT_ID,
 } from "./workflow-runtime";
 
@@ -89,6 +91,22 @@ export async function loadSettingsAttentionSummary(options?: {
     getLlmConfig(getAccountScopedSettings(accountId)),
     resolveIsOwner(repository, accountId),
   ]);
+
+  // 自建搜索源:**只读 DB,绝不探活**。这个函数在徽章轮询路径上(每 8s 一次),
+  // 在这里打网络等于每 8s 捶一遍用户的 PanSou。探活只在保存时做一次,结论存在
+  // PANSOU_HEALTH_SETTING_KEY 里,这里读它。
+  //
+  // custom 只认 DB 设置(不含 env PANSOU_BASE_URL):env 配的源从不经过保存探活,
+  // reachable 对它没有意义,拿一个从没被探过的源告警只会是假警报。
+  const scopedSettings = getAccountScopedSettings(accountId);
+  const [pansouBaseUrl, pansouHealth] = await Promise.all([
+    scopedSettings.getSetting(PANSOU_BASE_URL_SETTING_KEY),
+    scopedSettings.getSetting(PANSOU_HEALTH_SETTING_KEY),
+  ]);
+  const customSearchSource = Boolean(pansouBaseUrl?.trim());
+  // 没有结论时按「可达」处理:这条提醒只在有确凿失败证据时才响。宁可漏报也不
+  // 能对着一个从没探过的源(老用户在本次改动之前保存的)天天报假警。
+  const searchSourceReachable = (pansouHealth?.trim() ?? "") !== "" ? pansouHealth!.trim() === "ok" : true;
   // update_available 只对站主存在（见 buildSettingsAttentionItems 的 isOwner
   // 门控），所以非站主不该付这份代价：两次文件读 + 可能的 GitHub 探测，冷
   // 缓存时最多要等满 5s 超时——而徽章每 8s 轮询一次。
@@ -105,6 +123,7 @@ export async function loadSettingsAttentionSummary(options?: {
     })),
     brandLabel,
     llmConfigured: Boolean(llm.baseURL && llm.modelId),
+    searchSource: { custom: customSearchSource, reachable: searchSourceReachable },
     update,
     origin: options?.origin ?? DEFAULT_LOCAL_ORIGIN,
     ...(workspace.activeStorageId ? { activeStorageId: workspace.activeStorageId } : {}),

--- a/apps/web/lib/settings-attention-server.ts
+++ b/apps/web/lib/settings-attention-server.ts
@@ -103,7 +103,11 @@ export async function loadSettingsAttentionSummary(options?: {
     scopedSettings.getSetting(PANSOU_BASE_URL_SETTING_KEY),
     scopedSettings.getSetting(PANSOU_HEALTH_SETTING_KEY),
   ]);
-  const customSearchSource = Boolean(pansouBaseUrl?.trim());
+  // 判「是否配了自建源」要同时认 DB 与 env 注入:compose 用 PANSOU_BASE_URL 注入
+  // 自带容器,DB 是空的 —— 只看 DB 会把 env-only 场景误判成未配置,于是
+  // recordPanSouHealth 明明写了 unhealthy、徽章却永不亮(Copilot 评审)。
+  // 健康结论本身就是「有一个源在跑」的证据,作为兜底信号。
+  const customSearchSource = Boolean(pansouBaseUrl?.trim() || pansouHealth?.trim());
   // 没有结论时按「可达」处理:这条提醒只在有确凿失败证据时才响。宁可漏报也不
   // 能对着一个从没探过的源(老用户在本次改动之前保存的)天天报假警。
   const searchSourceReachable = (pansouHealth?.trim() ?? "") !== "" ? pansouHealth!.trim() === "ok" : true;

--- a/apps/web/lib/settings-attention.test.ts
+++ b/apps/web/lib/settings-attention.test.ts
@@ -68,8 +68,57 @@ describe("buildSettingsAttentionItems", () => {
     expect(items[0]?.href).toBe("/settings?tab=services");
   });
 
-  it("adds container update as info severity with version-scoped id + origin-threaded prompt", () => {
-    const container = buildSettingsAttentionItems({
+  /** 事故复盘:自建源挂了 6 天,产品从头到尾只说「暂未找到可用资源」。
+   *  Task 5 让检索退到官方源续命,但那恰恰让故障更隐蔽 —— 必须在设置页说出来。 */
+  it("warns when the custom search source is unreachable", () => {
+    const items = buildSettingsAttentionItems({
+      demo: false,
+      isOwner: true,
+      drives: [],
+      brandLabel, origin: ORIGIN,
+      llmConfigured: true,
+      update: null,
+      searchSource: { custom: true, reachable: false },
+    });
+    expect(items.map((i) => i.kind)).toEqual(["search_source_unreachable"]);
+    expect(items[0]?.severity).toBe("warning");
+    expect(items[0]?.href).toBe("/settings?tab=services");
+    // 正文必须交代「还在靠官方源撑着」,否则用户无从判断这条有多急。
+    expect(items[0]?.body).toContain("官方");
+  });
+
+  it("stays quiet when the custom search source is reachable", () => {
+    const items = buildSettingsAttentionItems({
+      demo: false,
+      isOwner: true,
+      drives: [],
+      brandLabel, origin: ORIGIN,
+      llmConfigured: true,
+      update: null,
+      searchSource: { custom: true, reachable: true },
+    });
+    expect(items).toEqual([]);
+  });
+
+  it("stays quiet when there is no custom search source (nothing for the user to fix)", () => {
+    const items = buildSettingsAttentionItems({
+      demo: false,
+      isOwner: true,
+      drives: [],
+      brandLabel, origin: ORIGIN,
+      llmConfigured: true,
+      update: null,
+      searchSource: { custom: false, reachable: false },
+    });
+    expect(items).toEqual([]);
+  });
+
+  it("accepts search_source_unreachable as a dismissible id", () => {
+    // 不加进白名单的话,用户点「不再提示」会被存储层静默丢弃。
+    expect(isAttentionItemId("search_source_unreachable")).toBe(true);
+  });
+
+  it("adds container update as info severity with version-scoped id + origin-threaded prompt", () => {    const container = buildSettingsAttentionItems({
       demo: false,
       isOwner: true,
       drives: [],

--- a/apps/web/lib/settings-attention.test.ts
+++ b/apps/web/lib/settings-attention.test.ts
@@ -118,7 +118,8 @@ describe("buildSettingsAttentionItems", () => {
     expect(isAttentionItemId("search_source_unreachable")).toBe(true);
   });
 
-  it("adds container update as info severity with version-scoped id + origin-threaded prompt", () => {    const container = buildSettingsAttentionItems({
+  it("adds container update as info severity with version-scoped id + origin-threaded prompt", () => {
+    const container = buildSettingsAttentionItems({
       demo: false,
       isOwner: true,
       drives: [],

--- a/apps/web/lib/settings-attention.ts
+++ b/apps/web/lib/settings-attention.ts
@@ -58,9 +58,10 @@ export function buildSettingsAttentionItems(input: {
   }>;
   brandLabel: (provider: string) => string;
   llmConfigured: boolean;
-  /** 自建搜索源状态。`custom` = 用户在设置页填了自己的地址;`reachable` = 上次
-   *  保存时探活的结论(存在 DB 里)。**刻意不在这里探活** —— 这个函数在徽章
-   *  轮询路径上,每 8s 一次,真打网络等于每 8s 捶一遍用户的 PanSou。 */
+  /** 自建搜索源状态。`custom` = 用户在设置页填了自己的地址;`reachable` =
+   *  最新健康态(两个来源:保存时探活 + 每次真实搜索后的运行时回写,见
+   *  recordPanSouHealth)。**刻意不在这里探活** —— 这个函数在徽章轮询路径上,
+   *  每 8s 一次,真打网络等于每 8s 捶一遍用户的 PanSou。 */
   searchSource?: { custom: boolean; reachable: boolean };
   update: Pick<DeploymentUpdateState, "kind" | "behind" | "currentShort" | "latestShort"> | null;
   /** Public request origin — baked into the update prompt's SSH/health-check steps. */

--- a/apps/web/lib/settings-attention.ts
+++ b/apps/web/lib/settings-attention.ts
@@ -3,7 +3,11 @@ import { buildContainerUpgradePrompt } from "./deployment-update";
 import { DEFAULT_SETTINGS_TAB, type SettingsTabId } from "./settings-tabs-model";
 
 export type AttentionSeverity = "info" | "warning" | "blocker";
-export type AttentionKind = "frozen_drive" | "update_available" | "missing_llm";
+export type AttentionKind =
+  | "frozen_drive"
+  | "update_available"
+  | "missing_llm"
+  | "search_source_unreachable";
 export type SettingsAttentionTab = SettingsTabId;
 
 export interface SettingsAttentionItem {
@@ -54,6 +58,10 @@ export function buildSettingsAttentionItems(input: {
   }>;
   brandLabel: (provider: string) => string;
   llmConfigured: boolean;
+  /** 自建搜索源状态。`custom` = 用户在设置页填了自己的地址;`reachable` = 上次
+   *  保存时探活的结论(存在 DB 里)。**刻意不在这里探活** —— 这个函数在徽章
+   *  轮询路径上,每 8s 一次,真打网络等于每 8s 捶一遍用户的 PanSou。 */
+  searchSource?: { custom: boolean; reachable: boolean };
   update: Pick<DeploymentUpdateState, "kind" | "behind" | "currentShort" | "latestShort"> | null;
   /** Public request origin — baked into the update prompt's SSH/health-check steps. */
   origin: string;
@@ -90,6 +98,22 @@ export function buildSettingsAttentionItems(input: {
       title: "还没配置 AI 模型",
       body: "填写 Base URL 和模型名后才能自动搜索与获取。",
       actionLabel: "去填写",
+      href: href("services"),
+    });
+  }
+
+  if (input.searchSource?.custom && !input.searchSource.reachable) {
+    // 只有用户自己配了源才提:没配的人无事可修,提了也只是噪音。
+    // 事故原型:自建源挂了 6 天,产品全程只说「暂未找到可用资源」。现在检索会
+    // 退到官方源续命 —— 这让功能不至于全断,但也让故障更隐蔽,所以必须在这里
+    // 明说,并给出可执行的排查方向(容器/地址/端口)。
+    items.push({
+      id: "search_source_unreachable",
+      kind: "search_source_unreachable",
+      severity: "warning",
+      title: "自建搜索源连不上",
+      body: "已自动改用官方搜索源继续工作，但官方源资源较少，命中率会下降。请检查 PanSou 容器是否在运行、地址与端口是否填对。",
+      actionLabel: "去检查",
       href: href("services"),
     });
   }
@@ -155,9 +179,10 @@ export const ATTENTION_SEEN_AT_KEY = "attention_seen_at";
 export const ATTENTION_DISMISSED_KEY = "attention_dismissed";
 export const ATTENTION_STATE_SINCE_KEY = "attention_state_since";
 
-const ATTENTION_ID_RE = /^(missing_llm|frozen:[A-Za-z0-9_-]{1,64}|update:[0-9a-f]{7,40})$/;
+const ATTENTION_ID_RE =
+  /^(missing_llm|search_source_unreachable|frozen:[A-Za-z0-9_-]{1,64}|update:[0-9a-f]{7,40})$/;
 
-/** Dismiss endpoint allow-list: only the three id shapes the builder can emit. */
+/** Dismiss endpoint allow-list: only the id shapes the builder can emit. */
 export function isAttentionItemId(id: string): boolean {
   return ATTENTION_ID_RE.test(id);
 }

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -912,17 +912,21 @@ function buildAccountContextResolver(): ResolveAccountWorkerContext {
 
 /** 记录自建搜索源的最新健康结论,供设置页徽章读取(它每 8s 轮询,不能自己打网络)。
  *  幂等:值未变化就不写,避免每次搜索都产生一次 DB 写。 */
-let lastRecordedPanSouHealth: string | null = null;
+//  ⚠️ 必须按账号分键:多用户模式下一个进程服务多个账号,不分键会让账号 B 的
+//  结论因为账号 A 刚写过同一个值而被跳过 —— 于是 B 的源挂了却永远不告警,
+//  正是本 PR 要消灭的那种静默。
+const lastRecordedPanSouHealth = new Map<string, string>();
 async function recordPanSouHealth(healthy: boolean): Promise<void> {
   const value = healthy ? "ok" : "unhealthy";
-  if (lastRecordedPanSouHealth === value) return;
   try {
+    const accountId = await getCurrentAccountId();
+    if (lastRecordedPanSouHealth.get(accountId) === value) return;
     await getWorkflowRepository().setAccountSetting(
-      await getCurrentAccountId(),
+      accountId,
       PANSOU_HEALTH_SETTING_KEY,
       value,
     );
-    lastRecordedPanSouHealth = value;
+    lastRecordedPanSouHealth.set(accountId, value);
   } catch (error) {
     // 搜索不能因为一次设置写失败而失败。但不静默:打出来,否则就是本 PR 要修的病。
     console.warn(
@@ -933,7 +937,7 @@ async function recordPanSouHealth(healthy: boolean): Promise<void> {
 
 /** Test-only: 清掉幂等缓存,免得跨用例串味。 */
 export function __resetPanSouHealthCacheForTests(): void {
-  lastRecordedPanSouHealth = null;
+  lastRecordedPanSouHealth.clear();
 }
 
 export async function runNextQueuedWorkflow() {

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1082,6 +1082,10 @@ export function resolveIsDesktop(env: Record<string, string | undefined> = proce
 
 export const PANSOU_BASE_URL_SETTING_KEY = "pansou_base_url";
 
+/** 上次探活结论（"ok" | 失败 reason）。设置页徽章每 8s 轮询一次，绝不能在
+ *  那条路径上真打网络，所以这里存保存时的结论供它读取。 */
+export const PANSOU_HEALTH_SETTING_KEY = "pansou_last_probe";
+
 /** Default public PanSou instance (author-hosted), used when neither the DB
  *  setting nor env overrides it. The compose stack injects PANSOU_BASE_URL to
  *  point at the bundled `pansou` service instead.

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -897,7 +897,7 @@ function buildAccountContextResolver(): ResolveAccountWorkerContext {
     const assrtToken = await getAssrtToken(scoped);
     return {
       storage: await getWorkerStorageExecutor(accountId, connectedStorageId),
-      resourceProvider: await getWorkerResourceProvider(scoped, driveProvider),
+      resourceProvider: await getWorkerResourceProvider(scoped, driveProvider, accountId),
       storageProvider: driveProvider,
       model,
       ...(assrtToken === undefined ? {} : { assrtToken }),
@@ -916,17 +916,20 @@ function buildAccountContextResolver(): ResolveAccountWorkerContext {
 //  结论因为账号 A 刚写过同一个值而被跳过 —— 于是 B 的源挂了却永远不告警,
 //  正是本 PR 要消灭的那种静默。
 const lastRecordedPanSouHealth = new Map<string, string>();
-async function recordPanSouHealth(healthy: boolean): Promise<void> {
+async function recordPanSouHealth(healthy: boolean, accountId?: string): Promise<void> {
   const value = healthy ? "ok" : "unhealthy";
   try {
-    const accountId = await getCurrentAccountId();
-    if (lastRecordedPanSouHealth.get(accountId) === value) return;
+    // 有 request scope(设置页/HTTP)时用请求账号;worker 路径没有 request scope,
+    // 必须用调用方传入的 run 所属账号 —— 否则多用户模式下所有健康结论都记到
+    // acct_default 名下,B 用户永远看不到「自建源连不上」的告警。
+    const resolved = accountId ?? (await getCurrentAccountId());
+    if (lastRecordedPanSouHealth.get(resolved) === value) return;
     await getWorkflowRepository().setAccountSetting(
-      accountId,
+      resolved,
       PANSOU_HEALTH_SETTING_KEY,
       value,
     );
-    lastRecordedPanSouHealth.set(accountId, value);
+    lastRecordedPanSouHealth.set(resolved, value);
   } catch (error) {
     // 搜索不能因为一次设置写失败而失败。但不静默:打出来,否则就是本 PR 要修的病。
     console.warn(
@@ -1718,6 +1721,7 @@ function parseTvCandidateId(candidateId: string): { tmdbId: number; seasonNumber
 async function getWorkerResourceProvider(
   settings: { getSetting(key: string): Promise<string | null> } = getWorkflowRepository(),
   provider: string = "pan115",
+  accountId?: string,
 ): Promise<ResourceProvider> {
   if (process.env.MEDIA_TRACK_WORKFLOW_ADAPTER === "pansou") {
     // Per-brand assembly: a quark drive gets PanSou restricted to quark links and
@@ -1742,7 +1746,7 @@ async function getWorkerResourceProvider(
           // 「保存时好的、之后才挂」。写失败不能影响搜索本身,所以 catch 后
           // 只记日志——但**不静默**,否则又是本 PR 要消灭的那个毛病。
           onSourceHealth: (healthy) => {
-            void recordPanSouHealth(healthy);
+            void recordPanSouHealth(healthy, accountId);
           },
         }),
       },

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1723,6 +1723,11 @@ async function getWorkerResourceProvider(
   provider: string = "pan115",
   accountId?: string,
 ): Promise<ResourceProvider> {
+  // accountId 仅用于健康结论回写(recordPanSouHealth)。多账户场景下,worker 在
+  // claim 后按 run 所属账号重建 provider(resolveWorkerDeps: ctx.resourceProvider
+  // ?? base),走的是 buildAccountContextResolver 那条带 accountId 的路径;这里的
+  // base provider 只在无 resolver(单用户/兜底)时被实际使用,此时 getCurrentAccountId()
+  // 正确地返回 default 账号,所以两处都不丢账号作用域。
   if (process.env.MEDIA_TRACK_WORKFLOW_ADAPTER === "pansou") {
     // Per-brand assembly: a quark drive gets PanSou restricted to quark links and
     // NO Prowlarr (磁力 115-only); a 115 drive gets PanSou(115/magnet) + Prowlarr.

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -910,6 +910,32 @@ function buildAccountContextResolver(): ResolveAccountWorkerContext {
   };
 }
 
+/** 记录自建搜索源的最新健康结论,供设置页徽章读取(它每 8s 轮询,不能自己打网络)。
+ *  幂等:值未变化就不写,避免每次搜索都产生一次 DB 写。 */
+let lastRecordedPanSouHealth: string | null = null;
+async function recordPanSouHealth(healthy: boolean): Promise<void> {
+  const value = healthy ? "ok" : "unhealthy";
+  if (lastRecordedPanSouHealth === value) return;
+  try {
+    await getWorkflowRepository().setAccountSetting(
+      await getCurrentAccountId(),
+      PANSOU_HEALTH_SETTING_KEY,
+      value,
+    );
+    lastRecordedPanSouHealth = value;
+  } catch (error) {
+    // 搜索不能因为一次设置写失败而失败。但不静默:打出来,否则就是本 PR 要修的病。
+    console.warn(
+      `[pansou-health] 记录健康态失败(不影响本次搜索): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+/** Test-only: 清掉幂等缓存,免得跨用例串味。 */
+export function __resetPanSouHealthCacheForTests(): void {
+  lastRecordedPanSouHealth = null;
+}
+
 export async function runNextQueuedWorkflow() {
   const repository = getWorkflowRepository();
   // §7 form B: the worker resolves each CLAIMED run's account credentials via
@@ -1704,6 +1730,13 @@ async function getWorkerResourceProvider(
             await settings.getSetting(PANSOU_BASE_URL_SETTING_KEY),
           ),
           allowedTypes,
+          // 把每次真实搜索观察到的结论回写,设置页徽章才有东西可读。缺了这条,
+          // 告警在生产中永远不触发:保存时探活只写 "ok",而本次事故恰恰是
+          // 「保存时好的、之后才挂」。写失败不能影响搜索本身,所以 catch 后
+          // 只记日志——但**不静默**,否则又是本 PR 要消灭的那个毛病。
+          onSourceHealth: (healthy) => {
+            void recordPanSouHealth(healthy);
+          },
         }),
       },
     ];

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1112,8 +1112,11 @@ export function resolveIsDesktop(env: Record<string, string | undefined> = proce
 
 export const PANSOU_BASE_URL_SETTING_KEY = "pansou_base_url";
 
-/** 上次探活结论（"ok" | 失败 reason）。设置页徽章每 8s 轮询一次，绝不能在
- *  那条路径上真打网络，所以这里存保存时的结论供它读取。 */
+/** 自建搜索源的最新健康结论。取值只有三种:`"ok"` / `"unhealthy"` / `""`(未配或
+ *  已清空)—— **不是**结构化 reason,别按 reason 去解析。
+ *  两个写入方:保存时探活(actions / config-io)与每次真实搜索后的回写
+ *  (recordPanSouHealth)。设置页徽章每 8s 轮询,绝不能在那条路径上打网络,
+ *  所以它只读这里。 */
 export const PANSOU_HEALTH_SETTING_KEY = "pansou_last_probe";
 
 /** Default public PanSou instance (author-hosted), used when neither the DB

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -83,6 +83,11 @@ import {
   type VerifiedFile,
   type WorkflowRepository,
 } from "@media-track/workflow";
+import {
+  buildPanSouProviderChain,
+  resolveUserPanSouBaseUrl,
+  DEFAULT_PANSOU_BASE_URL as PUBLIC_PANSOU_BASE_URL,
+} from "./pansou-chain";
 import { findDemoCandidateById, findDemoCandidateByTmdbId } from "./demo-candidates";
 import { seedDemoWorkflowRepository } from "./demo-workflow";
 import { resolveRegistration, deriveBootstrapState, canManageAccounts } from "./account-bootstrap";
@@ -1079,21 +1084,25 @@ export const PANSOU_BASE_URL_SETTING_KEY = "pansou_base_url";
 
 /** Default public PanSou instance (author-hosted), used when neither the DB
  *  setting nor env overrides it. The compose stack injects PANSOU_BASE_URL to
- *  point at the bundled `pansou` service instead. */
-export const DEFAULT_PANSOU_BASE_URL = "https://so.252035.xyz";
+ *  point at the bundled `pansou` service instead.
+ *  从 ./pansou-chain 再导出:装配链要用同一个常量判「用户配的是不是官方源」,
+ *  两份字面量一旦漂移,fallback 就会把官方源包成自己的备源、每次失败白跑两遍。 */
+export { DEFAULT_PANSOU_BASE_URL } from "./pansou-chain";
 
 /** The PanSou search aggregator base URL: DB setting > env PANSOU_BASE_URL >
  *  public default. No runtime container auto-detection — compose wires the
- *  service name and this lets a self-hoster override it by hand. */
+ *  service name and this lets a self-hoster override it by hand.
+ *  前两层复用 resolveUserPanSouBaseUrl:它和装配链共用一份优先级,免得这里改了
+ *  而检索路径没改(或反过来)。 */
 export async function getPanSouBaseUrl(
   repository: { getSetting(key: string): Promise<string | null> },
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
-  const dbValue = (await repository.getSetting(PANSOU_BASE_URL_SETTING_KEY))?.trim();
-  if (dbValue) return dbValue;
-  const envValue = env.PANSOU_BASE_URL?.trim();
-  if (envValue) return envValue;
-  return DEFAULT_PANSOU_BASE_URL;
+  const configured = resolveUserPanSouBaseUrl(
+    await repository.getSetting(PANSOU_BASE_URL_SETTING_KEY),
+    env,
+  );
+  return configured || PUBLIC_PANSOU_BASE_URL;
 }
 
 export const PROWLARR_BASE_URL_SETTING_KEY = "prowlarr_base_url";
@@ -1684,7 +1693,14 @@ async function getWorkerResourceProvider(
     const providers: Array<{ name: string; provider: ResourceProvider }> = [
       {
         name: "pansou",
-        provider: new PanSouResourceProvider({ baseURL: await getPanSouBaseUrl(settings), allowedTypes }),
+        // 用户配了自建源(DB 或 compose 注入的 env)就包一层 fallback:自建源挂掉时
+        // 退到官方源续命,并把结果标 degraded —— 而不是像事故里那样静默报「没找到」。
+        provider: buildPanSouProviderChain({
+          userBaseURL: resolveUserPanSouBaseUrl(
+            await settings.getSetting(PANSOU_BASE_URL_SETTING_KEY),
+          ),
+          allowedTypes,
+        }),
       },
     ];
     if (kinds.includes("prowlarr")) {

--- a/packages/workflow/src/acquisition-v2/fake-provider.ts
+++ b/packages/workflow/src/acquisition-v2/fake-provider.ts
@@ -10,6 +10,8 @@
  * on the id rather than assume one snapshot per search.
  */
 
+import type { MergedSourceHealth } from "../resource-source-health.js";
+
 export interface SimResourceCandidate {
   id: string;
   title: string;
@@ -19,6 +21,12 @@ export interface ResourceSnapshotV2 {
   id: string;
   keyword: string;
   candidates: SimResourceCandidate[];
+  /** 本次搜索各源的健康态，原样自域快照透传（domain.ts ResourceSnapshot.sourceHealth）。
+   *  可选：fake provider 与老 fixture 不带此字段，缺失按 healthy 处理。
+   *  存在的唯一理由是让沙箱能把「源挂了」与「确实没有这个资源」区分开——两者
+   *  在 candidates 层面完全同形（都是空数组）。丢掉它，agent 就只能上报
+   *  reportNoCoverage，用户看到「暂未找到可用资源」，系统故障被甩锅给资源。 */
+  sourceHealth?: MergedSourceHealth;
 }
 
 /** The provider surface the sandbox depends on — the fake and the real PanSou

--- a/packages/workflow/src/acquisition-v2/real-provider-adapter.ts
+++ b/packages/workflow/src/acquisition-v2/real-provider-adapter.ts
@@ -70,6 +70,9 @@ export class RealResourceProviderV2 implements ResourceProviderV2 {
         id: candidate.id,
         title: candidate.title,
       })),
+      // 源健康态必须穿过这个边界。它在这里被丢掉过一次,后果是 6 天里源挂着,
+      // agent 只看到空候选、照常 reportNoCoverage,用户看到「暂未找到可用资源」。
+      ...(snapshot.sourceHealth ? { sourceHealth: snapshot.sourceHealth } : {}),
     };
   }
 }

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -12,7 +12,7 @@ import type { SimTreeFile, StorageV2, TransferAttemptResult } from "./storage-11
 import { isSystemicTransferBlockMessage } from "./transfer-block.js";
 import { animeSearchTabooWarnings, type SearchProfile } from "./search-profile.js";
 import type { AuditEvent } from "../domain.js";
-import type { MergedSourceHealth } from "../resource-source-health.js";
+import { isMergedSourceEvidenceUsable, type MergedSourceHealth } from "../resource-source-health.js";
 
 /** Quality / subtitle / source tokens that PanSou share titles almost never carry,
  *  so appending them collapses recall (实测归零). Case-insensitive; word-ish so
@@ -753,12 +753,40 @@ export class TaskSandbox {
    *  tells the agent NOT to re-search the raw keyword (viewResourceSnapshot is
    *  free), and even a re-search hits dedup without touching seenKeywords — so
    *  counting only seenKeywords refused a well-behaved agent's honest report on
-   *  a truly-uncovered title and forced wasted turns (the 病1-style dead tail). */
+   *  a truly-uncovered title and forced wasted turns (the 病1-style dead tail).
+   *
+   *  Task 10: 光有搜索还不够——那些搜索还得是有效证据。证据基整体不健康时上报
+   *  被机械拒绝(SANDBOX_SOURCE_UNHEALTHY),因为「没有资源」这个结论不被一份
+   *  全是故障源的证据支持。只拦「全不健康」,不拦「部分不健康」。 */
   async reportNoCoverage(reason: string): Promise<{ reason: string; searchesPerformed: number }> {
     const evidenceKeywords = new Set([...this.seenKeywords, ...this.snapshotByKeyword.keys()]);
     if (evidenceKeywords.size === 0) {
       throw new Error(
         "SANDBOX_NO_PROVIDER_EVIDENCE: cannot report no-coverage before any real search ran (§9 infrastructure failure)",
+      );
+    }
+    // Task 10: 整个证据基都不健康 → 「没有资源」不是这份证据支持得起的结论。
+    // Task 9 已经把这件事告诉 agent 了,但那只是劝告;LLM 有时就是会无视警告,
+    // 于是源挂了 6 天、用户一直读到「暂未找到可用资源」。所以这里必须是机械的。
+    //
+    // 别甩锅(同 transfer-block.ts 的 systemicBlock):把系统故障报成「暂未找到
+    // 资源」是拿资源给系统问题背锅。这里只拦「全不健康」——只要有一份快照可用
+    // (healthy 或 degraded),就说明确实有源答过话,那是合法的「确实没有」,放行。
+    const snapshots = [...this.snapshotByKeyword.values()];
+    const unusable = snapshots.filter((snapshot) => !isMergedSourceEvidenceUsable(snapshot.sourceHealth));
+    if (snapshots.length > 0 && unusable.length === snapshots.length) {
+      const unhealthySources = [
+        ...new Set(unusable.flatMap((snapshot) => snapshot.sourceHealth?.unhealthySources ?? [])),
+      ];
+      const sources = unhealthySources.length > 0 ? unhealthySources.join("、") : "未知";
+      const statuses = [...new Set(unusable.map((snapshot) => snapshot.sourceHealth!.status))].join("/");
+      this.auditEvents.push({
+        type: "no_coverage_refused_source_unhealthy",
+        message: `拒绝无覆盖上报:证据基 ${snapshots.length} 份快照全部来自不健康的搜索源(${statuses}): ${sources}`,
+        data: { reason, status: statuses, unhealthySources, snapshotCount: snapshots.length },
+      });
+      throw new Error(
+        `SANDBOX_SOURCE_UNHEALTHY: 搜索源「${sources}」本次全程故障(${statuses}),你手上这 ${snapshots.length} 份快照没有一份是有效证据。「没有资源」这个结论不被这份证据支持,已拒绝上报——不要再改措辞重试。请直接结束本次任务并如实说明是搜索源故障(不是这部片子没有资源):本轮按「搜索源不可用」收尾,资源留待源恢复后重试。`,
       );
     }
     this.auditEvents.push({

--- a/packages/workflow/src/acquisition-v2/sandbox.ts
+++ b/packages/workflow/src/acquisition-v2/sandbox.ts
@@ -12,6 +12,7 @@ import type { SimTreeFile, StorageV2, TransferAttemptResult } from "./storage-11
 import { isSystemicTransferBlockMessage } from "./transfer-block.js";
 import { animeSearchTabooWarnings, type SearchProfile } from "./search-profile.js";
 import type { AuditEvent } from "../domain.js";
+import type { MergedSourceHealth } from "../resource-source-health.js";
 
 /** Quality / subtitle / source tokens that PanSou share titles almost never carry,
  *  so appending them collapses recall (实测归零). Case-insensitive; word-ish so
@@ -27,6 +28,28 @@ const STRIP_NOTICE =
 
 /** Threshold for large snapshot digestion hint (病3). */
 const LARGE_SNAPSHOT_DIGEST_THRESHOLD = 10;
+
+/**
+ * 把快照的源健康态翻成给 agent 的祈使句警告。返回 undefined 表示证据完整
+ * （healthy 或老快照无此字段）——那种情形下的空候选才是权威的「确实没有」，
+ * 必须保持可区分，所以这里绝不能对每个空快照都告警。
+ *
+ * 同一条教义见 transfer-block.ts：把系统故障报成「暂未找到资源」是拿资源
+ * 给系统问题背锅（别甩锅）。unreachable 与 protocol_error 分开措辞，因为用户的
+ * 处置动作不同（源挂了/网络不通 vs 地址填错了、那头根本不是 PanSou）。
+ */
+function sourceHealthWarning(health: MergedSourceHealth | undefined): string | undefined {
+  if (!health || health.status === "healthy") return undefined;
+  const sources = health.unhealthySources.length > 0 ? health.unhealthySources.join("、") : "未知";
+  switch (health.status) {
+    case "degraded":
+      return `搜索源「${sources}」本次未响应,只有部分源答复:本次结果是不完整证据。已返回的候选照常可用,可以正常筛选转存;但不要因为没搜到就下「没有资源」的结论,更不要据此 reportNoCoverage——缺的那部分源可能正好有。`;
+    case "protocol_error":
+      return `搜索源「${sources}」返回了无法解析的响应:配置的地址可能指向的根本不是 PanSou(填错地址/被网关或登录页拦截)。本次等于没搜,「没有资源」这个结论不被这份证据支持,不要 reportNoCoverage;请如实说明是搜索源配置有问题。`;
+    case "unreachable":
+      return `搜索源「${sources}」本次连不上,一个候选都没能取回。这是搜索源故障,不是这部片子没有资源:「没有资源」这个结论不被这份证据支持,不要 reportNoCoverage;请如实说明是搜索源不可用。`;
+  }
+}
 
 /** Strip quality/subtitle tokens from a search keyword and fold the resulting
  *  whitespace. `stripped` is true ONLY when an actual QUALITY_SUBTITLE_TOKEN was
@@ -273,12 +296,17 @@ export class TaskSandbox {
         message: `重复搜索「${effectiveKeyword}」第 ${count} 次`,
         data: { keyword: effectiveKeyword, count },
       });
+      // 复搜命中的是同一份不健康快照,警告必须跟着一起回——否则 agent 第二次
+      // 看到的还是一个「干净的空结果」,照样会去 reportNoCoverage。审计不重复
+      // 记（search_dedup 已记录这次复搜）。
+      const cachedHealthWarning = sourceHealthWarning(cachedSnapshot.sourceHealth);
+      const dedupWarnings = cachedHealthWarning ? [...tabooWarnings, cachedHealthWarning] : tabooWarnings;
       return {
         snapshot: cachedSnapshot,
         deduped: true,
         repeatNotice: this.repeatNotice(effectiveKeyword, count, cachedSnapshot.candidates.length),
         ...(notice ? { notice } : {}),
-        ...(tabooWarnings.length > 0 ? { warnings: tabooWarnings } : {}),
+        ...(dedupWarnings.length > 0 ? { warnings: dedupWarnings } : {}),
         ...(digestHint ? { digestHint } : {}),
       };
     }
@@ -313,11 +341,27 @@ export class TaskSandbox {
       this.pendingDigest = { keyword: effectiveKeyword, count: snapshot.candidates.length };
     }
 
+    // Task 9: 源不健康 → 明确告诉 agent 证据不完整。没有这一步,源挂掉与「确实
+    // 没有」在 agent 眼里同形(都是空候选),它只会 reportNoCoverage。
+    const healthWarning = sourceHealthWarning(snapshot.sourceHealth);
+    if (healthWarning) {
+      this.auditEvents.push({
+        type: "search_source_unhealthy",
+        message: `搜索「${effectiveKeyword}」时搜索源不健康(${snapshot.sourceHealth!.status}): ${snapshot.sourceHealth!.unhealthySources.join("、") || "未知"}`,
+        data: {
+          keyword: effectiveKeyword,
+          status: snapshot.sourceHealth!.status,
+          unhealthySources: snapshot.sourceHealth!.unhealthySources,
+        },
+      });
+    }
+    const searchWarnings = healthWarning ? [...tabooWarnings, healthWarning] : tabooWarnings;
+
     return {
       snapshot,
       ...(decision === "reserve" ? { note: this.reserveNote() } : {}),
       ...(notice ? { notice } : {}),
-      ...(tabooWarnings.length > 0 ? { warnings: tabooWarnings } : {}),
+      ...(searchWarnings.length > 0 ? { warnings: searchWarnings } : {}),
       ...(digestHint ? { digestHint } : {}),
     };
   }

--- a/packages/workflow/src/acquisition-v2/search-source-fault.ts
+++ b/packages/workflow/src/acquisition-v2/search-source-fault.ts
@@ -1,0 +1,70 @@
+import type { AuditEvent } from "../domain.js";
+
+/**
+ * 搜索源故障判定 —— `transfer-block.ts` 的搜索层孪生兄弟。
+ *
+ * 那个文件的教义（原话）：把账号级封锁报成「no_coverage / 暂未找到资源」是拿资源
+ * 给系统问题背锅（**别甩锅**）。这里是同一件事发生在更早的一层：搜索源连不上时，
+ * 一个候选都取不回来，集数算术于是判定 `no_coverage`，用户读到「暂未找到可用
+ * 资源」—— 真实案例里这样持续了 6 天，作者本人都被误导了两小时。
+ *
+ * 判定不靠猜：sandbox 在拒绝上报时写下结构化审计事件
+ * （`no_coverage_refused_source_unhealthy`，见 sandbox.reportNoCoverage），
+ * 这里只做读取与措辞。与 `classifyTransferBlock` 从 `transferAttempts` 分类
+ * 是同一形制，好让后来的读者只看到一种模式而不是两种。
+ */
+
+/** sandbox 拒绝无覆盖上报时写下的审计事件类型。 */
+const REFUSED_EVENT = "no_coverage_refused_source_unhealthy";
+/** 搜索期间源不健康的审计事件类型（agent 可能压根没走到上报那一步）。 */
+const UNHEALTHY_EVENT = "search_source_unhealthy";
+
+export interface SearchSourceFault {
+  /** 面向用户的一句话，直接进通知。 */
+  reason: string;
+  /** 哪些源出了问题，用于文案点名。 */
+  sources: string[];
+  /** 合并后的状态串（unreachable / protocol_error / 混合）。 */
+  status: string;
+}
+
+/**
+ * 从本次运行的审计事件里判定「这轮没覆盖是因为搜索源故障」。
+ *
+ * 返回 null 表示没有源故障证据 —— 此时「暂未找到资源」是诚实的结论，必须原样保留。
+ * 这是本模块最重要的边界：过度判定会让产品再也无法如实报告「确实没有」，
+ * 那比它要修的 bug 更糟。
+ */
+export function classifySearchSourceFault(
+  auditEvents: readonly AuditEvent[] | undefined,
+): SearchSourceFault | null {
+  if (!auditEvents || auditEvents.length === 0) {
+    return null;
+  }
+  const relevant = auditEvents.filter(
+    (event) => event.type === REFUSED_EVENT || event.type === UNHEALTHY_EVENT,
+  );
+  if (relevant.length === 0) {
+    return null;
+  }
+  // 只有「拒绝上报」才代表整轮证据全不健康。单条 search_source_unhealthy 可能
+  // 只是某一次搜索赶上抖动，之后又搜到了东西 —— 那种情况下报源故障是过度判定。
+  const refused = relevant.find((event) => event.type === REFUSED_EVENT);
+  if (!refused) {
+    return null;
+  }
+  const sources = stringArray(refused.data?.["unhealthySources"]);
+  const status = typeof refused.data?.["status"] === "string" ? refused.data["status"] : "unknown";
+  const named = sources.length > 0 ? sources.join("、") : "搜索源";
+  // protocol_error 与单纯连不上要给不同建议:前者是「地址指向的东西不是 PanSou」,
+  // 用户要去改配置;后者是「源挂了/网络不通」,等恢复或换源。
+  const isProtocol = status.includes("protocol_error") && !status.includes("unreachable");
+  const reason = isProtocol
+    ? `${named} 返回的不是 PanSou 接口格式（地址可能指向了别的服务），本轮没能取回任何候选。请检查搜索源地址后重试。`
+    : `${named} 本轮连不上，没能取回任何候选。已按「搜索源不可用」收尾，资源留待源恢复后自动重试。`;
+  return { reason, sources, status };
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}

--- a/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
@@ -16,6 +16,7 @@ import {
 } from "../domain.js";
 import { buildSeasonReport, buildSeriesReport, formatReportPushText } from "../notification-report.js";
 import { classifyTransferBlock } from "./transfer-block.js";
+import { classifySearchSourceFault } from "./search-source-fault.js";
 import type { RunAcquisitionV2WorkflowResult } from "./workflow-v2.js";
 
 /**
@@ -94,6 +95,11 @@ export function bridgeV2WorkflowToResult(input: {
   // "暂未找到资源" — the resource exists, the account is blocked.
   const transferBlock = classifyTransferBlock(v2.outcome.transferAttempts);
   const transferBlockReason = status === "no_coverage" && transferBlock ? transferBlock.reason : null;
+  // 同一条教义在更早一层:搜索源本轮全程故障时,一个候选都取不回来,集数算术
+  // 于是判 no_coverage、用户读到「暂未找到可用资源」—— 真实案例里这样持续了
+  // 6 天。判定读 sandbox 写下的结构化审计事件,不猜(见 classifySearchSourceFault)。
+  const sourceFault = classifySearchSourceFault(v2.auditEvents);
+  const searchSourceFaultReason = status === "no_coverage" && sourceFault ? sourceFault.reason : null;
 
   const notification = buildNotification({
     title,
@@ -101,6 +107,7 @@ export function bridgeV2WorkflowToResult(input: {
     seasons,
     status,
     transferBlockReason,
+    searchSourceFaultReason,
     newlyObtainedCodes,
     workflowRunId,
     now: input.now,
@@ -218,6 +225,7 @@ function buildNotification(input: {
   status: WorkflowStatus;
   /** Honest 转存失败 reason when transfers were systemically blocked (else null). */
   transferBlockReason?: string | null;
+  searchSourceFaultReason?: string | null;
   newlyObtainedCodes: string[];
   workflowRunId: string;
   now: () => string;
@@ -234,6 +242,7 @@ function buildNotification(input: {
       seasons: seasons.map((entry) => ({ season: entry.season, episodes: entry.episodes })),
       noCoverage,
       transferBlockReason: input.transferBlockReason ?? null,
+      searchSourceFaultReason: input.searchSourceFaultReason ?? null,
       meta: titleMeta,
       ...sizeInput(input),
     });
@@ -264,6 +273,7 @@ function buildNotification(input: {
     newlyObtained,
     noCoverage,
     transferBlockReason: input.transferBlockReason ?? null,
+    searchSourceFaultReason: input.searchSourceFaultReason ?? null,
     meta: titleMeta,
     ...sizeInput(input),
   });

--- a/packages/workflow/src/composite-provider.ts
+++ b/packages/workflow/src/composite-provider.ts
@@ -1,7 +1,12 @@
 import { createHash } from "node:crypto";
 import type { ResourceCandidate, ResourceSnapshot } from "./domain.js";
 import type { ResourceProvider } from "./ports.js";
-import { mergeSourceHealth, type SourceHealth, type SourceStatus } from "./resource-source-health.js";
+import {
+  classifySourceFailure,
+  mergeSourceHealth,
+  type SourceHealth,
+  type SourceStatus,
+} from "./resource-source-health.js";
 
 export interface CompositeResourceProviderOptions {
   providers: Array<{ name: string; provider: ResourceProvider }>;
@@ -32,7 +37,10 @@ export class CompositeResourceProvider implements ResourceProvider {
       const name = this.providers[index]!.name;
       if (result.status !== "fulfilled") {
         // 以前这里直接 continue,失败就此消失 —— 部分搜索看起来和完整搜索一样。
-        healths.push({ status: "unreachable", source: name });
+        // 用 classifySourceFailure 而非硬编码 unreachable:成员抛的可能是
+        // PanSouProtocolError(地址指向了别的服务),那与「源挂了」要给用户不同
+        // 的处置建议,不能在这一层就压平。
+        healths.push({ status: classifySourceFailure(result.reason), source: name });
         continue;
       }
       // 成员可能不抛错而是自报不健康(PanSou 就是这样),所以要读字段而不是
@@ -67,8 +75,12 @@ export class CompositeResourceProvider implements ResourceProvider {
   }
 }
 
-/** 把成员自报的合并态折回单源状态。degraded 只可能出现在多源成员上,对本层
- *  而言它意味着「那个成员的证据不完整」,按不可用处理更保守。 */
+/** 把成员自报的合并态折回单源状态。
+ *
+ *  ⚠️ degraded **按可用处理**(不是不可用)。这是刻意的,别按「保守」的直觉改回去:
+ *  degraded 意味着那个成员内部有子源挂了,但它确实答了话、确实返回了候选。若按
+ *  不可用处理,一个「有候选」的成员会让整体合并出 unreachable,于是快照自相矛盾
+ *  ——agent 会读到「一个候选都没能取回」而它手上明明有候选。 */
 function memberStatus(status: string | undefined): SourceStatus {
   // degraded 也算「答过话」:那个成员内部有子源挂了,但它确实返回了候选。
   // 压成 unreachable 会让整体合并出 unreachable,于是产生一个「有候选却说

--- a/packages/workflow/src/composite-provider.ts
+++ b/packages/workflow/src/composite-provider.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { ResourceCandidate, ResourceSnapshot } from "./domain.js";
 import type { ResourceProvider } from "./ports.js";
+import { mergeSourceHealth, type SourceHealth, type SourceStatus } from "./resource-source-health.js";
 
 export interface CompositeResourceProviderOptions {
   providers: Array<{ name: string; provider: ResourceProvider }>;
@@ -26,8 +27,18 @@ export class CompositeResourceProvider implements ResourceProvider {
     const merged: ResourceCandidate[] = [];
     const seen = new Set<string>();
     const sourceSnapshotIds: string[] = [];
-    for (const result of settled) {
-      if (result.status !== "fulfilled") continue; // a down source contributes nothing
+    const healths: SourceHealth[] = [];
+    for (const [index, result] of settled.entries()) {
+      const name = this.providers[index]!.name;
+      if (result.status !== "fulfilled") {
+        // 以前这里直接 continue,失败就此消失 —— 部分搜索看起来和完整搜索一样。
+        healths.push({ status: "unreachable", source: name });
+        continue;
+      }
+      // 成员可能不抛错而是自报不健康(PanSou 就是这样),所以要读字段而不是
+      // 只看 Promise 状态。缺字段的老 provider 视为 healthy(向后兼容)。
+      const own = result.value.sourceHealth;
+      healths.push({ status: memberStatus(own?.status), source: name });
       sourceSnapshotIds.push(result.value.id);
       for (const candidate of result.value.candidates) {
         const key = dedupeKey(candidate);
@@ -45,8 +56,22 @@ export class CompositeResourceProvider implements ResourceProvider {
       index,
     }));
 
-    return { id: snapshotId, provider: "composite", keyword: input.keyword, candidates, createdAt: this.now() };
+    return {
+      id: snapshotId,
+      provider: "composite",
+      keyword: input.keyword,
+      candidates,
+      createdAt: this.now(),
+      sourceHealth: mergeSourceHealth(healths),
+    };
   }
+}
+
+/** 把成员自报的合并态折回单源状态。degraded 只可能出现在多源成员上,对本层
+ *  而言它意味着「那个成员的证据不完整」,按不可用处理更保守。 */
+function memberStatus(status: string | undefined): SourceStatus {
+  if (status === undefined || status === "healthy") return "healthy";
+  return status === "protocol_error" ? "protocol_error" : "unreachable";
 }
 
 function dedupeKey(candidate: ResourceCandidate): string {

--- a/packages/workflow/src/composite-provider.ts
+++ b/packages/workflow/src/composite-provider.ts
@@ -70,7 +70,10 @@ export class CompositeResourceProvider implements ResourceProvider {
 /** 把成员自报的合并态折回单源状态。degraded 只可能出现在多源成员上,对本层
  *  而言它意味着「那个成员的证据不完整」,按不可用处理更保守。 */
 function memberStatus(status: string | undefined): SourceStatus {
-  if (status === undefined || status === "healthy") return "healthy";
+  // degraded 也算「答过话」:那个成员内部有子源挂了,但它确实返回了候选。
+  // 压成 unreachable 会让整体合并出 unreachable,于是产生一个「有候选却说
+  // 一个都没取回」的自相矛盾快照(Copilot 评审指出)。
+  if (status === undefined || status === "healthy" || status === "degraded") return "healthy";
   return status === "protocol_error" ? "protocol_error" : "unreachable";
 }
 

--- a/packages/workflow/src/composite-provider.ts
+++ b/packages/workflow/src/composite-provider.ts
@@ -82,10 +82,13 @@ export class CompositeResourceProvider implements ResourceProvider {
  *  不可用处理,一个「有候选」的成员会让整体合并出 unreachable,于是快照自相矛盾
  *  ——agent 会读到「一个候选都没能取回」而它手上明明有候选。 */
 function memberStatus(status: string | undefined): SourceStatus {
-  // degraded 也算「答过话」:那个成员内部有子源挂了,但它确实返回了候选。
-  // 压成 unreachable 会让整体合并出 unreachable,于是产生一个「有候选却说
-  // 一个都没取回」的自相矛盾快照(Copilot 评审指出)。
-  if (status === undefined || status === "healthy" || status === "degraded") return "healthy";
+  // degraded 必须**透传**而不是折向任何一端(两次 Copilot 评审的合流结论):
+  //  - 折成 unreachable →「有候选却说一个都没取回」的自相矛盾快照。
+  //  - 折成 healthy → 不完整证据看起来像完整证据,把「静默误导」从另一端放回来。
+  // degraded 意味着那个成员(比如回落官方源后的 FallbackResourceProvider)答了话、
+  // 给了候选,但证据不完整 —— 这个信号对上层判断「能不能下『没找到』结论」至关重要。
+  if (status === undefined || status === "healthy") return "healthy";
+  if (status === "degraded") return "degraded";
   return status === "protocol_error" ? "protocol_error" : "unreachable";
 }
 

--- a/packages/workflow/src/domain.ts
+++ b/packages/workflow/src/domain.ts
@@ -1,3 +1,5 @@
+import type { MergedSourceHealth } from "./resource-source-health.js";
+
 /**
  * The implicit account that owns all data in a single-user (multi-user disabled)
  * deployment, and the fail-closed default everywhere an account is not explicitly
@@ -132,6 +134,9 @@ export interface ResourceSnapshot {
   keyword: string;
   candidates: ResourceCandidate[];
   createdAt: string;
+  /** 本次搜索各源的健康态。可选：老快照与不关心健康态的 provider 不带此字段。
+   *  缺失时按 healthy 处理（向后兼容），因此新增判定必须显式检查而非假设存在。 */
+  sourceHealth?: MergedSourceHealth;
 }
 
 export interface AgentDecision {

--- a/packages/workflow/src/fallback-provider.ts
+++ b/packages/workflow/src/fallback-provider.ts
@@ -1,0 +1,84 @@
+import type { ResourceSnapshot } from "./domain.js";
+import type { ResourceProvider } from "./ports.js";
+import { mergeSourceHealth } from "./resource-source-health.js";
+
+export interface FallbackResourceProviderOptions {
+  /** 用户自建源。健康时永远优先。 */
+  primary: { name: string; provider: ResourceProvider };
+  /** 官方公共源。只有主源不可用时才动用。 */
+  secondary: { name: string; provider: ResourceProvider };
+}
+
+/**
+ * 优先级 fallback:主源不可用才落到备源。
+ *
+ * 两条刻意的设计:
+ * 1. **只有「不可用」才 fallback,「健康但没结果」不 fallback。** 后者是权威的
+ *    「确实没有」,再搜一遍备源只会让每一次未命中都翻倍耗时。
+ * 2. **fallback 成功后整体仍标 degraded。** 搜索是成功了,但用户配的源是坏的,
+ *    必须让他知道 —— 悄悄靠官方源续命,正是一个配置错误能活六天没人发现的原因。
+ *
+ * 刻意不做熔断器与 hedged request:本产品的搜索是低频后台任务,熔断器要维护
+ * 跨请求状态并调参(阈值/半开/冷却),复杂度远超收益;hedged request 会让每次
+ * 搜索都双打两个源,对公共免费源不礼貌。
+ */
+export class FallbackResourceProvider implements ResourceProvider {
+  private readonly primary: FallbackResourceProviderOptions["primary"];
+  private readonly secondary: FallbackResourceProviderOptions["secondary"];
+
+  constructor(options: FallbackResourceProviderOptions) {
+    this.primary = options.primary;
+    this.secondary = options.secondary;
+  }
+
+  async search(input: { keyword: string; workflowRunId?: string }): Promise<ResourceSnapshot> {
+    const primary = await attempt(this.primary.provider, input);
+    if (primary !== null && isUsable(primary)) {
+      return primary;
+    }
+
+    const secondary = await attempt(this.secondary.provider, input);
+    if (secondary !== null && isUsable(secondary)) {
+      // 搜索成功了,但主源坏着 —— 用 degraded 把这件事带出去。
+      return {
+        ...secondary,
+        sourceHealth: mergeSourceHealth([
+          { status: "unreachable", source: this.primary.name },
+          { status: "healthy", source: this.secondary.name },
+        ]),
+      };
+    }
+
+    // 两个都不可用:给出明确的故障快照,而不是一个看起来像「没找到」的空快照。
+    const base = secondary ?? primary;
+    return {
+      id: base?.id ?? `fallback_unreachable_${input.workflowRunId ?? "adhoc"}`,
+      provider: "fallback",
+      keyword: input.keyword,
+      candidates: [],
+      createdAt: base?.createdAt ?? new Date().toISOString(),
+      sourceHealth: mergeSourceHealth([
+        { status: "unreachable", source: this.primary.name },
+        { status: "unreachable", source: this.secondary.name },
+      ]),
+    };
+  }
+}
+
+async function attempt(
+  provider: ResourceProvider,
+  input: { keyword: string; workflowRunId?: string },
+): Promise<ResourceSnapshot | null> {
+  try {
+    return await provider.search(input);
+  } catch {
+    return null;
+  }
+}
+
+/** 缺 sourceHealth 的老 provider 视为可用(向后兼容)。degraded 也算可用 ——
+ *  证据不完整但确实拿到了东西,不值得为此再打一遍备源。 */
+function isUsable(snapshot: ResourceSnapshot): boolean {
+  const status = snapshot.sourceHealth?.status ?? "healthy";
+  return status === "healthy" || status === "degraded";
+}

--- a/packages/workflow/src/fallback-provider.ts
+++ b/packages/workflow/src/fallback-provider.ts
@@ -42,7 +42,7 @@ export class FallbackResourceProvider implements ResourceProvider {
     }
     // 主源的真实病因:抛错时来自 classifySourceFailure,自报不健康时来自它
     // 自己的 status。带着它走,fallback 之后 UI 仍能给出对症的建议。
-    const primaryStatus: Exclude<SourceStatus, "healthy"> = primary.ok
+    const primaryStatus: "unreachable" | "protocol_error" = primary.ok
       ? primary.snapshot.sourceHealth?.status === "protocol_error"
         ? "protocol_error"
         : "unreachable"
@@ -85,7 +85,9 @@ export class FallbackResourceProvider implements ResourceProvider {
 
 type Attempt =
   | { ok: true; snapshot: ResourceSnapshot }
-  | { ok: false; status: Exclude<SourceStatus, "healthy"> };
+  // attempt() 的 catch 只可能从 classifySourceFailure 得到这两种,不会出现
+  // degraded —— 类型收紧以免后续误把 degraded 当「异常原因」用。
+  | { ok: false; status: "unreachable" | "protocol_error" };
 
 /** 保留失败原因而不是 `catch { return null }`。丢掉它会把主源的
  *  protocol_error 压成 unreachable —— 而这两者存在的全部理由就是给用户

--- a/packages/workflow/src/fallback-provider.ts
+++ b/packages/workflow/src/fallback-provider.ts
@@ -1,6 +1,10 @@
 import type { ResourceSnapshot } from "./domain.js";
 import type { ResourceProvider } from "./ports.js";
-import { mergeSourceHealth } from "./resource-source-health.js";
+import {
+  classifySourceFailure,
+  mergeSourceHealth,
+  type SourceStatus,
+} from "./resource-source-health.js";
 
 export interface FallbackResourceProviderOptions {
   /** 用户自建源。健康时永远优先。 */
@@ -33,24 +37,31 @@ export class FallbackResourceProvider implements ResourceProvider {
 
   async search(input: { keyword: string; workflowRunId?: string }): Promise<ResourceSnapshot> {
     const primary = await attempt(this.primary.provider, input);
-    if (primary !== null && isUsable(primary)) {
-      return primary;
+    if (primary.ok && isUsable(primary.snapshot)) {
+      return primary.snapshot;
     }
+    // 主源的真实病因:抛错时来自 classifySourceFailure,自报不健康时来自它
+    // 自己的 status。带着它走,fallback 之后 UI 仍能给出对症的建议。
+    const primaryStatus: Exclude<SourceStatus, "healthy"> = primary.ok
+      ? primary.snapshot.sourceHealth?.status === "protocol_error"
+        ? "protocol_error"
+        : "unreachable"
+      : primary.status;
 
     const secondary = await attempt(this.secondary.provider, input);
-    if (secondary !== null && isUsable(secondary)) {
+    if (secondary.ok && isUsable(secondary.snapshot)) {
       // 搜索成功了,但主源坏着 —— 用 degraded 把这件事带出去。
       return {
-        ...secondary,
+        ...secondary.snapshot,
         sourceHealth: mergeSourceHealth([
-          { status: "unreachable", source: this.primary.name },
+          { status: primaryStatus, source: this.primary.name },
           { status: "healthy", source: this.secondary.name },
         ]),
       };
     }
 
     // 两个都不可用:给出明确的故障快照,而不是一个看起来像「没找到」的空快照。
-    const base = secondary ?? primary;
+    const base = secondary.ok ? secondary.snapshot : primary.ok ? primary.snapshot : null;
     return {
       id: base?.id ?? `fallback_unreachable_${input.workflowRunId ?? "adhoc"}`,
       provider: "fallback",
@@ -58,21 +69,36 @@ export class FallbackResourceProvider implements ResourceProvider {
       candidates: [],
       createdAt: base?.createdAt ?? new Date().toISOString(),
       sourceHealth: mergeSourceHealth([
-        { status: "unreachable", source: this.primary.name },
-        { status: "unreachable", source: this.secondary.name },
+        { status: primaryStatus, source: this.primary.name },
+        {
+          status: secondary.ok
+            ? secondary.snapshot.sourceHealth?.status === "protocol_error"
+              ? "protocol_error"
+              : "unreachable"
+            : secondary.status,
+          source: this.secondary.name,
+        },
       ]),
     };
   }
 }
 
+type Attempt =
+  | { ok: true; snapshot: ResourceSnapshot }
+  | { ok: false; status: Exclude<SourceStatus, "healthy"> };
+
+/** 保留失败原因而不是 `catch { return null }`。丢掉它会把主源的
+ *  protocol_error 压成 unreachable —— 而这两者存在的全部理由就是给用户
+ *  不同的处置建议(「地址填错了」vs「源挂了」)。在一个专门消灭
+ *  「静默吞错」的改动里再写一个 bare catch,是自相矛盾的。 */
 async function attempt(
   provider: ResourceProvider,
   input: { keyword: string; workflowRunId?: string },
-): Promise<ResourceSnapshot | null> {
+): Promise<Attempt> {
   try {
-    return await provider.search(input);
-  } catch {
-    return null;
+    return { ok: true, snapshot: await provider.search(input) };
+  } catch (error) {
+    return { ok: false, status: classifySourceFailure(error) };
   }
 }
 

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -65,6 +65,7 @@ export * from "./acquisition-v2/orchestrator.js";
 export * from "./acquisition-v2/directory-lifecycle.js";
 export * from "./acquisition-v2/sync-need.js";
 export * from "./acquisition-v2/workflow-v2.js";
+export * from "./acquisition-v2/search-source-fault.js";
 export * from "./acquisition-v2/workflow-v2-bridge.js";
 export * from "./acquisition-v2/run-tv-v2.js";
 export * from "./acquisition-v2/stub-model.js";

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -22,6 +22,7 @@ export * from "./commands.js";
 export * from "./pansou-provider.js";
 export * from "./prowlarr-provider.js";
 export * from "./composite-provider.js";
+export * from "./fallback-provider.js";
 export * from "./tmdb-provider.js";
 export * from "./subtitle-provider.js";
 export * from "./storage-115-executor.js";

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -14,6 +14,7 @@ export * from "./workflow-scope.js";
 export * from "./auth/password.js";
 export * from "./auth/session.js";
 export * from "./repository.js";
+export * from "./resource-source-health.js";
 export * from "./postgres.js";
 export { SqliteWorkflowRepository, createSqliteWorkflowRepository } from "./sqlite.js";
 export * from "./worker.js";

--- a/packages/workflow/src/movie-workflow-v2.ts
+++ b/packages/workflow/src/movie-workflow-v2.ts
@@ -15,6 +15,7 @@ import {
 } from "./domain.js";
 import { buildMovieReport, emptyRunOutcome, formatReportPushText } from "./notification-report.js";
 import { classifyTransferBlock } from "./acquisition-v2/transfer-block.js";
+import { classifySearchSourceFault } from "./acquisition-v2/search-source-fault.js";
 import type { ResourceProvider, StorageExecutor } from "./ports.js";
 import type { DeadLinkStore } from "./acquisition-v2/dead-links.js";
 import { readLandedSize, type LandedSize } from "./acquisition-v2/landed-size.js";
@@ -163,11 +164,19 @@ function buildResult(input: {
     input.landed,
     input.subtitleFallback ?? false,
   );
-  // 别甩锅: nothing landed could mean truly no resource (no_coverage) OR the
-  // account was systemically blocked (115 云下载配额不足/登录过期) — say which.
+  // 别甩锅: nothing landed could mean truly no resource (no_coverage), the account
+  // was systemically blocked (115 云下载配额不足/登录过期), OR the search source
+  // itself was down all run (源挂了 6 天却报「暂未找到资源」的那个真实案例) — say which.
+  // 电影与剧集共用 emptyRunOutcome,所以这两条必须同时接,否则电影仍在撒谎。
   const report = input.obtained
     ? baseReport
-    : { ...baseReport, ...emptyRunOutcome(classifyTransferBlock(input.attempts)?.reason ?? null) };
+    : {
+        ...baseReport,
+        ...emptyRunOutcome(
+          classifyTransferBlock(input.attempts)?.reason ?? null,
+          classifySearchSourceFault(input.auditEvents)?.reason ?? null,
+        ),
+      };
   const notification: NotificationEvent = {
     id: `notification_${input.request.workflowRunId}`,
     workflowRunId: input.request.workflowRunId,

--- a/packages/workflow/src/notification-report.ts
+++ b/packages/workflow/src/notification-report.ts
@@ -78,6 +78,10 @@ export interface SeasonReportInput {
    *  status `failed` — NOT "暂未找到资源" (the resource exists; the account is
    *  blocked). Only meaningful together with noCoverage. See classifyTransferBlock. */
   transferBlockReason?: string | null;
+  /** 搜索源本轮全程故障时的原因(见 classifySearchSourceFault)。与
+   *  transferBlockReason 同一形制:只在 noCoverage 时有意义,存在则覆盖
+   *  「暂未找到可用资源」——源连不上不等于这部片子没有资源(别甩锅)。 */
+  searchSourceFaultReason?: string | null;
   /** Real landed video files: count + summed bytes. The card/push show the true
    *  per-episode size from these (总字节 / 文件数), not a claimed quality tag. */
   fileCount?: number;
@@ -103,9 +107,19 @@ function sizeFields(input: { fileCount?: number; totalBytes?: number }): {
  *  Shared by the TV bridge and the movie workflow so both report identically. */
 export function emptyRunOutcome(
   transferBlockReason?: string | null,
+  searchSourceFaultReason?: string | null,
 ): { status: NotificationReportStatus; lines: string[] } {
   if (transferBlockReason && transferBlockReason.trim()) {
+    // 转存受阻优先于搜索源故障:能走到转存说明资源已经找到了,用户手上的问题是
+    // 「配额/登录/VIP」这种立刻可动手的事;而搜索源故障那句只会让他去查一个其实
+    // 已经工作过的源。给最靠近用户下一步动作的那条。
     return { status: "failed", lines: [`转存失败:${transferBlockReason.trim()}`] };
+  }
+  if (searchSourceFaultReason && searchSourceFaultReason.trim()) {
+    // 别甩锅:源连不上不等于这部片子没有资源。报 failed 而非 no_coverage ——
+    // no_coverage 会把它归进「确实没有、继续等」那一桶,而这是系统故障,用户
+    // 看一眼就该知道去修配置/等源恢复,而不是以为片源不存在。
+    return { status: "failed", lines: [searchSourceFaultReason.trim()] };
   }
   return { status: "no_coverage", lines: ["暂未找到可用资源 · 将持续尝试"] };
 }
@@ -127,7 +141,7 @@ export function buildSeasonReport(input: SeasonReportInput): NotificationReport 
     return {
       titleName: input.titleName,
       seasonLabel: label,
-      ...emptyRunOutcome(input.transferBlockReason),
+      ...emptyRunOutcome(input.transferBlockReason, input.searchSourceFaultReason),
       newlyObtained: [],
       realMissing,
       ...(input.meta ?? {}),
@@ -183,6 +197,8 @@ export function buildSeriesReport(input: {
   noCoverage?: boolean;
   /** See SeasonReportInput.transferBlockReason — honest 转存失败 when blocked. */
   transferBlockReason?: string | null;
+  /** See SeasonReportInput.searchSourceFaultReason — honest 搜索源故障. */
+  searchSourceFaultReason?: string | null;
   meta?: NotificationTitleMeta;
   fileCount?: number;
   totalBytes?: number;
@@ -191,7 +207,7 @@ export function buildSeriesReport(input: {
     return {
       titleName: input.titleName,
       seasonLabel: null,
-      ...emptyRunOutcome(input.transferBlockReason),
+      ...emptyRunOutcome(input.transferBlockReason, input.searchSourceFaultReason),
       newlyObtained: [],
       realMissing: [],
       ...(input.meta ?? {}),

--- a/packages/workflow/src/pansou-provider.ts
+++ b/packages/workflow/src/pansou-provider.ts
@@ -9,6 +9,7 @@ import {
   classifySourceFailure,
   mergeSourceHealth,
   PanSouProtocolError,
+  PanSouRequestError,
   type SourceHealth,
 } from "./resource-source-health.js";
 
@@ -86,9 +87,15 @@ export class PanSouResourceProvider implements ResourceProvider {
       body: JSON.stringify({ kw: keyword, res: "all" }),
       timeoutMs: this.requestTimeoutMs,
     });
+    // 两种「不是成功响应」必须区分,否则用户拿到错误的处置建议(Copilot 评审):
+    //  1. 响应带 code 字段 → 它**是** PanSou,只是报了错(限流/参数错)。
+    //     那是源侧的临时故障,不是「地址填错了」,不归 PanSouProtocolError。
+    //  2. 完全不是 PanSou 的形状(静态文件服务器 / 反代错误页 / 换了协议)
+    //     → 地址指错了地方,这才是 PanSouProtocolError。
+    if (isPanSouErrorResponse(response)) {
+      throw new PanSouRequestError(`PanSou 返回错误: ${JSON.stringify(response).slice(0, 200)}`);
+    }
     if (!isPanSouSuccessResponse(response)) {
-      // 连上了,但对方不是 PanSou(静态文件服务器 / 反代错误页 / 换了协议)。
-      // 以前这里静默返回 [],于是「地址填错了」看起来和「没有这个资源」一样。
       throw new PanSouProtocolError(`not a PanSou payload from ${this.baseURL}`);
     }
     const facts = collectLinkFacts(response.data.results);
@@ -176,6 +183,13 @@ async function defaultFetchJson(url: string, init: PanSouFetchInit): Promise<unk
     throw new Error(`PanSou search failed with HTTP ${response.status}`);
   }
   return response.json();
+}
+
+/** 响应带 code 字段 = 它按 PanSou 协议应答了,只是没成功(限流/参数错/服务端错)。
+ *  与「根本不是 PanSou」的关键区别:后者没有 code 字段。 */
+function isPanSouErrorResponse(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return typeof value["code"] === "number" && value["code"] !== 0;
 }
 
 function isPanSouSuccessResponse(value: unknown): value is {

--- a/packages/workflow/src/pansou-provider.ts
+++ b/packages/workflow/src/pansou-provider.ts
@@ -5,6 +5,12 @@ import type {
   ResourceType,
 } from "./domain.js";
 import type { ResourceProvider } from "./ports.js";
+import {
+  classifySourceFailure,
+  mergeSourceHealth,
+  PanSouProtocolError,
+  type SourceHealth,
+} from "./resource-source-health.js";
 
 export interface PanSouFetchInit {
   method: "POST";
@@ -80,7 +86,12 @@ export class PanSouResourceProvider implements ResourceProvider {
       body: JSON.stringify({ kw: keyword, res: "all" }),
       timeoutMs: this.requestTimeoutMs,
     });
-    const facts = isPanSouSuccessResponse(response) ? collectLinkFacts(response.data.results) : [];
+    if (!isPanSouSuccessResponse(response)) {
+      // 连上了,但对方不是 PanSou(静态文件服务器 / 反代错误页 / 换了协议)。
+      // 以前这里静默返回 [],于是「地址填错了」看起来和「没有这个资源」一样。
+      throw new PanSouProtocolError(`not a PanSou payload from ${this.baseURL}`);
+    }
+    const facts = collectLinkFacts(response.data.results);
     // Per-brand filter: a quark drive only sees quark links; a 115 drive only
     // sees 115/magnet. Keeps a candidate set that its executor can actually transfer.
     return this.allowedTypes ? facts.filter((fact) => this.allowedTypes!.has(fact.type)) : facts;
@@ -93,12 +104,16 @@ export class PanSouResourceProvider implements ResourceProvider {
     // judges the COMPLETE evidence — never a partial slice (no 抢跑). Speed comes
     // from the agent issuing FEWER searches, not from cutting this short.
     let facts: PanSouLinkFact[] = [];
+    let failure: unknown = null;
     for (let attempt = 0; attempt < this.maxSearchAttempts; attempt += 1) {
       let next: PanSouLinkFact[];
       try {
         next = await this.fetchFacts(input.keyword);
-      } catch {
-        break; // network/parse error mid-poll — keep the most complete set so far
+      } catch (error) {
+        // 只有「一条证据都没拿到」才算源不可用。中途失败但先前已有结果时,
+        // 保留旧行为(保住已拿到的最完整集合)——那不是源挂了,是轮询被打断。
+        failure = error;
+        break;
       }
       if (next.length > facts.length) {
         facts = next;
@@ -109,6 +124,10 @@ export class PanSouResourceProvider implements ResourceProvider {
         await this.wait(this.searchPollMs);
       }
     }
+    const health: SourceHealth =
+      failure !== null && facts.length === 0
+        ? { status: classifySourceFailure(failure), source: "pansou" }
+        : { status: "healthy", source: "pansou" };
     const snapshotId = createSnapshotId(input.keyword, facts, input.workflowRunId);
     const candidates: ResourceCandidate[] = facts.map((fact, index) => ({
       id: `${snapshotId}_candidate_${index + 1}`,
@@ -131,6 +150,7 @@ export class PanSouResourceProvider implements ResourceProvider {
       keyword: input.keyword,
       candidates,
       createdAt: this.now(),
+      sourceHealth: mergeSourceHealth([health]),
     };
   }
 }

--- a/packages/workflow/src/resource-source-health.ts
+++ b/packages/workflow/src/resource-source-health.ts
@@ -22,8 +22,19 @@ export interface MergedSourceHealth {
   unhealthySources: string[];
 }
 
-/** 协议层失败的哨兵前缀。provider 用它标记「连上了但对方不是 PanSou」。 */
+/** 协议层失败的哨兵前缀。仅作为跨进程/跨包的兜底识别手段——同进程内请抛
+ *  `PanSouProtocolError`，靠 instanceof 判定，避免改一句错误文案就把
+ *  protocol_error 静默降级成 unreachable（用户会因此拿到错误的排查建议）。 */
 export const PROTOCOL_ERROR_PREFIX = "PANSOU_BAD_RESPONSE";
+
+/** 「连上了，但对方不是 PanSou」。与仓库既有的 Pan115AuthError / QuarkAuthError
+ *  等同一形制。消息仍带 PROTOCOL_ERROR_PREFIX，使字符串兜底路径继续成立。 */
+export class PanSouProtocolError extends Error {
+  constructor(detail: string) {
+    super(`${PROTOCOL_ERROR_PREFIX}: ${detail}`);
+    this.name = "PanSouProtocolError";
+  }
+}
 
 const UNREACHABLE_CODES = new Set([
   "ECONNREFUSED",
@@ -42,6 +53,11 @@ const UNREACHABLE_CODES = new Set([
  * 停止排查，正是本次要修的病。
  */
 export function classifySourceFailure(error: unknown): Exclude<SourceStatus, "healthy"> {
+  // instanceof 优先:同进程内这是类型安全的判定。字符串前缀留作兜底,
+  // 覆盖跨包/跨进程(错误经序列化后 instanceof 失效)的情形。
+  if (error instanceof PanSouProtocolError) {
+    return "protocol_error";
+  }
   const message = error instanceof Error ? error.message : String(error);
   if (message.startsWith(PROTOCOL_ERROR_PREFIX)) {
     return "protocol_error";
@@ -49,14 +65,22 @@ export function classifySourceFailure(error: unknown): Exclude<SourceStatus, "he
   // 下面两个分支当前同值(都 unreachable),保留不是冗余而是分类学:它们记录了
   // 已经考虑过的失败条件。后续若要按错误类型分化重试/退避策略(ETIMEDOUT 值得
   // 重试、ECONNREFUSED 基本不值得),分叉点就在这里 —— 届时不必重新调研这份清单。
-  const code = (error as { code?: unknown } | null)?.code;
-  if (typeof code === "string" && UNREACHABLE_CODES.has(code)) {
-    return "unreachable";
-  }
-  if (/timed out|timeout|aborted/i.test(message)) {
+  // undici/Node fetch 把真实 socket 错误包在 cause 里:外层只是扁平的
+  // "fetch failed",code 在 cause 上。不解包的话 UNREACHABLE_CODES 在生产里
+  // 几乎永远匹配不上(结论仍对,但这份清单就成了摆设)。
+  if (hasRecognisedUnreachableCode(error)) {
     return "unreachable";
   }
   return "unreachable";
+}
+
+/** 该错误是否被 UNREACHABLE_CODES 清单**识别**（而非只是落到兜底分支）。
+ *  导出它的理由：`classifySourceFailure` 的兜底也返回 unreachable，因此仅断言
+ *  返回值无法区分「清单命中」与「兜底」——一个去掉 cause 解包的改动会让清单在
+ *  生产中形同虚设，而测试照样绿。这个谓词让那件事变得可断言。 */
+export function hasRecognisedUnreachableCode(error: unknown): boolean {
+  const code = errorCode(error) ?? errorCode((error as { cause?: unknown } | null)?.cause);
+  return code !== undefined && UNREACHABLE_CODES.has(code);
 }
 
 export function isSourceUsable(health: SourceHealth): boolean {
@@ -76,4 +100,9 @@ export function mergeSourceHealth(healths: readonly SourceHealth[]): MergedSourc
     status: unhealthy.length === healths.length ? "unreachable" : "degraded",
     unhealthySources,
   };
+}
+
+function errorCode(error: unknown): string | undefined {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === "string" ? code : undefined;
 }

--- a/packages/workflow/src/resource-source-health.ts
+++ b/packages/workflow/src/resource-source-health.ts
@@ -16,9 +16,14 @@ export interface SourceHealth {
 }
 
 /** 多源合并后的整体健康态。degraded = 部分源答了：拿到的候选可用，但
- *  「没找到」这个结论不成立（证据不完整）。 */
+ *  「没找到」这个结论不成立（证据不完整）。
+ *
+ *  `protocol_error` 必须能穿透合并层而不被压成 `unreachable`：这两者存在的
+ *  全部理由就是用户的处置动作不同（「地址填错了/那不是 PanSou」 vs
+ *  「源挂了/网络不通」）。压平之后会告诉一个填错地址的用户「你的源挂了」，
+ *  把他引向错误的排查方向 —— 那正是本次要消灭的那类误导。 */
 export interface MergedSourceHealth {
-  status: "healthy" | "degraded" | "unreachable";
+  status: "healthy" | "degraded" | "unreachable" | "protocol_error";
   unhealthySources: string[];
 }
 
@@ -96,8 +101,16 @@ export function mergeSourceHealth(healths: readonly SourceHealth[]): MergedSourc
     return { status: "healthy", unhealthySources: [] };
   }
   const unhealthySources = unhealthy.map((h) => h.source);
+  if (unhealthy.length !== healths.length) {
+    // 还有源在答:候选可用,但「没找到」不成立。此时具体是哪种失败不重要 ——
+    // 用户的当务之急是知道证据不完整,而不是去修某一个源。
+    return { status: "degraded", unhealthySources };
+  }
+  // 全挂。若所有失败同因,把这个因保留下来,好给出对症的处置建议;
+  // 混合失败则退回 unreachable(没有单一的建议可给)。
+  const everyStatus = new Set(unhealthy.map((h) => h.status));
   return {
-    status: unhealthy.length === healths.length ? "unreachable" : "degraded",
+    status: everyStatus.size === 1 && everyStatus.has("protocol_error") ? "protocol_error" : "unreachable",
     unhealthySources,
   };
 }

--- a/packages/workflow/src/resource-source-health.ts
+++ b/packages/workflow/src/resource-source-health.ts
@@ -92,6 +92,22 @@ export function isSourceUsable(health: SourceHealth): boolean {
   return health.status === "healthy";
 }
 
+/**
+ * 合并态是否算「可用证据」——即基于它下「没有资源」的结论是否站得住。
+ *
+ * degraded 算可用：至少一个源答了，拿到的候选是真的。有意不把 degraded 归为
+ * 不可用 —— 否则任何一个次要索引挂掉就再也报不出真实的「没有资源」，过于激进。
+ * healthy 走 isSourceUsable，不在这里重述分类学。
+ *
+ * 调用方需要「缺字段=healthy」的向后兼容时，自己传 undefined 进来即可。
+ * fallback-provider.ts 有一个同口径的本地谓词（它吃的是域快照，不是 V2 快照）。
+ */
+export function isMergedSourceEvidenceUsable(health: MergedSourceHealth | undefined): boolean {
+  if (!health) return true;
+  if (health.status === "degraded") return true;
+  return isSourceUsable({ status: health.status, source: health.unhealthySources.join("、") });
+}
+
 export function mergeSourceHealth(healths: readonly SourceHealth[]): MergedSourceHealth {
   if (healths.length === 0) {
     return { status: "healthy", unhealthySources: [] };

--- a/packages/workflow/src/resource-source-health.ts
+++ b/packages/workflow/src/resource-source-health.ts
@@ -75,7 +75,7 @@ const UNREACHABLE_CODES = new Set([
  * 「源可能有问题」，也不能把未知失败当成「确认没有资源」——后者会让用户
  * 停止排查，正是本次要修的病。
  */
-export function classifySourceFailure(error: unknown): Exclude<SourceStatus, "healthy"> {
+export function classifySourceFailure(error: unknown): "unreachable" | "protocol_error" {
   // instanceof 优先:同进程内这是类型安全的判定。字符串前缀留作兜底,
   // 覆盖跨包/跨进程(错误经序列化后 instanceof 失效)的情形。
   if (error instanceof PanSouProtocolError) {
@@ -130,25 +130,30 @@ export function mergeSourceHealth(healths: readonly SourceHealth[]): MergedSourc
   if (healths.length === 0) {
     return { status: "healthy", unhealthySources: [] };
   }
-  const unhealthy = healths.filter((h) => !isSourceUsable(h));
-  const unhealthySources = unhealthy.map((h) => h.source);
+  // 两个集合要分开:
+  //  - `unusable` = 完全不可用的源(unreachable/protocol_error),决定「是否全挂」。
+  //  - `unhealthySources` = 所有「不是完全健康」的源,决定「点名谁」。degraded 的
+  //    源(比如回落官方源后)必须也能被点名,否则全 degraded 时报 [] → 上层只能
+  //    显示「未知」。
+  const unusable = healths.filter((h) => !isSourceUsable(h));
+  const unhealthySources = healths.filter((h) => h.status !== "healthy").map((h) => h.source);
   // 任何源自报 degraded(比如回落官方源后)都说明整体证据不完整 —— 即使没有源
   // 完全挂掉。此时必须带 degraded 信号,否则「部分证据」看起来像「完整证据」。
   const anyDegraded = healths.some((h) => h.status === "degraded");
-  if (unhealthy.length === 0 && anyDegraded) {
+  if (unusable.length === 0 && anyDegraded) {
     return { status: "degraded", unhealthySources };
   }
-  if (unhealthy.length === 0) {
+  if (unusable.length === 0) {
     return { status: "healthy", unhealthySources };
   }
-  if (unhealthy.length !== healths.length) {
+  if (unusable.length !== healths.length) {
     // 还有源在答:候选可用,但「没找到」不成立。此时具体是哪种失败不重要 ——
     // 用户的当务之急是知道证据不完整,而不是去修某一个源。
     return { status: "degraded", unhealthySources };
   }
   // 全挂。若所有失败同因,把这个因保留下来,好给出对症的处置建议;
   // 混合失败则退回 unreachable(没有单一的建议可给)。
-  const everyStatus = new Set(unhealthy.map((h) => h.status));
+  const everyStatus = new Set(unusable.map((h) => h.status));
   return {
     status: everyStatus.size === 1 && everyStatus.has("protocol_error") ? "protocol_error" : "unreachable",
     unhealthySources,

--- a/packages/workflow/src/resource-source-health.ts
+++ b/packages/workflow/src/resource-source-health.ts
@@ -6,8 +6,14 @@
  */
 
 /** 单个源的状态。protocol_error 与 unreachable 分开，是因为它们的用户动作不同：
- *  前者「地址填错了/那不是 PanSou」，后者「源挂了/网络不通」。 */
-export type SourceStatus = "healthy" | "unreachable" | "protocol_error";
+ *  前者「地址填错了/那不是 PanSou」，后者「源挂了/网络不通」。
+ *
+ *  degraded 的存在是为了让「部分证据」的信号能穿过复合层:一个成员(比如
+ *  FallbackResourceProvider 回落官方源后)自报 degraded,意味着它**答了话、给了
+ *  候选**、但证据不完整。折成 healthy 会让不完整证据看起来像完整证据(把本 PR
+ *  要消灭的「静默误导」从另一端放回来);折成 unreachable 又会与「它确实给了
+ *  候选」自相矛盾。所以合并层必须**透传** degraded,而不是折向任何一端。 */
+export type SourceStatus = "healthy" | "degraded" | "unreachable" | "protocol_error";
 
 export interface SourceHealth {
   status: SourceStatus;
@@ -101,7 +107,7 @@ export function hasRecognisedUnreachableCode(error: unknown): boolean {
 }
 
 export function isSourceUsable(health: SourceHealth): boolean {
-  return health.status === "healthy";
+  return health.status === "healthy" || health.status === "degraded";
 }
 
 /**
@@ -125,10 +131,16 @@ export function mergeSourceHealth(healths: readonly SourceHealth[]): MergedSourc
     return { status: "healthy", unhealthySources: [] };
   }
   const unhealthy = healths.filter((h) => !isSourceUsable(h));
-  if (unhealthy.length === 0) {
-    return { status: "healthy", unhealthySources: [] };
-  }
   const unhealthySources = unhealthy.map((h) => h.source);
+  // 任何源自报 degraded(比如回落官方源后)都说明整体证据不完整 —— 即使没有源
+  // 完全挂掉。此时必须带 degraded 信号,否则「部分证据」看起来像「完整证据」。
+  const anyDegraded = healths.some((h) => h.status === "degraded");
+  if (unhealthy.length === 0 && anyDegraded) {
+    return { status: "degraded", unhealthySources };
+  }
+  if (unhealthy.length === 0) {
+    return { status: "healthy", unhealthySources };
+  }
   if (unhealthy.length !== healths.length) {
     // 还有源在答:候选可用,但「没找到」不成立。此时具体是哪种失败不重要 ——
     // 用户的当务之急是知道证据不完整,而不是去修某一个源。

--- a/packages/workflow/src/resource-source-health.ts
+++ b/packages/workflow/src/resource-source-health.ts
@@ -46,6 +46,9 @@ export function classifySourceFailure(error: unknown): Exclude<SourceStatus, "he
   if (message.startsWith(PROTOCOL_ERROR_PREFIX)) {
     return "protocol_error";
   }
+  // 下面两个分支当前同值(都 unreachable),保留不是冗余而是分类学:它们记录了
+  // 已经考虑过的失败条件。后续若要按错误类型分化重试/退避策略(ETIMEDOUT 值得
+  // 重试、ECONNREFUSED 基本不值得),分叉点就在这里 —— 届时不必重新调研这份清单。
   const code = (error as { code?: unknown } | null)?.code;
   if (typeof code === "string" && UNREACHABLE_CODES.has(code)) {
     return "unreachable";

--- a/packages/workflow/src/resource-source-health.ts
+++ b/packages/workflow/src/resource-source-health.ts
@@ -1,0 +1,76 @@
+/**
+ * 搜索源健康态。存在的唯一理由：让「源挂了」与「真没有这个资源」在数据上
+ * 可区分。在此之前两者都表现为 `candidates: []`，于是 agent 上报
+ * reportNoCoverage、用户看到「暂未找到可用资源」—— 把系统故障甩锅给资源。
+ * 同一条教义见 acquisition-v2/transfer-block.ts（账号被封锁 vs 链接确实死了）。
+ */
+
+/** 单个源的状态。protocol_error 与 unreachable 分开，是因为它们的用户动作不同：
+ *  前者「地址填错了/那不是 PanSou」，后者「源挂了/网络不通」。 */
+export type SourceStatus = "healthy" | "unreachable" | "protocol_error";
+
+export interface SourceHealth {
+  status: SourceStatus;
+  /** 源名（pansou / prowlarr / …），用于告知用户是哪个挂了。 */
+  source: string;
+}
+
+/** 多源合并后的整体健康态。degraded = 部分源答了：拿到的候选可用，但
+ *  「没找到」这个结论不成立（证据不完整）。 */
+export interface MergedSourceHealth {
+  status: "healthy" | "degraded" | "unreachable";
+  unhealthySources: string[];
+}
+
+/** 协议层失败的哨兵前缀。provider 用它标记「连上了但对方不是 PanSou」。 */
+export const PROTOCOL_ERROR_PREFIX = "PANSOU_BAD_RESPONSE";
+
+const UNREACHABLE_CODES = new Set([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
+  "ABORT_ERR",
+]);
+
+/**
+ * 把一个异常归类。**默认 unreachable 而不是 healthy**：宁可多报一次
+ * 「源可能有问题」，也不能把未知失败当成「确认没有资源」——后者会让用户
+ * 停止排查，正是本次要修的病。
+ */
+export function classifySourceFailure(error: unknown): Exclude<SourceStatus, "healthy"> {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.startsWith(PROTOCOL_ERROR_PREFIX)) {
+    return "protocol_error";
+  }
+  const code = (error as { code?: unknown } | null)?.code;
+  if (typeof code === "string" && UNREACHABLE_CODES.has(code)) {
+    return "unreachable";
+  }
+  if (/timed out|timeout|aborted/i.test(message)) {
+    return "unreachable";
+  }
+  return "unreachable";
+}
+
+export function isSourceUsable(health: SourceHealth): boolean {
+  return health.status === "healthy";
+}
+
+export function mergeSourceHealth(healths: readonly SourceHealth[]): MergedSourceHealth {
+  if (healths.length === 0) {
+    return { status: "healthy", unhealthySources: [] };
+  }
+  const unhealthy = healths.filter((h) => !isSourceUsable(h));
+  if (unhealthy.length === 0) {
+    return { status: "healthy", unhealthySources: [] };
+  }
+  const unhealthySources = unhealthy.map((h) => h.source);
+  return {
+    status: unhealthy.length === healths.length ? "unreachable" : "degraded",
+    unhealthySources,
+  };
+}

--- a/packages/workflow/src/resource-source-health.ts
+++ b/packages/workflow/src/resource-source-health.ts
@@ -41,6 +41,18 @@ export class PanSouProtocolError extends Error {
   }
 }
 
+/** 「按 PanSou 协议应答了,但报了错」—— 比如限流/参数错(code != 0)。这与
+ *  `PanSouProtocolError` 相反:后者表示「地址指向的东西不是 PanSou」,前者表示
+ *  「源是 PanSou,只是此刻临时出错」。分类上归 unreachable(临时故障,等恢复/重试),
+ *  绝不能归 protocol_error —— 否则会告诉一个源其实没配错的用户「地址填错了」,
+ *  把他引向错误的排查方向。 */
+export class PanSouRequestError extends Error {
+  constructor(detail: string) {
+    super(`PANSOU_REQUEST_ERROR: ${detail}`);
+    this.name = "PanSouRequestError";
+  }
+}
+
 const UNREACHABLE_CODES = new Set([
   "ECONNREFUSED",
   "ENOTFOUND",

--- a/packages/workflow/tests/composite-provider-health.test.ts
+++ b/packages/workflow/tests/composite-provider-health.test.ts
@@ -80,6 +80,40 @@ describe("CompositeResourceProvider source health", () => {
     expect(snapshot.sourceHealth?.unhealthySources).toEqual(["pansou"]);
   });
 
+  it("never reports unreachable while candidates were actually returned", async () => {
+    // 自相矛盾的快照:成员自报 degraded(内部有子源挂了)但确实给了候选。若把
+    // degraded 压成 unreachable,整体会变成「有候选却说一个都没取回」,agent
+    // 会读到一句假话。Copilot 评审指出的这一点。
+    const degradedWithCandidate: ResourceProvider = {
+      search: async () => ({
+        id: "s1",
+        provider: "stub",
+        keyword: "k",
+        createdAt: "2026-08-06T00:00:00.000Z",
+        sourceHealth: { status: "degraded", unhealthySources: ["prowlarr"] },
+        candidates: [
+          {
+            id: "c1",
+            snapshotId: "s1",
+            index: 0,
+            title: "命中",
+            type: "quark",
+            source: "pansou",
+            providerPayload: { url: "https://pan.quark.cn/s/abc" },
+          },
+        ],
+      }),
+    };
+    const composite = new CompositeResourceProvider({
+      providers: [{ name: "pansou", provider: degradedWithCandidate }],
+    });
+
+    const snapshot = await composite.search({ keyword: "k" });
+
+    expect(snapshot.candidates.length).toBe(1);
+    expect(snapshot.sourceHealth?.status).not.toBe("unreachable");
+  });
+
   it("preserves protocol_error when it is the single cause of total failure", async () => {
     // 「地址填错了」and「源挂了」need different user action, so the distinction
     // must survive the merge (see mergeSourceHealth).

--- a/packages/workflow/tests/composite-provider-health.test.ts
+++ b/packages/workflow/tests/composite-provider-health.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { CompositeResourceProvider } from "../src/composite-provider.js";
 import type { ResourceProvider } from "../src/ports.js";
 import type { ResourceSnapshot } from "../src/domain.js";
+import { PanSouProtocolError } from "../src/resource-source-health.js";
 
 function stubProvider(over: Partial<ResourceSnapshot> = {}): ResourceProvider {
   return {
@@ -128,6 +129,23 @@ describe("CompositeResourceProvider source health", () => {
       ],
     });
     const snapshot = await composite.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("protocol_error");
+  });
+
+  it("preserves protocol_error when a member THROWS PanSouProtocolError", async () => {
+    // 硬编码 unreachable 会把「地址指向了别的服务」压成「源挂了」,用户拿到
+    // 错误的处置建议(Copilot 评审的 suppressed 意见)。
+    const throwingProtocol: ResourceProvider = {
+      search: async () => {
+        throw new PanSouProtocolError("not a PanSou payload");
+      },
+    };
+    const composite = new CompositeResourceProvider({
+      providers: [{ name: "pansou", provider: throwingProtocol }],
+    });
+
+    const snapshot = await composite.search({ keyword: "k" });
+
     expect(snapshot.sourceHealth?.status).toBe("protocol_error");
   });
 

--- a/packages/workflow/tests/composite-provider-health.test.ts
+++ b/packages/workflow/tests/composite-provider-health.test.ts
@@ -132,6 +132,29 @@ describe("CompositeResourceProvider source health", () => {
     expect(snapshot.sourceHealth?.status).toBe("protocol_error");
   });
 
+  it("preserves a member's degraded signal (not folded to healthy)", async () => {
+    // 两次 Copilot 评审的合流结论:degraded 折成 healthy 会让「部分证据」看起来
+    // 像「完整证据」,把本 PR 要消灭的静默误导从另一端放回来。这个信号对上层
+    // 判断「能不能下『没找到』结论」至关重要。
+    const degradedProvider: ResourceProvider = {
+      search: async () => ({
+        id: "s1",
+        provider: "stub",
+        keyword: "k",
+        createdAt: "2026-08-06T00:00:00.000Z",
+        sourceHealth: { status: "degraded", unhealthySources: ["官方搜索源"] },
+        candidates: [],
+      }),
+    };
+    const composite = new CompositeResourceProvider({
+      providers: [{ name: "pansou", provider: degradedProvider }],
+    });
+
+    const snapshot = await composite.search({ keyword: "k" });
+
+    expect(snapshot.sourceHealth?.status).toBe("degraded");
+  });
+
   it("preserves protocol_error when a member THROWS PanSouProtocolError", async () => {
     // 硬编码 unreachable 会把「地址指向了别的服务」压成「源挂了」,用户拿到
     // 错误的处置建议(Copilot 评审的 suppressed 意见)。

--- a/packages/workflow/tests/composite-provider-health.test.ts
+++ b/packages/workflow/tests/composite-provider-health.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { CompositeResourceProvider } from "../src/composite-provider.js";
+import type { ResourceProvider } from "../src/ports.js";
+import type { ResourceSnapshot } from "../src/domain.js";
+
+function stubProvider(over: Partial<ResourceSnapshot> = {}): ResourceProvider {
+  return {
+    search: async () => ({
+      id: "s1",
+      provider: "stub",
+      keyword: "k",
+      candidates: [],
+      createdAt: "2026-08-06T00:00:00.000Z",
+      ...over,
+    }),
+  };
+}
+
+function throwingProvider(message: string, code?: string): ResourceProvider {
+  return {
+    search: async () => {
+      throw code ? Object.assign(new Error(message), { code }) : new Error(message);
+    },
+  };
+}
+
+describe("CompositeResourceProvider source health", () => {
+  it("is healthy when all members answered", async () => {
+    const composite = new CompositeResourceProvider({
+      providers: [
+        { name: "pansou", provider: stubProvider() },
+        { name: "prowlarr", provider: stubProvider() },
+      ],
+    });
+    const snapshot = await composite.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("healthy");
+    expect(snapshot.sourceHealth?.unhealthySources).toEqual([]);
+  });
+
+  it("is degraded and names the dead member when one throws", async () => {
+    const composite = new CompositeResourceProvider({
+      providers: [
+        { name: "pansou", provider: stubProvider() },
+        { name: "prowlarr", provider: throwingProvider("boom", "ECONNREFUSED") },
+      ],
+    });
+    const snapshot = await composite.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("degraded");
+    expect(snapshot.sourceHealth?.unhealthySources).toEqual(["prowlarr"]);
+  });
+
+  it("is unreachable when every member is down", async () => {
+    const composite = new CompositeResourceProvider({
+      providers: [
+        { name: "pansou", provider: throwingProvider("boom", "ECONNREFUSED") },
+        { name: "prowlarr", provider: throwingProvider("boom", "ETIMEDOUT") },
+      ],
+    });
+    const snapshot = await composite.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("unreachable");
+    expect(snapshot.sourceHealth?.unhealthySources).toEqual(["pansou", "prowlarr"]);
+  });
+
+  it("reads a member's OWN unhealthy self-report even though it did not throw", async () => {
+    // PanSou reports unreachable via sourceHealth rather than by throwing (Task 2),
+    // so reading only the Promise status would miss it entirely.
+    const composite = new CompositeResourceProvider({
+      providers: [
+        {
+          name: "pansou",
+          provider: stubProvider({
+            sourceHealth: { status: "unreachable", unhealthySources: ["pansou"] },
+          }),
+        },
+        { name: "prowlarr", provider: stubProvider() },
+      ],
+    });
+    const snapshot = await composite.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("degraded");
+    expect(snapshot.sourceHealth?.unhealthySources).toEqual(["pansou"]);
+  });
+
+  it("preserves protocol_error when it is the single cause of total failure", async () => {
+    // 「地址填错了」and「源挂了」need different user action, so the distinction
+    // must survive the merge (see mergeSourceHealth).
+    const composite = new CompositeResourceProvider({
+      providers: [
+        {
+          name: "pansou",
+          provider: stubProvider({
+            sourceHealth: { status: "protocol_error", unhealthySources: ["pansou"] },
+          }),
+        },
+      ],
+    });
+    const snapshot = await composite.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("protocol_error");
+  });
+
+  it("treats a member with NO sourceHealth field as healthy (back-compat)", async () => {
+    const composite = new CompositeResourceProvider({
+      providers: [{ name: "legacy", provider: stubProvider() }],
+    });
+    const snapshot = await composite.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("healthy");
+  });
+
+  it("still merges candidates from the surviving member when another is down", async () => {
+    // Health reporting must not cost us the results we DID get.
+    const withCandidate = stubProvider({
+      candidates: [
+        {
+          id: "c1",
+          snapshotId: "s1",
+          index: 0,
+          title: "命中",
+          type: "quark",
+          source: "pansou",
+          providerPayload: { url: "https://pan.quark.cn/s/abc" },
+        },
+      ],
+    });
+    const composite = new CompositeResourceProvider({
+      providers: [
+        { name: "pansou", provider: withCandidate },
+        { name: "prowlarr", provider: throwingProvider("boom", "ECONNREFUSED") },
+      ],
+    });
+    const snapshot = await composite.search({ keyword: "k" });
+    expect(snapshot.candidates.length).toBe(1);
+    expect(snapshot.sourceHealth?.status).toBe("degraded");
+  });
+});

--- a/packages/workflow/tests/empty-run-outcome-source-fault.test.ts
+++ b/packages/workflow/tests/empty-run-outcome-source-fault.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { emptyRunOutcome } from "../src/notification-report.js";
+
+/**
+ * 这是整个 PR 真正要证明的东西:源挂了的时候,用户读到的那句话变了。
+ * 前面所有 task 都只是让故障「可被检测」;只有这一层改变了用户看见什么。
+ */
+describe("emptyRunOutcome — 搜索源故障要说真话", () => {
+  it("源故障时不再说「暂未找到可用资源」", () => {
+    const out = emptyRunOutcome(null, "自建搜索源 本轮连不上，没能取回任何候选。");
+
+    expect(out.lines.join("")).not.toContain("暂未找到可用资源");
+    expect(out.lines.join("")).toContain("连不上");
+    // failed 而非 no_coverage:no_coverage 会把它归进「确实没有、继续等」那一桶。
+    expect(out.status).toBe("failed");
+  });
+
+  it("没有任何故障时,仍然如实报「暂未找到可用资源」（关键对照组）", () => {
+    // 若这条断言坏掉,产品就再也无法如实报告「确实没有」—— 那比它要修的 bug 更糟。
+    const out = emptyRunOutcome(null, null);
+
+    expect(out.status).toBe("no_coverage");
+    expect(out.lines).toEqual(["暂未找到可用资源 · 将持续尝试"]);
+  });
+
+  it("空串/空白的源故障原因不算故障（不因脏数据误报）", () => {
+    expect(emptyRunOutcome(null, "").status).toBe("no_coverage");
+    expect(emptyRunOutcome(null, "   ").status).toBe("no_coverage");
+  });
+
+  it("转存受阻优先于搜索源故障", () => {
+    // 能走到转存说明资源已经找到过了,用户的问题是配额/登录这种立刻可动手的事;
+    // 报搜索源故障只会让他去查一个其实工作过的源。
+    const out = emptyRunOutcome("配额不足", "搜索源连不上");
+
+    expect(out.lines.join("")).toContain("转存失败:配额不足");
+    expect(out.lines.join("")).not.toContain("搜索源");
+  });
+
+  it("转存受阻仍然照旧工作（未被新分支破坏）", () => {
+    const out = emptyRunOutcome("登录过期", null);
+
+    expect(out.status).toBe("failed");
+    expect(out.lines).toEqual(["转存失败:登录过期"]);
+  });
+});

--- a/packages/workflow/tests/fallback-provider.test.ts
+++ b/packages/workflow/tests/fallback-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { FallbackResourceProvider } from "../src/fallback-provider.js";
 import type { ResourceProvider } from "../src/ports.js";
 import type { ResourceSnapshot } from "../src/domain.js";
+import { PanSouProtocolError } from "../src/resource-source-health.js";
 
 function snapshotWith(over: Partial<ResourceSnapshot>): ResourceSnapshot {
   return {
@@ -110,6 +111,36 @@ describe("FallbackResourceProvider", () => {
     const snapshot = await provider.search({ keyword: "k" });
     expect(snapshot.id).toBe("official");
     expect(snapshot.sourceHealth?.status).toBe("degraded");
+  });
+
+  it("keeps the primary's protocol_error visible after falling back (not flattened to unreachable)", async () => {
+    // 「地址填错了」and「源挂了」need different remedies. A bare `catch` on the
+    // fallback path would discard the cause and the UI would tell a user with a
+    // typo'd URL that their source is down.
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: deadProvider("protocol_error") },
+      secondary: { name: "official", provider: okProvider("official") },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("degraded");
+    expect(snapshot.sourceHealth?.unhealthySources).toEqual(["user"]);
+  });
+
+  it("preserves protocol_error as the total-failure cause when the primary THREW it", async () => {
+    // The cause must survive an exception too, not just a self-reported status —
+    // that is the path a bare `catch { return null }` silently destroys.
+    const throwingProtocol: ResourceProvider = {
+      search: async () => {
+        throw new PanSouProtocolError("not a PanSou payload");
+      },
+    };
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: throwingProtocol },
+      secondary: { name: "official", provider: deadProvider("protocol_error") },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("protocol_error");
+    expect(snapshot.candidates).toEqual([]);
   });
 
   it("does NOT fall back when the primary is healthy but genuinely empty", async () => {

--- a/packages/workflow/tests/fallback-provider.test.ts
+++ b/packages/workflow/tests/fallback-provider.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { FallbackResourceProvider } from "../src/fallback-provider.js";
+import type { ResourceProvider } from "../src/ports.js";
+import type { ResourceSnapshot } from "../src/domain.js";
+
+function snapshotWith(over: Partial<ResourceSnapshot>): ResourceSnapshot {
+  return {
+    id: "s",
+    provider: "stub",
+    keyword: "k",
+    candidates: [],
+    createdAt: "2026-08-06T00:00:00.000Z",
+    ...over,
+  };
+}
+
+function okProvider(id: string): ResourceProvider {
+  return {
+    search: async () =>
+      snapshotWith({
+        id,
+        sourceHealth: { status: "healthy", unhealthySources: [] },
+        candidates: [
+          {
+            id: `${id}_c1`,
+            snapshotId: id,
+            index: 0,
+            title: "命中",
+            type: "quark",
+            source: id,
+            providerPayload: { url: `https://pan.quark.cn/s/${id}` },
+          },
+        ],
+      }),
+  };
+}
+
+function deadProvider(status: "unreachable" | "protocol_error" = "unreachable"): ResourceProvider {
+  return {
+    search: async () =>
+      snapshotWith({ id: "dead", sourceHealth: { status, unhealthySources: ["pansou"] } }),
+  };
+}
+
+describe("FallbackResourceProvider", () => {
+  it("uses the primary and never touches the secondary when the primary is healthy", async () => {
+    const secondary = okProvider("official");
+    const spy = vi.spyOn(secondary, "search");
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: okProvider("user") },
+      secondary: { name: "official", provider: secondary },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.id).toBe("user");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the secondary when the primary is unreachable", async () => {
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: deadProvider() },
+      secondary: { name: "official", provider: okProvider("official") },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.id).toBe("official");
+    expect(snapshot.candidates.length).toBe(1);
+  });
+
+  it("falls back when the primary is a protocol_error too (wrong address, not just down)", async () => {
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: deadProvider("protocol_error") },
+      secondary: { name: "official", provider: okProvider("official") },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.id).toBe("official");
+  });
+
+  it("marks the result degraded after a fallback so the primary's outage stays visible", async () => {
+    // The search succeeded, but the user's configured source is broken and they
+    // must still be told — silently limping along is how a misconfiguration
+    // survives for weeks (it survived six days in the reported case).
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: deadProvider() },
+      secondary: { name: "official", provider: okProvider("official") },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("degraded");
+    expect(snapshot.sourceHealth?.unhealthySources).toEqual(["user"]);
+  });
+
+  it("reports unreachable when BOTH sources are down", async () => {
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: deadProvider() },
+      secondary: { name: "official", provider: deadProvider() },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.sourceHealth?.status).toBe("unreachable");
+    expect(snapshot.candidates).toEqual([]);
+  });
+
+  it("falls back when the primary throws outright", async () => {
+    const throwing: ResourceProvider = {
+      search: async () => {
+        throw Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+      },
+    };
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: throwing },
+      secondary: { name: "official", provider: okProvider("official") },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.id).toBe("official");
+    expect(snapshot.sourceHealth?.status).toBe("degraded");
+  });
+
+  it("does NOT fall back when the primary is healthy but genuinely empty", async () => {
+    // Critical distinction: an authoritative "no results" must not trigger a
+    // second, slower search — that would double the cost of every miss.
+    const empty: ResourceProvider = {
+      search: async () =>
+        snapshotWith({ id: "user", sourceHealth: { status: "healthy", unhealthySources: [] } }),
+    };
+    const secondary = okProvider("official");
+    const spy = vi.spyOn(secondary, "search");
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: empty },
+      secondary: { name: "official", provider: secondary },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.id).toBe("user");
+    expect(snapshot.candidates).toEqual([]);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fall back when the primary lacks a sourceHealth field (back-compat)", async () => {
+    const legacy: ResourceProvider = { search: async () => snapshotWith({ id: "user" }) };
+    const secondary = okProvider("official");
+    const spy = vi.spyOn(secondary, "search");
+    const provider = new FallbackResourceProvider({
+      primary: { name: "user", provider: legacy },
+      secondary: { name: "official", provider: secondary },
+    });
+    const snapshot = await provider.search({ keyword: "k" });
+    expect(snapshot.id).toBe("user");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workflow/tests/pansou-provider-health.test.ts
+++ b/packages/workflow/tests/pansou-provider-health.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { PanSouResourceProvider } from "../src/pansou-provider.js";
+
+// NOTE: PanSou nests links under `result.links[]` (see collectLinkFacts) — a
+// result with a top-level `url` yields ZERO facts. The fixture must use the
+// real shape or "returns candidates" assertions can never pass.
+const OK_RESPONSE = {
+  code: 0,
+  data: {
+    results: [
+      {
+        title: "示例 S01",
+        channel: "telegram-a",
+        links: [
+          {
+            type: "quark",
+            url: "https://pan.quark.cn/s/abc123",
+            password: "",
+            datetime: "2026-08-01",
+          },
+        ],
+      },
+    ],
+  },
+};
+
+describe("PanSouResourceProvider source health", () => {
+  it("reports healthy and returns candidates on a good response", async () => {
+    const provider = new PanSouResourceProvider({
+      baseURL: "http://pansou.test",
+      fetchJson: async () => OK_RESPONSE,
+      wait: async () => {},
+    });
+
+    const snapshot = await provider.search({ keyword: "示例" });
+
+    expect(snapshot.sourceHealth?.status).toBe("healthy");
+    expect(snapshot.candidates.length).toBeGreaterThan(0);
+  });
+
+  it("reports unreachable instead of an empty no-results snapshot when the FIRST call fails", async () => {
+    // The reported bug: PanSou had been down for 6 days and the product kept
+    // saying 「暂未找到可用资源」.
+    const provider = new PanSouResourceProvider({
+      baseURL: "http://pansou.test",
+      fetchJson: async () => {
+        throw Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8899"), {
+          code: "ECONNREFUSED",
+        });
+      },
+      wait: async () => {},
+    });
+
+    const snapshot = await provider.search({ keyword: "示例" });
+
+    expect(snapshot.candidates).toEqual([]);
+    expect(snapshot.sourceHealth?.status).toBe("unreachable");
+  });
+
+  it("reports protocol_error when the endpoint answers but is not PanSou", async () => {
+    // Real scenario: the address pointed at a static file server.
+    const provider = new PanSouResourceProvider({
+      baseURL: "http://pansou.test",
+      fetchJson: async () => ({ hello: "i am not pansou" }),
+      wait: async () => {},
+    });
+
+    const snapshot = await provider.search({ keyword: "示例" });
+
+    expect(snapshot.candidates).toEqual([]);
+    expect(snapshot.sourceHealth?.status).toBe("protocol_error");
+  });
+
+  it("stays healthy when a LATER poll fails but earlier polls already produced results", async () => {
+    // The original catch existed to preserve partial results mid-poll. That must
+    // survive: real evidence was already obtained, so the source is not 'down'.
+    let call = 0;
+    const provider = new PanSouResourceProvider({
+      baseURL: "http://pansou.test",
+      fetchJson: async () => {
+        call += 1;
+        if (call === 1) return OK_RESPONSE;
+        throw new Error("connection reset mid-poll");
+      },
+      wait: async () => {},
+    });
+
+    const snapshot = await provider.search({ keyword: "示例" });
+
+    expect(snapshot.candidates.length).toBeGreaterThan(0);
+    expect(snapshot.sourceHealth?.status).toBe("healthy");
+  });
+
+  it("reports healthy with zero candidates when PanSou genuinely has nothing", async () => {
+    // The control that must NOT regress: a real empty result is an authoritative
+    // 'no resources' answer and must stay distinguishable from a failure.
+    const provider = new PanSouResourceProvider({
+      baseURL: "http://pansou.test",
+      fetchJson: async () => ({ code: 0, data: { results: [] } }),
+      wait: async () => {},
+    });
+
+    const snapshot = await provider.search({ keyword: "示例" });
+
+    expect(snapshot.candidates).toEqual([]);
+    expect(snapshot.sourceHealth?.status).toBe("healthy");
+  });
+
+  it("keeps polling across attempts (the streaming behaviour must not regress)", async () => {
+    // PanSou returns more results on later calls; the provider must not stop at
+    // the first non-growing response before attempt 1.
+    let call = 0;
+    const provider = new PanSouResourceProvider({
+      baseURL: "http://pansou.test",
+      fetchJson: async () => {
+        call += 1;
+        return call === 1
+          ? OK_RESPONSE
+          : {
+              code: 0,
+              data: {
+                results: [
+                  ...OK_RESPONSE.data.results,
+                  {
+                    title: "示例 S02",
+                    channel: "telegram-b",
+                    links: [
+                      {
+                        type: "quark",
+                        url: "https://pan.quark.cn/s/def456",
+                        password: "",
+                        datetime: "2026-08-02",
+                      },
+                    ],
+                  },
+                ],
+              },
+            };
+      },
+      wait: async () => {},
+    });
+
+    const snapshot = await provider.search({ keyword: "示例" });
+
+    expect(call).toBeGreaterThan(1);
+    expect(snapshot.candidates.length).toBe(2);
+    expect(snapshot.sourceHealth?.status).toBe("healthy");
+  });
+});

--- a/packages/workflow/tests/pansou-provider-health.test.ts
+++ b/packages/workflow/tests/pansou-provider-health.test.ts
@@ -106,6 +106,22 @@ describe("PanSouResourceProvider source health", () => {
     expect(snapshot.sourceHealth?.status).toBe("healthy");
   });
 
+  it("classifies a PanSou error response (code!=0) as unreachable, NOT protocol_error", async () => {
+    // code:400 的响应**是 PanSou**(按它的协议应答),只是报了错 —— 限流/参数错。
+    // 归 protocol_error 会让用户以为「地址填错了」,而实际上是源侧临时故障。
+    const provider = new PanSouResourceProvider({
+      baseURL: "http://pansou.test",
+      fetchJson: async () => ({ code: 400, message: "bad request" }),
+      wait: async () => {},
+    });
+
+    const snapshot = await provider.search({ keyword: "示例" });
+
+    expect(snapshot.candidates).toEqual([]);
+    expect(snapshot.sourceHealth?.status).toBe("unreachable");
+    expect(snapshot.sourceHealth?.status).not.toBe("protocol_error");
+  });
+
   it("keeps polling across attempts (the streaming behaviour must not regress)", async () => {
     // PanSou returns more results on later calls; the provider must not stop at
     // the first non-growing response before attempt 1.

--- a/packages/workflow/tests/resource-source-health.test.ts
+++ b/packages/workflow/tests/resource-source-health.test.ts
@@ -99,6 +99,31 @@ describe("mergeSourceHealth", () => {
     expect(merged.unhealthySources).toEqual(["pansou", "prowlarr"]);
   });
 
+  it("preserves protocol_error when it is the single cause of a total failure", () => {
+    // 「地址填错了」与「源挂了」的处置动作不同,压平成 unreachable 会把用户
+    // 引向错误的排查方向 —— 这两个状态存在的全部理由就是区分它们。
+    const merged = mergeSourceHealth([{ status: "protocol_error", source: "pansou" }]);
+    expect(merged.status).toBe("protocol_error");
+    expect(merged.unhealthySources).toEqual(["pansou"]);
+  });
+
+  it("falls back to unreachable when a total failure has mixed causes", () => {
+    // No single actionable remedy to offer, so do not imply one.
+    const merged = mergeSourceHealth([
+      { status: "protocol_error", source: "pansou" },
+      { status: "unreachable", source: "prowlarr" },
+    ]);
+    expect(merged.status).toBe("unreachable");
+  });
+
+  it("is degraded (not protocol_error) when another source still answers", () => {
+    const merged = mergeSourceHealth([
+      { status: "healthy", source: "prowlarr" },
+      { status: "protocol_error", source: "pansou" },
+    ]);
+    expect(merged.status).toBe("degraded");
+  });
+
   it("is healthy for an empty list (no sources configured is not a failure)", () => {
     const merged = mergeSourceHealth([]);
     expect(merged.status).toBe("healthy");

--- a/packages/workflow/tests/resource-source-health.test.ts
+++ b/packages/workflow/tests/resource-source-health.test.ts
@@ -116,6 +116,15 @@ describe("mergeSourceHealth", () => {
     expect(merged.status).toBe("unreachable");
   });
 
+  it("names a degraded source in unhealthySources so the UI can say WHO", () => {
+    // 全 degraded(没有任何源完全挂掉)时必须仍能点名是哪个源证据不完整,
+    // 否则 unhealthySources: [] → 上层告警只能显示「未知」(Copilot 评审)。
+    const merged = mergeSourceHealth([{ status: "degraded", source: "自建搜索源" }]);
+
+    expect(merged.status).toBe("degraded");
+    expect(merged.unhealthySources).toEqual(["自建搜索源"]);
+  });
+
   it("is degraded (not protocol_error) when another source still answers", () => {
     const merged = mergeSourceHealth([
       { status: "healthy", source: "prowlarr" },

--- a/packages/workflow/tests/resource-source-health.test.ts
+++ b/packages/workflow/tests/resource-source-health.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySourceFailure,
+  mergeSourceHealth,
+  isSourceUsable,
+} from "../src/resource-source-health.js";
+
+describe("classifySourceFailure", () => {
+  it("classifies connection refused as unreachable", () => {
+    const e = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8899"), {
+      code: "ECONNREFUSED",
+    });
+    expect(classifySourceFailure(e)).toBe("unreachable");
+  });
+
+  it("classifies DNS failure as unreachable", () => {
+    const e = Object.assign(new Error("getaddrinfo ENOTFOUND example.invalid"), {
+      code: "ENOTFOUND",
+    });
+    expect(classifySourceFailure(e)).toBe("unreachable");
+  });
+
+  it("classifies a timeout as unreachable", () => {
+    expect(classifySourceFailure(new Error("Request timed out after 8000ms"))).toBe("unreachable");
+  });
+
+  it("classifies a non-PanSou JSON shape as protocol_error", () => {
+    expect(classifySourceFailure(new Error("PANSOU_BAD_RESPONSE: not a PanSou payload"))).toBe(
+      "protocol_error",
+    );
+  });
+
+  it("falls back to unreachable for an unrecognised error rather than pretending success", () => {
+    expect(classifySourceFailure(new Error("something weird"))).toBe("unreachable");
+  });
+});
+
+describe("isSourceUsable", () => {
+  it("treats healthy as usable", () => {
+    expect(isSourceUsable({ status: "healthy", source: "pansou" })).toBe(true);
+  });
+
+  it("treats unreachable and protocol_error as unusable", () => {
+    expect(isSourceUsable({ status: "unreachable", source: "pansou" })).toBe(false);
+    expect(isSourceUsable({ status: "protocol_error", source: "pansou" })).toBe(false);
+  });
+});
+
+describe("mergeSourceHealth", () => {
+  it("is healthy when every source answered", () => {
+    const merged = mergeSourceHealth([
+      { status: "healthy", source: "pansou" },
+      { status: "healthy", source: "prowlarr" },
+    ]);
+    expect(merged.status).toBe("healthy");
+    expect(merged.unhealthySources).toEqual([]);
+  });
+
+  it("is degraded when some sources answered and some did not", () => {
+    const merged = mergeSourceHealth([
+      { status: "healthy", source: "pansou" },
+      { status: "unreachable", source: "prowlarr" },
+    ]);
+    expect(merged.status).toBe("degraded");
+    expect(merged.unhealthySources).toEqual(["prowlarr"]);
+  });
+
+  it("is unreachable when no source answered", () => {
+    const merged = mergeSourceHealth([
+      { status: "unreachable", source: "pansou" },
+      { status: "protocol_error", source: "prowlarr" },
+    ]);
+    expect(merged.status).toBe("unreachable");
+    expect(merged.unhealthySources).toEqual(["pansou", "prowlarr"]);
+  });
+
+  it("is healthy for an empty list (no sources configured is not a failure)", () => {
+    const merged = mergeSourceHealth([]);
+    expect(merged.status).toBe("healthy");
+    expect(merged.unhealthySources).toEqual([]);
+  });
+});

--- a/packages/workflow/tests/resource-source-health.test.ts
+++ b/packages/workflow/tests/resource-source-health.test.ts
@@ -3,6 +3,8 @@ import {
   classifySourceFailure,
   mergeSourceHealth,
   isSourceUsable,
+  PanSouProtocolError,
+  hasRecognisedUnreachableCode,
 } from "../src/resource-source-health.js";
 
 describe("classifySourceFailure", () => {
@@ -28,6 +30,29 @@ describe("classifySourceFailure", () => {
     expect(classifySourceFailure(new Error("PANSOU_BAD_RESPONSE: not a PanSou payload"))).toBe(
       "protocol_error",
     );
+  });
+
+  it("classifies PanSouProtocolError by instanceof, not by message text", () => {
+    // instanceof is the type-safe path; the string prefix is only a cross-process
+    // fallback. Renaming the message must not downgrade protocol_error.
+    expect(classifySourceFailure(new PanSouProtocolError("whatever wording"))).toBe(
+      "protocol_error",
+    );
+  });
+
+  it("unwraps error.cause to find the socket code (undici wraps it)", () => {
+    // Node fetch surfaces a flat "fetch failed" and hides ECONNREFUSED on .cause.
+    // Without unwrapping, UNREACHABLE_CODES would never match in production.
+    const wrapped = Object.assign(new Error("fetch failed"), {
+      cause: Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:8899"), {
+        code: "ECONNREFUSED",
+      }),
+    });
+    expect(classifySourceFailure(wrapped)).toBe("unreachable");
+    // Assert the MECHANISM, not just the outcome: the fallback also returns
+    // "unreachable", so without this the cause-unwrap could be deleted and the
+    // test would stay green (verified by mutation).
+    expect(hasRecognisedUnreachableCode(wrapped)).toBe(true);
   });
 
   it("falls back to unreachable for an unrecognised error rather than pretending success", () => {

--- a/packages/workflow/tests/search-source-fault.test.ts
+++ b/packages/workflow/tests/search-source-fault.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { classifySearchSourceFault } from "../src/acquisition-v2/search-source-fault.js";
+import type { AuditEvent } from "../src/domain.js";
+
+function refusedEvent(over: Partial<AuditEvent["data"]> = {}): AuditEvent {
+  return {
+    type: "no_coverage_refused_source_unhealthy",
+    message: "拒绝无覆盖上报",
+    data: { status: "unreachable", unhealthySources: ["自建搜索源"], snapshotCount: 2, ...over },
+  };
+}
+
+describe("classifySearchSourceFault", () => {
+  it("returns null with no audit events at all", () => {
+    expect(classifySearchSourceFault(undefined)).toBeNull();
+    expect(classifySearchSourceFault([])).toBeNull();
+  });
+
+  it("returns null for an ordinary run — a genuine absence must stay reportable", () => {
+    // THE critical control. Over-classifying would mean the product can never
+    // honestly say 「确实没有」 again, which is worse than the bug being fixed.
+    const events: AuditEvent[] = [
+      { type: "no_coverage_reported", message: "agent 上报无覆盖：搜遍了没有" },
+    ];
+    expect(classifySearchSourceFault(events)).toBeNull();
+  });
+
+  it("classifies a refused report as a source fault and names the source", () => {
+    const fault = classifySearchSourceFault([refusedEvent()]);
+    expect(fault).not.toBeNull();
+    expect(fault!.sources).toEqual(["自建搜索源"]);
+    expect(fault!.reason).toContain("自建搜索源");
+    // Must NOT imply the resource is absent.
+    expect(fault!.reason).not.toContain("暂未找到");
+  });
+
+  it("does NOT classify a lone mid-run unhealthy warning as a source fault", () => {
+    // One flaky search that later succeeded is not a source outage — the agent
+    // may well have found candidates afterwards. Only a refused report proves
+    // the whole evidence base was unusable.
+    const events: AuditEvent[] = [
+      { type: "search_source_unhealthy", message: "搜索时源不健康", data: { unhealthySources: ["x"] } },
+      { type: "no_coverage_reported", message: "后来搜到了但仍缺集" },
+    ];
+    expect(classifySearchSourceFault(events)).toBeNull();
+  });
+
+  it("gives protocol_error a different remedy than a plain outage", () => {
+    const outage = classifySearchSourceFault([refusedEvent({ status: "unreachable" })]);
+    const wrongThing = classifySearchSourceFault([refusedEvent({ status: "protocol_error" })]);
+    expect(outage!.reason).toContain("连不上");
+    expect(wrongThing!.reason).toContain("不是 PanSou");
+    expect(wrongThing!.reason).not.toEqual(outage!.reason);
+  });
+
+  it("treats a mixed status as an outage (no single actionable remedy)", () => {
+    const fault = classifySearchSourceFault([
+      refusedEvent({ status: "protocol_error/unreachable" }),
+    ]);
+    expect(fault!.reason).toContain("连不上");
+  });
+
+  it("falls back to a generic name when the source list is missing", () => {
+    const fault = classifySearchSourceFault([refusedEvent({ unhealthySources: [] })]);
+    expect(fault!.reason).toContain("搜索源");
+  });
+});

--- a/packages/workflow/tests/v2-real-provider-adapter.test.ts
+++ b/packages/workflow/tests/v2-real-provider-adapter.test.ts
@@ -91,6 +91,84 @@ describe("RealResourceProviderV2 — pansou → ResourceProviderV2 adapter", () 
     expect(registry.get("dead_magnet")).toBeUndefined();
   });
 
+  it("carries an unreachable sourceHealth through to the V2 snapshot (Task 9)", async () => {
+    const provider: ResourceProvider = {
+      search: async () => ({
+        ...realSnapshot(),
+        candidates: [],
+        sourceHealth: { status: "unreachable", unhealthySources: ["pansou"] },
+      }),
+    };
+    const adapter = new RealResourceProviderV2({
+      provider,
+      registry: new CandidateRegistry(),
+      workflowRunId: "run-1",
+    });
+
+    const view = await adapter.search("莉可丽丝 全集");
+
+    // 源挂了必须穿过 V2 边界。丢了它,沙箱就无法把「源故障」与「确实没有」区分开。
+    expect(view.sourceHealth).toEqual({ status: "unreachable", unhealthySources: ["pansou"] });
+  });
+
+  it("carries a healthy sourceHealth verbatim (pass-through, not dropped)", async () => {
+    const provider: ResourceProvider = {
+      search: async () => ({ ...realSnapshot(), sourceHealth: { status: "healthy", unhealthySources: [] } }),
+    };
+    const adapter = new RealResourceProviderV2({
+      provider,
+      registry: new CandidateRegistry(),
+      workflowRunId: "run-1",
+    });
+
+    const view = await adapter.search("莉可丽丝 全集");
+
+    expect(view.sourceHealth).toEqual({ status: "healthy", unhealthySources: [] });
+  });
+
+  it("omits sourceHealth when the domain snapshot has none (old providers keep working)", async () => {
+    const provider: ResourceProvider = { search: async () => realSnapshot() };
+    const adapter = new RealResourceProviderV2({
+      provider,
+      registry: new CandidateRegistry(),
+      workflowRunId: "run-1",
+    });
+
+    const view = await adapter.search("莉可丽丝 全集");
+
+    expect(view.sourceHealth).toBeUndefined();
+  });
+
+  it("dead-link filtering still works when sourceHealth is present (regression guard)", async () => {
+    const base = realSnapshot();
+    const snapshotWithDead: ResourceSnapshot = {
+      ...base,
+      candidates: [
+        { ...base.candidates[0]!, id: "live", providerPayload: { url: "https://115.com/s/livecode" } },
+        { ...base.candidates[0]!, id: "dead_share", providerPayload: { url: "https://115cdn.com/s/deadcode?password=x" } },
+      ],
+      sourceHealth: { status: "degraded", unhealthySources: ["prowlarr"] },
+    };
+    const deadLinkStore = {
+      recordDeadLink: async () => {},
+      listDeadLinkKeys: async () => ["115:deadcode"],
+    };
+    const registry = new CandidateRegistry();
+    const adapter = new RealResourceProviderV2({
+      provider: { search: async () => snapshotWithDead },
+      registry,
+      workflowRunId: "run-1",
+      deadLinkStore,
+    });
+
+    const view = await adapter.search("k1");
+
+    expect(view.candidates.map((c) => c.id)).toEqual(["live"]);
+    expect(view.sourceHealth).toEqual({ status: "degraded", unhealthySources: ["prowlarr"] });
+    expect(adapter.snapshots()[0]!.candidates.map((c) => c.id)).toEqual(["live"]);
+    expect(registry.get("dead_share")).toBeUndefined();
+  });
+
   it("agent-facing candidate exposes only id and title (no hints) — Task 3", async () => {
     const provider: ResourceProvider = { search: async () => realSnapshot() };
     const registry = new CandidateRegistry();

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { TaskSandbox } from "../src/acquisition-v2/sandbox.js";
 import { FakeResourceProviderV2 } from "../src/acquisition-v2/fake-provider.js";
+import { RealResourceProviderV2 } from "../src/acquisition-v2/real-provider-adapter.js";
+import { CandidateRegistry } from "../src/acquisition-v2/candidate-registry.js";
+import type { ResourceProvider } from "../src/ports.js";
 
 describe("TaskSandbox — searchResources (system-budgeted, dedup, snapshot-bound)", () => {
   it("returns the full candidate snapshot for a fresh keyword", async () => {
@@ -360,5 +363,169 @@ describe("sandbox 审计事件收集（病4）", () => {
     await sandbox.primeRawSnapshot("攻壳机动队");
     await sandbox.searchResources("攻壳机动队"); // dedup 命中，seenKeywords 不变
     await expect(sandbox.reportNoCoverage("确无资源")).resolves.toMatchObject({ searchesPerformed: 1 });
+  });
+});
+
+describe("sandbox 搜索源健康态 → agent 可见警告（Task 9）", () => {
+  /** 一个只按健康态作答的 provider：候选恒为空，用来把「源挂了」与「确实没有」
+   *  这两个在候选层面完全同形的情形对照起来。 */
+  function healthProvider(sourceHealth?: {
+    status: "healthy" | "degraded" | "unreachable" | "protocol_error";
+    unhealthySources: string[];
+  }, candidates: Array<{ id: string; title: string }> = []) {
+    return {
+      async search(keyword: string) {
+        return { id: `s_${keyword}`, keyword, candidates, ...(sourceHealth ? { sourceHealth } : {}) };
+      },
+    };
+  }
+
+  it("unreachable：警告点名搜索源失败，并明确「没有资源」不成立", async () => {
+    const sandbox = new TaskSandbox({
+      provider: healthProvider({ status: "unreachable", unhealthySources: ["pansou"] }),
+      titleTerms: ["攻壳机动队"],
+    });
+
+    const result = await sandbox.searchResources("攻壳机动队");
+
+    const warning = (result.warnings ?? []).find((w) => w.includes("搜索源"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("pansou");
+    expect(warning).toContain("没有资源");
+    expect(warning).toContain("reportNoCoverage");
+  });
+
+  it("protocol_error：警告与单纯挂掉相区分（地址可能不是 PanSou）", async () => {
+    const sandbox = new TaskSandbox({
+      provider: healthProvider({ status: "protocol_error", unhealthySources: ["pansou"] }),
+      titleTerms: ["攻壳机动队"],
+    });
+
+    const result = await sandbox.searchResources("攻壳机动队");
+
+    const warning = (result.warnings ?? []).find((w) => w.includes("搜索源"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("PanSou");
+    // 两种故障的处置动作不同，文案必须可分辨。
+    const unreachableSandbox = new TaskSandbox({
+      provider: healthProvider({ status: "unreachable", unhealthySources: ["pansou"] }),
+      titleTerms: ["攻壳机动队"],
+    });
+    const unreachable = await unreachableSandbox.searchResources("攻壳机动队");
+    expect(warning).not.toBe((unreachable.warnings ?? []).find((w) => w.includes("搜索源")));
+  });
+
+  it("degraded：告知证据不完整，但已拿到的候选仍可用", async () => {
+    const sandbox = new TaskSandbox({
+      provider: healthProvider({ status: "degraded", unhealthySources: ["prowlarr"] }, [{ id: "c1", title: "攻壳机动队 1080p" }]),
+      titleTerms: ["攻壳机动队"],
+    });
+
+    const result = await sandbox.searchResources("攻壳机动队");
+
+    const warning = (result.warnings ?? []).find((w) => w.includes("搜索源"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("prowlarr");
+    expect(warning).toContain("可用");
+    // 候选照常返回，degraded 不是阻断。
+    expect(result.snapshot?.candidates).toHaveLength(1);
+  });
+
+  it("healthy 且零候选：不产生源故障警告——这才是权威的「确实没有」（对照组）", async () => {
+    const healthy = new TaskSandbox({
+      provider: healthProvider({ status: "healthy", unhealthySources: [] }),
+      titleTerms: ["攻壳机动队"],
+    });
+    const noHealthField = new TaskSandbox({
+      provider: healthProvider(undefined),
+      titleTerms: ["攻壳机动队"],
+    });
+
+    const a = await healthy.searchResources("攻壳机动队");
+    const b = await noHealthField.searchResources("攻壳机动队");
+
+    expect(a.snapshot?.candidates).toHaveLength(0);
+    expect((a.warnings ?? []).some((w) => w.includes("搜索源"))).toBe(false);
+    expect((b.warnings ?? []).some((w) => w.includes("搜索源"))).toBe(false);
+    // 审计里也不该有源故障事件——否则运维会被健康的空搜索淹没。
+    expect(healthy.auditTrail().some((e) => e.type === "search_source_unhealthy")).toBe(false);
+    expect(noHealthField.auditTrail().some((e) => e.type === "search_source_unhealthy")).toBe(false);
+  });
+
+  it("源不健康时记审计事件（对齐 search_taboo_warning 形制）", async () => {
+    const sandbox = new TaskSandbox({
+      provider: healthProvider({ status: "unreachable", unhealthySources: ["pansou"] }),
+      titleTerms: ["攻壳机动队"],
+    });
+
+    await sandbox.searchResources("攻壳机动队");
+
+    const event = sandbox.auditTrail().find((e) => e.type === "search_source_unhealthy");
+    expect(event).toBeDefined();
+    expect(typeof event!.message).toBe("string");
+    expect(event!.message.length).toBeGreaterThan(0);
+    expect(event!.data?.status).toBe("unreachable");
+    expect(event!.data?.unhealthySources).toEqual(["pansou"]);
+    expect(event!.data?.keyword).toBe("攻壳机动队");
+  });
+});
+
+describe("真适配器 → 沙箱 端到端：健康态不能在接缝处掉（Task 9）", () => {
+  it("域快照的 unreachable 经 RealResourceProviderV2 一路到 agent 可见的 warnings", async () => {
+    // 这条用真适配器而不是内联 fake，专为守住那道接缝：适配器一旦重新丢掉
+    // sourceHealth（就是造成 6 天静默的那一手），这里必须红。
+    const domainProvider: ResourceProvider = {
+      search: async ({ keyword }) => ({
+        id: "snap_unreachable",
+        provider: "pansou",
+        keyword,
+        createdAt: "2026-06-14T00:00:00.000Z",
+        candidates: [],
+        sourceHealth: { status: "unreachable", unhealthySources: ["pansou"] },
+      }),
+    };
+    const adapter = new RealResourceProviderV2({
+      provider: domainProvider,
+      registry: new CandidateRegistry(),
+      workflowRunId: "run-1",
+    });
+    const sandbox = new TaskSandbox({ provider: adapter, titleTerms: ["攻壳机动队"] });
+
+    const result = await sandbox.searchResources("攻壳机动队");
+
+    expect(result.snapshot?.candidates).toHaveLength(0);
+    const warning = (result.warnings ?? []).find((w) => w.includes("搜索源"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("pansou");
+    expect(sandbox.auditTrail().some((e) => e.type === "search_source_unhealthy")).toBe(true);
+  });
+});
+
+describe("预搜(prime)路径也必须带上健康态警告（Task 9 生产主路径）", () => {
+  it("prime 时源就挂了：agent 复搜该词命中 dedup，警告仍随返回给它", async () => {
+    // 生产里系统会先 primeRawSnapshot，agent 被提示词引导去 viewResourceSnapshot。
+    // 当 prime 拿到 0 候选时，agent 通常会再 searchResources 同一个词 → 命中 dedup。
+    // 那条路径若不带警告，agent 看到的依旧是一个「干净的空结果」。
+    const sandbox = new TaskSandbox({
+      provider: {
+        async search(keyword: string) {
+          return {
+            id: `s_${keyword}`,
+            keyword,
+            candidates: [],
+            sourceHealth: { status: "unreachable" as const, unhealthySources: ["pansou"] },
+          };
+        },
+      },
+      titleTerms: ["攻壳机动队"],
+    });
+
+    await sandbox.primeRawSnapshot("攻壳机动队");
+    const result = await sandbox.searchResources("攻壳机动队");
+
+    expect(result.deduped).toBe(true);
+    const warning = (result.warnings ?? []).find((w) => w.includes("搜索源"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain("pansou");
   });
 });

--- a/packages/workflow/tests/v2-sandbox-search.test.ts
+++ b/packages/workflow/tests/v2-sandbox-search.test.ts
@@ -529,3 +529,122 @@ describe("预搜(prime)路径也必须带上健康态警告（Task 9 生产主�
     expect(warning).toContain("pansou");
   });
 });
+
+describe("证据全不健康时禁止上报「没有资源」（Task 10：从劝告变强制）", () => {
+  type Health = { status: "healthy" | "degraded" | "unreachable" | "protocol_error"; unhealthySources: string[] };
+
+  /** 按关键词分派健康态的 provider——这样一个证据基里可以同时存在健康与不健康
+   *  的快照，用来分辨「全不健康」与「部分不健康」这两种必须区别对待的情形。 */
+  function perKeywordProvider(plan: Record<string, { health?: Health; candidates?: Array<{ id: string; title: string }> }>) {
+    return {
+      async search(keyword: string) {
+        const entry = plan[keyword.trim()] ?? {};
+        return {
+          id: `s_${keyword}`,
+          keyword,
+          candidates: entry.candidates ?? [],
+          ...(entry.health ? { sourceHealth: entry.health } : {}),
+        };
+      },
+    };
+  }
+
+  it("证据基里每一份快照都不健康 → 拒绝上报,并点名是搜索源故障", async () => {
+    // Task 9 只给了 agent 一句警告。LLM 会无视警告——所以这里必须是机械的。
+    const sandbox = new TaskSandbox({
+      provider: perKeywordProvider({
+        攻壳机动队: { health: { status: "unreachable", unhealthySources: ["pansou"] } },
+        "攻殻機動隊": { health: { status: "protocol_error", unhealthySources: ["pansou"] } },
+      }),
+      titleTerms: ["攻壳机动队", "攻殻機動隊"],
+    });
+    await sandbox.searchResources("攻壳机动队");
+    await sandbox.searchResources("攻殻機動隊");
+
+    await expect(sandbox.reportNoCoverage("没搜到")).rejects.toThrow(/SANDBOX_SOURCE_UNHEALTHY/);
+    // 拒绝语必须点名源故障、否掉「没有资源」这个结论,并告诉 agent 改做什么。
+    await expect(sandbox.reportNoCoverage("没搜到")).rejects.toThrow(/搜索源/);
+    await expect(sandbox.reportNoCoverage("没搜到")).rejects.toThrow(/没有资源/);
+    await expect(sandbox.reportNoCoverage("没搜到")).rejects.toThrow(/pansou/);
+  });
+
+  it("只要有一份健康快照 → 放行（部分证据仍是证据）", async () => {
+    // agent 搜了、有源答了、确实没找到——这是合法的 no_coverage,不能拦。
+    const sandbox = new TaskSandbox({
+      provider: perKeywordProvider({
+        攻壳机动队: { health: { status: "unreachable", unhealthySources: ["pansou"] } },
+        "攻殻機動隊": { health: { status: "healthy", unhealthySources: [] } },
+      }),
+      titleTerms: ["攻壳机动队", "攻殻機動隊"],
+    });
+    await sandbox.searchResources("攻壳机动队");
+    await sandbox.searchResources("攻殻機動隊");
+
+    await expect(sandbox.reportNoCoverage("确无资源")).resolves.toMatchObject({ reason: "确无资源" });
+  });
+
+  it("全部健康且零候选 → 放行（权威的「确实没有」,最关键的对照组）", async () => {
+    // 这条断言守的是「产品还能不能报告真实的缺失」。它一红,修的这个 bug 就
+    // 被换成了一个更坏的 bug:任何真实的「没有资源」都再也报不出来。
+    const sandbox = new TaskSandbox({
+      provider: perKeywordProvider({
+        攻壳机动队: { health: { status: "healthy", unhealthySources: [] } },
+      }),
+      titleTerms: ["攻壳机动队"],
+    });
+    await sandbox.searchResources("攻壳机动队");
+
+    const report = await sandbox.reportNoCoverage("资源市场确无该作品");
+    expect(report.searchesPerformed).toBe(1);
+    expect(sandbox.auditTrail().some((e) => e.type === "no_coverage_reported")).toBe(true);
+  });
+
+  it("唯一证据是不健康的【预搜】快照、agent 一次都没搜 → 拒绝（就是那次 6 天静默的原形）", async () => {
+    // 生产主路径:系统 primeRawSnapshot,提示词明令 agent 别重搜该词。源当时挂着,
+    // 预搜拿回空快照,agent 直接 reportNoCoverage —— 用户读到「暂未找到可用资源」。
+    const sandbox = new TaskSandbox({
+      provider: perKeywordProvider({
+        攻壳机动队: { health: { status: "unreachable", unhealthySources: ["pansou"] } },
+      }),
+      titleTerms: ["攻壳机动队"],
+    });
+    await sandbox.primeRawSnapshot("攻壳机动队");
+
+    await expect(sandbox.reportNoCoverage("raw 快照无覆盖")).rejects.toThrow(/SANDBOX_SOURCE_UNHEALTHY/);
+  });
+
+  it("degraded 算可用证据 → 放行", async () => {
+    // 有意的选择:degraded = 至少一个源答了。若连 degraded 都拦,那么任何一个
+    // 次要索引挂掉就再也报不出「没有资源」——过于激进,会把这道闸变成噪音。
+    const sandbox = new TaskSandbox({
+      provider: perKeywordProvider({
+        攻壳机动队: { health: { status: "degraded", unhealthySources: ["prowlarr"] } },
+      }),
+      titleTerms: ["攻壳机动队"],
+    });
+    await sandbox.searchResources("攻壳机动队");
+
+    await expect(sandbox.reportNoCoverage("主源答了,确无")).resolves.toMatchObject({ searchesPerformed: 1 });
+  });
+
+  it("拒绝会记审计事件（对齐 no_coverage_reported / search_taboo_warning 形制）,且不记成功上报", async () => {
+    const sandbox = new TaskSandbox({
+      provider: perKeywordProvider({
+        攻壳机动队: { health: { status: "unreachable", unhealthySources: ["pansou"] } },
+      }),
+      titleTerms: ["攻壳机动队"],
+    });
+    await sandbox.searchResources("攻壳机动队");
+
+    await expect(sandbox.reportNoCoverage("没搜到")).rejects.toThrow(/SANDBOX_SOURCE_UNHEALTHY/);
+
+    const event = sandbox.auditTrail().find((e) => e.type === "no_coverage_refused_source_unhealthy");
+    expect(event).toBeDefined();
+    expect(typeof event!.message).toBe("string");
+    expect(event!.message.length).toBeGreaterThan(0);
+    expect(event!.data?.reason).toBe("没搜到");
+    expect(event!.data?.unhealthySources).toEqual(["pansou"]);
+    // 被拒的上报绝不能同时留下一条「已上报无覆盖」——否则审计自相矛盾。
+    expect(sandbox.auditTrail().some((e) => e.type === "no_coverage_reported")).toBe(false);
+  });
+});


### PR DESCRIPTION
用户实测：自建 PanSou 源挂了 **6 天**，产品全程说「🔍 暂未找到可用资源 · 将持续尝试」。作者本人排查了两小时才发现是源挂了 —— 普通用户只会以为这软件没用。

## 根因

「源挂了」与「真没有这个资源」在整条管线上是同一个值（`candidates: []`）。三处静默吞错：

| 位置 | 问题 |
|---|---|
| `pansou-provider.ts` `catch { break }` | 第一次调用就失败时 `facts` 仍为空 → 返回正常的空快照 |
| 同文件 `isPanSouSuccessResponse ? ... : []` | 对方是静态服务器/反代错误页时返回空数组，**连异常都没有** |
| `composite-provider.ts` | 注释直说 `a down source contributes nothing` —— 挂掉的成员被无声丢弃 |

仓库里本来就有正确教义 —— `transfer-block.ts` 的注释：把系统故障报成「暂未找到资源」是拿资源给系统问题背锅（**别甩锅**）。本 PR 是把同一条教义应用到搜索层。

## 修复（分层，共 14 commit）

1. **领域模型** `resource-source-health.ts` —— `MergedSourceHealth`（`healthy|degraded|unreachable|protocol_error`）。`protocol_error` 与 `unreachable` 刻意分开：前者「地址填错了」，后者「源挂了」，用户处置动作不同。
2. **provider 不吞错** —— 两处吞错点同时修（只修一处的话另一处会把异常吞掉，行为完全不变而测试照样绿）。
3. **多源合并** 汇报健康态：全答 healthy / 部分答 degraded / 全挂 unreachable。
4. **优先级 fallback** —— 用户源挂了自动退回官方源；但结果仍标 `degraded`，因为悄悄靠官方源续命正是配置错误能活 6 天的原因。「健康但没结果」**不** fallback（那是权威的「确实没有」，再搜一遍只会让每次未命中翻倍耗时）。
5. **保存时真实探活** —— 以前只校验 `^https?://`。两个入口都接（设置页 action + agent API）。
6. **设置页告警** —— 复用既有 `settings-attention` 框架。徽章每 8s 轮询，所以读存储结论而**不做网络 I/O**。
7. **健康态送达 agent** —— 修掉 V2 适配器接缝处的丢失，sandbox 给出中文警告 + 审计事件。
8. **机械拒绝** —— `reportNoCoverage` 在证据全不健康时抛错，不再只是「劝告」LLM。
9. **通知说真话** —— 这是唯一改变用户看见什么的一步。TV 与电影两条路径都接（共用 `emptyRunOutcome`，只接一条的话电影仍在撒谎）。

## 端到端验证（真打一个死地址）

对 `http://127.0.0.1:8899`（就是用户当时那个）实测：

```
① provider 判定: unreachable | 候选数: 0
② 分类为源故障: true
③ status: failed
④ 用户读到: 自建搜索源 本轮连不上，没能取回任何候选。
           已按「搜索源不可用」收尾，资源留待源恢复后自动重试。
⑤ 对照（真没资源）: no_coverage | 暂未找到可用资源 · 将持续尝试
```

**关键对照组（⑤）必须长绿**：若它坏掉，产品就再也无法如实报告「确实没有」—— 那比要修的 bug 更糟。

## 变异测试证据

每条断言都实测过「改坏了会不会红」：

| 变异 | 结果 |
|---|---|
| 删掉通知层源故障分支 | `expected '暂未找到可用资源 · 将持续尝试' not to contain '暂未找到可用资源'` —— 正是用户的原话投诉 |
| 只回退吞错点 2 | **2 failed**（含 `expected 'healthy' to be 'unreachable'`），印证「点 2 支配点 1」 |
| 删 `reportNoCoverage` 健康门禁 | 3 failed |
| 让健康源也判成故障 | 对照组立刻红 |
| 把 fallback 的 `attempt` 改回 bare catch | `expected 'unreachable' to be 'protocol_error'` |

## 护栏

`typecheck` ✅ ｜ `tsc -p apps/web` ✅ ｜ **`build:web`** ✅ ｜ 全量 **2947 passed / 15 skipped**（基线 2858，新增 89） ｜ 真实 Postgres 16 契约 53 passed 0 skipped

## 过程中修正的自身错误

- `mergeSourceHealth` 会把 `protocol_error` 压成 `unreachable`（**tsc 发现不了**，只是运行时不可达）→ 子代理正确 BLOCKED 而非硬改断言凑绿
- 我给的测试 fixture 形状是错的（`collectLinkFacts` 读 `result.links[]`），会导致「返回候选」类断言**永远不可能通过**
- 我在 `attempt()` 里写了 `catch { return null }` —— 在一个专门消灭静默吞错的 PR 里再写一个 bare catch，自相矛盾
- 我自己一个测试是假的：cause 解包用例只断言返回值，而兜底也返回同值，变异实测「删掉解包」照样绿 → 改为断言机制
- 字符串前缀契约不可强制 → 加 `PanSouProtocolError` 类（仓库已有 7 个同款先例）

## 已知取舍

- **严格拒绝**：探活打不通就不保存。代价是用户容器此刻没跑时存不进自建地址；逃生门是「清空 → 回落官方源」，拒绝文案已明确告知。
- **不做熔断器 / hedged request**：本产品搜索是低频后台任务，熔断器的跨请求状态与调参复杂度远超收益；hedged 会双打两个源，对公共免费源不礼貌。理由写在 `fallback-provider.ts` 类注释里。
- `sourceHealth` 可选，缺失按 healthy 处理（向后兼容），全链路一致。