### PR TITLE
fix(readme): star history 图表改用官方 sealed_token 恢复

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,4 +236,10 @@ This project actively participates in and endorses the [LINUX DO](https://linux.
 [![认可 LINUX DO](https://img.shields.io/badge/LINUX%20DO-认可-2ecc71?style=flat&labelColor=1f1f1f)](https://linux.do)
 
 ## Star History
-![Star History Chart](https://api.star-history.com/svg?repos=fancydirty/mediary-scout)
+<a href="https://www.star-history.com/?repos=fancydirty%2Fmediary-scout&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=fancydirty/mediary-scout&type=date&theme=dark&legend=top-left&sealed_token=SyhZxdVgoG8rffU_0ypYi7eroHlPNo9kj1V0_4F2L1vJ_C_Yw_DBBmDqGADi7kl916TTZJ8nmCCIK6osu_tfo__vf8AfSlwqk176hnpqc_oIg_PcmKuulA" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=fancydirty/mediary-scout&type=date&legend=top-left&sealed_token=SyhZxdVgoG8rffU_0ypYi7eroHlPNo9kj1V0_4F2L1vJ_C_Yw_DBBmDqGADi7kl916TTZJ8nmCCIK6osu_tfo__vf8AfSlwqk176hnpqc_oIg_PcmKuulA" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=fancydirty/mediary-scout&type=date&legend=top-left&sealed_token=SyhZxdVgoG8rffU_0ypYi7eroHlPNo9kj1V0_4F2L1vJ_C_Yw_DBBmDqGADi7kl916TTZJ8nmCCIK6osu_tfo__vf8AfSlwqk176hnpqc_oIg_PcmKuulA" />
+  </picture>
+</a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -189,4 +189,10 @@ docker compose up -d
 [![认可 LINUX DO](https://img.shields.io/badge/LINUX%20DO-认可-2ecc71?style=flat&labelColor=1f1f1f)](https://linux.do)
 
 ## Star History
-![Star History Chart](https://api.star-history.com/svg?repos=fancydirty/mediary-scout)
+<a href="https://www.star-history.com/?repos=fancydirty%2Fmediary-scout&type=date&legend=top-left">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=fancydirty/mediary-scout&type=date&theme=dark&legend=top-left&sealed_token=SyhZxdVgoG8rffU_0ypYi7eroHlPNo9kj1V0_4F2L1vJ_C_Yw_DBBmDqGADi7kl916TTZJ8nmCCIK6osu_tfo__vf8AfSlwqk176hnpqc_oIg_PcmKuulA" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=fancydirty/mediary-scout&type=date&legend=top-left&sealed_token=SyhZxdVgoG8rffU_0ypYi7eroHlPNo9kj1V0_4F2L1vJ_C_Yw_DBBmDqGADi7kl916TTZJ8nmCCIK6osu_tfo__vf8AfSlwqk176hnpqc_oIg_PcmKuulA" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=fancydirty/mediary-scout&type=date&legend=top-left&sealed_token=SyhZxdVgoG8rffU_0ypYi7eroHlPNo9kj1V0_4F2L1vJ_C_Yw_DBBmDqGADi7kl916TTZJ8nmCCIK6osu_tfo__vf8AfSlwqk176hnpqc_oIg_PcmKuulA" />
+  </picture>
+</a>


### PR DESCRIPTION
## 问题确认（#247 指出的是真的）

README 的 star history 图表**确实坏了**。我一开始只验了 HTTP 状态就误判成「官方好着」—— 实际上 `api.star-history.com` 返回 200 和一张 60KB 的合法 SVG，但**图里画的是错误信息**：

> GitHub restricted access to star data
> GitHub team is looking into it

根因是 **GitHub 于 2026-06-30 把 stargazers API 限制为仓库 admin/collaborator 才能读**。star-history 的服务器对任何人的仓库都不是 collaborator，于是几乎所有 README 内嵌图表一起失效。**这不是 star-history 的错，他们是被政策变更殃及的一方。**

## 采用的方案

官方针对「仓库所有者」给了正解：fine-grained token 经 star-history 加密成 `sealed_token` 贴进 README。明文 token 不出现在仓库里，服务端解密后在内存中用完即弃。

顺带升级成 `<picture>`，按读者的深/浅色模式自动切换主题。

## 为什么不采用 #247 的第三方替换

PR #247 把域名换成 `star-history.dera.page`。核实后不采用：

- 该域名主页是 Homer（自托管仪表盘）默认页 → **个人自建服务器，非官方镜像**
- 把项目门面的依赖交给不可控的第三方，对方关机 / token 过期 / 改图，两个 README 都会静默失效而我们不会收到通知
- 根因是 GitHub 政策，不是 star-history 的问题；官方既然给了正解，就没有理由绕开他们

（该 PR 的 SVG 内容我也查过，无 script / 无追踪 / 数据真实 —— 提交者没做坏事，只是解法不合适。）

## 验证

三个变体实测均返回**真实数据**（非错误图）：

| 变体 | 结果 |
|---|---|
| dark | HTTP 200, 65922 bytes, 含 `GitHub Stars` 轴, 无报错关键词 |
| light | HTTP 200, 65916 bytes |
| 默认 | HTTP 200, 65916 bytes, 日期轴 Jun 28 → Aug 16, Y 轴 1200 |

Y 轴 1200 与当前 **1347 stars** 吻合，确认数据真实。

## 安全

- diff 里**只有 `sealed_token`，无明文 PAT**（已 grep 确认）
- token 权限卡到最小：仅本仓库 + `Metadata: Read-only`（只能读公开 star 数）