### PR TITLE
Fix broken Star History chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,4 +236,4 @@ This project actively participates in and endorses the [LINUX DO](https://linux.
 [![认可 LINUX DO](https://img.shields.io/badge/LINUX%20DO-认可-2ecc71?style=flat&labelColor=1f1f1f)](https://linux.do)
 
 ## Star History
-![Star History Chart](https://api.star-history.com/svg?repos=fancydirty/mediary-scout)
+![Star History Chart](https://star-history.dera.page/svg?repos=fancydirty/mediary-scout)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -189,4 +189,4 @@ docker compose up -d
 [![认可 LINUX DO](https://img.shields.io/badge/LINUX%20DO-认可-2ecc71?style=flat&labelColor=1f1f1f)](https://linux.do)
 
 ## Star History
-![Star History Chart](https://api.star-history.com/svg?repos=fancydirty/mediary-scout)
+![Star History Chart](https://star-history.dera.page/svg?repos=fancydirty/mediary-scout)


### PR DESCRIPTION
The Star History chart in the README is currently broken, so readers cannot view the project's growth. Update the chart links in both English and Chinese README files to restore the chart.