### PR TITLE
feat(brand): 中文产品名「巡影」

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,9 @@
 <p align="center">
-  <img src="docs/images/hero.svg" alt="Mediary Scout" width="600">
+  <img src="docs/images/hero.svg" alt="巡影 · Mediary Scout" width="600">
 </p>
 
 <p align="center">
+  <b>巡影 · Mediary Scout</b><br>
   <b>给你自己网盘用的 agent 驱动媒体库。</b>
 </p>
 

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -24,6 +24,10 @@ export function onWindowClose(input: { isQuitting: boolean }): { preventDefault:
 export function trayMenuState(input: { openAtLogin: boolean; serverReady: boolean }): TrayMenuState {
   return {
     items: [
+      // 刻意只用中文短名(不是完整的「巡影 · Mediary Scout」):兄弟项都是
+      // 「● 运行中」「开机自启」「退出」这种短标签,塞完整品牌名会突兀。
+      // 「与其它应用区分」由托盘 tooltip 承担(main.ts:177,已是完整名)——
+      // 那才是悬停时显示的;菜单是点开后才看到的,此时用户已知道点的是谁。
       { id: "open", label: "打开 巡影", type: "normal", enabled: true },
       // The tray is only created after the server boots, so serverReady=false means the
       // server has STOPPED/crashed — not "starting". Show a stopped label, not a spinner.

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -24,7 +24,7 @@ export function onWindowClose(input: { isQuitting: boolean }): { preventDefault:
 export function trayMenuState(input: { openAtLogin: boolean; serverReady: boolean }): TrayMenuState {
   return {
     items: [
-      { id: "open", label: "打开 Mediary Scout", type: "normal", enabled: true },
+      { id: "open", label: "打开 巡影", type: "normal", enabled: true },
       // The tray is only created after the server boots, so serverReady=false means the
       // server has STOPPED/crashed — not "starting". Show a stopped label, not a spinner.
       { id: "status", label: input.serverReady ? "● 运行中" : "○ 已停止", type: "normal", enabled: false },

--- a/apps/desktop/src/lifecycle.ts
+++ b/apps/desktop/src/lifecycle.ts
@@ -26,8 +26,9 @@ export function trayMenuState(input: { openAtLogin: boolean; serverReady: boolea
     items: [
       // 刻意只用中文短名(不是完整的「巡影 · Mediary Scout」):兄弟项都是
       // 「● 运行中」「开机自启」「退出」这种短标签,塞完整品牌名会突兀。
-      // 「与其它应用区分」由托盘 tooltip 承担(main.ts:177,已是完整名)——
-      // 那才是悬停时显示的;菜单是点开后才看到的,此时用户已知道点的是谁。
+      // 「与其它应用区分」由托盘 tooltip 承担(main.ts 的 createTray() 里
+      // tray.setToolTip(...),已是完整名)—— 那才是悬停时显示的;菜单是点开
+      // 后才看到的,此时用户已知道点的是谁。
       { id: "open", label: "打开 巡影", type: "normal", enabled: true },
       // The tray is only created after the server boots, so serverReady=false means the
       // server has STOPPED/crashed — not "starting". Show a stopped label, not a spinner.

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -150,7 +150,9 @@ function createWindow(url: string): void {
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
-    title: "Mediary Scout",
+    // 显示用中文主名;技术标识(appId / productName)保持英文不变 —— 改那些会让
+    // 系统认成另一个应用,老用户升级时装出两份、数据还不通。
+    title: "巡影 · Mediary Scout",
     show: true,
   });
   mainWindow.on("close", (event) => {
@@ -172,7 +174,7 @@ function createTray(): void {
   const icon = nativeImage.createFromDataURL(TRAY_ICON_DATA_URL);
   icon.setTemplateImage(true); // macOS: auto-recolor for the menu bar
   tray = new Tray(icon);
-  tray.setToolTip("Mediary Scout");
+  tray.setToolTip("巡影 · Mediary Scout");
   refreshTray();
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,8 +4,8 @@ import "./globals.css";
 import { isDemoMode } from "../lib/demo-mode";
 
 export const metadata: Metadata = {
-  title: "Mediary Scout",
-  description: "Background media acquisition workflow dashboard.",
+  title: "巡影 · Mediary Scout",
+  description: "自建网盘的媒体获取 agent —— 搜索、转存、验证、追踪补缺。",
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {

--- a/apps/web/components/app-sidebar.tsx
+++ b/apps/web/components/app-sidebar.tsx
@@ -32,8 +32,8 @@ export function AppSidebar({
           <Aperture size={18} aria-hidden />
         </span>
         <span className="brand-copy">
-          <strong>Mediary Scout</strong>
-          <span>multi-drive media agent</span>
+          <strong>巡影 · Mediary Scout</strong>
+          <span>多网盘媒体 agent</span>
         </span>
       </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mediary Scout — 自建网盘的媒体获取 agent</title>
+  <title>巡影 · Mediary Scout — 自建网盘的媒体获取 agent</title>
   <meta name="description" content="指定一部影视，agent 跨源检索、择优转存进你自己的 夸克/115/光鸭/123/天翼 网盘、回读核对，并持续追踪缺集。macOS / Windows 桌面版，AGPL 开源、自部署。">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="Mediary Scout — 自建网盘的媒体获取 agent">
+  <meta property="og:title" content="巡影 · Mediary Scout — 自建网盘的媒体获取 agent">
   <meta property="og:description" content="指定一部影视，agent 跨源检索、择优转存进你自己的 夸克/115/光鸭/123/天翼 网盘、回读核对，并持续追踪缺集。macOS / Windows 桌面版，AGPL 开源、自部署。">
   <meta property="og:image" content="https://mediaryscout.app/assets/og.png">
   <meta property="og:url" content="https://mediaryscout.app/">
@@ -33,6 +33,7 @@
       "@type": "SoftwareApplication",
       "@id": "https://mediaryscout.app/#software",
       "name": "Mediary Scout",
+      "alternateName": "巡影",
       "url": "https://mediaryscout.app/",
       "description": "指定一部影视，agent 跨源检索、择优转存进你自己的 夸克/115/光鸭/123/天翼 网盘、回读核对，并持续追踪缺集。自部署，AGPL 开源。",
       "applicationCategory": "MultimediaApplication",
@@ -114,7 +115,7 @@
             <path d="m16.62 12-5.74 9.94"/>
           </g>
         </svg>
-        <span class="wordmark">Mediary Scout</span>
+        <span class="wordmark">巡影 · Mediary Scout</span>
       </div>
       <div class="nav-right">
         <div class="nav-links">


### PR DESCRIPTION
## 背景

社区 issue #246 提议起中文名（建议「影探」）。方向认同，但撞名自查后换了名字。

## 为什么不是「影探」

实测已有多个同名影视 App：影探 / 影探4K / 影探影视盒子，腾讯应用宝已收录（包名 `cn.yingtantv.yingtan`）。且它们清一色是「免费看全网影视、内置多线路」的灰色盒子。

本项目一直在与盗版划清界限（README 有专门 Disclaimer），叫这个名会被直接归到那一类 —— 这比商标风险更实际。搜索层面也会被那些下载站彻底淹没。

同理排除的：
- **觅影** — 除了灰色盒子，还撞了 V2EX 上的自托管海报墙播放器「觅影 OmniPlay」，同赛道直接混淆
- **剧探** — 撞已有的「剧探 Ai」

## 为什么是「巡影」

- 公开搜索层面无影视软件撞名
- **从产品自身长出来**：核心机制就叫**巡检**（每日定时巡检 / 手动巡检 / 巡检补齐缺集）
- 「巡」正是本项目区别于影视盒子的根本特征 —— 不是让你看片，是替你持续盯着、缺了就补。天然与那堆「免费看全网」的盒子拉开距离

## 改动原则

**英文名是技术标识，中文名只是显示副名。**

改（6 个文件，均为面向用户的显示位）：

| 位置 | 结果 |
|---|---|
| web 侧边栏 | `巡影 · Mediary Scout` + 副标题改中文 |
| 浏览器标题 + description | 同上，description 改为中文 |
| 桌面版窗口标题 / 托盘 tooltip | 同上 |
| 桌面版托盘菜单「打开」项 | `打开 巡影`（刻意用短名，见下） |
| 官网 title / og:title / 导航栏 wordmark | 同上 |
| 中文 README 主标题 | 图下方加中文名行 |

## 刻意不改（改了会出真问题）

- **`electron-builder.yml` 的 `appId` / `productName`** — 改了系统会认成另一个应用，老用户升级会装出两份且数据不通
- **官网 JSON-LD 的 `name` 保持英文**，中文走 `alternateName` — `layout.tsx:24` 的注释明说「两站都叫 Mediary Scout 帮搜索引擎判断主实体」，直接替换会破坏实体识别
- **托盘菜单「打开」项刻意只用中文短名**，不用完整的「巡影 · Mediary Scout」 — 兄弟项都是「● 运行中」「开机自启」「退出」这种短标签，塞完整品牌名会突兀；「与其它应用区分」由托盘 tooltip 承担（`main.ts:177`，已是完整名），那才是悬停托盘图标时显示的，菜单是点开后才看到的
- 包名 `@media-track/*`、仓库名、域名、英文 README
- `docs/superpowers/plans/*` — 历史计划是当时的记录，改了就失真

## 验证

- 核实托盘菜单按 `id` 分发（`main.ts:204` `id === "open"`）而非按 label，改 label 不会破坏点击
- **浏览器实测官网**：title / og:title / wordmark 均为「巡影 · Mediary Scout」，JSON-LD `name` 仍是 `Mediary Scout` + `alternateName: 巡影`
- 护栏：全量 **2879 passed**、`typecheck`、`tsc(web)`、`build:web` 全过

Refs #246
