### PR TITLE
chore(desktop): 发版 1.4.1 —— 手动巡检修复 + 自建搜索源故障修复

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@media-track/desktop",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "commonjs",
   "main": "dist/main.js",
   "scripts": {


### PR DESCRIPTION
## 本版发布内容

随 1.4.1 发布的桌面版修复（两个 PR 均已合入 main）：

### 1. 手动巡检 run 卡死修复（#235）
**症状**：手动触发巡检 → app 卡住 → 强退重开 → 一部剧永久停在「排队中」，且该季再也无法被巡检。

**根因**：巡检 run（`type3_monitor`）由 `reserveWorkflowRun` 直接以 `running` 创建，从不经过 `queued`；但崩溃恢复会把所有 `running` 一律改成 `queued` —— 而没有任何 worker 认领 `queued` 的这个 kind。更糟的是 `queued` 被算作活跃，`reserveWorkflowRun` 返回 `already_active`，该季永久被死 run 阻塞。

**修复**：崩溃恢复按 kind 分流 —— 有队列认领者的照旧 requeue，没有的直接终结为 `failed` + `orphan_unclaimable` 审计事件。容器版（Postgres）与桌面版（SQLite）同步修复，真实 Postgres 16 契约验证通过。

### 2. 自建搜索源故障伪装修复（#236）
**症状**：自建 PanSou 源挂了 **6 天**，产品全程说「🔍 暂未找到可用资源 · 将持续尝试」——作者本人排查两小时才发现是源挂了，普通用户只会以为软件没用。

**根因**：「源挂了」与「真没资源」在整条管线上是同一个值（`candidates: []`），三处静默吞错。

**修复**：
- 保存自建源地址时真实探活，打不通/不是 PanSou 就拒绝保存
- 运行时源挂了自动回落官方源（结果标 `degraded`，不再静默）
- 设置页出现「自建搜索源连不上」告警
- 通知如实说「搜索源故障」而非「暂未找到资源」
- `reportNoCoverage` 在证据全不健康时机械拒绝

## 发版方式

仅 bump 版本号，tag `v1.4.1` 触发 `release-desktop.yml`（macOS 签名公证 + Windows 安装冒烟测试 + 原子发布）。签名凭证在 CI secrets，本机无钥匙串依赖。

## 验证

- 全量 **2965 passed / 15 skipped**（两次修复各自的变异测试与真实 Postgres 契约验证，详见两个 PR）
- 本 PR 仅改 package.json 版本号，无代码变更