### PR TITLE
fix(web): 修复移动端顶栏与近期热门的两处布局挤压

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1315,10 +1315,17 @@ p {
      `.sidebar-top-identity .account-identity-menu` already does for the identity
      dropdown a few rules above. */
   .workspace-switcher {
-    /* Positioning context for the menu below (and it must not shrink/grow with
-       the menu's content width). */
+    /* Positioning context for the menu below. */
     position: relative;
-    flex: 0 0 auto;
+    /* Shrinkable (0 1), NOT 0 0: `storage.label` is free-form text from the
+       connected-storages table, so a long custom label ("我的家庭影音收藏主力盘")
+       would otherwise push the switcher past the viewport and make the whole page
+       scroll horizontally (measured: 280px wide, 49px past a 368px viewport).
+       The floor keeps a typical label ("103164004") from being ellipsised just
+       because `.brand` — which is also a default `0 1 auto` flex item — competes
+       for the row; only genuinely long labels get truncated. */
+    flex: 0 1 auto;
+    min-width: min(125px, 34vw);
   }
   .workspace-switcher .ws-menu {
     position: absolute;
@@ -1336,11 +1343,13 @@ p {
     z-index: 60;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
   }
-  /* Truncate long drive labels instead of widening the menu. */
+  /* The ellipsis itself is already declared for all viewports further down; what
+     it additionally needs here is permission to shrink. `.ws-label` is a flex item
+     of `.ws-current`, so it also defaults to min-width:auto and would hold its
+     full intrinsic width, leaving the ellipsis inert no matter how narrow the
+     switcher gets. */
   .workspace-switcher .ws-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    min-width: 0;
   }
 }
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1304,6 +1304,44 @@ p {
     align-items: stretch;
     gap: 10px;
   }
+
+  /* The drive switcher is a desktop sidebar control (see .workspace-switcher):
+     its `.ws-menu` expands INLINE, which is harmless in a fixed-width vertical
+     sidebar. On mobile the sidebar becomes a horizontal top bar, so an inline
+     menu joins the flex main-axis width calculation — opening it grew the
+     switcher 125px→161px and squeezed `.brand` 175px→139px, forcing the wordmark
+     to wrap onto a second line (top bar 49px→68px). Lift the menu out of flow so
+     opening it can't resize its row, mirroring what
+     `.sidebar-top-identity .account-identity-menu` already does for the identity
+     dropdown a few rules above. */
+  .workspace-switcher {
+    /* Positioning context for the menu below (and it must not shrink/grow with
+       the menu's content width). */
+    position: relative;
+    flex: 0 0 auto;
+  }
+  .workspace-switcher .ws-menu {
+    position: absolute;
+    /* Right-anchored: the switcher sits at the top bar's right end, so opening
+       leftward keeps the menu inside a ≤390px viewport. */
+    right: 0;
+    top: 100%;
+    min-width: 100%;
+    /* Wide enough for "夸克网盘 …5Kr2" without inheriting the summary's width,
+       but capped so it can't overflow a narrow phone. */
+    width: max-content;
+    max-width: min(240px, calc(100vw - 28px));
+    /* Above the page content; below the identity menu's 60 is fine (they can't
+       both be open in a way that overlaps meaningfully, but keep it explicit). */
+    z-index: 60;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+  /* Truncate long drive labels instead of widening the menu. */
+  .workspace-switcher .ws-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .candidate-actions {
@@ -3798,6 +3836,25 @@ select.setting-control {
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
+}
+/* Narrow phones: measured at 368px viewport, "近期热门"(71) + three pills(76×3)
+   + 3×10px gaps = 329px inline, but `.trending-head` only leaves ~320px (the
+   `每日更新 · 来自 TMDB` note shares the row), so the LAST pill wrapped alone onto
+   a second line and left-aligned under the heading — ragged and easy to miss.
+   329px of need maps to a ~376px viewport, so below that give the heading its own
+   line and let the three pills (248px together) share the next one; they still
+   fit down to ~300px. Deliberately NOT 390px+ — a 390px phone (iPhone 12–15) has
+   ~342px available and fits all four on one line, which reads better.
+   Scoped by width, not the 860px mobile breakpoint: the same squeeze appears in a
+   narrow desktop window. */
+@media (max-width: 376px) {
+  .trending-tabs {
+    /* The h2 takes a full row; the pills flow together on the row below. */
+    row-gap: 8px;
+  }
+  .trending-tabs h2 {
+    flex: 0 0 100%;
+  }
 }
 .trending-tabs h2 {
   margin: 0;


### PR DESCRIPTION
用户反馈的移动端两处布局问题（软路由 `192.168.100.1:3300`，390×844）。

## 问题一：展开网盘切换器会把品牌区挤到折行

移动端（≤860px）侧边栏变为横向顶栏，但网盘切换器的 `.ws-menu` 仍是**内联展开** —— 在固定宽度的竖向侧边栏里无害，到了横向 flex 顶栏就会参与主轴宽度计算：

| | 关闭 | 展开 |
|---|---|---|
| `.workspace-switcher` | 125px | 161px |
| `.brand` | 175px | **139px** |
| 顶栏高度 | 49px | **68px** |

`.brand` 被挤到 139px 后「Mediary Scout」字标折成两行、副标题也折行、logo 被推歪。

**修法**：`.ws-menu` 改绝对定位脱离文档流，`.workspace-switcher` 加 `position:relative` + `flex:0 0 auto`。右锚定（`right:0`）保证在 ≤390px 视口向左展开不出界。这与上方几条规则里 `.sidebar-top-identity .account-identity-menu` 对身份下拉的既有做法一致。

## 问题二：窄屏「热门动漫」单独折行

368px 实测：「近期热门」71px + 三个 pill 76×3 + 3×10px gap = **329px**，而 `.trending-head` 只余约 320px（同行还有「每日更新 · 来自 TMDB」），末个 pill 单独掉到第二行并左对齐于标题下方，参差且容易漏看。

**修法**：329px 的需求对应约 376px 视口，故 `≤376px` 时标题独占一行、三个 pill 同行（合计 248px，可缩至约 300px）。

**刻意不放宽到 390px**：iPhone 12–15 有约 342px 可用，四者同行观感更好，不该一并改掉。断点按宽度而非 860px 移动断点限定 —— 窄桌面窗口存在同样挤压。

## 验证

- 390×844 截图前后对比，两处均已修复（肉眼确认，非仅量几何）
- `npm run build:web` 通过
- 纯 CSS 新增，无删改、无 JS/DOM 改动

## 已知未做

以上验收在开发态下完成，**未在软路由真机跑构建产物**。按项目铁律 4，合并后建议部署再确认一遍。

## 一处自我修正

中途曾误判下拉菜单「飘了、未对齐按钮」，量测后 `summary.right` 与 `menu.right` 均为 334，右边缘严丝合缝；菜单宽 161 比按钮 125 多出的 36px 是右锚定下拉的正常形态。已按无需改动处理。
