### PR TITLE
fix(patrol): 完结剧缺集不再被巡检永久跳过

### DIFF
--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -1693,7 +1693,11 @@ function targetFromSearchCandidate(
     id: candidateId,
     mediaTitleId: title.id,
     seasonNumber,
-    status: season.latestAiredEpisode >= season.episodeCount ? "completed" : "active",
+    // Freshly tracked = nothing obtained yet → "active" even for a 完结 show.
+    // The bridge grades it "completed" only once fully obtained (see
+    // workflow-v2-bridge bridgeSeason). Marking it completed on airing alone made
+    // the patrol skip 完结剧-with-gaps forever.
+    status: "active",
     qualityPreference: defaultQuality(),
     storageDirectoryId: storageDirectoryIdForCandidate(candidateId),
     totalEpisodes: season.episodeCount,

--- a/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
+++ b/packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts
@@ -48,7 +48,10 @@ export interface V2BridgeSeasonIntent {
   totalEpisodes: number;
   latestAiredEpisode: number;
   qualityPreference: string;
-  /** Tracked status; defaults to completed when fully aired, else active. */
+  /** Persisted status of the season, if any. IGNORED for the completed decision:
+   *  bridgeSeason recomputes status purely from the obtained facts (a season is
+   *  completed iff fully acquired), so a stale "completed" never sticks a season
+   *  that still has a real gap. Kept only so callers can pass their row through. */
   status?: SeasonStatus;
 }
 
@@ -177,20 +180,27 @@ function bridgeSeason(input: {
     });
   }
 
+  // A season is "completed" ONLY when it is actually fully ACQUIRED — every
+  // aired episode obtained and the obtained count covering the whole season —
+  // never merely because every episode has AIRED. A 完结 (fully-aired) drama
+  // whose acquisition left gaps must stay "active" so the daily patrol keeps
+  // filling it; grading it "completed" on airing alone made the patrol skip it
+  // forever (这一秒过火 缺 1-13, 永不消逝的电波 缺全集, 醒来 缺 21).
+  //
+  // intent.status is deliberately NOT trusted here: this bridge is the sole
+  // post-creation writer of season.status, so it recomputes from the obtained
+  // facts. A stale "completed" therefore can never stick a season that still
+  // has a real gap, and if TMDB later grows the season the new gap correctly
+  // reverts it to active so the patrol resumes. The graduation season-sync.ts
+  // promises ("only the finale — all obtained — graduates it to completed")
+  // happens here: an active season that becomes fully obtained turns completed
+  // so the patrol stops re-sweeping a finished show and the library drops 追更中.
   const fullyAired = intent.totalEpisodes > 0 && intent.latestAiredEpisode >= intent.totalEpisodes;
-  const baseStatus: SeasonStatus = intent.status ?? (fullyAired ? "completed" : "active");
-  // The finale graduation season-sync.ts promises ("only the finale — all
-  // obtained — graduates it to completed"). Callers pass the persisted status
-  // through, and this bridge is the only post-creation writer of it — so an
-  // active season that is now fully aired AND fully obtained must graduate
-  // HERE, or the patrol re-sweeps a finished show daily and the library keeps
-  // 追更中 while the notification claims 不再追踪. A season with real aired
-  // gaps stays active so the sweep keeps filling them; completed never reverts.
   const fullyObtained =
     fullyAired &&
     episodes.filter((episode) => episode.airStatus === "aired").every((episode) => episode.obtained) &&
     episodes.filter((episode) => episode.obtained).length >= intent.totalEpisodes;
