### PR TITLE
Fix Alipay browser checkout redirects

### DIFF
--- a/workers/scout-connect/src/alipay-checkout.test.ts
+++ b/workers/scout-connect/src/alipay-checkout.test.ts
@@ -186,7 +186,7 @@ describe("GET /alipay/checkout", () => {
       expect(response.status).toBe(200);
       expect(response.headers.get("cache-control")).toBe("no-store");
       expect(response.headers.get("content-security-policy")).toContain(
-        "form-action https://openapi.alipay.com",
+        "form-action https://openapi.alipay.com https://unitradeprod.alipay.com https://excashier.alipay.com",
       );
       expect(await response.text()).toContain("https://openapi.alipay.com/gateway.do");
     }
@@ -248,8 +248,11 @@ describe("GET /alipay/checkout", () => {
       deps,
     );
     const csp = response.headers.get("content-security-policy") ?? "";
-    expect(csp).toContain("form-action https://openapi-sandbox.dl.alipaydev.com");
+    expect(csp).toContain(
+      "form-action https://openapi-sandbox.dl.alipaydev.com https://unitradeprod-sandbox.dl.alipaydev.com https://excashier-sandbox.dl.alipaydev.com",
+    );
     expect(csp).not.toContain("form-action https://openapi.alipay.com");
+    expect(csp).not.toContain("https://unitradeprod.alipay.com");
     expect(await response.text()).toContain("https://openapi-sandbox.dl.alipaydev.com/gateway.do");
     expect(sandboxCalls[0]).toEqual({
       outTradeNo: created.order.out_trade_no,

--- a/workers/scout-connect/src/html/payment-success-page.test.ts
+++ b/workers/scout-connect/src/html/payment-success-page.test.ts
@@ -43,4 +43,11 @@ describe("paymentSuccessPage (server-confirmed Alipay state)", () => {
     expect(html).toContain("clearTimeout(requestTimeout)");
     expect(html).not.toContain("? AbortSignal.timeout(8000) : undefined");
   });
+
+  it("emits syntactically valid browser JavaScript", () => {
+    const html = paymentSuccessPage();
+    const script = /<script>\s*([\s\S]*?)<\/script>/.exec(html)?.[1];
+    expect(script).toBeDefined();
+    expect(() => new Function(script!)).not.toThrow();
+  });
 });

--- a/workers/scout-connect/src/html/payment-success-page.ts
+++ b/workers/scout-connect/src/html/payment-success-page.ts
@@ -84,7 +84,7 @@ ${BRAND_BAR}
       if (response.status === 401) {
         stop();
         title.textContent = "请先登录";
-        detail.innerHTML = "登录后才能查看这笔订单。<a href=\"/login?next=%2Fpayment-success%3Forder%3D" + encodeURIComponent(order) + "\">前往登录</a>";
+        detail.innerHTML = "登录后才能查看这笔订单。<a href='/login?next=%2Fpayment-success%3Forder%3D" + encodeURIComponent(order) + "'>前往登录</a>";
         return;
       }
       if (response.status === 404) {

--- a/workers/scout-connect/src/http.ts
+++ b/workers/scout-connect/src/http.ts
@@ -39,6 +39,8 @@ export function htmlPage(
   // 挡成裂图(curl 能拿到,浏览器不行 —— 这类 bug 只有真在浏览器里看才发现)。
   const posters = opts.posters === true;
   // Only the one-time same-origin checkout hop may submit a form to Alipay.
+  // Chromium applies form-action across redirects. Both official gateways issue a
+  // redirect through unitradeprod to excashier, so the full owned chain must be allowed.
   // The tier-selection and return pages use same-origin fetch only.
   const alipayForm = opts.alipayForm;
   const csp = [
@@ -54,9 +56,9 @@ export function htmlPage(
     `img-src 'self' data:${posters ? ` ${POSTER_IMG_SOURCE}` : ""}`,
     "base-uri 'none'",
     alipayForm === "sandbox"
-      ? "form-action https://openapi-sandbox.dl.alipaydev.com"
+      ? "form-action https://openapi-sandbox.dl.alipaydev.com https://unitradeprod-sandbox.dl.alipaydev.com https://excashier-sandbox.dl.alipaydev.com"
       : alipayForm
-        ? "form-action https://openapi.alipay.com"
+        ? "form-action https://openapi.alipay.com https://unitradeprod.alipay.com https://excashier.alipay.com"
         : "form-action 'self'",
     "frame-ancestors 'none'",
   ].join("; ");


### PR DESCRIPTION
## Summary
- allow the two official Alipay cashier redirect hosts in the one-time checkout page CSP
- fix a generated payment-confirmation script quoting error that prevented status polling
- add regression coverage for the complete CSP chain and generated JavaScript syntax

## Verification
- scout-connect: 54 files, 790 tests passed
- Worker TypeScript passed
- repository lint passed
- real Edge sandbox flow: ¥45 checkout reached Alipay cashier, payment fulfilled a 3-month entitlement, full refund tombstoned the entitlement and removed access

No production payment or production deployment was performed by this PR.