### PR TITLE
fix(web): 详情页按当前网盘读取集状态，多盘同剧不再串盘

### DIFF
--- a/apps/web/lib/title-hub.ts
+++ b/apps/web/lib/title-hub.ts
@@ -202,9 +202,13 @@ export async function getTitleHubView(tmdbId: number, storageId?: string): Promi
     const tracked = trackedBySeason.get(seasonNumber);
     const targetSeason = target?.seasons.find((season) => season.seasonNumber === seasonNumber);
     if (tracked) {
+      // Scope to THIS workspace's drive: the same season can be tracked on
+      // several drives (醒来 on 123 21/22 and on 115 0/22), and an unscoped
+      // lookup returned the other drive's episodes on the detail page.
       const view = await getTrackedSeasonStatusView({
         repository,
         trackedSeasonId: tracked.season.id,
+        scope,
       });
       seasons.push({
         seasonNumber,

--- a/apps/web/lib/workflow-runtime.ts
+++ b/apps/web/lib/workflow-runtime.ts
@@ -757,10 +757,12 @@ export async function getWorkflowStatusView(
   if (!firstTracked) {
     return null;
   }
+  // Read the spotlight season on the SAME drive it was picked from — the same
+  // season may be tracked on other drives with different episode states.
   return getTrackedSeasonStatusView({
     repository: targetRepository,
     trackedSeasonId: firstTracked.season.id,
-    accountId: resolvedAccountId,
+    scope: { accountId: resolvedAccountId, connectedStorageId: firstTracked.connectedStorageId },
   });
 }
 

--- a/packages/workflow/src/queries.ts
+++ b/packages/workflow/src/queries.ts
@@ -1,4 +1,4 @@
-import type { ScopeArg } from "./workflow-scope.js";
+import type { WorkflowScope } from "./workflow-scope.js";
 import {
   episodeNumberFromCode,
   type AirStatus,
@@ -38,12 +38,14 @@ export async function getTrackedSeasonStatusView(input: {
   trackedSeasonId: string;
   /** Legacy account-only scope (no drive filter). Prefer `scope`. */
   accountId?: string;
-  /** Full (account, drive) scope. The same season can be tracked on several
-   *  drives with different episode states, and an account-only lookup lands on
-   *  whichever drive's row the store returns first — the 123 醒来 detail page
+  /** Full (account, drive) scope — deliberately NOT `ScopeArg`, so a bare
+   *  accountId string cannot be passed here and silently drop the drive filter.
+   *  The same season can be tracked on several drives with different episode
+   *  states; an unscoped lookup returns an arbitrary drive's copy (Postgres:
+   *  first row; in-memory: latest run across drives) — the 123 醒来 detail page
    *  showed the 115 copy's 0/22 while the card correctly said 21/22. Callers
-   *  rendering a specific workspace MUST pass its connectedStorageId here. */
-  scope?: ScopeArg;
+   *  rendering a specific workspace MUST pass its connectedStorageId. */
+  scope?: WorkflowScope;
 }): Promise<TrackedSeasonStatusView | null> {
   const state = await input.repository.getTrackedSeasonState(
     input.trackedSeasonId,

--- a/packages/workflow/src/queries.ts
+++ b/packages/workflow/src/queries.ts
@@ -1,3 +1,4 @@
+import type { ScopeArg } from "./workflow-scope.js";
 import {
   episodeNumberFromCode,
   type AirStatus,
@@ -35,9 +36,19 @@ export interface TrackedSeasonStatusView {
 export async function getTrackedSeasonStatusView(input: {
   repository: WorkflowRepository;
   trackedSeasonId: string;
+  /** Legacy account-only scope (no drive filter). Prefer `scope`. */
   accountId?: string;
+  /** Full (account, drive) scope. The same season can be tracked on several
+   *  drives with different episode states, and an account-only lookup lands on
+   *  whichever drive's row the store returns first — the 123 醒来 detail page
+   *  showed the 115 copy's 0/22 while the card correctly said 21/22. Callers
+   *  rendering a specific workspace MUST pass its connectedStorageId here. */
+  scope?: ScopeArg;
 }): Promise<TrackedSeasonStatusView | null> {
-  const state = await input.repository.getTrackedSeasonState(input.trackedSeasonId, input.accountId);
+  const state = await input.repository.getTrackedSeasonState(
+    input.trackedSeasonId,
+    input.scope ?? input.accountId,
+  );
   if (!state) {
     return null;
   }

--- a/packages/workflow/tests/queries.test.ts
+++ b/packages/workflow/tests/queries.test.ts
@@ -67,6 +67,56 @@ describe("getTrackedSeasonStatusView", () => {
     ]);
   });
 
+  // 123 醒来 bug (2026-09-04): the same season tracked on two drives. The detail
+  // page must show THAT drive's episodes — passing only accountId drops the
+  // storage filter, and the unfiltered lookup lands on whichever drive's row
+  // comes first (the 115 copy at 0/22) while the library card correctly said
+  // 21/22 for the 123 copy.
+  it("scopes the view to the requested drive when the season is tracked on multiple drives", async () => {
+    const repository = new InMemoryWorkflowRepository();
+    const { title, season } = fixture();
+    const emptyEpisodes = createEpisodeStates({
+      trackedSeasonId: season.id,
+      seasonNumber: season.seasonNumber,
+      totalEpisodes: season.totalEpisodes,
+      latestAiredEpisode: season.latestAiredEpisode,
+    });
+    const snapshot = (storageId: string, runId: string, startedAt: string, obtained: boolean) => ({
+      accountId: "acct_1",
+      connectedStorageId: storageId,
+      title,
+      season,
+      workflowRun: { ...workflowRun(season), id: runId, startedAt },
+      episodes: emptyEpisodes.map((episode) =>
+        episode.airStatus === "aired" ? { ...episode, obtained } : episode,
+      ),
+      resourceSnapshots: [],
+      decisions: [],
+      transferAttempts: [],
+      notifications: [],
+    });
+    // The drive with NOTHING has the more recent run, so an unscoped "latest
+    // snapshot wins" lookup would pick it and report 0 obtained.
+    await repository.saveWorkflowRunSnapshot(snapshot("cs_pan123", "run_123", "2026-09-01T00:00:00.000Z", true));
+    await repository.saveWorkflowRunSnapshot(snapshot("cs_115", "run_115", "2026-09-02T00:00:00.000Z", false));
+
+    const view123 = await getTrackedSeasonStatusView({
+      repository,
+      trackedSeasonId: season.id,
+      scope: { accountId: "acct_1", connectedStorageId: "cs_pan123" },
+    });
+    expect(view123?.obtainedCount).toBe(2);
+    expect(view123?.missingAiredCount).toBe(0);
+
+    const view115 = await getTrackedSeasonStatusView({
+      repository,
+      trackedSeasonId: season.id,
+      scope: { accountId: "acct_1", connectedStorageId: "cs_115" },
+    });
+    expect(view115?.obtainedCount).toBe(0);
+    expect(view115?.missingAiredCount).toBe(2);
+  });
+
   it("returns null when the tracked season does not exist", async () => {
     const view = await getTrackedSeasonStatusView({
       repository: new InMemoryWorkflowRepository(),

--- a/packages/workflow/tests/queries.test.ts
+++ b/packages/workflow/tests/queries.test.ts
@@ -69,9 +69,10 @@ describe("getTrackedSeasonStatusView", () => {
 
   // 123 醒来 bug (2026-09-04): the same season tracked on two drives. The detail
   // page must show THAT drive's episodes — passing only accountId drops the
-  // storage filter, and the unfiltered lookup lands on whichever drive's row
-  // comes first (the 115 copy at 0/22) while the library card correctly said
-  // 21/22 for the 123 copy.
+  // storage filter and the unscoped lookup returns an arbitrary drive's copy
+  // (the 115 copy at 0/22) while the library card correctly said 21/22 for 123.
+  // Which copy "wins" unscoped is repository-specific: Postgres takes the first
+  // row, InMemoryWorkflowRepository takes the latest run across drives.
   it("scopes the view to the requested drive when the season is tracked on multiple drives", async () => {
     const repository = new InMemoryWorkflowRepository();
     const { title, season } = fixture();
@@ -95,8 +96,9 @@ describe("getTrackedSeasonStatusView", () => {
       transferAttempts: [],
       notifications: [],
     });
-    // The drive with NOTHING has the more recent run, so an unscoped "latest
-    // snapshot wins" lookup would pick it and report 0 obtained.
+    // InMemoryWorkflowRepository picks the latest run across drives when
+    // unscoped; give the drive with NOTHING the more recent run so an unscoped
+    // read would report 0 obtained — the scoped reads below must not.
     await repository.saveWorkflowRunSnapshot(snapshot("cs_pan123", "run_123", "2026-09-01T00:00:00.000Z", true));
     await repository.saveWorkflowRunSnapshot(snapshot("cs_115", "run_115", "2026-09-02T00:00:00.000Z", false));
 


### PR DESCRIPTION
## 症状
123 网盘「醒来」详情页显示 **0/22 全缺**，媒体库卡片同一部剧正确显示 **21/22**。

## 根因
`getTitleHubView` 调 `getTrackedSeasonStatusView` 时只传 `trackedSeasonId`，未传工作区 scope → 查询退化为「仅账号、无网盘过滤」。同一季在 115/123 两盘各有一行 `tracked_seasons`（episode_states 分别 0/22 与 21/22），无过滤时 `rows[0]` 落到 115 那行，详情页渲染出另一块盘的状态。卡片走 `listTrackedSeasonStates(scope)` 带网盘过滤所以正确。

## 修复
- `getTrackedSeasonStatusView` 新增 `scope?: ScopeArg`，透传 repository；`accountId` 保留 legacy。
- `title-hub.getTitleHubView` 传工作区 scope。
- `workflow-runtime.getWorkflowStatusView` spotlight 同样按所选季所在盘 scope（同类隐患）。

## 测试（TDD）
- `queries.test.ts`：同一季两盘、空盘 run 更新，按 scope 分别 2/0 与 0/2（先 RED 后 GREEN）。
- workflow 1452 passed，apps/web 569 passed；双 tsc 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)