-  const status: SeasonStatus = baseStatus === "active" && fullyObtained ? "completed" : baseStatus;
+  const status: SeasonStatus = fullyObtained ? "completed" : "active";
 
   const season: TrackedSeason = {
     id: trackedSeasonId,

--- a/packages/workflow/src/commands.ts
+++ b/packages/workflow/src/commands.ts
@@ -199,7 +199,11 @@ export async function queueSeriesInitialization(input: {
     id: `${input.title.id}_s${firstSeason.seasonNumber}`,
     mediaTitleId: input.title.id,
     seasonNumber: firstSeason.seasonNumber,
-    status: firstSeason.latestAiredEpisode >= firstSeason.totalEpisodes ? "completed" : "active",
+    // Enqueue-time lock row: nothing obtained yet → "active" even for a 完结
+    // series. The bridge grades it "completed" only once fully obtained; grading
+    // it completed on airing alone would leave a failed/pre-bridge run stuck
+    // completed-with-gaps and the patrol would skip it forever.
+    status: "active",
     qualityPreference: "4K",
     storageDirectoryId: "",
     totalEpisodes: firstSeason.totalEpisodes,

--- a/packages/workflow/src/tmdb-provider.ts
+++ b/packages/workflow/src/tmdb-provider.ts
@@ -383,7 +383,11 @@ export async function prepareTrackingTarget(input: TvTrackingTargetInput): Promi
       id: `${titleId}_s${input.seasonNumber}`,
       mediaTitleId: titleId,
       seasonNumber: input.seasonNumber,
-      status: latestAiredEpisode >= totalEpisodes ? "completed" : "active",
+      // A freshly-tracked season has obtained NOTHING yet, so it starts "active"
+      // (has episodes to acquire) even for a 完结/fully-aired show. The bridge
+      // graduates it to "completed" only once actually fully obtained; marking it
+      // completed at track time made the patrol skip 完结剧-with-gaps forever.
+      status: "active",
       qualityPreference: input.qualityPreference,
       storageDirectoryId: input.storageDirectoryId ?? "",
       totalEpisodes,

--- a/packages/workflow/tests/tmdb-provider.test.ts
+++ b/packages/workflow/tests/tmdb-provider.test.ts
@@ -95,6 +95,56 @@ describe("TmdbMetadataProvider", () => {
     });
   });
 
+  // 完结剧缺集 bug (2026-09-04): a freshly-tracked season has obtained NOTHING, so
+  // it must start "active" — even for a fully-aired (完结) show. Marking it
+  // "completed" at track time (aired >= total) makes the patrol skip it forever
+  // when the initial acquisition leaves gaps.
+  it("prepares a fully-aired (完结) TV target as active — nothing obtained yet", async () => {
+    const provider = new TmdbMetadataProvider({
+      readToken: "token",
+      fetchJson: async (url) => {
+        if (url.includes("/tv/240001?")) {
+          return {
+            id: 240001,
+            name: "醒来",
+            original_name: "醒来",
+            first_air_date: "2026-08-01",
+            number_of_episodes: 22,
+            overview: "",
+            poster_path: null,
+            backdrop_path: null,
+            last_episode_to_air: { season_number: 1, episode_number: 22 },
+            seasons: [{ season_number: 1, episode_count: 22 }],
+          };
+        }
+        if (url.includes("/tv/240001/season/1?")) {
+          return {
+            id: 1,
+            season_number: 1,
+            episodes: Array.from({ length: 22 }, (_, index) => ({
+              episode_number: index + 1,
+              name: `Episode ${index + 1}`,
+              air_date: `2026-08-${String(index + 1).padStart(2, "0")}`,
+            })),
+          };
+        }
+        throw new Error(`Unexpected URL ${url}`);
+      },
+    });
+
+    const target = await prepareTrackingTarget({
+      tmdbId: 240001,
+      mediaType: "tv",
+      seasonNumber: 1,
+      qualityPreference: "4K",
+      metadataProvider: provider,
+    });
+
+    expect(target.season.latestAiredEpisode).toBe(22);
+    expect(target.season.totalEpisodes).toBe(22);
+    expect(target.season.status).toBe("active");
+  });
+
   it("uses aired season episodes when last_episode_to_air is absent or from another season", async () => {
     const provider = new TmdbMetadataProvider({
       readToken: "token",

--- a/packages/workflow/tests/v2-bridge.test.ts
+++ b/packages/workflow/tests/v2-bridge.test.ts
@@ -276,4 +276,58 @@ describe("bridgeV2WorkflowToResult — V2 facts → per-season WorkflowResult sh
     expect(result.notification.kind).toBe("series_initialized");
     expect(result.notification.title).toBe("示例剧");
   });
+
+  // 完结剧缺集 bug (2026-09-04): a season is "completed" ONLY when fully OBTAINED,
+  // never merely because every episode has AIRED. A fully-aired (完结) drama whose
+  // initial acquisition left gaps must stay "active" so the daily patrol keeps
+  // filling it — otherwise it graduates to completed at track time and is skipped
+  // forever (这一秒过火 缺 1-13, 永不消逝的电波 缺全集, 醒来 缺 21).
+  it("type2 init: fully aired but a LEADING gap remains (obtained 14-33 of 33) → stays active", () => {
+    const missing = Array.from({ length: 33 }, (_, i) => `S01E${String(i + 1).padStart(2, "0")}`);
+    const obtained = missing.slice(13); // E14..E33; E01..E13 missing
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type2",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 33, latestAiredEpisode: 33, qualityPreference: "4K" }],
+      v2: v2Result({ missingBefore: missing, obtained, stillMissing: missing.slice(0, 13) }),
+      workflowRunId: "run-x",
+      now: () => "2026-09-04T00:00:00.000Z",
+    });
+
+    expect(result.seasons[0]!.season.status).toBe("active");
+  });
+
+  it("type2 init: fully aired but NOTHING obtained (no_coverage) → stays active, not completed", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type2",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 3, latestAiredEpisode: 3, qualityPreference: "4K" }],
+      v2: v2Result({
+        missingBefore: ["S01E01", "S01E02", "S01E03"],
+        obtained: [],
+        stillMissing: ["S01E01", "S01E02", "S01E03"],
+      }),
+      workflowRunId: "run-x",
+      now: () => "2026-09-04T00:00:00.000Z",
+    });
+
+    expect(result.seasons[0]!.season.status).toBe("active");
+  });
+
+  it("a stale persisted status:'completed' does NOT stick a season that still has a real gap → active", () => {
+    const result = bridgeV2WorkflowToResult({
+      title,
+      mode: "type3",
+      seasons: [{ seasonNumber: 1, totalEpisodes: 3, latestAiredEpisode: 3, qualityPreference: "4K", status: "completed" }],
+      v2: v2Result({
+        missingBefore: ["S01E02"],
+        obtained: ["S01E01", "S01E03"],
+        stillMissing: ["S01E02"],
+      }),
+      workflowRunId: "run-x",
+      now: () => "2026-09-04T00:00:00.000Z",
+    });
+
+    expect(result.seasons[0]!.season.status).toBe("active");
+  });
 });

--- a/packages/workflow/tests/v2-series-queue.test.ts
+++ b/packages/workflow/tests/v2-series-queue.test.ts
@@ -161,6 +161,27 @@ describe("queueSeriesInitialization + runQueuedSeriesInitialization (live series
     expect(afterRun.status).toBe("already_tracked");
   });
 
+  // 完结剧缺集 bug (2026-09-04): the enqueue-time lock row must start "active".
+  // season 1 here is fully aired (2/2); grading it "completed" on airing alone
+  // means a run that fails before the bridge overwrites status leaves a
+  // completed-with-gaps season the patrol skips forever.
+  it("queues a fully-aired series with the lock season as active — not completed on airing alone", async () => {
+    const repository = new InMemoryWorkflowRepository();
+    await queueSeriesInitialization({
+      title: theBoys,
+      seasons, // season 1 is fully aired (2/2)
+      keyword: "黑袍纠察队 4K",
+      repository,
+      createWorkflowRunId: () => "run_series_lock",
+      now: () => "2026-09-04T00:00:00.000Z",
+    });
+
+    const states = await repository.listTrackedSeasonStates();
+    expect(states).toHaveLength(1);
+    expect(states[0]!.season.seasonNumber).toBe(1);
+    expect(states[0]!.season.status).toBe("active");
+  });
+
   it("lands an anime title under the separate anime parent, not the TV parent", async () => {
     const anime: MediaTitle = {
       id: "tmdb_tv_240411",


### PR DESCRIPTION
## 症状
已完结（全部集数已播）的剧，若首次获取没拿全，会被标成 `status=completed`，从此再不进每日巡检，缺集永远补不上。

Live 生产 DB 实证 4 部卡死：
| 剧 | 应有(aired) | 实有(obtained) |
|---|---|---|
| 兵自风中来 | 36 | 20 |
| 永不消逝的电波 | 38 | **0** |
| 这一秒过火 | 33 | 32（缺 1-13） |
| 醒来 | 22 | 21 |

## 根因
三处代码把「已播完(fullyAired)」错当「已完成(completed)」，与「是否已获取」无关：
- `packages/workflow/src/acquisition-v2/workflow-v2-bridge.ts`（权威落库点）：`baseStatus = intent.status ?? (fullyAired ? "completed" : "active")` 且 `completed` 永不回退 → 完结剧只要没拿全就永久卡 completed。
- `packages/workflow/src/tmdb-provider.ts`（`prepareTrackingTarget` 追踪初始 status）
- `apps/web/lib/workflow-runtime.ts`（`trackingTargetFromCandidateId` 追踪初始 status）

巡检 `worker.ts` 选剧门 `status !== "active"` 跳过 completed 季。**在更剧免疫**（`latestAired < total` → active），所以过去缺尾集的在更剧一直正常——真正的判别变量是「追踪时是否已完结」，而非缺头/缺尾。

## 修复
确立正确语义：**season 只有「全部已播集都已获取」才 completed；追踪时（零获取）永远 active。**
- bridge：`status = fullyObtained ? "completed" : "active"`，不再信任 `intent.status`、不再以 `fullyAired` 定 completed。它是每次获取/巡检后 status 的唯一裁决者，覆盖 type2/series/type3 全路径。
- 两处追踪初始 status 一律 `"active"`。

## 测试（TDD）
- `v2-bridge.test.ts`：完结剧缺排头集 / 零获取 / 带陈旧 completed 但仍有缺口 → 均应 active（3 个新测试，先 RED 后 GREEN）。
- `tmdb-provider.test.ts`：完全已播剧追踪时 status 应为 active。
- 全 workflow 套件 1450 passed；`apps/web` + `packages/workflow` tsc 双绿。

## 存量数据
DB 里已卡死的 4 部另在实例直接订正 `status→active` 使其重回巡检（数据订正，非代码，不随本 PR）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)